### PR TITLE
add changes made to the BIDS tables for the mnc2bids conversion script

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -477,7 +477,12 @@ INSERT INTO `ImagingFileTypes` (type, description) VALUES
   ('txt',      'text file'),
   ('nii',      'NIfTI file'),
   ('nrrd',     'NRRD file format (used by DTIPrep)'),
-  ('grid_0',   'MNI BIC non-linear field for non-linear transformation');
+  ('grid_0',   'MNI BIC non-linear field for non-linear transformation')
+  ('json',   'JSON file'),
+  ('readme', 'README file'),
+  ('tsv',    'Tab separated values (TSV) file'),
+  ('bval',   'NIfTI DWI file with b-values'),
+  ('bvec',   'NIfTI DWI file with b-vectors');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -797,18 +802,34 @@ INSERT INTO `bids_scan_type` (BIDSScanType) VALUES
   ('T2w'),
   ('dwi');
 
+CREATE TABLE `bids_phase_encoding_direction` (
+  `BIDSPhaseEncodingDirectionID`   int(3) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSPhaseEncodingDirectionName` varchar(3) NOT NULL,
+  PRIMARY KEY (`BIDSPhaseEncodingDirectionID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_phase_encoding_direction (BIDSPhaseEncodingDirectionName) VALUES
+  ('i'),
+  ('i-'),
+  ('j'),
+  ('j-'),
+  ('k'),
+  ('k-');
+
 CREATE TABLE `bids_mri_scan_type_rel` (
-  `MRIScanTypeID`             int(10) UNSIGNED NOT NULL,
-  `BIDSCategoryID`            int(3)  UNSIGNED DEFAULT NULL,
-  `BIDSScanTypeSubCategoryID` int(3)  UNSIGNED DEFAULT NULL,
-  `BIDSScanTypeID`            int(3)  UNSIGNED DEFAULT NULL,
-  `BIDSEchoNumber`            int(3)  UNSIGNED DEFAULT NULL,
+  `MRIScanTypeID`                int(10) UNSIGNED NOT NULL,
+  `BIDSCategoryID`               int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeSubCategoryID`    int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeID`               int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSEchoNumber`               int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSPhaseEncodingDirectionID` int(3)  UNSIGNED DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
   KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
-  CONSTRAINT `FK_bids_mri_scan_type_rel`     FOREIGN KEY (`MRIScanTypeID`)             REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_bids_category`              FOREIGN KEY (`BIDSCategoryID`)            REFERENCES `bids_category`(`BIDSCategoryID`),
-  CONSTRAINT `FK_bids_scan_type_subcategory` FOREIGN KEY (`BIDSScanTypeSubCategoryID`) REFERENCES `bids_scan_type_subcategory` (`BIDSScanTypeSubCategoryID`),
-  CONSTRAINT `FK_bids_scan_type`             FOREIGN KEY (`BIDSScanTypeID`)            REFERENCES `bids_scan_type` (`BIDSScanTypeID`)
+  CONSTRAINT `FK_bids_mri_scan_type_rel`        FOREIGN KEY (`MRIScanTypeID`)                REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_bids_category`                 FOREIGN KEY (`BIDSCategoryID`)               REFERENCES `bids_category`(`BIDSCategoryID`),
+  CONSTRAINT `FK_bids_scan_type_subcategory`    FOREIGN KEY (`BIDSScanTypeSubCategoryID`)    REFERENCES `bids_scan_type_subcategory` (`BIDSScanTypeSubCategoryID`),
+  CONSTRAINT `FK_bids_scan_type`                FOREIGN KEY (`BIDSScanTypeID`)               REFERENCES `bids_scan_type` (`BIDSScanTypeID`),
+  CONSTRAINT `FK_bids_phase_encoding_direction` FOREIGN KEY (`BIDSPhaseEncodingDirectionID`) REFERENCES `bids_phase_encoding_direction` (`BIDSPhaseEncodingDirectionID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
@@ -852,6 +873,50 @@ INSERT INTO bids_mri_scan_type_rel
     NULL
   );
 
+
+CREATE TABLE `bids_export_file_level_category` (
+  `BIDSExportFileLevelCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelCategoryName` varchar(12) NOT NULL,
+  PRIMARY KEY (`BIDSExportFileLevelCategoryID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_export_file_level_category (BIDSExportFileLevelCategoryName) VALUES
+  ('study'),
+  ('image'),
+  ('session');
+
+CREATE TABLE `bids_export_non_imaging_file_category` (
+  `BIDSNonImagingFileCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSNonImagingFileCategoryName` varchar(40) NOT NULL,
+  PRIMARY KEY (`BIDSNonImagingFileCategoryID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_export_non_imaging_file_category (BIDSNonImagingFileCategoryName) VALUES
+  ('dataset_description'),
+  ('README'),
+  ('bids-validator-config'),
+  ('participants_list_file'),
+  ('session_list_of_scans');
+
+CREATE TABLE `bids_export_files` (
+  `BIDSExportedFileID`           int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelID`        int(10) unsigned NOT NULL,
+  `FileID`                       int(10) unsigned DEFAULT NULL,
+  `SessionID`                    int(10) unsigned DEFAULT NULL,
+  `BIDSNonImagingFileCategoryID` int(10) unsigned DEFAULT NULL,
+  `BIDSCategoryID`               int(3)  unsigned DEFAULT NULL,
+  `FileType`                     varchar(12) NOT NULL,
+  `FilePath`                     varchar(255) NOT NULL,
+  PRIMARY KEY (`BIDSExportedFileID`),
+  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelID`)        REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
+  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                       REFERENCES `files`   (`FileID`),
+  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                    REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`) REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
+  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)               REFERENCES `bids_category` (`BIDSCategoryID`),
+  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                     REFERENCES `ImagingFileTypes` (`type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
 -- ********************************
 -- MRI violations tables
 -- ********************************
@@ -890,7 +955,7 @@ CREATE TABLE `mri_violations_log` (
   PRIMARY KEY (`LogID`),
   CONSTRAINT `FK_tarchive_mriViolationsLog_1`
     FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`),
-  CONSTRAINT `FK_mri_checks_group_1` 
+  CONSTRAINT `FK_mri_checks_group_1`
     FOREIGN KEY (`MriProtocolChecksGroupID`) REFERENCES `mri_protocol_checks_group` (`MriProtocolChecksGroupID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -899,21 +899,21 @@ INSERT INTO bids_export_non_imaging_file_category (BIDSNonImagingFileCategoryNam
   ('session_list_of_scans');
 
 CREATE TABLE `bids_export_files` (
-  `BIDSExportedFileID`           int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `BIDSExportFileLevelID`        int(10) unsigned NOT NULL,
-  `FileID`                       int(10) unsigned DEFAULT NULL,
-  `SessionID`                    int(10) unsigned DEFAULT NULL,
-  `BIDSNonImagingFileCategoryID` int(10) unsigned DEFAULT NULL,
-  `BIDSCategoryID`               int(3)  unsigned DEFAULT NULL,
-  `FileType`                     varchar(12) NOT NULL,
-  `FilePath`                     varchar(255) NOT NULL,
+  `BIDSExportedFileID`            int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelCategoryID` int(10) unsigned NOT NULL,
+  `FileID`                        int(10) unsigned DEFAULT NULL,
+  `SessionID`                     int(10) unsigned DEFAULT NULL,
+  `BIDSNonImagingFileCategoryID`  int(10) unsigned DEFAULT NULL,
+  `BIDSCategoryID`                int(3)  unsigned DEFAULT NULL,
+  `FileType`                      varchar(12) NOT NULL,
+  `FilePath`                      varchar(255) NOT NULL,
   PRIMARY KEY (`BIDSExportedFileID`),
-  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelID`)        REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
-  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                       REFERENCES `files`   (`FileID`),
-  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                    REFERENCES `session` (`ID`),
-  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`) REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
-  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)               REFERENCES `bids_category` (`BIDSCategoryID`),
-  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                     REFERENCES `ImagingFileTypes` (`type`)
+  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelCategoryID`) REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
+  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                        REFERENCES `files`   (`FileID`),
+  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                     REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`)  REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
+  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)                REFERENCES `bids_category` (`BIDSCategoryID`),
+  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                      REFERENCES `ImagingFileTypes` (`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -477,12 +477,12 @@ INSERT INTO `ImagingFileTypes` (type, description) VALUES
   ('txt',      'text file'),
   ('nii',      'NIfTI file'),
   ('nrrd',     'NRRD file format (used by DTIPrep)'),
-  ('grid_0',   'MNI BIC non-linear field for non-linear transformation')
-  ('json',   'JSON file'),
-  ('readme', 'README file'),
-  ('tsv',    'Tab separated values (TSV) file'),
-  ('bval',   'NIfTI DWI file with b-values'),
-  ('bvec',   'NIfTI DWI file with b-vectors');
+  ('grid_0',   'MNI BIC non-linear field for non-linear transformation'),
+  ('json',     'JSON file'),
+  ('readme',   'README file'),
+  ('tsv',      'Tab separated values (TSV) file'),
+  ('bval',     'NIfTI DWI file with b-values'),
+  ('bvec',     'NIfTI DWI file with b-vectors');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -134,9 +134,13 @@ DROP TABLE IF EXISTS `document_repository`;
 DROP TABLE IF EXISTS `document_repository_categories`;
 
 DROP TABLE IF EXISTS `bids_mri_scan_type_rel`;
+DROP TABLE IF EXISTS `bids_export_files`;
 DROP TABLE IF EXISTS `bids_category`;
 DROP TABLE IF EXISTS `bids_scan_type`;
 DROP TABLE IF EXISTS `bids_scan_type_subcategory`;
+DROP TABLE IF EXISTS `bids_phase_encoding_direction`;
+DROP TABLE IF EXISTS `bids_export_non_imaging_file_category`;
+DROP TABLE IF EXISTS `bids_export_file_level_category`;
 DROP TABLE IF EXISTS `violations_resolved`;
 DROP TABLE IF EXISTS `mri_violations_log`;
 DROP TABLE IF EXISTS `mri_protocol_checks_group_target`;

--- a/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
+++ b/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
@@ -1,0 +1,98 @@
+--
+-- Add necessary file types in ImagingFileTypes
+--
+INSERT INTO ImagingFileTypes (type, description) VALUES
+('json',   'JSON file'),
+('readme', 'README file'),
+('tsv',    'Tab separated values (TSV) file'),
+('bval',   'NIfTI DWI file with b-values'),
+('bvec',   'NIfTI DWI file with b-vectors');
+
+
+--
+-- Create table to store PhaseEncodingDirection possible values
+--
+DROP TABLE IF EXISTS `bids_phase_encoding_direction`;
+CREATE TABLE `bids_phase_encoding_direction` (
+  `BIDSPhaseEncodingDirectionID`   int(3) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSPhaseEncodingDirectionName` varchar(3) NOT NULL,
+  PRIMARY KEY (`BIDSPhaseEncodingDirectionID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_phase_encoding_direction (BIDSPhaseEncodingDirectionName) VALUES
+('i'),
+('i-'),
+('j'),
+('j-'),
+('k'),
+('k-');
+
+
+--
+-- Alter table bids_mri_scan_type_rel to add a PhaseEncodingDirection field
+--
+ALTER TABLE bids_mri_scan_type_rel ADD COLUMN BIDSPhaseEncodingDirectionID int(3) unsigned DEFAULT NULL;
+ALTER TABLE bids_mri_scan_type_rel
+    ADD CONSTRAINT `FK_bids_phase_encoding_direction`
+        FOREIGN KEY (`BIDSPhaseEncodingDirectionID`)
+            REFERENCES `bids_phase_encoding_direction` (`BIDSPhaseEncodingDirectionID`);
+
+
+--
+-- Table structure for `bids_file_level_category`
+--
+DROP TABLE IF EXISTS `bids_export_file_level_category`;
+CREATE TABLE `bids_export_file_level_category` (
+  `BIDSExportFileLevelCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelCategoryName` varchar(12) NOT NULL,
+  PRIMARY KEY (`BIDSExportFileLevelCategoryID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_export_file_level_category (BIDSExportFileLevelCategoryName) VALUES
+  ('study'),
+  ('image'),
+  ('session');
+
+
+
+--
+-- BIDS non-imaging file types
+--
+DROP TABLE IF EXISTS `bids_export_non_imaging_file_category`;
+CREATE TABLE `bids_export_non_imaging_file_category` (
+  `BIDSNonImagingFileCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSNonImagingFileCategoryName` varchar(40) NOT NULL,
+  PRIMARY KEY (`BIDSNonImagingFileCategoryID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO bids_export_non_imaging_file_category (BIDSNonImagingFileCategoryName) VALUES
+  ('dataset_description'),
+  ('README'),
+  ('bids-validator-config'),
+  ('participants_list_file'),
+  ('session_list_of_scans');
+
+
+--
+-- Table structure for table `bids_export_files`
+--
+DROP TABLE IF EXISTS `bids_export_files`;
+CREATE TABLE `bids_export_files` (
+  `BIDSExportedFileID`           int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelID`        int(10) unsigned NOT NULL,
+  `FileID`                       int(10) unsigned DEFAULT NULL,
+  `SessionID`                    int(10) unsigned DEFAULT NULL,
+  `BIDSNonImagingFileCategoryID` int(10) unsigned DEFAULT NULL,
+  `BIDSCategoryID`               int(3)  unsigned DEFAULT NULL,
+  `FileType`                     varchar(12) NOT NULL,
+  `FilePath`                     varchar(255) NOT NULL,
+  PRIMARY KEY (`BIDSExportedFileID`),
+  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelID`)        REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
+  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                       REFERENCES `files`   (`FileID`),
+  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                    REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`) REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
+  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)               REFERENCES `bids_category` (`BIDSCategoryID`),
+  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                     REFERENCES `ImagingFileTypes` (`type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+

--- a/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
+++ b/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
@@ -12,7 +12,6 @@ INSERT INTO ImagingFileTypes (type, description) VALUES
 --
 -- Create table to store PhaseEncodingDirection possible values
 --
-DROP TABLE IF EXISTS `bids_phase_encoding_direction`;
 CREATE TABLE `bids_phase_encoding_direction` (
   `BIDSPhaseEncodingDirectionID`   int(3) unsigned NOT NULL AUTO_INCREMENT,
   `BIDSPhaseEncodingDirectionName` varchar(3) NOT NULL,
@@ -41,7 +40,6 @@ ALTER TABLE bids_mri_scan_type_rel
 --
 -- Table structure for `bids_file_level_category`
 --
-DROP TABLE IF EXISTS `bids_export_file_level_category`;
 CREATE TABLE `bids_export_file_level_category` (
   `BIDSExportFileLevelCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
   `BIDSExportFileLevelCategoryName` varchar(12) NOT NULL,
@@ -58,7 +56,6 @@ INSERT INTO bids_export_file_level_category (BIDSExportFileLevelCategoryName) VA
 --
 -- BIDS non-imaging file types
 --
-DROP TABLE IF EXISTS `bids_export_non_imaging_file_category`;
 CREATE TABLE `bids_export_non_imaging_file_category` (
   `BIDSNonImagingFileCategoryID`   int(10) unsigned NOT NULL AUTO_INCREMENT,
   `BIDSNonImagingFileCategoryName` varchar(40) NOT NULL,
@@ -76,7 +73,6 @@ INSERT INTO bids_export_non_imaging_file_category (BIDSNonImagingFileCategoryNam
 --
 -- Table structure for table `bids_export_files`
 --
-DROP TABLE IF EXISTS `bids_export_files`;
 CREATE TABLE `bids_export_files` (
   `BIDSExportedFileID`            int(10) unsigned NOT NULL AUTO_INCREMENT,
   `BIDSExportFileLevelCategoryID` int(10) unsigned NOT NULL,

--- a/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
+++ b/SQL/New_patches/2021-06-11_exported_files_BIDS_tables.sql
@@ -78,21 +78,21 @@ INSERT INTO bids_export_non_imaging_file_category (BIDSNonImagingFileCategoryNam
 --
 DROP TABLE IF EXISTS `bids_export_files`;
 CREATE TABLE `bids_export_files` (
-  `BIDSExportedFileID`           int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `BIDSExportFileLevelID`        int(10) unsigned NOT NULL,
-  `FileID`                       int(10) unsigned DEFAULT NULL,
-  `SessionID`                    int(10) unsigned DEFAULT NULL,
-  `BIDSNonImagingFileCategoryID` int(10) unsigned DEFAULT NULL,
-  `BIDSCategoryID`               int(3)  unsigned DEFAULT NULL,
-  `FileType`                     varchar(12) NOT NULL,
-  `FilePath`                     varchar(255) NOT NULL,
+  `BIDSExportedFileID`            int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `BIDSExportFileLevelCategoryID` int(10) unsigned NOT NULL,
+  `FileID`                        int(10) unsigned DEFAULT NULL,
+  `SessionID`                     int(10) unsigned DEFAULT NULL,
+  `BIDSNonImagingFileCategoryID`  int(10) unsigned DEFAULT NULL,
+  `BIDSCategoryID`                int(3)  unsigned DEFAULT NULL,
+  `FileType`                      varchar(12) NOT NULL,
+  `FilePath`                      varchar(255) NOT NULL,
   PRIMARY KEY (`BIDSExportedFileID`),
-  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelID`)        REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
-  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                       REFERENCES `files`   (`FileID`),
-  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                    REFERENCES `session` (`ID`),
-  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`) REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
-  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)               REFERENCES `bids_category` (`BIDSCategoryID`),
-  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                     REFERENCES `ImagingFileTypes` (`type`)
+  CONSTRAINT `FK_bef_BIDSExportFileLevelID`        FOREIGN KEY (`BIDSExportFileLevelCategoryID`) REFERENCES `bids_export_file_level_category` (`BIDSExportFileLevelCategoryID`),
+  CONSTRAINT `FK_bef_FileID`                       FOREIGN KEY (`FileID`)                        REFERENCES `files`   (`FileID`),
+  CONSTRAINT `FK_bef_SessionID`                    FOREIGN KEY (`SessionID`)                     REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_bef_BIDSNonImagingFileCategoryID` FOREIGN KEY (`BIDSNonImagingFileCategoryID`)  REFERENCES `bids_export_non_imaging_file_category` (`BIDSNonImagingFileCategoryID`),
+  CONSTRAINT `FK_bef_ModalityType`                 FOREIGN KEY (`BIDSCategoryID`)                REFERENCES `bids_category` (`BIDSCategoryID`),
+  CONSTRAINT `FK_bef_FileType`                     FOREIGN KEY (`FileType`)                      REFERENCES `ImagingFileTypes` (`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 


### PR DESCRIPTION
## Brief summary of changes

This PR modifies the BIDS tables used to convert MINC datasets into BIDS datasets. In addition, it adds tables to store the path to the created files under the BIDS structure in the database so later on it can be queried via the API.

- Table modification (in green) required for the BIDS protocol identification and file naming scheme
![BIDS_protocol_and_filename_mapping](https://user-images.githubusercontent.com/1402456/121702003-7b2ba200-ca9f-11eb-8ae2-88b536154257.png)

- New tables (in green) where the converted BIDS files will be located
![BIDS_converted_files_table_structure](https://user-images.githubusercontent.com/1402456/121702012-7e269280-ca9f-11eb-937d-c97df8ac6708.png)


#### Testing instructions

1. Ensure the SQL patch in the `SQL/New_patches` are correctly executing
2. Ensure the schema `SQL/0000-00-00-schema.sql` is loading properly
3. Ensure the `SQL/9999-99-99-drop_tables.sql` is properly cleaning all the BIDS tables

#### Link(s) to related issue(s)

* Required by the changes made in https://github.com/aces/Loris-MRI/pull/636 