### PR TITLE
Fix the 9999-99-99-drop_tables.sql file

### DIFF
--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -142,6 +142,7 @@ DROP TABLE IF EXISTS `mri_violations_log`;
 DROP TABLE IF EXISTS `mri_protocol_checks_group_target`;
 DROP TABLE IF EXISTS `mri_protocol_checks`;
 DROP TABLE IF EXISTS `mri_protocol_checks_group`;
+DROP TABLE IF EXISTS `mri_upload_rel`;
 DROP TABLE IF EXISTS `mri_upload`;
 DROP TABLE IF EXISTS `mri_protocol_group_target`;
 DROP TABLE IF EXISTS `MRICandidateErrors`;
@@ -155,11 +156,13 @@ DROP TABLE IF EXISTS `mri_scan_type`;
 DROP TABLE IF EXISTS `mri_scanner`;
 DROP TABLE IF EXISTS `mri_processing_protocol`;
 DROP TABLE IF EXISTS `ImagingFileTypes`;
-DROP TABLE IF EXISTS `mri_upload_rel`;
 
 DROP TABLE IF EXISTS `tarchive_files`;
 DROP TABLE IF EXISTS `tarchive_series`;
 DROP TABLE IF EXISTS `tarchive`;
+
+DROP TABLE IF EXISTS `hrrt_archive_files`;
+DROP TABLE IF EXISTS `hrrt_archive`;
 
 DROP TABLE IF EXISTS `history`;
 DROP TABLE IF EXISTS `Visit_Windows`;
@@ -181,7 +184,5 @@ DROP TABLE IF EXISTS `visit_project_subproject_rel`;
 DROP TABLE IF EXISTS `visit`;
 DROP TABLE IF EXISTS `project_subproject_rel`;
 DROP TABLE IF EXISTS `consent_group`;
-DROP TABLE IF EXISTS `hrrt_archive_files`;
-DROP TABLE IF EXISTS `hrrt_archive`;
 DROP TABLE IF EXISTS `Project`;
 DROP TABLE IF EXISTS `subproject`;


### PR DESCRIPTION
## Brief summary of changes

While testing the execution of `9999-99-99-drop_tables.sql ` in https://github.com/aces/Loris/pull/7474, I noticed it is not executing properly. The changes attached fix the order of the DROP statements so that the SQL file works without having to disable the foreign keys.