### PR TITLE
[PageDecorator] fix sites affiliation tooltips

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -203,8 +203,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $tpl_data['user']['permissions']          = $this->user->getPermissions();
         $tpl_data['user']['user_from_study_site'] = $oneIsStudySite;
         $tpl_data['userNumSites']         = count($site_arr);
-        $tpl_data['user']['SitesTooltip'] = str_replace(
-            ";",
+        $tpl_data['user']['SitesTooltip'] = implode(
             "<br/>",
             $this->user->getSiteNames()
         );


### PR DESCRIPTION
In previous releases, the tooltips was build from a string of `;` separated values. Now we use an array of site names returned from `User::getSItenames()`. 

#### Testing instructions (if applicable)
Before this fix, the site affiliation should show the word `Array`. 
After this fix, it should be a list of sitenames each on its own line.