### PR TITLE
[Instrument API] expand saving functionality to include Candidate age calculations and scoring

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -171,7 +171,8 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
         try {
             $instrumentname = $this->_instrument->testName;
             $this->_instrument->clearInstrument();
-            $this->_instrument->_save($data[$instrumentname]);
+            $this->_instrument->_saveValues($data[$instrumentname]);
+            $this->_instrument->score();
         } catch (\Throwable $e) {
             error_log($e->getMessage());
             return new \LORIS\Http\Response\JSON\InternalServerError();
@@ -208,7 +209,8 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         try {
             $instrumentname = $this->_instrument->testName;
-            $this->_instrument->_save($data[$instrumentname]);
+            $this->_instrument->_saveValues($data[$instrumentname]);
+            $this->_instrument->score();
         } catch (\Throwable $e) {
             error_log($e->getMessage());
             return new \LORIS\Http\Response\JSON\InternalServerError();

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -173,6 +173,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $this->_instrument->clearInstrument();
             $this->_instrument->_saveValues($data[$instrumentname]);
             $this->_instrument->score();
+            $this->_instrument->updateDataEntryCompletionStatus();
         } catch (\Throwable $e) {
             error_log($e->getMessage());
             return new \LORIS\Http\Response\JSON\InternalServerError();
@@ -211,6 +212,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $instrumentname = $this->_instrument->testName;
             $this->_instrument->_saveValues($data[$instrumentname]);
             $this->_instrument->score();
+            $this->_instrument->updateDataEntryCompletionStatus();
         } catch (\Throwable $e) {
             error_log($e->getMessage());
             return new \LORIS\Http\Response\JSON\InternalServerError();

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -585,14 +585,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if ($this->form->validate()) {
             $this->form->process(array(&$this, '_saveValues'), true);
             $this->score();
-
-            // determine the data entry completion status, and store that in
-            // the database
-            $dataEntryCompletionStatus
-                = $this->_determineDataEntryCompletionStatus();
-            $this->_setDataEntryCompletionStatus(
-                $dataEntryCompletionStatus
-            );
+            $this->updateDataEntryCompletionStatus();
         } else {
             $submittedData = $this->form->getSubmitValues();
 
@@ -629,6 +622,23 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         }
 
         return true;
+    }
+
+    /**
+     * This checks the current status of and instrument's data entry and updates
+     * it accordingly in the database
+     *
+     * @return void
+     */
+    final public function updateDataEntryCompletionStatus(): void
+    {
+        // determine the data entry completion status, and store that in
+        // the database
+        $dataEntryCompletionStatus
+            = $this->_determineDataEntryCompletionStatus();
+        $this->setDataEntryCompletionStatus(
+            $dataEntryCompletionStatus
+        );
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -630,7 +630,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @return void
      */
-    final public function updateDataEntryCompletionStatus(): void
+    public function updateDataEntryCompletionStatus(): void
     {
         // determine the data entry completion status, and store that in
         // the database


### PR DESCRIPTION
## Brief summary of changes
Currently the API only calls the `_save()` function which stores the data sent to it in the appropriate instrument. That workflow is not symmetrical to saving on the front end which computes the age and scores.

This PR is not making it 100% symmetrical either since validation is not being added but it gets closer to the target

#### Testing instructions (if applicable)

1. try saving an instrument using the API and see if scoring and candidate age calculations are done

#### Link(s) to related issue(s)

* Resolves #7460 
