### PR TITLE
[User] Remove usage of GROUP_CONCAT - based from 23.0

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -65,13 +65,7 @@ class User extends UserPermissions
         $DB =& Database::singleton();
 
         // get user data from database
-        $query = "SELECT users.*,
-            GROUP_CONCAT(psc.Name ORDER BY psc.Name SEPARATOR ';') AS Sites
-            FROM users
-            LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
-            LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
-            WHERE users.UserID = :UID
-            GROUP BY users.ID";
+        $query = "SELECT * FROM users WHERE UserID = :UID";
 
         $row = $DB->pselectRow($query, array('UID' => $username));
 
@@ -85,15 +79,29 @@ class User extends UserPermissions
 
         // get user sites
         $user_centerID_query =  $DB->pselect(
-            "SELECT CenterID FROM user_psc_rel upr
-                        WHERE upr.UserID= :UID",
+            "
+             SELECT
+               upr.CenterID,
+               psc.Name
+             FROM
+               user_psc_rel upr
+             LEFT JOIN
+               psc
+               ON (upr.CenterID = psc.CenterID)
+             WHERE
+               upr.UserID= :UID
+            ",
             array('UID' => $row['ID'])
         );
-        $user_cid            = array();
+
+        $user_cid  = array();
+        $sitenames = [];
         foreach ($user_centerID_query as $key=>$val) {
             // Convert string representation of ID to int
             $user_cid[$key] = intval($val['CenterID']);
+            $sitenames[]    = $val['Name'];
         }
+        $row['Sites'] = implode(';', $sitenames);
 
         $user_pid = $DB->pselectCol(
             "SELECT ProjectID FROM user_project_rel upr WHERE upr.UserId=:uid",


### PR DESCRIPTION
Since group_concat limits the length of the string to 1024 characters by defaults, it becomes problematic for studies that have many sites. 

* Resolves #7480
