### PR TITLE
[LorisForm] Fix quotation display in text elements

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -568,13 +568,12 @@ class LorisForm
                     // This is more for consistency since it would be odd to apply a
                     // filter to a checkbox value
                     $filteredValues[$k]
-                        = $this->_getFilteredValue("{$name}[$k]", $rawValue);
+                        = htmlspecialchars($this->_getFilteredValue("{$name}[$k]", $rawValue));
                 }
-
                 return $filteredValues;
             } else {
                 // if submitted value is not an array, filter it
-                return $this->_getFilteredValue($name, $_REQUEST[$name]);
+                return htmlspecialchars($this->_getFilteredValue($name, $_REQUEST[$name]));
             }
         }
 
@@ -596,7 +595,6 @@ class LorisForm
                     $rawValue = $value == 'on' ? 1 : 0;
                     return $this->_getFilteredValue($name, $rawValue);
                 }
-
                 return $this->_getFilteredValue(
                     $name,
                     $_REQUEST[$fieldName][$fieldIdx]
@@ -930,7 +928,6 @@ class LorisForm
             $readonly = 'readonly';
         }
         $value = $this->getValue($el['name']);
-        $value = str_replace('"', '&quot;', $value);
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
                 isset($el['onchange']) && $el['onchange']

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -930,6 +930,7 @@ class LorisForm
             $readonly = 'readonly';
         }
         $value = $this->getValue($el['name']);
+        $value = str_replace('"', '&quot;', $value);
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
                 isset($el['onchange']) && $el['onchange']
@@ -954,7 +955,7 @@ class LorisForm
 
             . (
                 (!empty($value) || $value === '0')
-                ? ' value="' . $this->getValue($el['name']) . '"'
+                ? ' value="' . $value . '"'
                 : ''
               )
             . $disabled

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -781,6 +781,17 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _saveValues(array $values): void
     {
+        foreach($values AS $key => $val) {
+            if(!is_array($val)){
+                $values[$key] = htmlspecialchars_decode($val);
+            } else {
+                $value = [];
+                foreach ($val as $v) {
+                    $value[] = htmlspecialchars_decode($v);
+                }
+                $values[$key] = $value;
+            }
+        }
         //Convet date/timestamps into database format
         if (empty($this->dateTimeFields)) {
             $this->dateTimeFields = array("Date_taken");


### PR DESCRIPTION
## Brief summary of changes
This PR escape quotations in the text element HTML rendering so that the value will not get cut off, and will display properly.

#### Testing instructions (if applicable)

1. Go to an instrument with text element fields (not including text area element since the issue did not apply to those elements)
2. Outside of this PR, attempt to save a value in the text element that has quotations in it.
3. Notice that it does not display properly after clicking "save"
4. check out this PR
5. Attempt again to save a value with quotations in it

#### Link(s) to related issue(s)

* Resolves #7489
