### PR TITLE
[Filter] Fix Menu Filter logic to recognise sex for exact match

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -441,7 +441,7 @@ class NDB_Menu_Filter extends NDB_Menu
                 $query .= " AND $field";
             } elseif (strtolower(substr($field, -8)) == 'centerid'
                 || strtolower(substr($field, -10)) == 'categoryid'
-                || strtolower(substr($field, -6)) == 'sex'
+                || strtolower(substr($field, -3)) == 'sex'
                 || (isset($this->EqualityFilters)
                 && in_array($field, $this->EqualityFilters))
             ) {


### PR DESCRIPTION
This PR fixes a missing change from #3897 where gender was changed to sex but the substring query was not altered accordingly.

Fixes #7492