### PR TITLE
[Config] Assign user creating project to a newly created project

### DIFF
--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -45,6 +45,10 @@ if ($projectID == 'new') {
     }
 
     $project = \Project::createNew($projectName, $projectAlias, $recTarget);
+    $db->insert(
+        'user_project_rel',
+        ["UserID"=>$user->getId(),"ProjectID"=>$project->getId()]
+    );
 } else {
     // Update Project fields
     $project = \Project::getProjectFromID($projectID);


### PR DESCRIPTION
## Brief summary of changes

This fixes the issue where a newly created project is hidden from all users including the one who created the project and all admins. 


#### Testing instructions (if applicable)

1.  go to the config module -> "To configure study projects click here."
2. create a new project
3. make sure the user who created the project is automatically assigned the project in the user_project_rel table

#### Link(s) to related issue(s)

* Resolves #7459
