### PR TITLE
[Configuration] Fix saving of values when no previous value present

### DIFF
--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -74,20 +74,29 @@
     <div class="config-form-group" id="{$node['ID']}">
     {foreach from=$node['Value'] key=k item=v}
         {if $node['AllowMultiple'] == 1}<div class="input-group entry">{/if}
-        {if $node['DataType'] eq 'boolean'}
-            {call createRadio k=$k v=$v d=$node['Disabled']}
-        {elseif $node['DataType'] eq 'instrument'}
-            {call createInstrument k=$k v=$v d=$node['Disabled']}
-        {elseif $node['DataType'] eq 'scan_type'}
-            {call createScanType k=$k v=$v d=$node['Disabled']}
-        {elseif $node['DataType'] eq 'email'}
-            {call createEmail k=$k v=$v d=$node['Disabled']}
-        {elseif $node['DataType'] eq 'textarea'}
-            {call createTextArea k=$k v=$v d=$node['Disabled']}
-        {elseif $node['DataType'] eq 'lookup_center'}
-            {call createLookUpCenterNameUsing k=$k v=$v d=$node['Disabled']}
+
+        {if $k == 0}
+            {assign var=id value={"add-"|cat:$node['ID']} }
         {else}
-            {call createText k=$k v=$v d=$node['Disabled']}
+            {assign var=id value=$k}
+        {/if}
+
+        {if $node['DataType'] eq 'boolean'}
+            {call createRadio k=$id v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'instrument'}
+            {call createInstrument k=$id v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'scan_type'}
+            {call createScanType k=$id v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'date_format'}
+            {call createDateFormat k=$id v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'email'}
+            {call createEmail k=$id v=$id d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'textarea'}
+            {call createTextArea k=$id v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'lookup_center'}
+            {call createLookUpCenterNameUsing k=$id v=$v d=$node['Disabled']}
+        {else}
+            {call createText k=$id v=$v d=$node['Disabled']}
         {/if}
         {if $node['AllowMultiple'] == 1}
             <div class="input-group-btn">


### PR DESCRIPTION
When there is a value in ConfigSettings but not Config, the value does
not get saved to the database but silently discarded. This is caused by
the save logic assuming that the ID always exists to update. However,
other logic in the configuration saving deletes from the Config table
if the value is "". This means that once a config option is set to the
empty string it can never be saved again. (This can also happen for
new ConfigSettings.)

Since the name used for the text field in the HTML is the Config table ID
(which doesn't exist) and not the ConfigSetting ID to support ConfigSetting
options that allow multiple entries, the name of the ID is "0" in the form
and can not be converted to a ConfigSetting to change the statement from an
update to an insertOnDuplicateUpdate. AllowMultiple settings, on the other
hand use "add-ConfigSettingID" or "remove-ConfigSettingID" as their name.

This modifies the template to use add-ConfigSettingID when the ConfigID is
"0" in order to have it inserted if it does not exist, regardless of the
AllowMultiple setting for the ConfigSetting.