### PR TITLE
[DQT] Check for scan types in MRI Importer script

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -63,6 +63,10 @@ class CouchDBMRIImporter
     function run()
     {
         $ScanTypes = $this->getScanTypes();
+        if (empty($scanTypes)) {
+            fwrite(STDERR, "No scan types found to import.\n");
+            exit(1);
+        }
         $this->updateDataDict($ScanTypes);
 
         $CandidateData = $this->getCandidateData($ScanTypes);


### PR DESCRIPTION
Add a check to verify that GetScanTypes returned some
valid, configured scan types with data in CouchDB import
script.

If the import script is run with no scan types, it currently
only imports the session QC status. The fact that the script
failed to import the important data isn't caught until after
a user tries to use the DQT.

This adds a check to error out if getScanTypes does not return
any scan types at import time.
