### PR TITLE
[Utility] Refactor getVisitInstruments function

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -745,40 +745,26 @@ class Utility
      *                            to know the existing visit labels
      *
      * @return array Array of instruments which exist for the given visit label
-     *               array is of the form
-     *               array(0 => array('Test_name_display' => $TestName))?
-     *
-     * @note    Function comment written by Dave, not the author of this function.
-     *       The return value format seems weird. Should possibly be refactored.
-     * @note    Used in:
-     *      - behavioural_qc/php/NDB_Form_behavioural_qc.class.inc
-     *      - behavioural_qc/ajax/GetInstruments.php
-     * @cleanup
+     *               array is of the form [$Test_name => $Full_name]
      */
     static function getVisitInstruments(string $visit_label): array
     {
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        if ($DB->ColumnExists('test_battery', 'Test_name_display')) {
-            $test_names = $DB->pselect(
-                "SELECT DISTINCT Test_name_display FROM test_battery
-                WHERE Visit_label=:vl",
-                ['vl' => $visit_label]
-            );
-        } else {
-            $test_names = $DB->pselect(
-                "SELECT DISTINCT t.Full_name as Test_name_display FROM session s
-                JOIN candidate c ON (c.candid=s.candid)
-                JOIN psc ON (s.CenterID = psc.CenterID)
-                JOIN flag f ON (f.sessionid=s.id)
-                JOIN test_names t ON (f.test_name=t.Test_name)
-                WHERE c.Active='Y' AND s.Active='Y' AND s.Visit_label =:vl
-                AND psc.CenterID != '1' AND c.Entity_type != 'Scanner'
-                ORDER BY t.Full_name",
-                ['vl' => $visit_label]
-            );
-        }
+        $test_names = $DB->pselectColWithIndexKey(
+            "SELECT DISTINCT t.Test_name, t.Full_name
+            FROM session s
+            JOIN candidate c ON (c.CandID=s.CandID)
+            JOIN psc ON (s.CenterID=psc.CenterID)
+            JOIN flag f ON (f.sessionID=s.id)
+            JOIN test_names t ON (f.test_name=t.Test_name)
+            WHERE c.Active='Y' AND s.Active='Y' AND s.Visit_label =:vl
+            AND psc.CenterID != '1' AND c.Entity_type != 'Scanner'
+            ORDER BY t.Full_name",
+            ['vl' => $visit_label],
+            'Test_name'
+        );
 
         return $test_names;
     }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -612,12 +612,18 @@ class UtilityTest extends TestCase
             ->method('pselect')
             ->willReturn(
                 [
-                    ['name1' => 'display1']
+                    ['name1' => 'display1',
+                        'TestName'          => 'name1',
+                        'Visit_label'       => 'V1'
+                    ]
                 ]
             );
 
         $this->assertEquals(
-            ['name1' => 'display1'],
+            ['name1' => 'display1',
+                'TestName'          => 'name1',
+                'Visit_label'       => 'V1'
+            ],
             Utility::getVisitInstruments('V1')
         );
     }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -612,10 +612,7 @@ class UtilityTest extends TestCase
             ->method('pselectColWithIndexKey')
             ->willReturn(
                 [
-                    ['name1' => 'display1',
-                        'TestName'    => 'name1',
-                        'Visit_label' => 'V1'
-                    ]
+                    'name1' => 'display1'
                 ]
             );
 

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -620,9 +620,7 @@ class UtilityTest extends TestCase
             );
 
         $this->assertEquals(
-            ['name1' => 'display1',
-                'TestName'    => 'name1',
-                'Visit_label' => 'V1'
+            ['name1' => 'display1'
             ],
             Utility::getVisitInstruments('V1')
         );

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -613,16 +613,16 @@ class UtilityTest extends TestCase
             ->willReturn(
                 [
                     ['name1' => 'display1',
-                        'TestName'          => 'name1',
-                        'Visit_label'       => 'V1'
+                        'TestName'    => 'name1',
+                        'Visit_label' => 'V1'
                     ]
                 ]
             );
 
         $this->assertEquals(
             ['name1' => 'display1',
-                'TestName'          => 'name1',
-                'Visit_label'       => 'V1'
+                'TestName'    => 'name1',
+                'Visit_label' => 'V1'
             ],
             Utility::getVisitInstruments('V1')
         );

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -611,51 +611,11 @@ class UtilityTest extends TestCase
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->willReturn(
-                [
-                    ['Test_name_display' => 'display1',
-                        'TestName'          => 'name1',
-                        'Visit_label'       => 'V1'
-                    ]
-                ]
+                ['name1' => 'display1']
             );
 
         $this->assertEquals(
-            [0 => ['Test_name_display' => 'display1',
-                'TestName'          => 'name1',
-                'Visit_label'       => 'V1'
-            ]
-            ],
-            Utility::getVisitInstruments('V1')
-        );
-    }
-
-    /**
-     * Test an edge case of getVisitInstruments() where there is no
-     * 'Test_name_display' column in the given table
-     *
-     * @covers Utility::getVisitInstruments
-     * @return void
-     */
-    public function testGetVisitInstrumentsWithoutTestNameDisplay()
-    {
-
-        $this->_dbMock->expects($this->any())
-            ->method('pselect')
-            ->willReturn(
-                [
-                    ['Full_name' => 'display1',
-                        'TestName'    => 'name1',
-                        'Visit_label' => 'V1'
-                    ]
-                ]
-            );
-
-        $this->assertEquals(
-            [0 => ['Full_name' => 'display1',
-                'TestName'    => 'name1',
-                'Visit_label' => 'V1'
-            ]
-            ],
+            ['name1' => 'display1'],
             Utility::getVisitInstruments('V1')
         );
     }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -609,7 +609,7 @@ class UtilityTest extends TestCase
     {
 
         $this->_dbMock->expects($this->any())
-            ->method('pselect')
+            ->method('pselectColWithIndexKey')
             ->willReturn(
                 [
                     ['name1' => 'display1',

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -611,7 +611,9 @@ class UtilityTest extends TestCase
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->willReturn(
-                ['name1' => 'display1']
+                [
+                    ['name1' => 'display1']
+                ]
             );
 
         $this->assertEquals(


### PR DESCRIPTION
## Brief summary of changes

Comment in Utility Class

>      * @note    Function comment written by Dave, not the author of this function.
>      *       The return value format seems weird. Should possibly be refactored.
>      * @note    Used in:
>      *      - behavioural_qc/php/NDB_Form_behavioural_qc.class.inc
>      *      - behavioural_qc/ajax/GetInstruments.php
>      * @cleanup


I should mention that the files mentioned in the comment no longer exist and as far as I can tell there are no other uses of this function in the code base.

#### Testing instructions (if applicable)

1. Use the utility somewhere and make sure the output is in the form of an array: `[$Test_name => $Full_name]`

