### PR TITLE
[instrument_builder] Add REDCap CSV --> .linst functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ requesting a new account and will be displayed in the User Accounts module (PR #
  - Fix fatal errors on submission. (PR #6822)
 #### Instrument Builder
 - Fix for error 'Max value must be larger than min value' when clicking 'Add Row'. (PR #6810)
+- Ability to load a REDCap .csv instrument data dictionary, modify it in the builder, and save it as a .linst file.
 #### EEG Browser
 - Signal Visualization, Events and Electrode map (PR #7387)
 - Site/Project/subproject filters only displays entries user has permission for. (PR #7400)
@@ -110,8 +111,6 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 - New tool `populate_visits.php` to backpopulate visits from the `config.xml`, `session` table and `Visit_Windows` table into the `visit` and `visit_project_subproject_rel` (#7663)
 - Deprecation of the `populate_visit_windows.php` tool in favour of `populate_visits.php` (#7663)
 
-#### Instrument Builder
-- Ability to load a REDCap .csv instrument data dictionary, modify it in the builder, and save it as a .linst file.
 ### Clean Up
 - Removal of unused variables and unnecessary branching from `getBattery()` and `getBatteryVerbose()` functions (PR #7167)
 - Removal of the violated_scans_edit permission (PR #6747)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 - New tool `populate_visits.php` to backpopulate visits from the `config.xml`, `session` table and `Visit_Windows` table into the `visit` and `visit_project_subproject_rel` (#7663)
 - Deprecation of the `populate_visit_windows.php` tool in favour of `populate_visits.php` (#7663)
 
+#### Instrument Builder
+- Ability to load a REDCap .csv instrument data dictionary, modify it in the builder, and save it as a .linst file.
 ### Clean Up
 - Removal of unused variables and unnecessary branching from `getBattery()` and `getBatteryVerbose()` functions (PR #7167)
 - Removal of the violated_scans_edit permission (PR #6747)

--- a/modules/instrument_builder/README.md
+++ b/modules/instrument_builder/README.md
@@ -5,6 +5,8 @@
 The instrument builder provides a graphical interface for users to
 design and build instruments to be installed on a LORIS instance.
 
+The interface also allows users to load and modify an existing instrument, in either .linst format or a REDCap .csv format.
+
 ## Intended Users
 
 The instrument builder is intended to be used by non-programmers who

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -218,7 +218,22 @@ var Instrument = {
                                 Values : {},
                                 AllowMultiple : specialCase
                             };
-                            options = pieces[3].split("{-}");
+                            try {
+                              options = pieces[3].split("{-}");
+                            } catch (error) {
+                              console.error(error);
+                              var alertMessage = [
+                                "Syntax error found on element named: ",
+                                tempElement.Name,
+                                ".",
+                                React.createElement('br'),
+                                "Instrument file unable to load.",
+                                React.createElement('br'),
+                                "Please verify the content of your LINST or CSV file!",
+                              ];
+                              callback.error("syntaxError", alertMessage);
+                              return;
+                            }
                             for (option of options) {
                                 keyVal = option.split("=>");
                                 if (keyVal[0].indexOf('not_answered') == -1) {
@@ -383,7 +398,7 @@ var Instrument = {
               const newLinst = parsedCSV.map((line) => {
                 // Table name
                 if (tableName !== '' && tableName !== line["Form Name"]) {
-                  callback.error("multiple tests in csv file");  
+                  callback.error("multipleTests");
                 } else if (tableName === '') {
                   tableName = line["Form Name"]; 
                 }

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -164,7 +164,7 @@ var Instrument = {
    },
     load: function (file, callback) {
         var reader = new FileReader();
-            ParseInstrument = function () {
+            ParseInstrument = function (content) {
                 var elementNames = [];
                 var Elements = [{
                         Type        : "ElementGroup",
@@ -172,6 +172,7 @@ var Instrument = {
                         Description : "Top",
                         Elements    : []
                     }],
+                    rules = (content.rules) ? content.rules.split("\n") : [],
                     fileInfo = {
                         fileName: '',
                         instrumentName: ''
@@ -179,7 +180,7 @@ var Instrument = {
                     tempElement = {},
                     specialCase = false,
                     currentPage = 0,
-                    lines = this.result.split("\n"),
+                    lines = (content.result) ? content.result.split("\n") : this.result.split("\n"),
                     options,
                     keyVal;
                 for (line of lines) {
@@ -357,8 +358,225 @@ var Instrument = {
                 }
                 callback.success(Elements, fileInfo);
             };
+            ConvertCSV = function () {
+              const lines = parseCSVFile(this.result);
+              // Extract headers
+              const headersLine = lines[0];
+              const headers = parseCSVRow(headersLine);
+              // Extract data from subsequent lines
+              const dataLines = lines.slice(1);
+              const data = dataLines.map(parseCSVRow);
+              // Transform to object
+              const parsedCSV = data.map((array) => {
+                let dataObject = {};
+                headers.forEach((header, index) => {
+                  dataObject[header] = array[index];
+                });
+                return dataObject;
+              });
+              let content = '';
+              let tableName = '';
+              let title = '';
+              let sectionHeader = null;
+              let lineContent = '';
+              let rulesContent = '';
+              const newLinst = parsedCSV.map((line) => {
+                // Table name
+                if (tableName !== '' && tableName !== line["Form Name"]) {
+                  callback.error("multiple tests in csv file");  
+                } else if (tableName === '') {
+                  tableName = line["Form Name"]; 
+                }
+                // title - take from table name
+                if (title === '') {
+                  const titleArr = tableName.split('_').map((word) => {
+                    return (word.charAt(0).toUpperCase() + word.slice(1));
+                  });
+                  title = titleArr.join(" ");
+                }
+                // Section header and subtest
+                if (line["Section Header"] != undefined
+                    && line["Section Header"] !== ''
+                    && line["Section Header"] !== sectionHeader
+                ) {
+                  sectionHeader = line["Section Header"];
+                  lineContent += "page{@}{@}" + sectionHeader + "\n";
+                  lineContent += "header{@}{@}" + sectionHeader + "\n";
+                }
+                let elementName = line["Variable / Field Name"];
+                const elementType = line["Field Type"];
+                // Replace newline in description with a slash
+                const elementDescription = (line["Field Label"] || '').replace(/\n\n/g, "/ ");
+                const validationType = line["Text Validation Type OR Show Slider Number"];
+                const minValue = line["Text Validation Min"];
+                const maxValue = line["Text Validation Max"];
+                const branching = line["Branching Logic (Show field only if...)"];
+                const required = line["Required Field?"];
+                let linstType = '';
+                switch (elementType) {
+                  case "checkbox":
+                    linstType = "multiselect{@}";
+                  case "radio":
+                    linstType = "select{@}";
+                    lineContent += linstType;
+                    lineContent += elementName + "{@}" + elementDescription + "{@}";
+                    lineContent += "NULL=>''";
+                    const options = line["Choices, Calculations, OR Slider Labels"];
+                    let optionsContent = [];
+                    if (options != undefined) {
+                      const optionsArr = options.split(" | ");
+                      optionsContent = optionsArr.map((option) => {
+                        const value = option.split(/, (.+)/)[0];
+                        const label = option.split(/, (.+)/)[1];
+                        const optionContent = "{-}'" + value + "'=>'" + label + "'";
+                        return optionContent;
+                      });
+                    }
+                    lineContent += optionsContent.join("");
+                    lineContent += "{-}'not_answered'=>'Not Answered'\n";
+                    break;
+                  case "yesno":
+                    lineContent += "select{@}";
+                    lineContent += elementName + "{@}" + elementDescription + "{@}";
+                    lineContent += "NULL=>''";
+                    lineContent += "{-}'1'=>'Yes'{-}'0'=>'No'";
+                    lineContent += "{-}'not_answered'=>'Not Answered'\n";
+                    break;
+                  case "text":
+                    // Date element type
+                    if (validationType == "date_dmy"
+                      || validationType == "date_ymd"
+                    ) {
+                      let dropdown = "";
+                      let dateFormat = "";
+                      // If element name ends with "_date", make it a standard date
+                      // Otherwise, it can be a basic date
+                      if (elementName.substring(elementName.length - 5) == "_date") {
+                        // provide not_answered option
+                        dropdown = "select{@}" + elementName + "_status" +
+                          "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                      } else {
+                        dateFormat = "BasicDate";
+                      }  
+                      lineContent += "date{@}";
+                      lineContent += elementName + "{@}" + elementDescription;
+                      lineContent += "{@}" + minValue;
+                      lineContent += "{@}" + maxValue;
+                      lineContent += "{@}" + dateFormat + "\n";
+                      lineContent += dropdown;
+                    } else if (validationType == "number") {
+                    // Numeric element type
+                      lineContent += "numeric{@}";
+                      lineContent += elementName + "{@}" + elementDescription;
+                      lineContent += "{@}" + minValue;
+                      lineContent += "{@}" + maxValue + "\n";
+                      lineContent += "select{@}" + elementName + "_status" +
+                        "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                    } else {
+                    // Text
+                      lineContent += "text{@}";
+                      lineContent += elementName + "{@}" + elementDescription + "\n";
+                      lineContent += "select{@}" + elementName + "_status" +
+                        "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                    }
+                    break;
+                  case "notes":
+                    lineContent += "textarea{@}";
+                    lineContent += elementName + "{@}" + elementDescription + "\n";
+                    lineContent += "select{@}" + elementName + "_status" +
+                      "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                    break;
+                  case "calc":
+                    lineContent += "static{@}";
+                    lineContent += elementName + "{@}" + elementDescription + "\n";
+                    elementName = '';
+                    break;
+                  case "descriptive":
+                    lineContent += "static{@}{@}" + elementDescription + "\n";
+                    elementName = '';
+                    break;
+                }
+                // Add rules
+                if (elementName != '') {
+                  if (branching != undefined && branching != '') {
+                    // then add rules
+                    let dependentValue = '';
+                    let dependentField = branching.match(/\[(.*?)\]/) ? branching.match(/\[(.*?)\]/)[1] : '';
+                    if (dependentField.includes("(") && dependentField.includes(")")) {
+                      // multiselect with CONTAINS
+                      let substring = dependentField.match(/\((.*?)\)/);
+                      dependentValue = substring[1];
+                      dependentField = dependentField.replace(substring, '');
+                      rulesContent += elementName + "{-}Required{-}" + dependentField + "{@}CONTAINS{@}" + dependentValue + "\n";
+                    } else if (dependentField !== '') {
+                      //select with ==
+                      dependentValue = branching.match(/\'(.*?)\'/) ? branching.match(/\'(.*?)\'/)[1] : ''; 
+                      rulesContent += elementName + "{-}Required{-}" + dependentField + "{@}=={@}" + dependentValue + "\n";
+                    } 
+                  } else {
+                    if (required != 'y') {
+                      rulesContent += elementName + "{-}Not required{-}" + elementName + "{@}=={@}NEVER_REQUIRED" + "\n";
+                    }
+                  }
+                }
+              });
+              content += "table{@}" + tableName + "\n";
+              content += "title{@}" + title + "\n";
+              // Add metadata fields
+              content += "date{@}Date_taken{@}Date of Administration{@}{@}\n";
+              content += "static{@}Candidate_Age{@}Candidate Age (Months)\n";
+              content += "static{@}Window_Difference{@}Window Difference (+/- Days)\n";
+              content += "select{@}Examiner{@}Examiner{@}NULL=>''\n";
+              content += lineContent;
+              const csv = {};
+              csv.result = content;
+              csv.rules = rulesContent;
+              ParseInstrument(csv);
+            };
+            parseCSVFile = (csvfile) => {
+              let insideQuote = false,
+                  entries = [],
+                  entry = [];
+              csvfile.split('').forEach((char) => {
+                if (char === '"') {
+                  insideQuote = !insideQuote;
+                  entry.push(char);
+                } else {
+                  if (char == "\n" && !insideQuote) {
+                    entries.push(entry.join(''));
+                    entry = [];
+                  } else {
+                    entry.push(char);
+                  }
+                }
+              });
+              entries.push(entry.join(''));  
+              return entries;
+            };
+            parseCSVRow = (row) => {
+              let insideQuote = false,
+                  entries = [],
+                  entry = [];
+              row.split('').forEach((char) => {
+                if (char === '"') {
+                  insideQuote = !insideQuote;
+                } else {
+                  if (char == "," && !insideQuote) {
+                    entries.push(entry.join(''));
+                    entry = [];
+                  } else {
+                    entry.push(char);
+                  }
+                }
+              });
+              entries.push(entry.join(''));
+              return entries;
+            };
         if (file.name.split('.')[1] === 'linst') {
             reader.onload = ParseInstrument;
+            var data = reader.readAsText(file);
+        } else if (file.name.split('.')[1] === 'csv') {
+            reader.onload = ConvertCSV;
             var data = reader.readAsText(file);
         } else {
             callback.error("typeError");

--- a/modules/instrument_builder/js/instrument_builder.rules.js
+++ b/modules/instrument_builder/js/instrument_builder.rules.js
@@ -1,7 +1,7 @@
 var Rules = {
-    render: function () {
-        var content = '',
-            rules = document.getElementById("rules_workspace"),
+    render: function (rules) {
+        var content = rules.join("\n"),
+            workspace = document.getElementById("rules_workspace"),
             Rule,
             row,
             fs,
@@ -9,30 +9,46 @@ var Rules = {
             value,
             i;
 
-         for(i=1; i < rules.rows.length; i++) {
-            row = rules.rows[i]
-            Rule = new Array();
-            Rule.push(row.firstChild.innerText); // Question
-            Rule.push(row.firstChild.nextSibling.nextSibling.nextSibling.innerText)
+            if (workspace) {
+          for(i=1; i < workspace.rows.length; i++) {
+              row = workspace.rows[i]
+              Rule = new Array();
+              Rule.push(row.firstChild.innerText); // Question
+              Rule.push(row.firstChild.nextSibling.nextSibling.nextSibling.innerText)
 
-            value = row.firstChild.nextSibling.nextSibling.innerText;
-            operator = "{@}=={@}";
+              value = row.firstChild.nextSibling.nextSibling.innerText;
+              operator = "{@}=={@}";
 
-            // Check if it's a regex
-            if(value.substring(0, 3) === '=~ ') {
-                value = value.substring(3);
-                operator = '{@}=~{@}';
-            }
-            Rule.push(row.firstChild.nextSibling.innerText + operator + value);
-            content += Rule.join("{-}")
-            content += "\n";
+              // Check if it's a regex
+              if(value.substring(0, 3) === '=~ ') {
+                  value = value.substring(3);
+                  operator = '{@}=~{@}';
+              }
+              Rule.push(row.firstChild.nextSibling.innerText + operator + value);
+              content += Rule.join("{-}")
+              content += "\n";
+          }
         }
-         return content;
+        return content;
     },
-    save: function () {
-        var name = document.getElementById("filename").value || "instrument";
+    save: function (saveInfo) {
+      if (saveInfo.rules.length != 0) {
+        var name = saveInfo.fileName || "instrument",
+            content = this.render(saveInfo.rules),
+            element = document.createElement("a"),
+            blob = new Blob([content], { type: 'text/plain;base64' }),
+            url = URL.createObjectURL(blob);
 
-        fs = saveAs(this.render().getBlob("text/plain;charset=utf-8"), name + ".rules");
+            element.href = url;
+            element.download = name + ".rules";
+            element.style.display = "none";
+            // add element to the document so that it can be clicked
+            // this is need to download in firefox
+            document.body.appendChild(element);
+            element.click();
+            // remove the element once it has been clicked
+            document.body.removeChild(element);
+      }
     },
 
     addNew: function () {

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -120,6 +120,22 @@ class LoadPane extends Component {
           class: 'alert alert-danger alert-dismissible',
         };
         break;
+      case 'multipleTests':
+        alert = {
+          message: 'Error!',
+          details: 'Multiple tests in .csv file',
+          display: 'block',
+          class: 'alert alert-danger alert-dismissible',
+        };
+        break;
+      case 'syntaxError':
+        alert = {
+          message: 'Error!',
+          details: this.state.alertMessage,
+          display: 'block',
+          class: 'alert alert-danger alert-dismissible',
+        };
+        break;
       default:
         break;
     }

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -126,6 +126,15 @@ class LoadPane extends Component {
     return (
       <TabPane Title='Load Instrument' {...this.props}>
         <div className='col-sm-6 col-xs-12'>
+          <i>
+            Note: You may load either a LORIS .linst format or a REDCap
+            .csv format.
+          </i><br></br>
+          <i>
+            If loading a .csv format, make sure the file contains the data
+            dictionary of only one instrument.
+          </i><br></br>
+          <br></br>
           <div id='load_alert'
                style={{display: alert.display}}
                className={alert.class}
@@ -171,6 +180,7 @@ class SavePane extends Component {
     this.state = {
       fileName: '',
       instrumentName: '',
+      rules: [],
     };
     this.loadState = this.loadState.bind(this);
     this.onChangeFile = this.onChangeFile.bind(this);
@@ -187,6 +197,7 @@ class SavePane extends Component {
     this.setState({
       fileName: newState.fileName,
       instrumentName: newState.instrumentName,
+      rules: newState.rules,
     });
   }
 
@@ -753,6 +764,7 @@ class InstrumentBuilderApp extends Component {
       this.refs.savePane.state,
       this.refs.buildPane.state.Elements
     );
+    Rules.save(this.refs.savePane.state);
   }
 
   /**

--- a/modules/instrument_builder/test/TestPlan.md
+++ b/modules/instrument_builder/test/TestPlan.md
@@ -28,6 +28,9 @@ Instrument builder Test Plan
 6.  Re-load existing instrument
   * 6.a Add questions
   * 6.b Save instrument file and ensure new changes are reflected in the file
-7. Install and test instrument
-8. Add and test some basic rules for the instrument (see the `bmi` in this repo for examples
-9. Test functionality on mutiple broswers.
+7.  Load existing REDCap instrument
+  * 7.a Add questions
+  * 7.b Save instrument file and ensure new changes are reflected in the file
+8. Install and test instrument
+9. Add and test some basic rules for the instrument (see the `bmi` in this repo for examples
+10. Test functionality on mutiple broswers.


### PR DESCRIPTION
## Brief summary of changes

- [x] Have you updated related documentation?

This PR adds the functionality to load onto the instrument builder a REDCap data dictionary for an instrument in .csv format. Note: you cannot load the entire REDCap data dictionary - you have to extract a single instrument's data dictionary for upload.

The loading functionality will render the instrument under the 'Build' tab as usual i.e. as for linst format, and allow to 'Save' the data dictionary as a .linst instrument. I have also added the capability of downloading rules if they exist in the .csv file.

_**Caveat:**_ This PR is dependent on a new XINValidate feature. I created a "CONTAINS" operator for the XINValidateMultiSelect() function of NDB_BVL_Instrument_LINST.class.inc (on QPN), to work with REDCap rules for multiselect. E.g.:

```
[site] = '3' <--- normal select element
[income_source(8)] = '1' <--- multi select i.e. this field is required if option 8 was selected (among other potential options selected)
```
I can either add the "CONTAINS" feature in this PR, in a separate PR, or take it out completely as it doesn't yet exist in LORIS.

**_Another note_**: I had to play with already messy code, some that were there but never used i.e. `modules/instrument_builder/js/instrument_builder.rules.js ` seems to be doing something but was never implemented on the module. I tried to utilize it for this PR, but maybe there is a better way to code the .rules download. I'm open to all feedback, I coded this all fairly quickly.

#### Testing instructions (if applicable)

1. Load a test .linst file as you would normally. Notice how the instrument is rendered on the 'Build' tab. Make some modifications to the instrument if you like. Save the instrument under the 'Save' tab. Look at the linst file and make sure it is what you expect.
2. Take a REDCap .csv data dictionary for 1 instrument. (If you don't have one, let me know and I can share one with you). Load the .csv file as you would a .linst file. The instrument should be rendered as you would expect in the 'Build' tab. Make sure there are no errors. You can 'Save' the instrument, giving you a .linst file and maybe a .rules file. Read the .linst  file and make sure it is what you expect, following the same format as the linst file generated from step 1.
3. Generate the SQL file for the instrument: `cat $instrument.linst  | php tools/generate_tables_sql_and_testNames.php`
Check the SQL statements were generated fine.
4. Run the SQL script and make sure you get no SQL errors.
5. Add the instrument to the test_battery table.
6. Run `php tools/assign_missing_instruments.php`
7. Test the instrument on the front end, and make sure it works like any normal linst instrument

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
