### PR TITLE
[Publication] Set Content-Type for ajax responses

### DIFF
--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -20,6 +20,7 @@ if (isset($_REQUEST['action'])) {
 
     if ($action === 'getData') {
         if (userCanGetData($db, $user)) {
+            header('Content-Type: application/json');
             exit(json_encode(getData($db)));
         } else {
             http_response_code(403);
@@ -31,6 +32,7 @@ if (isset($_REQUEST['action'])) {
     } elseif ($action === 'getProjectData') {
         $id = $_REQUEST['id'];
         if (userCanGetData($db, $user, $id)) {
+            header('Content-Type: application/json');
             exit(json_encode(getProjectData($db, $user, $id)));
         } else {
             http_response_code(403);


### PR DESCRIPTION
This sets the Content-Type header for the ajax responses
in the publication module. Because it's not explicitly
set, PHP is defaulting to text/html. This means that, in
the event that a user directly accesses the endpoint, the
browser will interpret the page as HTML, not JSON, and interpret
any HTML data in the object as HTML tags, opening the possibility of
an XSS attack if the an someone is tricked into accessing the
ajax endpoint directly.

The frontend isn't directly vulnerable, because the data is only
interpreted by React.

Setting the Content-Type explicitly to the correct "application/json"
means that browsers should interpret the data correctly even if
accessed directly, rather than interpretting HTML tags.

Thanks to @0xSmiley for reporting this.