### PR TITLE
[Security] Fix SameSite cookie CSRF protection

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -31,6 +31,7 @@ set_include_path(
     __DIR__ . "/../project/libraries:" .
     __DIR__ . "/../php/libraries"
 );
+ini_set('session.use_strict_mode', '1');
 
 require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -25,6 +25,7 @@ session_cache_limiter("");
 // PHP documentation says this should always be enabled for session security.
 // PHP documentation says this is disabled by default.
 // Explicitly enable it.
+// phpcs:ignore
 // See: https://www.php.net/manual/en/session.configuration.php#ini.session.use-strict-mode
 ini_set('session.use_strict_mode', '1');
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -22,6 +22,12 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // to be done before NDB_Client starts the PHP session.)
 session_cache_limiter("");
 
+// PHP documentation says this should always be enabled for session security.
+// PHP documentation says this is disabled by default.
+// Explicitly enable it.
+// See: https://www.php.net/manual/en/session.configuration.php#ini.session.use-strict-mode
+ini_set('session.use_strict_mode', '1');
+
 // FIXME: The code in NDB_Client should mostly be replaced by middleware.
 $client = new \NDB_Client;
 $client->initialize();

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -16,6 +16,8 @@
  */
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 ini_set('default_charset', 'utf-8');
+ini_set('session.use_strict_mode', '1');
+
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once 'NDB_Config.class.inc';
 require_once 'Smarty_hook.class.inc';

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -132,8 +132,8 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        $sessionOptions = array('cookie_httponly' => true);
-        $sessionOptions['cookie_samesite'] = true;
+        $sessionOptions = ['cookie_httponly' => true];
+        $sessionOptions['cookie_samesite'] = "Strict";
 
         // API Detect
         if (strpos(


### PR DESCRIPTION
This fixes 2 issues related to the SameSite cookie CSRF protection:

1. The session variable that indicates to use it was set to "true".
   However, it should be a string indicating the value to use (either
   "strict" or "lax"). See: https://www.php.net/manual/en/session.configuration.php#ini.session.cookie-samesite
2. The use_strict_mode setting (See: https://www.php.net/manual/en/session.configuration.php#ini.session.use-strict-mode)
   in PHP is not enabled by default. This means that, even when logging out, the
   session_destroy/session_start procedure reuses the old cookie and does not set a new cookie with
   the proper samesite flag. All the PHP documentation I've seen says use_strict_mode should always
   be enabled, but defaults to disabled. This explicitly overrides the php.ini setting (default false)
   to set it at the beginning of the code, ensuring that NDB_Client properly generates a new session cookie.