### PR TITLE
physiological_annotation_* schema changes

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -204,7 +204,7 @@ CREATE TABLE `physiological_archive` (
 -- Create physiological_annotation_file_type table
 CREATE TABLE `physiological_annotation_file_type` (
     `FileType`        VARCHAR(20)   NOT NULL UNIQUE,
-    `Description` VARCHAR(255),
+    `Description`     VARCHAR(255),
     PRIMARY KEY (`FileType`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -243,7 +243,7 @@ CREATE TABLE `physiological_annotation_parameter` (
     `AnnotationParameterID` INT(10)      UNSIGNED NOT NULL AUTO_INCREMENT,
     `AnnotationFileID`      INT(10)      UNSIGNED NOT NULL,
     `Sources`               VARCHAR(255),
-    `Author`                VARCHAR(50),
+    `Author`                VARCHAR(255),
     PRIMARY KEY (`AnnotationParameterID`),
     CONSTRAINT `FK_annotation_file_ID`
         FOREIGN KEY (`AnnotationFileID`)
@@ -252,9 +252,10 @@ CREATE TABLE `physiological_annotation_parameter` (
 
 -- Create an annotation_label_type table
 CREATE TABLE `physiological_annotation_label` (
-  `AnnotationLabelID`    INT(5)       UNSIGNED NOT NULL      AUTO_INCREMENT,
-  `LabelName`            VARCHAR(255)          NOT NULL      UNIQUE,
-  `LabelDescription`         VARCHAR(255)          DEFAULT NULL,
+  `AnnotationLabelID`    INT(5)       UNSIGNED NOT NULL AUTO_INCREMENT,
+  `AnnotationFileID`     INT(10)      UNSIGNED DEFAULT NULL,
+  `LabelName`            VARCHAR(255) NOT NULL,
+  `LabelDescription`     TEXT         DEFAULT NULL,
   PRIMARY KEY (`AnnotationLabelID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -280,6 +281,19 @@ CREATE TABLE `physiological_annotation_instance` (
     CONSTRAINT `FK_annotation_label_ID`
         FOREIGN KEY (`AnnotationLabelID`)
         REFERENCES `physiological_annotation_label` (`AnnotationLabelID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Create physiological_annotation_rel table
+CREATE TABLE `physiological_annotation_rel` (
+    `AnnotationTSV`  INT(10)    UNSIGNED NOT NULL,
+    `AnnotationJSON` INT(10)    UNSIGNED NOT NULL,
+    PRIMARY KEY (`AnnotationTSV`, `AnnotationJSON`),
+    CONSTRAINT `FK_AnnotationTSV`
+        FOREIGN KEY (`AnnotationTSV`)
+        REFERENCES `physiological_annotation_file` (`AnnotationFileID`),
+    CONSTRAINT `FK_AnnotationJSON`
+        FOREIGN KEY (`AnnotationJSON`)
+        REFERENCES `physiological_annotation_file` (`AnnotationFileID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Insert into physiological_output_type

--- a/SQL/New_patches/2021-08-25-physiological_annotation_schema_changes.sql
+++ b/SQL/New_patches/2021-08-25-physiological_annotation_schema_changes.sql
@@ -1,0 +1,23 @@
+ALTER TABLE `physiological_annotation_label`
+MODIFY COLUMN LabelDescription TEXT;
+
+ALTER TABLE `physiological_annotation_label`
+ADD COLUMN AnnotationFileID INT(10) UNSIGNED DEFAULT NULL AFTER AnnotationLabelID;
+
+DROP INDEX LabelName ON `physiological_annotation_label`;
+
+ALTER TABLE `physiological_annotation_parameter`
+MODIFY COLUMN Author VARCHAR(255);
+
+CREATE TABLE `physiological_annotation_rel` (
+    `AnnotationTSV`  INT(10)    UNSIGNED NOT NULL,
+    `AnnotationJSON` INT(10)    UNSIGNED NOT NULL,
+    PRIMARY KEY (`AnnotationTSV`, `AnnotationJSON`),
+    CONSTRAINT `FK_AnnotationTSV`
+        FOREIGN KEY (`AnnotationTSV`)
+        REFERENCES `physiological_annotation_file` (`AnnotationFileID`),
+    CONSTRAINT `FK_AnnotationJSON`
+        FOREIGN KEY (`AnnotationJSON`)
+        REFERENCES `physiological_annotation_file` (`AnnotationFileID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+


### PR DESCRIPTION
This PR makes changes to the schema of table physiological_annotation_label to fix 2 problems:

- LabelDescription can exceed the max size of 255;
- LabelName can be non-unique if the same keyword is used for different dataset.
  To manage duplicates, the UNIQUE constraint is dropped and a new column AnnotationFileID is added.

This PR makes changes to the schema of table physiological_annotation_parameter to fix:
- Author can exceed the max size of 50;

This PR adds a new table, physiological_annotation_rel, to map annotations TSV with their corresponding annotations JSON.