### PR TITLE
[imaging_browser] Escape the header table in view session page

### DIFF
--- a/modules/imaging_browser/templates/table_session_header.tpl
+++ b/modules/imaging_browser/templates/table_session_header.tpl
@@ -20,20 +20,20 @@
     </thead>
     <tbody>
         <tr>
-            <td>{$subject.mriqcstatus}</td>
-            <td>{$subject.pscid}_{$subject.candid}_{$subject.visitLabel}</td>
-            <td>{$subject.pscid}</td>
-            <td>{$subject.candid}</td>
-            <td>{$subject.visitLabel}</td>
-            <td>{$subject.site}</td>
+            <td>{$subject.mriqcstatus|escape}</td>
+            <td>{$subject.pscid|escape}_{$subject.candid|escape}_{$subject.visitLabel|escape}</td>
+            <td>{$subject.pscid|escape}</td>
+            <td>{$subject.candid|escape}</td>
+            <td>{$subject.visitLabel|escape}</td>
+            <td>{$subject.site|escape}</td>
             <td>{if $subject.mriqcpending=="Y"}<img src="{$baseurl}/images/check_blue.gif" width="12" height="12">{else}&nbsp;{/if}</td>
-            <td>{$subject.dob}</td>
-            <td>{$subject.sex}</td>
-            <td>{$outputType}</td>
-            <td>{$subject.scanner}</td>
-            <td>{$subject.SubprojectTitle}</td>
+            <td>{$subject.dob|escape}</td>
+            <td>{$subject.sex|escape}</td>
+            <td>{$outputType|escape}</td>
+            <td>{$subject.scanner|escape}</td>
+            <td>{$subject.SubprojectTitle|escape}</td>
             {if $useEDC}
-            <td>{$subject.edc}</td>
+            <td>{$subject.edc|escape}</td>
             {/if}
         </tr>
     </tbody>


### PR DESCRIPTION
The header table in the imaging_browser viewSession page is generated
by smarty, but the variables are not properly escaped. This adds the
`|escape` filter to all the outputs to fix reflected XSS attacks on that page.
(In particular, the outputType which comes from the URL, but all variables
are HTML escaped in this PR just to be on the safe side.)