### PR TITLE
[LINST] Fixed default date field null error

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -564,7 +564,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 case 'date':
                     if ($addElements) {
                         if ($pieces[3] == 1900 && $pieces[4] == 2100) {
-                            $dateOptions = null;
+                            $dateOptions = [];
                         } else {
                             $dateOptions = array(
                                 'language'         => 'en',


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a PHP typing issue caused by the default values of a dateElement generated from the instrument builder

Error:
```
[php7:error] [pid 14345] [client 10.121.40.204:59323] PHP Fatal error:  Uncaught TypeError: Argument 3 passed to NDB_BVL_Instrument::addDateElement() must be of the type array, null given, called in /var/www/loris/php/libraries/NDB_BVL_Instrument_LINST.class.inc on line 620 and defined in /var/www/loris/php/libraries/NDB_BVL_Instrument.class.inc:1900\nStack trace:\n#0 /var/www/loris/php/libraries/NDB_BVL_Instrument_LINST.class.inc(620): NDB_BVL_Instrument->addDateElement('collection_date', '3. 
```

Instrument section
```
...
date{@}collection_date_date{@}3. Date of tissue collection:{@}1901{@}2100{@}
...
```

More details:
When creating a date element in the instrument builder without specifying start and end values, the module defaults the values 
to 1900 and 2100 which in turn cause an error when rendering the instrument. This should fix that error without changing any functionality
