### PR TITLE
[Imaging Browser] Sequence Type filter fix

### DIFF
--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -132,8 +132,7 @@ class Imaging_Browser extends \DataFrameworkMenu
         ];
 
         $all_scan_types = array_values(\Utility::getScanTypeList());
-        $sequenceTypes = array_combine($all_scan_types, $all_scan_types);
-        
+        $sequenceTypes  = array_combine($all_scan_types, $all_scan_types);
 
         $config = \NDB_Config::singleton();
         $toTable_scan_types = $config->getSetting('tblScanTypes');

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -131,31 +131,20 @@ class Imaging_Browser extends \DataFrameworkMenu
             'N' => 'New',
         ];
 
-        // get list of scan types
-        $all_scan_types = \Utility::getScanTypeList();
+        $all_scan_types = array_values(\Utility::getScanTypeList());
+        $sequenceTypes = array_combine($all_scan_types, $all_scan_types);
+        
 
-        // get list of scan types that should be present in the data table
-        // Get the intersection between all the scan types and those
-        // that are desired to go into imaging browser table, based on
-        // array values rather than keys (hence the array_flip), then flip
-        // the resulting array back to revert it to a key/value (i.e.
-        // acquisition protocol ID/scan type) combination.
         $config = \NDB_Config::singleton();
         $toTable_scan_types = $config->getSetting('tblScanTypes');
-        $scan_id_types      = array_flip(
-            array_intersect_key(
-                array_flip($all_scan_types),
-                array_flip($toTable_scan_types)
-            )
-        );
 
         return [
             'sites'         => $siteList,
             'projects'      => $list_of_projects,
             'visitQCStatus' => $visitQCStatus,
-            'sequenceTypes' => $all_scan_types,
+            'sequenceTypes' => $sequenceTypes,
             'pendingNew'    => $pending,
-            'configLabels'  => $scan_id_types,
+            'configLabels'  => $toTable_scan_types,
         ];
 
     }

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -529,7 +529,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$dccid,
             self::$display,
             self::$clearFilter,
-            'DCC422',
+            '475906',
             '6 rows'
         );
         $this->_filterTest(

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -544,7 +544,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             'Pumpernickel',
-            'of 27'
+            'of 29'
         );
         $this->_filterTest(
             self::$visitLabel,

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -586,7 +586,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             'dwi25',
-            'of 34'
+            'of 27'
         );
         $this->_filterTest(
             self::$pendingNew,

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -529,8 +529,8 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$dccid,
             self::$display,
             self::$clearFilter,
-            '300001',
-            '0 rows'
+            'DCC422',
+            '6 rows'
         );
         $this->_filterTest(
             self::$project,
@@ -544,7 +544,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             'Pumpernickel',
-            '20 rows'
+            'of 27'
         );
         $this->_filterTest(
             self::$visitLabel,
@@ -579,14 +579,14 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             'dwi65',
-            '0 rows'
+            '16 rows'
         );
         $this->_filterTest(
             self::$sequenceType,
             self::$display,
             self::$clearFilter,
             'dwi25',
-            '0 rows'
+            'of 34'
         );
         $this->_filterTest(
             self::$pendingNew,

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -579,7 +579,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             'dwi65',
-            '16 rows'
+            '12 rows'
         );
         $this->_filterTest(
             self::$sequenceType,


### PR DESCRIPTION
## Brief summary of changes
Change the keys of the multiselect to make them match the values in the cells. It use to be `[scan_type_id => scan_type_label]` because the scan_type_id was sent to the backend to apply the filters. Now that the filtering is done in the frontend, the options needs to be `[scan_type_label => scan_type_label]`.

#### Testing instructions (if applicable)
1. Go to `Imaging Browser`
2. Select a value in the `Sequence Type` filter
3. Notice there are now results in the data table
4. The multiselect is an OR so selecting multiple values creates an unions.

#### Link(s) to related issue(s)

* Resolves #7563

P.S: This is changing some expected values in the tests.

- One of the tests on DCCID should check for an exact number of row that is not zero.
- The test on `Pumpernickel` project was looking for the string `20 rows` but that is just the maximum of rows displayed; not the actual number or remaining rows after the filtering.
- There are 34 rows that have `dwi25` as a SequenceType. This filter did not seem to work since the test were written.