### PR TITLE
[Security] Add 2 more Content-Security-Policy options

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -129,6 +129,8 @@ class NDB_Client
             . "script-src 'self' 'unsafe-inline' 'unsafe-eval' $CaptchaDomains; "
             . "font-src 'self' data:; "
             . "img-src 'self' data:; "
+            . "frame-ancestors 'none'; "
+            . "form-action 'self'; "
             . $config_additions
         );
         // start php session


### PR DESCRIPTION
This adds to more CSP directives that are defined in CSP Level 3.
(See: https://w3c.github.io/webappsec-csp/)

`frame-ancestors: 'none'` prevents LORIS from being embedded in an
iframe. This prevents the class of attacks where a third party embeds
the page in an iframe, but covers it with an invisible div to intercept
clicks or other interactions.

`form-action: self` prevents forms from submitting data to a target that
is off-site.

## Testing Instructions
1. Embed your LORIS instance in an off-site page such as

    ```
    <html>
        <body>
            <iframe src="http://localhost:8000">
        </body>
    </html>
    ```
2. Access that page, you should get a security warning instead of an embedded version of your LORIS instance