### PR TITLE
[candidate_list] Update test plan, README

### DIFF
--- a/modules/candidate_list/README.md
+++ b/modules/candidate_list/README.md
@@ -35,10 +35,8 @@ can exclusively see candidates at study sites with which they are affiliated.
 
 ## Configurations
 
-The `useEDC` variable (_"Use EDC"_) can be configured to show or hide the
-"EDC" column in the data table. "EDC" stands for "Expected Date Of Confinement",
-which refers to the pregnancy due date. This variable can be turned on or off
-in the Configurations module.
+The "EDC" column is only displayed in the data table if the `useEDC` variable
+(_"Use EDC"_) is configured to 'Yes' in the Configuration module.
 
 ## Interactions with LORIS
 
@@ -46,8 +44,11 @@ The "Scan Done" column indicates whether or not a scan was performed
 for that candidate. If a scan was performed, the value "Y" in the column
 will contain a link to the `imaging_browser` module prefiltered for that candidate.
 
-Clicking on the link in the PSCID column takes the user to the
-`timepoint_list` page for that candidate. For users who do *not*
-have the `access_all_profiles` permission, an _Open Profile_ form can be
-used to access a candidate from a restricted site if the correct CandID
-and PSCID are provided.
+Clicking on the link in the PSCID column takes the user to the `timepoint_list`
+page for that candidate. Users who do *not* have the `access_all_profiles`
+permission will only be able to see, and navigate to the `timepoint_list` page of,
+candidates from sites with which the user is affiliated. For these users, a
+separate form appears (by clicking the _Open Profile_ button) for the user to fill
+out in order to access candidates not displayed. This is done by entering in the
+form a candidate's CandID/PSCID combination. This is intended to allow users
+to only see candidates whose CandID and PSCID they already have access to.

--- a/modules/candidate_list/README.md
+++ b/modules/candidate_list/README.md
@@ -5,13 +5,14 @@
 The candidate list is intended to provide a menu from which users
 can access specific candidates while browsing LORIS data.
 
-It is referred to as "Access Profiles" in the LORIS menus.
+It is referred to as "Access Profile" in the LORIS menus.
 
 ## Intended Users
 
 The candidate list is primarily used by data entry staff in order
-to access the `timepoint_list` module (and `instrument_list`
-from there) in order to access the candidate and perform data entry.
+to access Candidate Profile pages (the `timepoint_list` module,
+which further navigates to `instrument_list`) in order to access
+the candidate and perform data entry.
 
 Other user groups may use it for filtering candidate profiles for
 reviewing candidate data status.
@@ -24,30 +25,29 @@ to other relevant LORIS modules where applicable.
 ## Permissions
 
 Accessing the `candidate_list` module requires either the `data_entry`
-permission and at least one study site, or the `access_all_profiles`
-permission.
+permission (_"Access Profile: View/Create Candidates and Timepoints - Own Sites"_)
+and at least one study site, or the `access_all_profiles`
+permission (_"Access Profile: View Candidates and Timepoints - All Sites"_).
 
 Users with the `access_all_profiles` permission can see every
 candidate in LORIS, while users with only the `data_entry` permission
-can exclusively see candidates at study sites where they are affiliated.
+can exclusively see candidates at study sites with which they are affiliated.
 
 ## Configurations
 
-The `useEDC` configuration variable has a similar function for the
-"EDC" ("EDC" stands for "Expected Date Of Confinement" which refers
-to the pregnancy due date) column.
+The `useEDC` variable (_"Use EDC"_) can be configured to show or hide the
+"EDC" column in the data table. "EDC" stands for "Expected Date Of Confinement",
+which refers to the pregnancy due date. This variable can be turned on or off
+in the Configurations module.
 
 ## Interactions with LORIS
 
 The "Scan Done" column indicates whether or not a scan was performed
-for that candidate. When a scan was performed (i.e. it has the value
-"Y"), clicking the table cell links to the `imaging_browser` module
-prefiltered for that candidate.
+for that candidate. If a scan was performed, the value "Y" in the column
+will contain a link to the `imaging_browser` module prefiltered for that candidate.
 
-Clicking on the cell in the PSCID column takes the user to the
-`timepoint_list` page for that candidate. The link is only clickable
-if the user does *not* have the `data_entry` permission. For users
-who have the `data_entry` permission, a separate form appears for
-the user to type the CandID/PSCID combo in order to access the
-candidate.  This is intended to prevent data entry errors caused
-by accidentally clicking on the wrong row before doing data entry.
+Clicking on the link in the PSCID column takes the user to the
+`timepoint_list` page for that candidate. For users who do *not*
+have the `access_all_profiles` permission, an _Open Profile_ form can be
+used to access a candidate from a restricted site if the correct CandID
+and PSCID are provided.

--- a/modules/candidate_list/test/TestPlan.md
+++ b/modules/candidate_list/test/TestPlan.md
@@ -1,34 +1,33 @@
 # Access Profile Test Plan
 
-1. Access access profile page, ensure that it renders.[Automation Testing]
-2. Verify that either the permission access_all_profiles or data_entry is required for access the page.[Automation Testing]
-3. Verify that if data_entry and not access_all_profiles permissions, can only see subjects from own site.[Automation Testing]
-4. Verify that if data_entry and not access_all_profiles permissions, check that initial filter state is Cohort = All.[Automation Testing]
-5. Verify advanced/basic filter toggle works.[Automation Testing]
-6. Verify advanced filters are expanded on page load when an advanced filter is set, and collapsed otherwise.[Automation Testing]
-7. Check that each dropdown has the correct options.[Automation Testing]
-8. Test each filter individually
+1. Access "Access Profile" page, ensure that it renders.[Automation Testing]
+2. Verify that either the permission "Access Profile: View Candidates and Timepoints - All Sites" or "Access Profile: View/Create Candidates and Timepoints - Own Sites" is required to access the page.[Automation Testing]
+3. Verify that with the "Access Profile: View/Create Candidates and Timepoints - Own Sites" permission and without the "Access Profile: View Candidates and Timepoints - All Sites" permission, only subjects from the user's own sites can be viewed.[Automation Testing]
+4. Verify that the "Show Advanced Filters"/"Hide Advanced Filters" toggle works.[Automation Testing]
+5. Check that each dropdown has the correct options.[Automation Testing]
+6. Test each filter individually
    [ ] Site
    [ ] DCCID
    [ ] PSCID
+   [ ] Visit Label
    [ ] Cohort
    [ ] Project
-   [ ] Scan done
+   [ ] Scan Done
    [ ] Participant Status
-   [ ] Biological Sex
-   [ ] Number of visits
-   [ ] Date of birth
+   [ ] Sex
+   [ ] Visit Count
+   [ ] DoB
    [ ] Feedback
+   [ ] Entity Type
+   [ ] EDC
    [Automation Testing]
-9. Click "Clear Form" and ensure filters are reset to same state as #2.
-10. Ensure that columns are sortable by clicking on them.
-11. Filter for Scan done. Ensure that "Yes" link points to correct scan in imaging browser.
-12. Ensure PSCID link points to correct timepoint_list page.
-13. Ensure that for candidates with feedback, feedback column is displayed and in the correct colour.
-14. Ensure that the Open Profile panel only appears when not access_all_profiles permissions.
-15. Enter wrong PSCID/DCCID combination and click Open Profile. Ensure that you get an error.
-Incorrect PSCID/DCCID combinations in the filter form should not give such an error.
-It should return that no results were found.
-16. Enter correct PSCID/DCCID combination and ensure that it loads correct timepoint_list page
-17. Remove access_all_profiles permission and ensure that PSCID links are clickable.
-18. Change useEDC config variable to _no_ from the Configuration Module and ensure filters are removed from menu.
+7. Click "Clear Filter" and ensure filters are reset to same state as #2.
+8. Ensure that columns are sortable by clicking on the column headers.
+9. Filter for Scan Done "Yes". Ensure that, in the 'Scan Done' column of the data table, the "Y" link for a candidate points to the Imaging Browser, with its 'PSCID' filter set to that of the candidate.
+10. Ensure the 'PSCID' link points to the correct Candidate Profile page.
+11. Ensure that for candidates with feedback, the 'Feedback' column is displayed and in the correct colour: green for "Closed", and red for "Opened".
+12. Ensure that the Open Profile button only appears without "Access Profile: View Candidates and Timepoints - All Sites" permission.
+13. Click 'Open Profile', enter wrong PSCID/DCCID combination and click 'Open Profile' again. Ensure an error is thrown.
+Alternatively, an incorrect PSCID/DCCID combination in the Selection Filter form should not give such an error; it should return that no results were found.
+14. Enter a correct PSCID/DCCID combination in the 'Open Profile' form and ensure that it loads the correct Candidate Profile page
+15. In the Configuration module, set the Study variable 'Use EDC' to _No_. Ensure that the _EDC_ filter and the _EDC_ column are removed from the Selection Filter form and data table, respectively.


### PR DESCRIPTION
## Brief summary of changes

- [x] Have you updated related documentation?

### Test Plan

- updates the language of the test plan, particularly the naming of certain elements on the candidate list page. 
- removes items 4 and 6, which seem to be left over from before the Reactification of the module, and re-enumerates the list.
- removes item 17 because PSCID links are now always clickable, regardless of permission. this is because the workflow for using the 'Open Profile' form was changed. The form was previously used when the PSCID was not clickable. Now, the form is used only to access restricted candidates (from a site with which you are not affiliated)

### README

- clarifies useEDC section
- corrects permission and  use of Open Profile form. I believe this workflow was changed to only be used to view a restricted candidate when the user does not have access to all candidates. The data entry error reasoning is no longer relevant.

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
