### PR TITLE
[webpack] Target directories for ESlint

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,6 +160,7 @@ const config = [
     devtool: 'source-map',
     plugins: [
       new ESLintPlugin({
+        files: ['modules/', 'jsx/', 'htdocs/js'],
         cache: true,
       }),
       new CopyPlugin({


### PR DESCRIPTION
## Brief summary of changes
The reason for this is to prevent eslint from parsing and flagging every error in random JS files (including local directories) and only targetting LORIS files. 

For more context, when working on multiple projects, one way of mani[ulating project directories is to swap in and out different project directories. without this change, running make dev would fail every single time due to errors in JS files in old projects and unmaintained overrides.