### PR TITLE
[User_accnout] can't create a new user

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -463,6 +463,9 @@ class Edit_User extends \NDB_Form
         }
         // update the user
         if ($this->isCreatingNewUser()) {
+            $set["Password_hash"] = new \Password(
+                                    htmlspecialchars_decode($values['Password_hash'])
+                                    );
             // insert a new user
             \User::insert($set);
             $user = \User::factory($set['UserID']);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -351,7 +351,6 @@ class Edit_User extends \NDB_Form
                     [
                         'full_name'   => $values['Real_name'],
                         'radiologist' => $ex_radiologist,
-                        'userID'      => $uid,
                     ]
                 );
                 $examinerID = $DB->pselectOne(
@@ -486,6 +485,15 @@ class Edit_User extends \NDB_Form
                     ]
                 );
             }
+                $DB->update(
+                    'examiners',
+                    [
+                        'userID'      => $uid,
+                    ],
+                    [
+                        "full_name" => $values['Real_name'],
+                    ]
+                );
         } else {
             // update the user
             $user = \User::factory($this->identifier);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -464,8 +464,8 @@ class Edit_User extends \NDB_Form
         // update the user
         if ($this->isCreatingNewUser()) {
             $set["Password_hash"] = new \Password(
-                                    htmlspecialchars_decode($values['Password_hash'])
-                                    );
+                htmlspecialchars_decode($values['Password_hash'])
+            );
             // insert a new user
             \User::insert($set);
             $user = \User::factory($set['UserID']);


### PR DESCRIPTION
## Brief summary of changes
Before the new user is not created, the Userid is '', so it can't insert into the "examiners" table.
remove the '' value from insert function.  
#### Testing instructions (if applicable)

1. create a new user with an examiner and without an examiner.

#### Link(s) to related issue(s)
[User Accounts] Unable to create new user 500 Error returned #7623

