### PR TITLE
[SQL] Fixing incorrect update statement in EEG SQL patch

### DIFF
--- a/SQL/New_patches/2021-02-19_electrophysiology_annotation_tables.sql
+++ b/SQL/New_patches/2021-02-19_electrophysiology_annotation_tables.sql
@@ -116,5 +116,4 @@ INSERT INTO physiological_annotation_label
     (22, 'sleep_k-complex',     'sleep K-complex'),
     (23, 'scorelabeled',        'a global label indicating that the EEG has been annotated with SCORE.');
 
-UPDATE physiological_output_type SET OutputTypeName='derivative' WHERE PhysiologicalOutputTypeID=2;
-
+UPDATE physiological_output_type SET OutputTypeName='derivative' WHERE OutputTypeName='derivatives';


### PR DESCRIPTION
Changed the final UPDATE statement in this [SQL patch](https://github.com/aces/Loris/blob/main/SQL/New_patches/2021-02-19_electrophysiology_annotation_tables.sql) to update based on the name in the `OutputTypeName` column rather than based on the auto-incremented ID. 

Resolves #7653 