### PR TITLE
[tools] CouchDB_Import_Instruments.php Error

### DIFF
--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -185,12 +185,21 @@ class CouchDBInstrumentImporter
             'modified'  => 0,
             'unchanged' => 0,
         ];
+        $lorisinstance = new \LORIS\LorisInstance(
+            \NDB_Factory::singleton()->database(),
+            \NDB_Factory::singleton()->config(),
+            [
+              __DIR__ . "/../project/modules",
+              __DIR__ . "/../modules/",
+            ]
+        );
         foreach ($Instruments as $instrument => $name) {
             // Since the testname does not always match the table name in the
             // the database, we need to instantiate the object to get the
             // table name.
             // We need to check if it is a JSONData instrument or SQL data
             $instrumentObj = \NDB_BVL_Instrument::factory(
+                $lorisinstance,
                 $instrument,
                 '',
                 ''


### PR DESCRIPTION
## Brief summary of changes
fix the CouchDB_Import_Instruments.php Error
run "php CouchDB_Import_Instruments.php" got error "
PHP Fatal error: Uncaught TypeError: NDB_BVL_Instrument::factory(): Argument #1 ($loris) must be of type LORIS\LORISInstance, string given, called in /var/www/Loris/tools/CouchDB_Import_Instruments.php on line 196 and defined in /var/www/Loris/php/libraries/NDB_BVL_Instrument.class.inc:225
"
Go to 'tools'
run "php CouchDB_Import_Instruments.php"
https://github.com/aces/Loris/issues/7680
