### PR TITLE
[EEG Browser] Update documentation for PB requirements and bugfix

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -41,8 +41,10 @@ jobs:
     - name: Change PHP Version in Dockerfile
       run: sed -i "s/7.4/${{ matrix.php }}/g" Dockerfile.test.php7
 
-    - name: Install OS package dependencies
-      run: sudo apt-get install -y protobuf-compiler
+    - name: Install package dependencies
+      run: sudo apt-get install -y protobuf-compiler 
+           && cd modules/electrophysiology_browser/jsx/react-series-data-viewer/
+           && protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/
 
     - name: Install composer dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/modules/electrophysiology_browser/README.md
+++ b/modules/electrophysiology_browser/README.md
@@ -33,3 +33,16 @@ electrophysiology_browser_view_site
 
 You can download all the files related to a recording (channel information,
 electrode information, task event information, the actual recording...).
+
+## Installation requirements to use the visualization features
+The visualization component requires Protocol Buffers v3.0.0 or higher.
+For install instructions, you can refer to the Protocol Buffers GitHub page: https://github.com/protocolbuffers/protobuf
+
+In order to automatically generate the protoc compiled files, add the following block in `modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json`: 
+``` 
+"scripts": {
+  "postinstall": "protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/"
+}
+```
+and run `npm run install` from the loris root directory.
+

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -339,7 +339,9 @@ class ElectrophysiologySessionView extends Component {
             >
               <div className="react-series-data-viewer-scoped col-xs-12">
                 <EEGLabSeriesProvider
-                  chunksURL={chunksURLs?.[file.splitData?.splitIndex]}
+                  chunksURL={
+                    chunksURLs?.[file.splitData?.splitIndex] || chunksURLs
+                  }
                   epochsURL={epochsURL}
                   electrodesURL={electrodesURL}
                 >

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json
@@ -35,9 +35,6 @@
     "@types/react-dom": "^16.9.9",
     "@types/react-redux": "7.1.16"
   },
-  "scripts": {
-    "postinstall": "protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/"
-  },
   "license": "MIT",
   "repository": "https://github.com/aces/react-series-data-viewer"
 }


### PR DESCRIPTION
- Adds Protocol Buffers to the list of the EEG Browser module dependencies (required since 57aa485).
- Fix a problem preventing the signals to display.