### PR TITLE
[Menu] Fix Sites tooltip

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -203,10 +203,9 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $tpl_data['user']['permissions']          = $this->user->getPermissions();
         $tpl_data['user']['user_from_study_site'] = $oneIsStudySite;
         $tpl_data['userNumSites']         = count($site_arr);
-        $tpl_data['user']['SitesTooltip'] = str_replace(
-            ";",
+        $tpl_data['user']['SitesTooltip'] = implode(
             "<br/>",
-            $this->user->getSiteNames()
+            $this->user->getSiteNames(),
         );
 
         $tpl_data['hasHelpEditPermission'] = $this->user->hasPermission(


### PR DESCRIPTION
Fix sites displaying as "Array" in menu tooltip.

This bug was introduced by f6de5f8bbc when the helper
function was turned from a string to an array.

Resolves #7671