### PR TITLE
[Raisinbread] Add missing admin permissions

### DIFF
--- a/raisinbread/RB_files/RB_user_perm_rel.sql
+++ b/raisinbread/RB_files/RB_user_perm_rel.sql
@@ -60,5 +60,8 @@ INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,63);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,64);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,65);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,66);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,67);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,68);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,69);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

There were 3 permissions missing from the user_perm_rel insert for admin in raisinbread. This also meant that those 3 permissions could not be given to other users from the front end because users can not grant permissions that they themselves do not have.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1.  From outside of this PR, log into the admin account on raisinbread data.
2. Attempt to grant a new user one of the following permissions: `survey_accounts_view`, `imaging_quality_control_view`, `behavioural_quality_control_view`
3. Notice that these permissions were not added to the user_perm_rel table for the new user (or admin)
4. Source raisinbread from inside this PR
5. Repeat step 2
6. Notice that the permissions are now successfully added

#### Link(s) to related issue(s)

* Resolves #7599
