### PR TITLE
[EEGBrowser] Fix for missing import (protoc)

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/chunks/index.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/chunks/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore
 import {FloatChunk} from '../protocol-buffers/chunk_pb';
 import {fetchBlob} from '../ajax';
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-no-jquery": "^2.6.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-webpack-plugin": "2.1.0",
+    "null-loader": "^4.0.1",
     "style-loader": "^1.1.3",
     "terser-webpack-plugin": "^1.3.0",
     "ts-loader": "^8.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const optimization = {
     }),
   ],
 };
+
 const resolve = {
   alias: {
     util: path.resolve(__dirname, './htdocs/js/util'),
@@ -46,29 +47,49 @@ const resolve = {
 };
 
 const mod = {
-  rules: [
-    {
-      test: /\.(jsx?|tsx?)$/,
-      exclude: /node_modules/,
-      use: [
-        {
-          loader: 'babel-loader?cacheDirectory',
-        },
-      ],
-    },
-    {
-      test: /\.css$/,
-      use: [
-        'style-loader',
-        'css-loader',
-      ],
-    },
-    {
-      test: /\.tsx?$/,
-      loader: 'ts-loader',
-    },
-  ],
+  rules: [],
 };
+
+// If no compiled chunk.proto found, desactivate compilation
+// on the file importing it to avoid import errors
+// chunk.proto is only required for EEG visualization and requires protoc
+if (!fs.existsSync(
+  './modules/electrophysiology_browser/jsx/react-series-data-viewer/src/'
+  + 'protocol-buffers/chunk_pb.js')
+) {
+  mod.rules.push({
+    test: /react-series-data-viewer\/src\/chunks/,
+    use: 'null-loader',
+  });
+}
+
+mod.rules.push(
+  {
+    test: /\.(jsx?|tsx?)$/,
+    exclude: /node_modules/,
+    use: [
+      {
+        loader: 'babel-loader?cacheDirectory',
+      },
+    ],
+  },
+  {
+    test: /\.css$/,
+    use: [
+      'style-loader',
+      'css-loader',
+    ],
+  },
+  {
+    test: /\.tsx?$/,
+    use: [
+      {
+        loader: 'ts-loader',
+        options: {onlyCompileBundledFiles: true},
+      },
+    ],
+  },
+);
 
 /**
  * Creates a webpack config entry for a LORIS module named


### PR DESCRIPTION
Fix a Cannot find module error on compilation when protoc is not installed and chunk_pb.js has not been generated.

```
[tsl] ERROR in /var/www/loris_1/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/chunks/index.tsx(1,26)
          TS2307: Cannot find module '../protocol-buffers/chunk_pb' or its corresponding type declarations.
```