### PR TITLE
[Instrument] Fix type error in some instruments

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2860,7 +2860,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // Disable form if data entry is complete
         $user      = $request->getAttribute("user");
         $sessionID = $request->getQueryParams()["sessionID"];
-        $timepoint = \Timepoint::singleton(new SessionID($sessionID));
+        if ($sessionID !== null) {
+            $timepoint = \Timepoint::singleton(new SessionID($sessionID));
+        }
 
         // create an instrument status object
         $status = new \NDB_BVL_InstrumentStatus($this->loris);


### PR DESCRIPTION
When accessing an instrument from RB, I got the error:

```
Fatal error: Uncaught TypeError: Argument 1 passed to ValidatableIdentifier::__construct() must be of the type string, null given, called in
/home/driusan/Code/Loris/php/libraries/NDB_BVL_Instrument.class.inc on line 2863 and defined in /home/driusan/Code/Loris/php/libraries/Valida
tableIdentifier.php:57 Stack trace: #0 /home/driusan/Code/Loris/php/libraries/NDB_BVL_Instrument.class.inc(2863): ValidatableIdentifier->__co
nstruct(NULL) #1 /home/driusan/Code/Loris/src/Middleware/UserPageDecorationMiddleware.php(241): NDB_BVL_Instrument->handle(Object(Laminas\Dia
ctoros\ServerRequest)) #2 /home/driusan/Code/Loris/src/Middleware/PageDecorationMiddleware.php(57): LORIS\Middleware\UserPageDecorationMiddle
ware->process(Object(Laminas\Diactoros\ServerRequest), Object(NDB_BVL_Instrument_aosi)) #3 /home/driusan/Code/Loris/php/libraries/NDB_Page.cl
ass.inc(735): LORIS\Middleware\PageDecorationMiddleware->process(Object(Laminas\Diactoros\ServerRequest), Object(NDB_BVL_Instrument_aosi)) #4
 /home/driusan/Code/Loris/php/libraries/NDB_BVL_In in /home/driusan/Code/Loris/php/libraries/ValidatableIdentifier.php on line 57
```

This fixes the type error so that the instrument page loads.

## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
