### PR TITLE
[mri_violations] Scrolling

### DIFF
--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -221,9 +221,9 @@
         $(header).parent().find('.frozenHeader').is(':visible')
       ) {
         addFrozenHeaderColm(header);
-        return true;
+        return colmStatic;
       }
-      return false;
+      return colmStatic;
     }
     return colmStatic;
   };
@@ -302,7 +302,11 @@
           $(child1).addClass(id + 'FrozenColumn');
         });
         $(this).parent().scroll(function() {
-          colmStatic = freezeColm(id, colmStatic);
+          if (window.innerWidth <= document.getElementById(
+            'dynamictable'
+          ).offsetWidth) {
+            colmStatic = freezeColm(id, colmStatic);
+          }
         });
       }
       return this;

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -224,8 +224,6 @@
         return true;
       }
       return false;
-      // return;
-      // return true;
     }
     return colmStatic;
   };

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -188,44 +188,6 @@
     $(frozenCell).html($($('.dynamictableFrozenColumn')[0]).html());
     $(frozenHeader).after(frozenCell);
   };
-  let freezeColm = function(tableID, colmStatic) {
-    let statColPos = $('.' + tableID + 'FrozenColumn').offset().left;
-    let statColWid = $('.' + tableID + 'FrozenColumn').outerWidth();
-    let leftScrollPos = $('.leftScrollBar').offset().left;
-    let leftScrollWid = $('.leftScrollBar').outerWidth();
-    let nextColPos = $('.' + tableID + 'Next').offset().left;
-    let tablePos = $('#' + tableID).offset().left;
-    let header = $('#' + tableID).siblings('.frozenHeader')[0];
-
-    if (colmStatic === true) {
-      if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
-        $('.' + tableID).each(function(key, value) {
-          if (key >= 0) {
-            $(value).css('height', '');
-          }
-        });
-        $('.' + tableID + 'FrozenColumn').removeClass('static-col colm-static');
-        $(header).find('.dynamictableFrozenColumn').css({padding: '8px'});
-        $('.headerColm').remove();
-        return false;
-      }
-    } else if (statColPos <= leftScrollWid + leftScrollPos) {
-      $('.' + tableID + 'FrozenColumn').each(function(key, value) {
-        if (key >= 0) {
-          let height = $(value).next().outerHeight();
-          $(value).outerHeight(height);
-        }
-      });
-      $('.' + tableID + 'FrozenColumn').addClass('static-col colm-static');
-      if ($(header).parent().find('.headerColm').length === 0 &&
-        $(header).parent().find('.frozenHeader').is(':visible')
-      ) {
-        addFrozenHeaderColm(header);
-      }
-      return true;
-    }
-    return colmStatic;
-  };
 
   $.fn.DynamicTable = function(options) {
     if (options && options.removeDynamicTable) {
@@ -237,7 +199,6 @@
       let rightLink;
       let table = this;
       let id = $(table).attr('id');
-      let colmStatic = false;
       let column;
       let columnNumber;
       let child1;

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -221,9 +221,8 @@
         $(header).parent().find('.frozenHeader').is(':visible')
       ) {
         addFrozenHeaderColm(header);
-        return colmStatic;
+        return true;
       }
-      return colmStatic;
     }
     return colmStatic;
   };

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -221,8 +221,11 @@
         $(header).parent().find('.frozenHeader').is(':visible')
       ) {
         addFrozenHeaderColm(header);
+        return true;
       }
-      return true;
+      return false;
+      // return;
+      // return true;
     }
     return colmStatic;
   };
@@ -301,19 +304,9 @@
           $(child1).addClass(id + 'FrozenColumn');
         });
         $(this).parent().scroll(function() {
-          const windowWidth = window.innerWidth;
-          const dataTableWidth = document.getElementById(
-            'dynamictable'
-          ).offsetWidth;
-          if (windowWidth + 35 >= dataTableWidth) {
-            // window width is too close to dynamictable width
-            // so we "return this" and skip setting colmStatic.
-            return this;
-          }
           colmStatic = freezeColm(id, colmStatic);
         });
       }
-
       return this;
     });
     return this;

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -221,8 +221,9 @@
         $(header).parent().find('.frozenHeader').is(':visible')
       ) {
         addFrozenHeaderColm(header);
-        return true;
+        return colmStatic;
       }
+      return true;
     }
     return colmStatic;
   };

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -90,6 +90,7 @@
     if ((element.offsetHeight < element.scrollHeight) ||
         (element.offsetWidth < element.scrollWidth)) {
       // Your element has overflow
+
       $(wrapper).on('scroll', function() {
         let leftScroll = $(wrapper).scrollLeft();
         $(headers).scrollLeft(leftScroll);
@@ -195,6 +196,7 @@
     let nextColPos = $('.' + tableID + 'Next').offset().left;
     let tablePos = $('#' + tableID).offset().left;
     let header = $('#' + tableID).siblings('.frozenHeader')[0];
+
     if (colmStatic === true) {
       if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
         $('.' + tableID).each(function(key, value) {

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -190,14 +190,13 @@
   let freezeColm = function(tableID, colmStatic) {
     let statColPos = $('.' + tableID + 'FrozenColumn').offset().left;
     let statColWid = $('.' + tableID + 'FrozenColumn').outerWidth();
-    let leftScrollPos = $('.leftScrollBar').offset().left + 25;
-    let leftScrollWid = $('.leftScrollBar').outerWidth() + 100;
+    let leftScrollPos = $('.leftScrollBar').offset().left;
+    let leftScrollWid = $('.leftScrollBar').outerWidth();
     let nextColPos = $('.' + tableID + 'Next').offset().left;
     let tablePos = $('#' + tableID).offset().left;
     let header = $('#' + tableID).siblings('.frozenHeader')[0];
     if (colmStatic === true) {
       if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
-        $('.' + tableID + 'Next').width(200);
         $('.' + tableID).each(function(key, value) {
           if (key >= 0) {
             $(value).css('height', '');
@@ -209,22 +208,6 @@
         return false;
       }
     } else if (statColPos <= leftScrollWid + leftScrollPos) {
-      $('.' + tableID + 'FrozenColumn').each(function(key, value) {
-        if (key >= 0) {
-          let height = $(value).next().outerHeight();
-          $(value).outerHeight(height);
-        }
-      });
-      $('.' + tableID + 'FrozenColumn').addClass('static-col colm-static');
-      if ($(header).parent().find('.headerColm').length === 0 &&
-        $(header).parent().find('.frozenHeader').is(':visible')
-      ) {
-        addFrozenHeaderColm(header);
-      }
-      return true;
-    } else if (
-      document.documentElement.clientWidth < 1400
-      && leftScrollWid < 55 && leftScrollPos < 25) {
       $('.' + tableID + 'FrozenColumn').each(function(key, value) {
         if (key >= 0) {
           let height = $(value).next().outerHeight();

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -188,6 +188,44 @@
     $(frozenCell).html($($('.dynamictableFrozenColumn')[0]).html());
     $(frozenHeader).after(frozenCell);
   };
+  let freezeColm = function(tableID, colmStatic) {
+    let statColPos = $('.' + tableID + 'FrozenColumn').offset().left;
+    let statColWid = $('.' + tableID + 'FrozenColumn').outerWidth();
+    let leftScrollPos = $('.leftScrollBar').offset().left;
+    let leftScrollWid = $('.leftScrollBar').outerWidth();
+    let nextColPos = $('.' + tableID + 'Next').offset().left;
+    let tablePos = $('#' + tableID).offset().left;
+    let header = $('#' + tableID).siblings('.frozenHeader')[0];
+
+    if (colmStatic === true) {
+      if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
+        $('.' + tableID).each(function(key, value) {
+          if (key >= 0) {
+            $(value).css('height', '');
+          }
+        });
+        $('.' + tableID + 'FrozenColumn').removeClass('static-col colm-static');
+        $(header).find('.dynamictableFrozenColumn').css({padding: '8px'});
+        $('.headerColm').remove();
+        return false;
+      }
+    } else if (statColPos <= leftScrollWid + leftScrollPos) {
+      $('.' + tableID + 'FrozenColumn').each(function(key, value) {
+        if (key >= 0) {
+          let height = $(value).next().outerHeight();
+          $(value).outerHeight(height);
+        }
+      });
+      $('.' + tableID + 'FrozenColumn').addClass('static-col colm-static');
+      if ($(header).parent().find('.headerColm').length === 0 &&
+        $(header).parent().find('.frozenHeader').is(':visible')
+      ) {
+        addFrozenHeaderColm(header);
+      }
+      return true;
+    }
+    return colmStatic;
+  };
 
   $.fn.DynamicTable = function(options) {
     if (options && options.removeDynamicTable) {
@@ -199,6 +237,7 @@
       let rightLink;
       let table = this;
       let id = $(table).attr('id');
+      let colmStatic = false;
       let column;
       let columnNumber;
       let child1;
@@ -260,6 +299,18 @@
           child1 = $(value).children().get(columnNumber);
           // height = $(child1).next().outerHeight();
           $(child1).addClass(id + 'FrozenColumn');
+        });
+        $(this).parent().scroll(function() {
+          const windowWidth = window.innerWidth;
+          const dataTableWidth = document.getElementById(
+            'dynamictable'
+          ).offsetWidth;
+          if (windowWidth + 35 >= dataTableWidth) {
+            // window width is too close to dynamictable width
+            // so we "return this" and skip setting colmStatic.
+            return this;
+          }
+          colmStatic = freezeColm(id, colmStatic);
         });
       }
 

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -90,7 +90,6 @@
     if ((element.offsetHeight < element.scrollHeight) ||
         (element.offsetWidth < element.scrollWidth)) {
       // Your element has overflow
-
       $(wrapper).on('scroll', function() {
         let leftScroll = $(wrapper).scrollLeft();
         $(headers).scrollLeft(leftScroll);
@@ -191,14 +190,14 @@
   let freezeColm = function(tableID, colmStatic) {
     let statColPos = $('.' + tableID + 'FrozenColumn').offset().left;
     let statColWid = $('.' + tableID + 'FrozenColumn').outerWidth();
-    let leftScrollPos = $('.leftScrollBar').offset().left;
-    let leftScrollWid = $('.leftScrollBar').outerWidth();
+    let leftScrollPos = $('.leftScrollBar').offset().left + 25;
+    let leftScrollWid = $('.leftScrollBar').outerWidth() + 100;
     let nextColPos = $('.' + tableID + 'Next').offset().left;
     let tablePos = $('#' + tableID).offset().left;
     let header = $('#' + tableID).siblings('.frozenHeader')[0];
-
     if (colmStatic === true) {
       if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
+        $('.' + tableID + 'Next').width(200);
         $('.' + tableID).each(function(key, value) {
           if (key >= 0) {
             $(value).css('height', '');
@@ -210,6 +209,22 @@
         return false;
       }
     } else if (statColPos <= leftScrollWid + leftScrollPos) {
+      $('.' + tableID + 'FrozenColumn').each(function(key, value) {
+        if (key >= 0) {
+          let height = $(value).next().outerHeight();
+          $(value).outerHeight(height);
+        }
+      });
+      $('.' + tableID + 'FrozenColumn').addClass('static-col colm-static');
+      if ($(header).parent().find('.headerColm').length === 0 &&
+        $(header).parent().find('.frozenHeader').is(':visible')
+      ) {
+        addFrozenHeaderColm(header);
+      }
+      return true;
+    } else if (
+      document.documentElement.clientWidth < 1400
+      && leftScrollWid < 55 && leftScrollPos < 25) {
       $('.' + tableID + 'FrozenColumn').each(function(key, value) {
         if (key >= 0) {
           let height = $(value).next().outerHeight();
@@ -299,9 +314,6 @@
           child1 = $(value).children().get(columnNumber);
           // height = $(child1).next().outerHeight();
           $(child1).addClass(id + 'FrozenColumn');
-        });
-        $(this).parent().scroll(function() {
-          colmStatic = freezeColm(id, colmStatic);
         });
       }
 


### PR DESCRIPTION
## Brief summary of changes

The odd scrolling behaviour "bug" is from the jquery.dynamictable.js code.

Basically, the scrolling glitch happens when the static column "PatientName" is attempted to be always shown but the table width & browser width conflicts with all the other "widths" of the table columns.

This is a rare bug happening when the user's browser width including the table's columns widths are just right for the bug to happen. Furthermore, the module mri_violations hasn't been reactified and (I believe) only non-reactified tables attempt to show a static column like "PatientName" when scrolling throughout the table if the table width is too large.

My solution was to delete the code that attempts to always show the static column like "PatientName" and so the bug will never happen. The functionality that's rarely used anymore is lost but it solves a complicated bug.

#### Testing instructions (if applicable)

See issue ticket for testing instructions.

#### Link(s) to related issue(s)

* Resolves #7203
