### PR TITLE
[EEG Browser] Typo, testplan and bugfixes.

### DIFF
--- a/modules/electrophysiology_browser/README.md
+++ b/modules/electrophysiology_browser/README.md
@@ -43,7 +43,7 @@ electrode information, task event information, the actual recording) -- as well 
 
 New annotations or edits to existing annotations made through the browser must also be updated in the derivative files stored in the filesystem, before a user tries to download a derivative file package. To do this automatically, a script is provided under `tools/update_annotation_files.php`, and a cron job should be set up to execute it regularly, e.g. every evening. 
 
-## Installation requirements to use the visualization features
+## <a name="installation-requirements-to-use-the-visualization-features"></a> Installation requirements to use the visualization features
 The visualization component requires Protocol Buffers v3.0.0 or higher.
 For install instructions, you can refer to the Protocol Buffers GitHub page: https://github.com/protocolbuffers/protobuf
 

--- a/modules/electrophysiology_browser/README.md
+++ b/modules/electrophysiology_browser/README.md
@@ -53,4 +53,5 @@ In order to automatically generate the protoc compiled files, add the following 
   "postinstall": "protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/"
 }
 ```
-and run `npm run install` from the loris root directory.
+and run `make dev` or 'npm install && npm run compile' from the loris root directory.
+

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/README.md
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/README.md
@@ -23,7 +23,7 @@ To install the Protocol Buffers Compiler (protoc), run:
 `apt install -y protobuf-compiler`
 
 
-## User manual
+## <a name="user-manual"></a> User manual
 
 The EEG Browser visualization component adds support for some useful visual helpers: The **Signal Viewer** and the **Electrode Map**.
 

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -86,23 +86,25 @@ class EEGLabSeriesProvider extends Component<CProps> {
 
     Promise.race(racers(fetchJSON, chunksURL, '/index.json')).then(
       ({json, url}) => {
-        const {channelMetadata, shapes, timeInterval, seriesRange} = json;
-        this.store.dispatch(
-          setDatasetMetadata({
-            chunksURL: url,
-            channelMetadata,
-            shapes,
-            timeInterval,
-            seriesRange,
-            limit,
-          })
-        );
-        this.store.dispatch(setChannels(emptyChannels(
-            Math.min(this.props.limit, channelMetadata.length),
-            1
-        )));
-        this.store.dispatch(setDomain(timeInterval));
-        this.store.dispatch(setInterval(timeInterval));
+        if (json) {
+          const {channelMetadata, shapes, timeInterval, seriesRange} = json;
+          this.store.dispatch(
+            setDatasetMetadata({
+              chunksURL: url,
+              channelMetadata,
+              shapes,
+              timeInterval,
+              seriesRange,
+              limit,
+            })
+          );
+          this.store.dispatch(setChannels(emptyChannels(
+              Math.min(this.props.limit, channelMetadata.length),
+              1
+          )));
+          this.store.dispatch(setDomain(timeInterval));
+          this.store.dispatch(setInterval(timeInterval));
+        }
       }
     ).then(() => Promise.race(racers(fetchText, epochsURL)).then((text) => {
         if (!(typeof text.json === 'string'

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -190,6 +190,7 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                 parentHeight={viewerHeight}
                 key={`${index}`}
                 scales={scales}
+                opacity={0.7}
               />
             );
           })
@@ -451,7 +452,10 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                         type='number'
                         style={{width: '55px'}}
                         value={offsetIndex}
-                        onChange={(e) => setOffsetIndex(parseInt(e.target.value))}
+                        onChange={(e) => {
+                          let value = parseInt(e.target.value);
+                          !isNaN(value) && setOffsetIndex(value);
+                        }}
                       />
                       {' '}
                       to {hardLimit} of {channelMetadata.length}

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -23,13 +23,13 @@
 13. Test that if changes have been made to the session's annotations, the downloaded annotation files are correctly updated to match [Manual Testing]
 
 ### C. Visualization  
-13. Follow the [module README extra installation steps](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser#installation-requirements-to-use-the-visualization-features) 
+13. Follow the [module README extra installation steps](modules/electrophysiology_browser#installation-requirements-to-use-the-visualization-features) 
 and make sure the [Signal Viewer panel] displays correctly on the screen. (Documentation: see modules/electrophysiology_browser/jsx/react-series-data-viewer#user-manual )
 14. Delete modules/electrophysiology_browser/jsx/react-series-data-viewer/src/protocol-buffers/chunk_pb.js and revert the change made 
 to modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json to simulate an environement for which the extra installation steps have not been run yet. 
 Make sure `make dev` runs without failing, and that except the Signal Viewer panel, all the other components in the page display well. 
 15. Temporarily desactivate an entry in `physiological_parameter_file` 
-for a ParameterTypeID IN (SELECT ParameterTypeID from parameter_type WHERE Name = 'electrophyiology_chunked_dataset_path')
+for a ParameterTypeID IN (SELECT ParameterTypeID from parameter_type WHERE Name = 'electrophysiology_chunked_dataset_path')
 and a chosen PhysiologicalFileID to simulate an environment for which the visualization components are not loaded.
 Load the corresponding session page and make sure that except the Signal Viewer panel, the rest of the page displays well, either with or without the extra installation steps.
 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -24,7 +24,7 @@
 
 ### C. Visualization  
 13. Follow the [module README extra installation steps](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser#installation-requirements-to-use-the-visualization-features) 
-and make sure the [Signal Viewer panel](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser/jsx/react-series-data-viewer#user-manual) displays correctly on the screen.
+and make sure the [Signal Viewer panel] displays correctly on the screen. (Documentation: see modules/electrophysiology_browser/jsx/react-series-data-viewer#user-manual )
 14. Delete modules/electrophysiology_browser/jsx/react-series-data-viewer/src/protocol-buffers/chunk_pb.js and revert the change made 
 to modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json to simulate an environement for which the extra installation steps have not been run yet. 
 Make sure `make dev` runs without failing, and that except the Signal Viewer panel, all the other components in the page display well. 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -22,6 +22,17 @@
 12. Test Breadcrumb link back to Electrophysiology Browser. [Automated Testing]
 13. Test that if changes have been made to the session's annotations, the downloaded annotation files are correctly updated to match [Manual Testing]
 
+### C. Visualization  
+13. Follow the [module README extra installation steps](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser#installation-requirements-to-use-the-visualization-features) 
+and make sure the [Signal Viewer panel](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser/jsx/react-series-data-viewer#user-manual) displays correctly on the screen.
+14. Delete modules/electrophysiology_browser/jsx/react-series-data-viewer/src/protocol-buffers/chunk_pb.js and revert the change made 
+to modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json to simulate an environement for which the extra installation steps have not been run yet. 
+Make sure `make dev` runs without failing, and that except the Signal Viewer panel, all the other components in the page display well. 
+15. Temporarily desactivate an entry in `physiological_parameter_file` 
+for a ParameterTypeID IN (SELECT ParameterTypeID from parameter_type WHERE Name = 'electrophyiology_chunked_dataset_path')
+and a chosen PhysiologicalFileID to simulate an environment for which the visualization components are not loaded.
+Load the corresponding session page and make sure that except the Signal Viewer panel, the rest of the page displays well, either with or without the extra installation steps.
+
 _For extra credit: Verify LORIS Menu permissions_ 
 User can view the top-level LORIS Menu _Electrophysiology_ and Menu item : _Electrophysiology Browser_ if and only if user has either permission:
    * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -23,8 +23,9 @@
 13. Test that if changes have been made to the session's annotations, the downloaded annotation files are correctly updated to match [Manual Testing]
 
 ### C. Visualization  
-13. Follow the [module README extra installation steps](modules/electrophysiology_browser#installation-requirements-to-use-the-visualization-features) 
-and make sure the [Signal Viewer panel] displays correctly on the screen. (Documentation: see modules/electrophysiology_browser/jsx/react-series-data-viewer#user-manual )
+
+13. Follow the [module README extra installation steps](../README.md#installation-requirements-to-use-the-visualization-features) 
+and make sure the [Signal Viewer panel] displays correctly on the screen. (Documentation: see [react-series-data-viewer README](../jsx/react-series-data-viewer/README.md#user-manual))
 14. Delete modules/electrophysiology_browser/jsx/react-series-data-viewer/src/protocol-buffers/chunk_pb.js and revert the change made 
 to modules/electrophysiology_browser/jsx/react-series-data-viewer/package.json to simulate an environement for which the extra installation steps have not been run yet. 
 Make sure `make dev` runs without failing, and that except the Signal Viewer panel, all the other components in the page display well. 


### PR DESCRIPTION
Add instructions to the test plan, solves a typo in the EEG Browser README, and a few bug fixes: 
- console error when json is null (no chunks).
- add opacity on the event bars
- fix a bug when pagination is set to NULL.
