### PR TITLE
[survey_accounts] Ensure Multiselect Value is Array

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -566,9 +566,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         //Convert select multiple elements into a lorisform array
         if (!empty($this->selectMultipleElements)) {
             foreach ($this->selectMultipleElements AS $elname) {
-                if (isset($defaults[$elname])
-                    && stristr($defaults[$elname], "{@}")
-                ) {
+                if (isset($defaults[$elname])) {
                     $defaults[$elname] = explode("{@}", $defaults[$elname]);
                 }
             }


### PR DESCRIPTION
Fix issue where multiselect value is of type string instead of array when only one value is selected

## Brief summary of changes

- With the addition of support for PHP8, the function `in_array(string needle, array haystack)` expects the parameter `haystack` to be of type `array`. Unlink PHP7.4, PHP8 will throw an error instead of a warning. When mapping the multiselect values from the DB, we expected the special chars `{@}` to be present in the string and only exploded the string if it was. In the case when only one value is selected the chars `{@}` aren't present and so the string is never split into an array. This would then cause the `haystack` value to be of type `string` instead of `array`. This PR removes the check for the special chars `{@}` and just always calls the explode method no matter if the `{@}` is present or not. by doing this it will always force the string to be converted to an array.

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #7675 
