### PR TITLE
[php/libraries/UserPermissions.class.inc] can't get longname

### DIFF
--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -317,7 +317,7 @@ class UserPermissions
         // Module Long Name: action description
         foreach ($results as $key=>$perm) {
             $newDesc = '';
-            if (!empty($perm['moduleID'])) {
+            if (!empty($perm['moduleID']) && !empty($modules[$perm['moduleID']])) {
                 $newDesc = $modules[$perm['moduleID']]->getLongName() . ": ";
             }
             $newDesc .= empty($perm['action']) ? "" : $perm['action'] . " ";

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -302,13 +302,13 @@ class UserPermissions
         if (!$this->hasPermission('superuser')) {
             $query  .= "JOIN user_perm_rel up ON (p.permID=up.PermID)
                 LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
-                LEFT JOIN modules m ON (p.moduleID=m.ID)
+                LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'
             WHERE up.userID = :UID
                 ORDER BY p.categoryID, m.Name, p.description";
             $results = $DB->pselect($query, ['UID' => $this->userID]);
         } else {
             $query  .= "LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
-                LEFT JOIN modules m ON (p.moduleID=m.ID)";
+                LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'";
             $results = $DB->pselect($query, []);
 
         }
@@ -317,7 +317,7 @@ class UserPermissions
         // Module Long Name: action description
         foreach ($results as $key=>$perm) {
             $newDesc = '';
-            if (!empty($perm['moduleID']) && !empty($modules[$perm['moduleID']])) {
+            if (!empty($perm['moduleID'])) {
                 $newDesc = $modules[$perm['moduleID']]->getLongName() . ": ";
             }
             $newDesc .= empty($perm['action']) ? "" : $perm['action'] . " ";

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -302,8 +302,8 @@ class UserPermissions
         if (!$this->hasPermission('superuser')) {
             $query  .= "JOIN user_perm_rel up ON (p.permID=up.PermID)
                 LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
-                LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'
-            WHERE up.userID = :UID
+                LEFT JOIN modules m ON p.moduleID=m.ID
+            WHERE up.userID = :UID and m.Active='Y'
                 ORDER BY p.categoryID, m.Name, p.description";
             $results = $DB->pselect($query, ['UID' => $this->userID]);
         } else {

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -185,12 +185,15 @@ class UserTest extends TestCase
     private $_moduleInfo = [
         0 => [
             'ID'   => 2,
-            'Name' => 'candidate_list'
+            'Name' => 'candidate_list',
+            'Active' => 'Y',
         ],
         1 => [
             'ID'   => 5,
-            'Name' => 'timepoint_list'
+            'Name' => 'timepoint_list',
+            'Active' => 'Y',
         ],
+
     ];
 
     private $_userPermInfo = [0 => ['permID' => 1,
@@ -1127,15 +1130,7 @@ class UserTest extends TestCase
         $this->assertEquals(
             $this->_user->getPermissionsVerbose(),
             [
-                0 => ['permID' => '1',
-                    'code'        => "superuser",
-                    'description' => "superuser description",
-                    'type'        => "superuser category",
-                    'action'      => null,
-                    'moduleID'    => null,
-                    'label'       => 'superuser description'
-                ],
-                1 => ['permID' => '2',
+                0 => ['permID' => '2',
                     'code'        => "test_permission",
                     'description' => "description 1",
                     'type'        => "category 1",
@@ -1143,7 +1138,7 @@ class UserTest extends TestCase
                     'moduleID'    => '2',
                     'label'       => "Access Profile: View description 1"
                 ],
-                2 => ['permID' => '3',
+                1 => ['permID' => '3',
                     'code'        => "test_permission2",
                     'description' => "description 2",
                     'type'        => "category 2",
@@ -1151,7 +1146,7 @@ class UserTest extends TestCase
                     'moduleID'    => '5',
                     'label'       => "Timepoint List: Edit description 2"
                 ],
-                3 => ['permID' => '4',
+                2 => ['permID' => '4',
                     'code'        => 'test_permission3',
                     'description' => 'description 3',
                     'type'        => null,

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -1140,7 +1140,7 @@ class UserTest extends TestCase
                     'description' => "description 1",
                     'type'        => "category 1",
                     'action'      => "View",
-                    'moduleID'    => 2,
+                    'moduleID'    => '2',
                     'label'       => "Access Profile: View description 1"
                 ],
                 2 => ['permID' => '3',
@@ -1148,7 +1148,7 @@ class UserTest extends TestCase
                     'description' => "description 2",
                     'type'        => "category 2",
                     'action'      => "Edit",
-                    'moduleID'    => 5,
+                    'moduleID'    => '5',
                     'label'       => "Timepoint List: Edit description 2"
                 ],
                 3 => ['permID' => '4',
@@ -1156,7 +1156,7 @@ class UserTest extends TestCase
                     'description' => 'description 3',
                     'type'        => null,
                     'action'      => 'View/Create',
-                    'moduleID'    => 5,
+                    'moduleID'    => '5',
                     'label'       => 'Timepoint List: View/Create description 3'
                 ]
             ]

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -184,13 +184,13 @@ class UserTest extends TestCase
 
     private $_moduleInfo = [
         0 => [
-            'ID'   => 2,
-            'Name' => 'candidate_list',
+            'ID'     => 2,
+            'Name'   => 'candidate_list',
             'Active' => 'Y',
         ],
         1 => [
-            'ID'   => 5,
-            'Name' => 'timepoint_list',
+            'ID'     => 5,
+            'Name'   => 'timepoint_list',
             'Active' => 'Y',
         ],
 


### PR DESCRIPTION
## Brief summary of changes
if set one module as "No"  in the module_manager, user account module can't edit the user ( 500 error)
module[1] = y
module[2] = n
module[3] = y
when one user has module 2 permission, it will call module[2]->getLongName function. 
#### Testing instructions (if applicable)

1. set one module as "No" in module_manager.
2. create a new user or edit a user without 500 error.
