### PR TITLE
[bvl_feedback] Only show icon if module enabled

### DIFF
--- a/modules/bvl_feedback/test/TestPlan.md
+++ b/modules/bvl_feedback/test/TestPlan.md
@@ -6,13 +6,14 @@
  * Any instrument
 [Automation Test]
 2. Remove 'bvl_feedback' permission by unchecking 'Behavioural Feedback' in the User Accounts module. Behavioural feedback button should no longer appear.
-3. Click on the behavioural feedback button. A slide-out panel should appear on the right-hand side with the following:
+3. Re-add bvl_feedback permission and disable bvl_feedback module. Behavioural feedback button should not appear.
+4. Click on the behavioural feedback button. A slide-out panel should appear on the right-hand side with the following:
  * Open Thread Summary
  * New profile level feedback
  * Feedback Threads
-4. Click on the chevron arrow on each section and make sure it toggles open/closed.
-5. Type something in the 'New profile level feedback' text box and choose a 'Feedback Type' from the dropdown. Click 'Save data'.
-6. 'Open Thread Summary' and 'Feedback Threads' should update with the submitted thread. 
+5. Click on the chevron arrow on each section and make sure it toggles open/closed.
+6. Type something in the 'New profile level feedback' text box and choose a 'Feedback Type' from the dropdown. Click 'Save data'.
+7. 'Open Thread Summary' and 'Feedback Threads' should update with the submitted thread.
  * Open Thread Summary
     * QC class should be what page the feedback was submitted on (i.e. profile, instrument)
     * Instrument should be populated if QC class is instrument
@@ -24,12 +25,12 @@
     * The Feedback Type should appear under 'Type'
     * Current user and date should appear under 'Author'
     * 'Status' should be set to 'opened'
-7. Click on the chevron next to the status. You should be able to see the original text box thread entry.
-8. Click on the pencil button and 'Add a thread entry'. Click on 'Send'. Click on the chevron next to the status. You should be able to see the original text box thread entry and the one you just entered.
-9. Click on 'opened' and choose a different status. Status should be updated.
+8. Click on the chevron next to the status. You should be able to see the original text box thread entry.
+9. Click on the pencil button and 'Add a thread entry'. Click on 'Send'. Click on the chevron next to the status. You should be able to see the original text box thread entry and the one you just entered.
+10. Click on 'opened' and choose a different status. Status should be updated.
 
 ### Widget registration on the dashboard page
 
-10. Verify that if a user has the 'bvl_feedback' permission, the latest Behavioural Feedback Notifications are displayed (4 at most) in the Behavioural Feedback panel. Clicking on a feedback thread will take you to the proper page.
-11. Check that if a document notification occurred since the last login, it is labeled as 'New' in the Behavioural Feedback panel.
-12. Check that a 'New' notification is not labeled 'New' anymore after login in again.
+11. Verify that if a user has the 'bvl_feedback' permission, the latest Behavioural Feedback Notifications are displayed (4 at most) in the Behavioural Feedback panel. Clicking on a feedback thread will take you to the proper page.
+12. Check that if a document notification occurred since the last login, it is labeled as 'New' in the Behavioural Feedback panel.
+13. Check that a 'New' notification is not labeled 'New' anymore after login in again.

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -141,6 +141,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         if ($page !== null
             && method_exists($page, 'getFeedbackPanel')
+            && $loris->hasModule("bvl_feedback")
             && $user->hasPermission('bvl_feedback')
             && $candID !== null
         ) {


### PR DESCRIPTION
The bvl_feedback module can technically be disabled, but the pencil
icon for submitting feedback is added by middleware outside of the
module. Update the Middleware to not display bvl_feedback icon if
the module is disabled.

Resolves #7521