### PR TITLE
[next_stage] Updated test plan for clarity

### DIFF
--- a/modules/next_stage/test/TestPlan.md
+++ b/modules/next_stage/test/TestPlan.md
@@ -13,8 +13,10 @@
    [Manual Testing]
 6. Create a timepoint where the age (date entered minus DoB) falls within the
    AgeMin and AgeMax for a `test_battery`. The `test_battery` needs to have a 
-   matching `subprojectID` and a NULL `Visit_label`. Ensure that those 
-   instruments are inserted.
+   matching `subprojectID` and a NULL `Visit_label`. There should be no 
+   other `test_battery` entries with the `Visit_label` set to the visit label 
+   of the timepoint. Ensure that the instruments of the `test_battery` with the 
+   NULL `Visit_label` are inserted.
    [Manual Testing]
 7. Create a timepoint where there is a `test_battery` entry for the
    `Visit_label` and `subprojectID`, and start the stage. Ensure that those 


### PR DESCRIPTION
Updated Step 6 of the test plan to clarify that the instruments of the test_battery entry with a NULL visit label and that falls within the candidate's age should only be displayed for a timepoint if there does **not** exist other test_battery entries where the visit label is set to the visit of the timepoint. See [this section](https://github.com/aces/Loris/blob/main/modules/battery_manager/help/battery_manager.md#visitlabel) of the module help text for the behaviour expected. 

* Resolves #7641
