### PR TITLE
[BVL_feedback] fix icon display issue

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -138,7 +138,10 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
         $page = $request->getAttribute("pageclass");
-
+        $bvl_module = \Database::singleton()->pselectone(
+            "SELECT Name FROM modules WHERE Active='Y' and Name='bvl_feedback'",
+            []
+        );
         if ($page !== null
             && method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
@@ -153,10 +156,11 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
                 $candID,
                 $sessionID
             );
-
-            $tpl_data['bvl_feedback'] = \NDB_BVL_Feedback::bvlFeedbackPossible(
+            if ($bvl_module) {
+                $tpl_data['bvl_feedback'] = \NDB_BVL_Feedback::bvlFeedbackPossible(
                 $this->PageName
-            );
+                );
+            }
         }
 
         // This shouldn't exist. (And if it does, it shouldn't reference


### PR DESCRIPTION
## Brief summary of changes
if the bvl_feedback module is not active, then the icon should disappear.
#### Testing instructions (if applicable)
set bvl_feedback module as not activated then check the "bvl" icon on the top menu.


#### Link(s) to related issue(s)

https://github.com/aces/Loris/issues/7521