### PR TITLE
[user_account] Fix error when loading the page in the case the user have site's only permission set.

### DIFF
--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -45,7 +45,7 @@ class UserSiteMatch implements \LORIS\Data\Filter
             // If the Resource belongs to multiple CenterIDs, the user can
             // access the data if the user is part of any of those centers.
             foreach ($resource->getCenterIDs() as $site) {
-                if ($user->hasCenter($site)) {
+                if ($user->hasCenter(new \CenterID($site))) {
                        return true;
                 }
             }


### PR DESCRIPTION
#### Testing instructions (if applicable)

1. Create a new user and assign them the `User Accounts: View/Create/Edit User Accounts - Own Sites` permission
2. Login as new users and go to User Accounts page
3. The page should load with all users at you given site.

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/7642
