### PR TITLE
[Tests] Replace webDriver->findElement with safeFindElement

### DIFF
--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -59,7 +59,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
             $this->url . "/create_timepoint/".
             "?candID=900000&identifier=900000&subprojectID=1"
         );
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString("Create Time Point", $bodyText);
@@ -96,10 +96,10 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $select  = $this->safeFindElement(WebDriverBy::Name("#subproject"));
         $element = new WebDriverSelect($select);
         $element->selectByVisibleText($subproject);
-        $this->webDriver->findElement(
+        $this->safeFindElement(
             WebDriverBy::Name("#visit")
         )->sendKeys($visitlabel);
-        $this->webDriver->findElement(
+        $this->safeFindElement(
             WebDriverBy::Name(".col-sm-9 > .btn")
         )->click();
         sleep(1);
@@ -136,7 +136,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $this->safeGet(
             $this->url . "/create_timepoint/?candID=900000&identifier=900000"
         );
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
 

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -330,8 +330,9 @@ class DashboardTest extends LorisIntegrationTest
     public function testDashboardPageLoads()
     {
         $this->safeGet($this->url . '/dashboard/');
-        $welcomeText = $this->webDriver
-            ->findElement(WebDriverBy::cssSelector(".welcome"))->getText();
+        $welcomeText = $this->safeFindElement(
+            WebDriverBy::cssSelector(".welcome")
+        )->getText();
         $this->assertStringContainsString("Welcome", $welcomeText);
     }
 
@@ -346,29 +347,26 @@ class DashboardTest extends LorisIntegrationTest
     public function testDashboardRecruitmentView()
     {
         $this->safeGet($this->url . '/dashboard/');
-        $views = $this->webDriver
-            ->findElement(
-                WebDriverBy::Xpath(
-                    "//*[@id='lorisworkspace']/div[1]".
+        $views = $this->safeFindElement(
+            WebDriverBy::Xpath(
+                "//*[@id='lorisworkspace']/div[1]".
                     "/div[2]/div[1]/div/div/button"
-                )
-            );
+            )
+        );
         $views->click();
 
-        $assertText1 = $this->webDriver
-            ->findElement(
-                WebDriverBy::XPath(
-                    "//*[@id='lorisworkspace']/div[1]".
+        $assertText1 = $this->safeFindElement(
+            WebDriverBy::XPath(
+                "//*[@id='lorisworkspace']/div[1]".
                     "/div[2]/div[1]/div/div/ul/li[1]/a"
-                )
-            )->getText();
-        $assertText2 = $this->webDriver
-            ->findElement(
-                WebDriverBy::XPath(
-                    "//*[@id='lorisworkspace']/div[1]".
+            )
+        )->getText();
+        $assertText2 = $this->safeFindElement(
+            WebDriverBy::XPath(
+                "//*[@id='lorisworkspace']/div[1]".
                     "/div[2]/div[1]/div/div/ul/li[2]/a"
-                )
-            )->getText();
+            )
+        )->getText();
         $this->assertStringContainsString("View overall recruitment", $assertText1);
         $this->assertStringContainsString("View site breakdown", $assertText2);
     }
@@ -564,8 +562,9 @@ class DashboardTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . '/main.php?logout=true');
         $this->login("UnitTester", $this->validPassword);
-        $welcomeText = $this->webDriver
-            ->findElement(WebDriverBy::cssSelector(".welcome"))->getText();
+        $welcomeText = $this->safeFindElement(
+            WebDriverBy::cssSelector(".welcome")
+        )->getText();
         $this->assertStringContainsString("Unit Tester", $welcomeText);
     }
     /**
@@ -578,8 +577,9 @@ class DashboardTest extends LorisIntegrationTest
     private function _testPlan2()
     {
         $this->safeGet($this->url . '/dashboard/');
-        $testText = $this->webDriver
-            ->findElement(WebDriverBy::Id("overall-recruitment"))->getText();
+        $testText = $this->safeFindElement(
+            WebDriverBy::Id("overall-recruitment")
+        )->getText();
         $this->assertStringContainsString(
             "Please add a recruitment target for Overall Recruitment.",
             $testText
@@ -616,8 +616,9 @@ class DashboardTest extends LorisIntegrationTest
             )
         )->click();
         $this->safeGet($this->url . '/dashboard/');
-        $testText = $this->webDriver
-            ->findElement(WebDriverBy::Id("overall-recruitment"))->getText();
+        $testText = $this->safeFindElement(
+            WebDriverBy::Id("overall-recruitment")
+        )->getText();
         $this->assertStringContainsString(
             "888",
             $testText
@@ -634,12 +635,11 @@ class DashboardTest extends LorisIntegrationTest
     private function _testPlan5And6()
     {
         $this->safeGet($this->url . '/dashboard/');
-        $testText = $this->webDriver
-            ->findElement(
-                WebDriverBy::Xpath(
-                    "//*[@id='lorisworkspace']/div/div[1]/div[2]"
-                )
-            )->getText();
+        $testText = $this->safeFindElement(
+            WebDriverBy::Xpath(
+                "//*[@id='lorisworkspace']/div/div[1]/div[2]"
+            )
+        )->getText();
         $this->assertStringNotContainsString(
             "There have been no candidates registered yet.",
             $testText
@@ -656,12 +656,11 @@ class DashboardTest extends LorisIntegrationTest
     private function _testPlan7And8()
     {
         $this->safeGet($this->url . '/dashboard/');
-        $testText = $this->webDriver
-            ->findElement(
-                WebDriverBy::Xpath(
-                    "//*[@id='lorisworkspace']/div/div[1]/div[3]"
-                )
-            )->getText();
+        $testText = $this->safeFindElement(
+            WebDriverBy::Xpath(
+                "//*[@id='lorisworkspace']/div/div[1]/div[3]"
+            )
+        )->getText();
         $this->assertStringContainsString(
             "Scan sessions per site",
             $testText

--- a/modules/dictionary/test/datadictTest.php
+++ b/modules/dictionary/test/datadictTest.php
@@ -93,7 +93,7 @@ class DictionaryTestIntegrationTest extends LorisIntegrationTest
             )
         );
 
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString("Data Dictionary", $bodyText);

--- a/modules/instrument_list/test/instrument_listTest.php
+++ b/modules/instrument_list/test/instrument_listTest.php
@@ -52,7 +52,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
             $this->url .
             "/instrument_list/?candID=300001&sessionID=1"
         );
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString(
@@ -73,7 +73,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
             $this->url .
             "/instrument_list/?candID=300001&sessionID=1"
         );
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString(
@@ -94,7 +94,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
             $this->url .
             "/instrument_list/?candID=300001&sessionID=1"
         );
-        $bodyText = $this->webDriver->findElement(
+        $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringNotContainsString(


### PR DESCRIPTION
This replaces all remaining instances of $this->webDriver->findElement
with $this->safeFindElement. This is unlikely to completely fix the
random test failures, but should help with some that still have
problems.