### PR TITLE
[test] Add safeTextContent method and use it

### DIFF
--- a/modules/bvl_feedback/test/BvlFeedbackTest.php
+++ b/modules/bvl_feedback/test/BvlFeedbackTest.php
@@ -14,6 +14,8 @@
 require_once __DIR__
     . "/../../../test/integrationtests/".
     "LorisIntegrationTest.class.inc";
+
+use Facebook\WebDriver\WebDriverBy;
 /**
  * Configuration module automated integration tests
  *
@@ -40,25 +42,25 @@ class BvlFeedbackTest extends LorisIntegrationTest
     {
         // Candidate Profile
         $this->safeGet($this->url . "/300002/");
-        $this->webDriver->executescript(
-            "document.querySelector('#nav-right >".
-            " li:nth-child(1) > a > span').click()"
+        $this->safeClick(
+            WebDriverBy::cssSelector(
+                "#nav-right > li:nth-child(1) > a > span"
+            )
         );
-        $text = $this->webDriver->executescript(
-            "return document.querySelector".
-            "('#bvl_feedback_menu > div.breadcrumb-panel > a').textContent"
+        $text = $this->safeTextContent(
+            WebDriverBy::cssSelector(
+                "#bvl_feedback_menu > div.breadcrumb-panel > a"
+            )
         );
         $this->assertStringContainsString("Feedback for PSCID: ", $text);
         // Instrument List
         $this->safeGet($this->url . "/instrument_list/?candID=300001&sessionID=1");
-        $this->webDriver->executescript(
-            "document.querySelector('#nav-right > li:nth-child(1) > a > span').".
-            "click()"
+        $this->safeClick(
+            WebDriverBy::cssSelector(
+                "#nav-right > li:nth-child(1) > a > span"
+            )
         );
-        $text = $this->webDriver->executescript(
-            "return document.querySelector".
-            "('#bvl_feedback_menu').textContent"
-        );
+        $text = $this->safeTextContent(WebDriverBy::id("bvl_feedback_menu"));
         $this->assertStringContainsString("Feedback for PSCID: ", $text);
         //Todo: Any instrument
 

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -352,7 +352,6 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         $this->safeGet($this->url . "/candidate_list/");
         $link = self::$pscidLink;
-        sleep(1);
         $this->safeClick(WebDriverBy::cssSelector($link));
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -12,7 +12,6 @@
  * @link     https://github.com/aces/Loris
  */
 use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverSelect;
 require_once __DIR__ . "/../../../test/integrationtests"
     . "/LorisIntegrationTestWithCandidate.class.inc";
 
@@ -76,33 +75,6 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $this->markTestSkipped(
             'Skipping tests until Travis and React get along better.'
         );
-    }
-
-    /**
-     * Create a timepoint with three parameters.
-     *
-     * @param string $canID      ID of candidate
-     * @param string $subproject text of subproject
-     * @param string $visitlabel text of visit label
-     *
-     * @return void
-     */
-    private function _createTimepoint($canID, $subproject, $visitlabel)
-    {
-        $this->safeGet(
-            $this->url . "/create_timepoint/?candID=" . $canID .
-            "&identifier=" .$canID
-        );
-        $select  = $this->safeFindElement(WebDriverBy::Name("#subproject"));
-        $element = new WebDriverSelect($select);
-        $element->selectByVisibleText($subproject);
-        $this->safeFindElement(
-            WebDriverBy::Name("#visit")
-        )->sendKeys($visitlabel);
-        $this->safeFindElement(
-            WebDriverBy::Name(".col-sm-9 > .btn")
-        )->click();
-        sleep(1);
     }
 
 

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -211,10 +211,13 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
             "return document.querySelector('$location').textContent"
         );
         $this->assertEquals('View Images', $text);
-        $this->webDriver->executescript(
-            "document.querySelector('$location').click()"
+        $this->safeClick(WebDriverBy::cssSelector($location));
+
+        $this->waitForElement(
+            WebDriverBy::cssSelector(
+                '#bc2>a:nth-child(3)>div'
+            )
         );
-        sleep(1);
         $text = $this->webDriver->executescript(
             "return document.querySelector('#bc2>a:nth-child(3)>div').textContent"
         );

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -94,9 +94,10 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
     {
         $this->markTestSkipped("This method isn't working properly on travis.");
         $this->safeGet($this->url . "/document_repository/");
+        $this->waitForElement(WebDriverBy::id("tab-upload"));
         $this->webDriver->executescript(
             "document.querySelector('#tab-upload').click()"
-        );sleep(300);
+        );
         $text = $this->webDriver->executescript(
             "return document.querySelector('#upload > div > div > form > div >".
             "div:nth-child(1) > h3').textContent"
@@ -150,7 +151,6 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
          $this->safeFindElement(WebDriverBy::Id("commentsEdit"))
              ->sendKeys("This is a test comment!");
          $this->safeFindElement(WebDriverBy::Id("postEdit"))->click();
-         sleep(3);
 
         $this->safeFindElement(
             WebDriverBy::Name("File_name")
@@ -179,7 +179,6 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("filter")
         )->click();
-         sleep(3);
          $text = $this->safeFindElement(WebDriverBy::cssSelector("tbody"), 3000)
              ->getText();
          $this->assertEquals('', $text);

--- a/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
+++ b/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
@@ -431,7 +431,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         $this->safeGet($this->url . "/electrophysiology_browser/sessions/999999");
         $bodyText
-            = $this->safeFindElement(WebDriverBy::cssSelector("body"))
+            = $this->safeFindElement(WebDriverBy::cssSelector("#eegSessionView"))
             ->getText();
         $this->assertStringContainsString("Electrophysiology Browser", $bodyText);
     }

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -323,7 +323,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             "/mri_violations/mri_protocol_violations/"
         );
         $value = "#bc2 > a:nth-child(3)";
-        $text = $this->safeTextContent(WebDriverBy::cssSelector($value));
+        $text  = $this->safeTextContent(WebDriverBy::cssSelector($value));
         $this->assertEquals("Mri Protocol Violations", $text);
     }
 
@@ -341,7 +341,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             "/mri_violations/mri_protocol_check_violations/"
         );
         $value = "#bc2 > a:nth-child(3) > div";
-        $text = $this->safeTextContent(WebDriverBy::cssSelector($value));
+        $text  = $this->safeTextContent(WebDriverBy::cssSelector($value));
         $this->assertEquals("Mri Protocol Check Violations", $text);
     }
 

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -322,12 +322,9 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             $this->url .
             "/mri_violations/mri_protocol_violations/"
         );
-        sleep(1);
         $value = "#bc2 > a:nth-child(3)";
-        $text  = $this->webDriver->executescript(
-            "return document.querySelector('$value').textContent"
-        );
-            $this->assertEquals("Mri Protocol Violations", $text);
+        $text = $this->safeTextContent(WebDriverBy::cssSelector($value));
+        $this->assertEquals("Mri Protocol Violations", $text);
     }
 
     /**
@@ -343,12 +340,9 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             $this->url .
             "/mri_violations/mri_protocol_check_violations/"
         );
-        sleep(1);
         $value = "#bc2 > a:nth-child(3) > div";
-        $text  = $this->webDriver->executescript(
-            "return document.querySelector('$value').textContent"
-        );
-            $this->assertEquals("Mri Protocol Check Violations", $text);
+        $text = $this->safeTextContent(WebDriverBy::cssSelector($value));
+        $this->assertEquals("Mri Protocol Check Violations", $text);
     }
 
     /**
@@ -543,15 +537,15 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("filter")
         )->click();
-        sleep(1);
+
         $resolutionStatus = "#dynamictable > tbody > tr > td:nth-child(10) > select";
         $savebtn          = "#mri_violations > div.pull-right > input:nth-child(1)";
+
+        $this->waitForElement(WebDriverBy::cssSelector($resolutionStatus));
         $this->webDriver->executescript(
             "document.querySelector('$resolutionStatus').value='other'"
         );
-        $this->webDriver->executescript(
-            "document.querySelector('$savebtn').click()"
-        );
+        $this->safeClick(WebDriverBy::cssSelector($savebtn));
         $this->safeGet($this->url . "/mri_violations/resolved_violations/");
         sleep(1);
         $body = $this->webDriver->getPageSource();
@@ -670,7 +664,12 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("filter")
         )->click();
-        sleep(1);
+
+        $this->waitForElement(
+            WebDriverBy::cssSelector(
+                '#datatable > div > div.table-header.panel-heading > div'
+            )
+        );
         $bodyText = $this->webDriver->executescript(
             "return document.querySelector(
                     '#datatable > div > div.table-header.panel-heading > div')
@@ -690,6 +689,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . "/mri_violations/");
         foreach ($this->_loadingUI as $key => $value) {
+            $this->waitForElement(WebDriverBy::cssSelector($value));
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -330,9 +330,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                  input.dispatchEvent(event);
                 "
             );
-            $bodyText = $this->webDriver->executescript(
-                "return document.querySelector('$table').textContent"
-            );
+            $bodyText = $this->safeTextContent(WebDriverBy::cssSelector($table));
             $this->assertStringContainsString($records, $bodyText);
         } else {
             $this->safeFindElement(WebDriverBy::cssSelector($element));
@@ -343,16 +341,13 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                  input.dispatchEvent(event);
                 "
             );
-            $bodyText = $this->webDriver->executescript(
-                "return document.querySelector('$table').textContent"
-            );
+            $bodyText = $this->safeTextContent(WebDriverBy::cssSelector($table));
             $this->assertStringContainsString($records, $bodyText);
         }
         //test clear filter
         $btn = self::$clearFilter;
-        $this->webDriver->executescript(
-            "document.querySelector('$btn').click();"
-        );
+        $this->safeClick(WebDriverBy::cssSelector($btn));
+        $this->waitForElement(WebDriverBy::cssSelector($element));
         $inputText = $this->webDriver->executescript(
             "return document.querySelector('$element').value"
         );

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -638,7 +638,7 @@ abstract class LorisIntegrationTest extends TestCase
         $webElement = $this->safeFindElement($by, $waitPeriod);
 
         return $this->webDriver->executeScript(
-            "return arguments[0].textcontent;",
+            "return arguments[0].textContent;",
             [$webElement]
         );
     }

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -540,12 +540,32 @@ abstract class LorisIntegrationTest extends TestCase
      */
     function safeFindElement(WebDriverBy $by, $waitPeriod=15)
     {
+        $this->waitForElement($by, $waitPeriod);
+        return $this->webDriver->findElement($by);
+    }
+
+    /**
+     * Wrapper method for WebDriverWait to reduce boilerplate. It will
+     * It will sleep until the element is located on the page.
+     *
+     * @param WebDriverBy $by         Criteria used to find the element on the page.
+     * @param int         $waitPeriod After this amount of seconds, the wait period
+     *                                finishes and an exception is thrown.
+     *
+     * @throws Facebook\WebDriver\Exception\NoSuchElementException
+     *          if the element cannot be found after the
+     *                                wait period.
+     *
+     * @return void
+     */
+    function waitForElement($by, $waitPeriod=15)
+    {
         $wait = new WebDriverWait($this->webDriver, $waitPeriod, 500);
         $wait->until(
             WebDriverExpectedCondition::visibilityOfElementLocated($by)
         );
-        return $this->webDriver->findElement($by);
     }
+
 
     /**
      * Safely click on a page element, even if not yet visible. The click is done
@@ -600,6 +620,28 @@ abstract class LorisIntegrationTest extends TestCase
         }
     }
 
+    /**
+     * Gets the content of $by, after waiting for it to load on the
+     * page. If a maximum period of $waitPeriod passes, will throw
+     * an exception causing the test to fail.
+     *
+     * @param WebDriverBy $by         Criteria used to find the element
+     *                                on the page.
+     * @param int         $waitPeriod After this amount of seconds, the
+     *                                wait period finishes and an
+     *                                exception is thrown.
+     *
+     * @return string the textcontent of $by
+     */
+    function safeTextContent(WebDriverBy $by, $waitPeriod=15)
+    {
+        $webElement = $this->safeFindElement($by, $waitPeriod);
+
+        return $this->webDriver->executeScript(
+            "return arguments[0].textcontent;",
+            [$webElement]
+        );
+    }
     /**
      * Ensures that the module loads if and only if the user has the correct
      * permissions.


### PR DESCRIPTION
One of my PRs randomly failed on mri_violations tests. The
problem appears to be that code is using javascript->execute
script to get the text content of some elements. However, if
an action was just triggered by javascript, the element may
not yet have appeared on the page. This

1. Extracts the wait code from safeFindElement to a waitForElement
   wrapper, to reduce boiler plate when a test needs to wait
   for an element
2. Adds a safeTextContent helper, which will wait for an element
   to appear before running executescript on it.
3. Updates various tests (ones that I found by either grepping the
   code for "sleep" or were randomly failing on other PRs) to use
   these methods.
4. Changes some execute scripts which just do a "click" to use
   the analogous safeClick method (which already exists).

This is not done throughout all tests yet, but hopefully fixes some
of the problematic ones (if it works).