### PR TITLE
[Test] Integration test random failure fix test

### DIFF
--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -180,17 +180,7 @@ abstract class LorisIntegrationTest extends TestCase
         $passwordEl->sendKeys($password);
 
         $login = $this->safeFindElement(WebDriverBy::Name("login"));
-        $login->click();
-
-        // Explicitly wait until the page is loaded.
-        // Wait up to a minute, because sometimes when multiple tests
-        // are run one will fail due to the login taking too long?
-        $this->webDriver->wait(120, 1000)->until(
-            WebDriverExpectedCondition::visibilityOfElementLocated(
-                WebDriverBy::xpath("//div[@id='page'] | //input[@name='username']")
-            )
-        );
-
+        $this->clickToLoadNewPage($login);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

I have noticed that each random failure was showing the dashboard page instead of the one asked by safeGet. I figured that the login step was causing somewhat causing the issue. Looking at the login function, it calls click on a button which loads the dashboard page. But is safeGet is called too early than the old body is the login page instead of the dashboard page. When the login page is finally detached from the DOM, safeGet returns the dashboard page instead.