### PR TITLE
[candidate_parameters] Allow clearing of consent status

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -450,6 +450,7 @@ function editConsentStatusFields(\Database $db)
         // Validate data
         $recordExists  = array_key_exists($consentID, $candidateConsent);
         $oldStatus     = $candidateConsent[$consentID]['Status'] ?? null;
+        $oldDate       = $candidateConsent[$consentID]['DateGiven'] ?? null;
         $oldWithdrawal = $candidateConsent[$consentID]['DateWithdrawn'] ?? null;
         $validated     = false;
 
@@ -505,7 +506,14 @@ function editConsentStatusFields(\Database $db)
                 echo('A status is missing for at least one consent type.
                       Please select a valid status for all consent types.');
                 return;
+            } elseif (!empty($oldStatus)
+                || !empty($oldDate)
+                || !empty($oldWithdrawal)
+            ) {
+                // Only update empty fields if they were not already empty
+                $validated = true;
             }
+
             break;
         }
 

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -99,11 +99,21 @@ class ConsentStatus extends Component {
             if (this.state.Data.consents.hasOwnProperty(consent)) {
                 const oldConsent = this.state.Data.consentStatuses[consent];
                 const newConsent = this.state.formData[consent];
-                // Clear withdrawal date if consent status changes from no
-                // (or empty if uncleaned data) to yes
                 if (formElement === consent) {
+                    // Clear withdrawal date if consent status changes from no
+                    // (or empty if uncleaned data) to yes
                     if ((newConsent === 'yes' && oldConsent !== 'yes') ||
-                        (newConsent === 'no' && oldConsent === null)) {
+                        (newConsent === 'no' &&
+                            (oldConsent === null || oldConsent === '')
+                        )
+                    ) {
+                        formData[consent + '_withdrawal'] = '';
+                        formData[consent + '_withdrawal2'] = '';
+                    }
+                    // Clear date if response set back to null
+                    if (newConsent === '' && oldConsent !== null) {
+                        formData[consent + '_date'] = '';
+                        formData[consent + '_date2'] = '';
                         formData[consent + '_withdrawal'] = '';
                         formData[consent + '_withdrawal2'] = '';
                     }
@@ -300,18 +310,20 @@ class ConsentStatus extends Component {
         const newConsent = this.state.formData[consentName];
         const withdrawalDate = this.state.Data.withdrawals[consentName];
         // Define defaults
-        let emptyOption = true;
         let dateRequired = false;
+        let responseDateDisabled = true;
         let withdrawalRequired = false;
         // Let date of withdrawal field be disabled until it is needed
         let withdrawalDisabled = true;
 
         // If answer to consent is 'yes', require date of consent
         if (newConsent === 'yes') {
+            responseDateDisabled = false;
             dateRequired = true;
         }
         // If answer to consent is 'no', require date of consent
         if (newConsent === 'no') {
+            responseDateDisabled = false;
             dateRequired = true;
             // If answer was previously 'yes' and consent is now being withdrawn, enable and require withdrawal date
             // If consent was previously withdrawn and stays withdrawn, enable and require withdrawal date
@@ -321,10 +333,6 @@ class ConsentStatus extends Component {
                 withdrawalDisabled = false;
                 withdrawalRequired = true;
             }
-        }
-        // Disallow clearing a valid consent status by removing empty option
-        if (oldConsent === 'no' || oldConsent === 'yes') {
-            emptyOption = false;
         }
 
         // Set up elements
@@ -353,14 +361,13 @@ class ConsentStatus extends Component {
                     onUserInput={this.setFormData}
                     disabled={disabled}
                     required={false}
-                    emptyOption={emptyOption}
                 />
                 <DateElement
                     label={consentDateLabel}
                     name={consentDate}
                     value={this.state.formData[consentDate]}
                     onUserInput={this.setFormData}
-                    disabled={disabled}
+                    disabled={disabled || responseDateDisabled}
                     required={dateRequired}
                 />
                 <DateElement
@@ -368,7 +375,7 @@ class ConsentStatus extends Component {
                     name={consentDate2}
                     value={this.state.formData[consentDate2]}
                     onUserInput={this.setFormData}
-                    disabled={disabled}
+                    disabled={disabled || responseDateDisabled}
                     required={dateRequired}
                 />
                 <DateElement


### PR DESCRIPTION
## Brief summary of changes
This PR allows users to set a consent status back to null. I chose not to do this with a "Clear" button because a clear button would mean you are clearing all or none of the consent statuses on the page, or otherwise we would need a clear button for each individual consent. Instead, the participant can set the status to be empty and update the consent as usual. The date and withdrawal date are cleared and disabled when the status is set back to empty. 

#### Testing instructions (if applicable)

1. Check that you are successfully able to update a consent status from non-null to empty
2. Check that when you update the status to empty, it only updates empty values for that consent and not for any other consent that was already empty
3. Make sure that the consent status history is updated appropriately
3. Check that all of the validation for consent still persists:
- The status should be required if a date is entered
- a date should be required if the status is entered
- a withdrawal date should be required if the consent status is changed from yes to no only

#### Link(s) to related issue(s)

* Resolves #4149
