### PR TITLE
[candidate list] when pscid and dccid don't match, missing error message.

### DIFF
--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -58,18 +58,6 @@ class ValidateIDs extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        // The parent handles things like hasAccess checks.
-        $resp = parent::handle($request);
-        switch ($resp->getStatusCode()) {
-        case 200:
-            // If it was a 200 code, it just means display was called and
-            // access validated. We still need to do other validations
-            // and add the result body.
-            break;
-        default:
-            return $resp;
-        }
-
         // Ensure it's a GET request.
         if ($request->getMethod() != "GET") {
             return (new \LORIS\Http\Response())


### PR DESCRIPTION
## Brief summary of changes
remove the request access check. only keep the request methods validation, like other modules.
#### Testing instructions (if applicable)
input an invalid DCCID or PSCID, then show the error message like the screenshot below.
#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.
![Screen Shot 2021-11-03 at 11 59 42 PM](https://user-images.githubusercontent.com/9876007/140255814-7bda6791-1a27-4665-9f54-4b0ccb620da5.png)
)
[candidate_list] Open Profile form gives 500 error #7612
