### PR TITLE
[Instruments] Escaping issue sub-optimal - Redirect on save success to load defaults from database

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2881,9 +2881,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $req = $request->getParsedBody();
+        $req     = $request->getParsedBody();
+        $success = false;
         if ($request->getMethod() === "POST" && !isset($req['ClearInstrument'])) {
-            $this->save();
+            $success = $this->save();
         }
 
         // Disable form if data entry is complete
@@ -2911,6 +2912,22 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             && $this->DataEntryType !== 'DirectEntry'
         ) {
             $this->freeze();
+        }
+
+        if ($success) {
+            $sessionID = $request->getQueryParams()["sessionID"];
+            $candID    = $request->getQueryParams()["candID"];
+            $baseURL   = \NDB_Factory::singleton()->settings()->getBaseURL();
+            $pageURL   = !empty($this->page) ? urlencode($this->page) ."/" : "";
+            $url       = $baseURL . "/instruments/" .
+                urlencode($this->testName) . "/" .
+                $pageURL .
+                '?commentID=' . urlencode($this->getCommentID()) .
+                '&candID=' . urlencode($candID) .
+                '&sessionID=' . urlencode($sessionID);
+            return (new \LORIS\Http\Response())
+                ->withStatus(303)
+                ->withHeader("Location", $url);
         }
 
         return (new \LORIS\Http\Response())


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the escaping issue that occurs when a text field in an instrument contains an HTML special character. The solution employed here is to redirect on successful save to reload data directly from the database instead of loading it using the _POST data.

Cons:
 - This solution is **sub-optimal** because the escaping issue will still occur when an error is detected on instrument save and the values MUST be reloaded from the _POST array where the reload can not occur to avoid losing the unsaved data.

Pros:
 - relatively minor changes
 - easy to test

Alternate to: #7777
Fixes #7489
Replaces #7490

#### Testing instructions (if applicable)

1. Go to an instrument with text element fields (not including text area element since the issue did not apply to those elements)
2. Outside of this PR, attempt to save a value in the text element that has quotations in it.
3. Notice that it does not display properly after clicking "save"
4. check out this PR
5. Attempt again to save a value with quotations in it

Make sure to test other usecases as well
1. behaviour when the form contains an error
2. behaviour when there are multiple `"`,`<`,`>` or `&` in the string
3. behaviour when the instrument status sidebar is modified (is it affected by the reload)

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
