### PR TITLE
[Instruments] Escaping issue optimal - Only HTML escape on data retrieval

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -145,7 +145,7 @@ class EditExaminer extends \NDB_Form
                 if ($date_cert != "") {
                     $data['date_cert'] = $date_cert;
                 }
-                $DB->insert(
+                $DB->unsafeinsert(
                     'certification',
                     $data
                 );
@@ -227,7 +227,7 @@ class EditExaminer extends \NDB_Form
                         if ($date_cert != "") {
                             $data['date_cert'] = $date_cert;
                         }
-                        $DB->update(
+                        $DB->unsafeupdate(
                             'certification',
                             $data,
                             [
@@ -264,7 +264,6 @@ class EditExaminer extends \NDB_Form
                 }
             }
         }
-        header("Refresh:0");
     }
 
     /**

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -233,7 +233,7 @@ class Examiner extends \NDB_Menu_Filter_Form
         );
 
         if (empty($examinerID)) {
-            $DB->insert(
+            $DB->unsafeinsert(
                 'examiners',
                 [
                     'full_name'   => $fullName,

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -86,7 +86,7 @@ class HelpFile
         $DB = \NDB_Factory::singleton()->database();
 
         // insert a help file
-        $DB->insert('help', $set);
+        $DB->unsafeinsert('help', $set);
         // return the help ID
         return intval($DB->lastInsertID);
     }
@@ -103,7 +103,7 @@ class HelpFile
     {
         // update the help file
         \NDB_Factory::singleton()->database()
-            ->update('help', $set, ['helpID' => $this->helpID]);
+            ->unsafeupdate('help', $set, ['helpID' => $this->helpID]);
 
         return true;
     }

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -43,13 +43,6 @@ class My_Preferences extends \NDB_Form
             'Country',
             'Fax',
         ];
-        // Prevent Javascript injection on all fields
-        foreach ($fieldsThatAreStrings as $fieldName) {
-            // this check prevents PHP Notices
-            if (!empty($defaults[$fieldName])) {
-                $defaults[$fieldName] = htmlspecialchars($defaults[$fieldName]);
-            }
-        }
 
         foreach ($defaults['examiner'] as $cid=>$vals) {
             //sets pending approval info

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -27,23 +27,6 @@ class My_Preferences extends \NDB_Form
         // remove the password hash
         unset($defaults['Password_hash']);
 
-        // An array of each field that requires front-end sanitization
-        $fieldsThatAreStrings = [
-            'UserID',
-            'First_name',
-            'Last_name',
-            'Real_name',
-            'Email',
-            'Degree',
-            'Institution',
-            'Address',
-            'City',
-            'State',
-            'Zip_code',
-            'Country',
-            'Fax',
-        ];
-
         foreach ($defaults['examiner'] as $cid=>$vals) {
             //sets pending approval info
             if ($cid=='pending') {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -96,30 +96,6 @@ class Edit_User extends \NDB_Form
                 $defaults["permID[$value]"] = 'on';
             }
 
-            // An array of each field that requires front-end sanitization
-            $fieldsThatAreStrings = [
-                'UserID',
-                'First_name',
-                'Last_name',
-                'Real_name',
-                'Email',
-                'Degree',
-                'Institution',
-                'Address',
-                'City',
-                'State',
-                'Zip_code',
-                'Country',
-                'Fax',
-            ];
-            // Prevent Javascript injection on all fields
-            foreach ($fieldsThatAreStrings as $fieldName) {
-                // this check prevents PHP Notices
-                if (!empty($defaults[$fieldName])) {
-                    $defaults[$fieldName] = htmlspecialchars($defaults[$fieldName]);
-                }
-            }
-
             $defaults['examiner'] = $defaults['examiner'] ?? [];
             foreach ($defaults['examiner'] as $cid=>$vals) {
                 //sets pending approval info
@@ -419,7 +395,7 @@ class Edit_User extends \NDB_Form
                 // If examiner not in table and radiologist, pending and current
                 // sites fields set add the examiner to the examiner table
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $DB->insert(
+                $DB->unsafeinsert(
                     'examiners',
                     [
                         'full_name'   => $values['Real_name'],

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -706,7 +706,7 @@ class LorisForm
             }
         }
 
-        return $newValue;
+        return htmlspecialchars($newValue);
     }
 
     /**

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -706,7 +706,7 @@ class LorisForm
             }
         }
 
-        return htmlspecialchars($newValue);
+        return $newValue;
     }
 
     /**
@@ -820,7 +820,7 @@ class LorisForm
         if (empty($el['name'])) {
             return $el['label'];
         }
-        $val = $this->getValue($el['name']);
+        $val = htmlspecialchars($this->getValue($el['name']));
         return $val;
     }
     /**
@@ -857,7 +857,7 @@ class LorisForm
         }
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg':''" : "''";
-        $value    = $this->getValue($el['name']);
+        $value    = htmlspecialchars($this->getValue($el['name']));
         $format   = 'date';
 
         if (array_key_exists('options', $el) && isset($el['options']['format'])) {
@@ -946,7 +946,7 @@ class LorisForm
         if (isset($el['readonly'])) {
             $readonly = 'readonly';
         }
-        $value = $this->getValue($el['name']);
+        $value = htmlspecialchars($this->getValue($el['name']));
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
                 isset($el['onchange']) && $el['onchange']
@@ -971,7 +971,7 @@ class LorisForm
 
             . (
                 (!empty($value) || $value === '0')
-                ? ' value="' . $this->getValue($el['name']) . '"'
+                ? ' value="' . $value . '"'
                 : ''
               )
             . $disabled
@@ -1043,7 +1043,7 @@ class LorisForm
      */
     function timeHTML($el, $type='time')
     {
-        $timeStamp = $this->getValue($el['name']);
+        $timeStamp = htmlspecialchars($this->getValue($el['name']));
         $smarty    = new Smarty_NeuroDB;
         $value     = [
             'H' => null,
@@ -1087,7 +1087,7 @@ class LorisForm
      */
     function yearHTML($el)
     {
-        $year   = $this->getValue($el['name']);
+        $year   = htmlspecialchars($this->getValue($el['name']));
         $smarty = new Smarty_NeuroDB;
         $value  = explode('-', $year)[0];
 
@@ -1132,7 +1132,7 @@ class LorisForm
     {
         $cls      = empty($el['class']) ? "" : "class=\"$el[class]\"";
         $disabled = '';
-        $val      = $this->getValue($el['name']);
+        $val      = htmlspecialchars($this->getValue($el['name']));
         if (isset($el['disabled']) || $this->frozen) {
             $disabled = 'disabled';
         }
@@ -1171,12 +1171,9 @@ class LorisForm
         if (isset($el['cols'])) {
             $dims .= " cols=\"$el[cols]\"";
         }
-        $value = $this->getValue($el['name']);
+        $value = htmlspecialchars($this->getValue($el['name']));
         return "<textarea name=\"$el[name]\" $cls $dims $disabled>"
-            . (
-                !empty($value)
-                ? $this->getValue($el['name']) : ''
-              )
+            . (!empty($value) ? $value : '')
             ."</textarea>";
     }
 
@@ -1588,7 +1585,7 @@ class LorisForm
             // Quickform advanced checkbox
             return $this->advCheckboxHTML($el);
         }
-        $val      = $this->getValue($el['name']);
+        $val      = htmlspecialchars($this->getValue($el['name']));
         $checked  = '';
         $value    = '';
         $disabled = '';
@@ -1623,7 +1620,7 @@ class LorisForm
      */
     function advCheckboxHTML($el)
     {
-        $val      = $this->getValue($el['name']);
+        $val      = htmlspecialchars($this->getValue($el['name']));
         $checked  = '';
         $disabled = '';
         $value    = $el["checkStates"];

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -769,7 +769,7 @@ class LorisForm
             }
 
             $strOptions .= "<option value='$optionKey' $selected>"
-                .$optionVal
+                . htmlspecialchars($optionVal)
                 . "</option>";
         }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -833,10 +833,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $values = Utility::nullifyEmpty($values, $key);
         }
 
+        // If the instrument is saving as JSON into the Data column, the
+        // table may not exist, so don't try and update it.
         if ($this->jsonData !== true && !empty($values)) {
-            // If the instrument is saving as JSON into the Data column, the
-            // table may not exist, so don't try and update it.
-            $db->update(
+            // Use unsafe update to avoid storing HTML escaped values in the database
+            // instead values should be escaped on display
+            $db->unsafeUpdate(
                 $this->table,
                 $values,
                 ['CommentID' => $this->getCommentID()]

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -183,7 +183,7 @@ class User extends UserPermissions implements
      */
     public static function insert(array $set): void
     {
-        \Database::singleton()->insert('users', $set);
+        \Database::singleton()->unsafeinsert('users', $set);
     }
 
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -197,7 +197,7 @@ class User extends UserPermissions implements
      */
     public function update(array $set): void
     {
-        \Database::singleton()->update(
+        \Database::singleton()->unsafeupdate(
             'users',
             $set,
             ['UserID' => $this->userInfo['UserID']]

--- a/tools/single_use/instrument_HTML_escape_repair.php
+++ b/tools/single_use/instrument_HTML_escape_repair.php
@@ -1,0 +1,299 @@
+<?php declare(strict_types=1);
+/**
+ * This tool checks instrument data for multi-escaped characters that have
+ * been stored in the database due to a bug present in LORIS since before
+ * version 19.0.
+ *
+ * This tool can be used to report cases of multi-escaped character as well
+ * as identify if the escaping caused data truncation.
+ *
+ * This tool does not fix or modify the data in anyway, it simply reads from t
+ * he database.
+ */
+
+require_once __DIR__."/../generic_includes.php";
+
+// LOGGING
+$dir = __DIR__ . "/../logs/";
+if (!is_dir($dir)) {
+    mkdir($dir);
+}
+$date    = strftime("%Y-%m-%d_%H:%M");
+$logPath = "$dir/instrument_HTML_escape_repair_$date.log";
+$logfp   = fopen($logPath, 'a');
+
+if (!$logfp) {
+    printError(
+        "No logs can be generated, path:$logPath ".
+        "does not exist or can not be written to.\n"
+    );
+}
+//PARSE ARGUMENTS
+$actions = [
+    'use-database',
+    'use-objects',
+];
+
+if (!isset($argv[1])
+    || $argv[1] === 'help'
+    || in_array('-h', $argv, true)
+    || !in_array($argv[1], $actions, true)
+    || ($argc === 3 && $argv[2] !== "repair")
+    || $argc > 3
+) {
+    showHelp();
+}
+
+// Flag enabling/disabling repair mode
+$repair = false;
+if (isset($argv[2]) && $argv[2] === 'repair') {
+    $repair = true;
+}
+
+// Flag targeting use or database only without instantiation of Instrument objects
+$useDatabase = false;
+if (isset($argv[1]) && $argv[1] === 'use-database') {
+    $useDatabase =true;
+}
+
+// Flag targeting use of Instrument objects
+$useObjects = false;
+if (isset($argv[1]) && $argv[1] === 'use-objects') {
+    $useObjects =true;
+}
+
+$loris = new \LORIS\LorisInstance(
+    $DB,
+    $config,
+    [
+        __DIR__ . "/../../project/modules",
+        __DIR__ . "/../../modules/",
+    ]
+);
+
+// DEFINE VARIABLES
+// All instruments looked at
+$instrumentNames = $DB->pselectCol("SELECT Test_name FROM test_names", []);
+// Array of all fields containing any escaped characters
+$escapedEntries = [];
+// Array of database tables and columns containing escaped characters.
+$escapedFields = [];
+// Boolean flag for identify non-impacted databases and terminating.
+$escapeDetected = false;
+
+$databaseName = $config->getSetting('database')['database'];
+
+// FIRST loop just reporting all potential problematic fields
+foreach ($instrumentNames as $instrumentName) {
+    printOut("Checking $instrumentName");
+
+    $instrumentCIDs = $DB->pselectCol(
+        "SELECT CommentID FROM flag WHERE Test_name=:tn",
+        ["tn" => $instrumentName]
+    );
+
+    $instrumentData =[];
+    if ($useObjects) {
+        try {
+            $instrument = \NDB_BVL_Instrument::factory($loris, $instrumentName);
+        } catch (Exception $e) {
+            printError(
+                "There was an error instantiating instrument $instrumentName.
+            This instrument will be skipped."
+            );
+            printError($e->getMessage());
+            continue;
+        }
+        foreach ($instrumentCIDs as $cid) {
+            $instrumentInstance = \NDB_BVL_Instrument::factory(
+                $loris,
+                $instrumentName,
+                $cid
+            );
+            $instrumentCandData = $instrumentInstance->getInstanceData();
+
+            $instrumentData[$cid] = $instrumentCandData;
+        }
+    } else if ($useDatabase) {
+        //Check if table by that name exists
+        if (!$DB->tableExists($instrumentName)) {
+            printError(
+                "No table by the name `$instrumentName` was found in the
+            database. This instrument will be skipped"
+            );
+        };
+        $instrumentData = $DB->pselectWithIndexKey(
+            "SELECT * FROM $instrumentName",
+            [],
+            "CommentID"
+        );
+    }
+    // Go through all fields and identify which have any escaped characters
+    foreach ($instrumentData as $cid => $instrumentCandData) {
+        foreach ($instrumentCandData as $field => $value) {
+            // regex detecting any escaped character in the database
+            if (!empty($value)
+                && preg_match('/&(amp;)*(gt;|lt;|quot;|amp;)/', $value)
+            ) {
+                $escapedEntries[$instrumentName][$cid][$field] = $value;
+                $escapedFields[$instrumentName][] = $field;
+                $escapeDetected = true;
+            }
+        }
+    }
+}
+
+//SECOND loop, depending on flags, report or fix values.
+if ($escapeDetected && !empty($escapedEntries)) {
+    printOut(
+        "Below is a list of all entries in the database instruments which " .
+        "contain escaped characters"
+    );
+    printOut($escapedEntries);
+    printOut("\n\n");
+} else {
+    printOut("No errors have been detected. End !");
+}
+
+// Check if repair mode enabled and attempt to fix data
+if ($repair) {
+    foreach ($escapedEntries as $instrumentName=>$CIDs) {
+        foreach ($CIDs as $cid=>$fields) {
+
+            //preg_replace will replace each escape type with it's couterpart
+            $newValues = preg_replace(
+                [
+                    '/&(amp;)*(gt;)/',
+                    '/&(amp;)*(lt;)/',
+                    '/&(amp;)*(quot;)/',
+                    '/&(amp;)*(amp;)/'
+                ],
+                ['>','<','"','&'],
+                $fields
+            );
+            printOut("Fixing Data in $instrumentName instrument for CommentID:$cid");
+            if ($useObjects) {
+                $instrumentInstance = \NDB_BVL_Instrument::factory(
+                    $loris,
+                    $instrumentName,
+                    $cid
+                );
+                $instrumentInstance->_saveValues($newValues);
+            } else if ($useDatabase) {
+                // LOGIC BELOW IS AN EXACT COPY OF THE NDB_BVL_INSTRUMENT
+                // CLASS SAVING LOGIC
+                $DB->unsafeupdate(
+                    $instrumentName,
+                    $newValues,
+                    ["CommentID"=>$cid]
+                );
+                // Extract the old data and merge it with what was submitted so
+                // that we don't overwrite data from other pages.
+                $oldData = $DB->pselectOne(
+                    "SELECT Data FROM flag WHERE CommentID=:cid",
+                    ['cid' => $cid]
+                );
+
+                if (!empty($oldData) && $oldData !== "null") {
+                    $oldData = json_decode($oldData, true);
+                } else {
+                    $oldData = [];
+                }
+                $newData = array_merge($oldData ?? [], $newValues);
+
+                // Save the JSON to the flag.Data column.
+                //
+                // json_encode ensures that this is safe. If we use the safe wrapper,
+                // HTML encoding the quotation marks will make it invalid JSON.
+                $DB->unsafeUpdate(
+                    "flag",
+                    ["Data" => json_encode($newData)],
+                    ['CommentID' => $cid]
+                );
+
+            }
+            //log modified values
+            printOut("Old Values:");
+            printOut($fields);
+            printOut("New Values:");
+            printOut($newValues);
+        }
+    }
+}
+
+fclose($logfp);
+
+
+/**
+ * Prints to log file
+ *
+ * @param $message Message
+ *
+ * @return void
+ */
+function logMessage($message)
+{
+    global $logfp;
+    if (!$logfp) {
+        //The log file could not be instantiated
+        //use print instead
+        print_r($message);
+    }
+    $now_string = strftime("%Y-%m-%d %H:%M:%S");
+    fwrite($logfp, "[$now_string] ".print_r($message, true)."\n");
+
+}
+
+/**
+ * Prints to STDERR
+ *
+ * @param $message Message
+ *
+ * @return void
+ */
+function printError($message)
+{
+    logMessage($message);
+    fwrite(STDERR, "$message \n");
+}
+
+/**
+ * Prints to STDOUT
+ *
+ * @param $message Message
+ *
+ * @return void
+ */
+function printOut($message)
+{
+    logMessage($message);
+    print_r($message);
+    print_r("\n");
+}
+
+/**
+ * Show help
+ *
+ * @return void
+ */
+function showHelp()
+{
+    echo "\n\n*** Fix Double Escaped Fields ***\n\n";
+
+    echo "Usage:
+    instrument_HTML_escape_repair.php [help | -h]  -> ".
+        "displays this message
+    instrument_HTML_escape_repair.php use-database -> ".
+        "Runs in reporting mode using only the database instrument names and tables
+    instrument_HTML_escape_repair.php use-objects  -> ".
+        "Runs in reporting mode using the database and ".
+        "instantiating Instrument objects.
+    instrument_HTML_escape_repair.php [use-database | use-objects] repair -> ".
+        "Runs in repair mode and uses the selected method ".
+        "(database or Instrument objects) to do it
+
+    Note: in the event where use-objects fails, try use-database.
+    \n\n";
+
+    die();
+}

--- a/tools/single_use/instrument_double_escape_report.php
+++ b/tools/single_use/instrument_double_escape_report.php
@@ -52,6 +52,15 @@ if (isset($argv[1]) && $argv[1] === 'use-objects') {
     $useObjects =true;
 }
 
+$lorisinstance = new \LORIS\LorisInstance(
+    $DB,
+    $config,
+    [
+        __DIR__ . "/../../project/modules",
+        __DIR__ . "/../../modules/",
+    ]
+);
+
 // DEFINE VARIABLES
 // All instruments looked at
 $instrumentNames = $DB->pselectCol("SELECT Test_name FROM test_names", array());
@@ -83,7 +92,7 @@ foreach($instrumentNames as $instrumentName) {
     $instrumentData=array();
     if ($useObjects) {
         try {
-            $instrument = \NDB_BVL_Instrument::factory($instrumentName);
+            $instrument = \NDB_BVL_Instrument::factory($lorisinstance, $instrumentName);
         } catch (Exception $e) {
             printError(
                 "There was an error instantiating instrument $instrumentName.
@@ -93,7 +102,7 @@ foreach($instrumentNames as $instrumentName) {
             continue;
         }
         foreach ($instrumentCIDs as $cid) {
-            $instrumentInstance = \NDB_BVL_Instrument::factory($instrumentName, $cid);
+            $instrumentInstance = \NDB_BVL_Instrument::factory($lorisinstance, $instrumentName, $cid);
             $instrumentCandData = $instrumentInstance->getInstanceData();
 
             // instrument name and table name might differ
@@ -153,7 +162,7 @@ if ($errorsDetected) {
 
     if(!empty($escapedEntries)) {
         printOut(
-            "Below is a list of all entries in the database instruemnts which " .
+            "Below is a list of all entries in the database instruments which " .
             "contain escaped characters"
         );
         print_r($escapedEntries);


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the escaping issue that occurs when a text field in an instrument contains an HTML special character. The solution employed here is to avoid HTML escaping special characters before database save and to instead escape them on form load (in the display logic).

Cons:
 - This solution is major and might have wider effects that predicted on any other form in loris still using lorisforms

Pros:
 - optimal permanent solution, not a temporary hack
 - Collateral advantage of preventing scripting in filter fields

Modules using LorisForm affected by changes (other than instruments):
- [x] examiners
- [x] help_editor
- [x] my_preferences
- [x] user_accounts
- [ ] ...

Modules NOT using LorisForm (directly loading data) affected by changes: (added to https://github.com/aces/Loris/projects/27)
- [ ] configuration
- [ ] publication
   - This will need it's own ticket. Files allow some special characters that it shouldn't. some fields get HTML char decoded, some dont. 
- [ ] acknowledgements
- [ ] bvl_feedback
- [ ] candidate_parameters
- [ ] data_release
- [ ] document_repository
- [ ] electrophysiology_browser
- [ ] genomic_browser
- [ ] issue_tracker
- [ ] media (edit function only)

Modules NOT loading any data on forms (LorisForm or otherwise)
- [x] survey_accounts
- [x] imaging_uploader
   - Does not seem to allow special characters by constantly validating matches with PSCID,DCCID and visitlabel; no free text allowed

Found using search on
- [x] createText
- [x] addBasicText
- [x] addBasicTextArea
- [ ] ~addTextAreaGroup~ (unused)
- [ ] ~createTextArea~ (unused)
- [ ] ~addTextAreaGroup~ (unused)
- [ ] ~createDate~ (unnecessary)
- [ ] ~addDate~ (unnecessary)
- [ ] ~createStatic~ (unnecessary)
- [ ] ~addStatic~ (unnecessary)
- [ ] ~createTime~ (unnecessary/unused)
- [ ] ~addTime~ (unnecessary/unused)
- [ ] ~year~ (unnecessary/unused)
- [ ] ~file~ (unnecessary/unused)
- [ ] ~checkbox~  (unnecessary/unused)


Alternate to: #7776
Fixes #7489
Replaces #7490

#### Testing instructions (if applicable)

1. Go to an instrument with text element fields (not including text area element since the issue did not apply to those elements)
2. Outside of this PR, attempt to save a value in the text element that has quotations in it.
3. Notice that it does not display properly after clicking "save"
4. check out this PR
5. Attempt again to save a value with quotations in it

Make sure to test other usecases as well
1. behaviour when the form contains an error (triggering a reload with erroneous fields highlighted)
2. behaviour when there are multiple `"`,`<`,`>` or `&` in the string
3. behaviour when the instrument status sidebar is modified (is it affected by the reload)


Review:
 - Make sure all field types that should be escaped are escaped (select fields?)
#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
