### PR TITLE
[user account] fix can't show email errors

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1071,7 +1071,6 @@ class Edit_User extends \NDB_Form
                     $errors['UserID_Group']
                         = 'The user name must not exceed 255 characters';
                 }
-
                 // Check that user name does not contain a whitespace character
                 if (preg_match('/\s/', $effectiveUID)) {
                     // Note: email addresses can contain comments which themselves
@@ -1164,7 +1163,7 @@ class Edit_User extends \NDB_Form
             && $values['NA_Password'] == "on"
             && $values['SendEmail'] != "on"
         ) {
-            $errors['Email_Group']
+            $errors['Email']
                 = 'When generating a new password, '
                 . 'please notify the user by checking Send email to user box';
         }
@@ -1192,7 +1191,7 @@ class Edit_User extends \NDB_Form
         if (!empty($values['Email'])) {
             $emailError = $this->_getEmailError($DB, $values['Email']);
             if (!is_null($emailError)) {
-                $errors['Email_Group'] = $emailError;
+                $errors['Email'] = $emailError;
             } elseif ($this->isCreatingNewUser()) {
                 if ($values['Email'] != $values['__ConfirmEmail']) {
                     $errors['__ConfirmEmail'] = 'Email and confirmed email '
@@ -1201,7 +1200,7 @@ class Edit_User extends \NDB_Form
             }
         } else {
             // No email entered: error
-            $errors['Email_Group'] = 'You must enter an email address';
+            $errors['Email'] = 'You must enter an email address';
         }
 
         //======================================

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -1,5 +1,6 @@
 <br />
 <form method="post" name="edit_user" autocomplete="off">
+    {if $form.errors}
     <div class="alert alert-danger" role="alert">
         The form you submitted contains data entry errors
     </div>
@@ -265,10 +266,10 @@
     	</div>
     </div>
     {/if}
-    {if $form.errors.Email_Group|default}
+    {if $form.errors.Email|default}
     <div class="row form-group has-error">
         <div class="col-sm-offset-2">
-            <font class="form-error">{$form.errors.Email_Group}</font>
+            <font class="form-error">{$form.errors.Email}</font>
         </div>
     {else}
     <div class="row form-group">
@@ -285,7 +286,7 @@
         <div class="col-sm-4">{$form.SendEmail.html}</div>
         {if $form.errors.Email|default}
             <div class="col-sm-offset-2">
-                <font class="form-error">{$form.errors.Email_Group}</font>
+                <font class="form-error">{$form.errors.Email}</font>
             </div>
         {/if}
     </div>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -1,6 +1,5 @@
 <br />
 <form method="post" name="edit_user" autocomplete="off">
-    {if $form.errors}
     <div class="alert alert-danger" role="alert">
         The form you submitted contains data entry errors
     </div>
@@ -266,9 +265,11 @@
     	</div>
     </div>
     {/if}
-
-    {if $form.errors.Email|default}
+    {if $form.errors.Email_Group|default}
     <div class="row form-group has-error">
+        <div class="col-sm-offset-2">
+            <font class="form-error">{$form.errors.Email_Group}</font>
+        </div>
     {else}
     <div class="row form-group">
     {/if}
@@ -284,7 +285,7 @@
         <div class="col-sm-4">{$form.SendEmail.html}</div>
         {if $form.errors.Email|default}
             <div class="col-sm-offset-2">
-                <font class="form-error">{$form.errors.Email}</font>
+                <font class="form-error">{$form.errors.Email_Group}</font>
             </div>
         {/if}
     </div>


### PR DESCRIPTION
## Brief summary of changes
fix the variable name
#### Testing instructions (if applicable)
input an invalid email to create or edit a user, then the error shows on the page.
#### Link(s) to related issue(s)
https://github.com/aces/Loris/issues/7746

![Screen Shot 2021-11-05 at 11 44 09 AM](https://user-images.githubusercontent.com/9876007/140540146-f386da1a-7941-4f12-9565-f3976518ab1e.png)
)
