### PR TITLE
[BrainBrowser] Fix duplicate download of image data

### DIFF
--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -754,7 +754,7 @@ $(function() {
         $.ajax({
           url: loris.BaseURL + "/brainbrowser/ajax/image.php",
           data: 'file_id=' + minc_id,
-          method: 'GET',
+          method: 'HEAD',
           success: function (response, status, jqXHR) {
             let type = jqXHR.getResponseHeader('Content-Type');
             let fileid = jqXHR.getResponseHeader('X-FileID');


### PR DESCRIPTION
This fixes an issue where image data is downloaded twice by
BrainBrowser. The brainbrowser.loris.js file makes a request to
image.php to get metadata for the file from http headers, and then passes
the URL to brainbrowser which makes a separate data.

Replace the GET request with a HEAD request from the LORIS side so
that only the brainbrowser library downloads the data.

Resolves #7805