### PR TITLE
[survey_accounts] Fixed base URL not being set properly

### DIFF
--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -313,7 +313,9 @@ class NDB_Factory
      */
     public function setBaseURL(string $baseURL)
     {
-        $this->_baseURL = $baseURL;
+        // Reset static settings object so that the base URL can be properly set
+        self::$_settings = null;
+        $this->_baseURL  = $baseURL;
     }
     /**
      * Returns a singleton settings object

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -118,6 +118,8 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $baseurl = $uri->withPath($baseurl)->withQuery("");
             $request = $request->withAttribute("baseurl", $baseurl->__toString());
 
+            // Reset factory object so that the base URL can be reset
+            $factory->reset();
             $factory->setBaseURL($baseurl);
 
             $module  = \Module::factory($modulename);

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -118,8 +118,6 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $baseurl = $uri->withPath($baseurl)->withQuery("");
             $request = $request->withAttribute("baseurl", $baseurl->__toString());
 
-            // Reset factory object so that the base URL can be reset
-            $factory->reset();
             $factory->setBaseURL($baseurl);
 
             $module  = \Module::factory($modulename);


### PR DESCRIPTION
When `\NDB_Factory::singleton()->settings()->getBaseURL()` was called, an empty string was returned, so the emails sent to users when a survey is created were not displaying the correct URL. This bug fix should also solve similar errors from occurring in other modules that use the above line.

The issue occurs because the line `$DB = $factory->database()` is called in [NDB_Cient](https://github.com/aces/Loris/blob/6356a1ea5d01e719ca560695d31bcf569004f3e6/php/libraries/NDB_Client.class.inc#L59) before the baseURL for the factory object is set to the correct value in the BaseRouter using `setBaseURL`. The database() function constructs the factory's static Settings object with an empty baseURL, so the baseURL ends up being an empty string instead of the correct value. This bug is fixed by adding the line  `$factory->reset()` before setting the URL, which resets the Settings object and its variables.  

#### Testing instructions (if applicable)

**For the survey account module**
1. Go to the Survey Accounts page and add a new survey
2. Include an email address and select "Email Survey"
3. Check that the email contains a **clickable** link that directs you to the correct survey 

**For the bug in general:**
To see that the line `\NDB_Factory::singleton()->settings()->getBaseURL()` works correctly throughout the codebase, you can add an error_log message anywhere it is used and see that it returns the base URL for your Loris instance. 

#### Link to related issue

* Resolves #7668
