### PR TITLE
[EEG Browser][Bugfix] Fix Epochs and Electrodes URL Retrieval

### DIFF
--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -206,16 +206,22 @@ class ElectrophysiologySessionView extends Component {
                 ),
             epochsURL:
                 dbEntry
-                && dbEntry.file.downloads[3]?.file
-                && loris.BaseURL
-                + '/electrophysiology_browser/file_reader/?file='
-                + dbEntry.file.downloads[3].file,
+                && dbEntry.file.downloads.map(
+                  (group) =>
+                    group.links[3]?.file
+                    && loris.BaseURL
+                      + '/electrophysiology_browser/file_reader/?file='
+                      + group.links[3].file
+                ),
             electrodesURL:
                 dbEntry
-                && dbEntry.file.downloads[1]?.file
-                && loris.BaseURL
-                + '/electrophysiology_browser/file_reader/?file='
-                + dbEntry.file.downloads[1].file,
+                && dbEntry.file.downloads.map(
+                  (group) =>
+                    group.links[1]?.file
+                    && loris.BaseURL
+                      + '/electrophysiology_browser/file_reader/?file='
+                      + group.links[1].file
+                ),
           }));
 
           this.setState({


### PR DESCRIPTION
## Brief summary of changes
This PR addresses the issue reported in #7810 

#### Testing instructions (if applicable)

1. Go to `EEG Browser`
2. Ensure that the events panel and electrode panels are visible


<img width="1440" alt="Screen Shot 2021-11-09 at 10 05 30 AM" src="https://user-images.githubusercontent.com/34260251/140949408-3a7dab35-e594-45b1-9d88-356dc9071ac2.png">
<img width="1440" alt="Screen Shot 2021-11-09 at 10 05 39 AM" src="https://user-images.githubusercontent.com/34260251/140949432-1dc4cc79-d760-4058-a88d-09611dd04bfd.png">


#### Link(s) to related issue(s)

* Resolves #7810 
