### PR TITLE
[issue_tracker] Fix loading of page without superuser permission

### DIFF
--- a/modules/battery_manager/php/test.class.inc
+++ b/modules/battery_manager/php/test.class.inc
@@ -30,16 +30,26 @@ class Test implements
     \LORIS\StudyEntities\MultiSiteHaver
 {
     public $row;
+    private ?\CenterID $center;
+    private \LORIS\LorisInstance $loris;
 
     /**
      * Create a new Test Instance.
      *
-     * @param array $row The row (in the same format as \Database::pselectRow returns
-     *                   returns
+     * @param \LORIS\LorisInstance $loris  The LORIS instance with the test
+     * @param ?\CenterID           $center The site this test is
+                                           applied at, if applicable
+     * @param array                $row    The row (in the same format as
+                                           \Database::pselectRow returns
      */
-    public function __construct(array $row)
-    {
-        $this->row = $row;
+    public function __construct(
+        \LORIS\LorisInstance $loris,
+        ?\CenterID $center,
+        array $row
+    ) {
+        $this->row    = $row;
+        $this->center = $center;
+        $this->loris  = $loris;
     }
 
     /**
@@ -56,14 +66,19 @@ class Test implements
      * Returns the CenterID for this row, for filters such as
      * \LORIS\Data\Filters\UserSiteMatch to match again.
      *
-     * @return array The CenterIDs
+     * @return \CenterID[] array The CenterIDs
      */
     public function getCenterIDs() : array
     {
-        $siteList = array_keys(\Utility::getSiteList(false));
-        $cids     = isset($this->row['centerId']) ? [$this->row['centerId']]
-            : $siteList;
-        return $cids;
+        if ($this->center !== null) {
+            return [$this->center];
+        }
+        return array_map(
+            function ($site) {
+                return $site->getCenterID();
+            },
+            $this->loris->getAllSites()
+        );
     }
 
     /**

--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -29,7 +29,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class TestEndpoint implements RequestHandlerInterface
+class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
 {
 
     /**
@@ -121,7 +121,7 @@ class TestEndpoint implements RequestHandlerInterface
      */
     private function _getDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new TestProvisioner();
+        $provisioner = new TestProvisioner($this->loris);
 
         if ($this->user->hasPermission('access_all_profiles') == false) {
             $provisioner = $provisioner->filter(
@@ -142,7 +142,7 @@ class TestEndpoint implements RequestHandlerInterface
     private function _putInstance(ServerRequestInterface $request)
     {
         $testArray = json_decode($request->getBody()->getContents(), true);
-        $test      = new Test($testArray);
+        $test      = new Test($this->loris, null, $testArray);
         return $this->_saveInstance($test);
     }
 
@@ -156,7 +156,7 @@ class TestEndpoint implements RequestHandlerInterface
     private function _postInstance(ServerRequestInterface $request)
     {
         $testArray = json_decode($request->getBody()->getContents(), true);
-        $test      = new Test($testArray);
+        $test      = new Test($this->loris, null, $testArray);
         $test->row['active'] = 'Y';
         return $this->_saveInstance($test);
     }

--- a/modules/battery_manager/php/testprovisioner.class.inc
+++ b/modules/battery_manager/php/testprovisioner.class.inc
@@ -30,11 +30,16 @@ namespace LORIS\battery_manager;
  */
 class TestProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
+    private \LORIS\LorisInstance $loris;
+
     /**
-     * Create a Test Instance, which get rows fro mthe test_battery table.
+     * Create a Test Instance, which get rows from the test_battery table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance with the battery
      */
-    public function __construct()
+    public function __construct(\LORIS\LorisInstance $loris)
     {
+        $this->loris = $loris;
         parent::__construct(
             "SELECT b.id,
                t.Test_name as testName,
@@ -65,6 +70,12 @@ class TestProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        return new Test($row);
+        return new Test(
+            $this->loris,
+            isset($row['centerId'])
+                ? new \CenterID($row['centerId'])
+                : null,
+            $row
+        );
     }
 }

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -54,7 +54,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
      */
     function getDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new IssueRowProvisioner();
+        $provisioner = new IssueRowProvisioner($this->loris);
 
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();

--- a/modules/issue_tracker/php/issuerow.class.inc
+++ b/modules/issue_tracker/php/issuerow.class.inc
@@ -22,10 +22,10 @@ class IssueRow implements
     /**
      * Create a new IssueRow
      *
-     * @param array   $row    The row (in the same format as \Database::pselectRow
-     *                        returns.
-     * @param array   $cids   The centerIDs affiliated with this row.
-     * @param \Module $module The module that this issue is for.
+     * @param array       $row    The row (in the same format
+                                  as \Database::pselectRow returns.)
+     * @param \CenterID[] $cids   The centerIDs affiliated with this row.
+     * @param \Module     $module The module that this issue is for.
      */
     public function __construct(array $row, array $cids, \Module $module)
     {

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -30,17 +30,24 @@ namespace LORIS\issue_tracker;
  */
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-    private $_siteList;
+    private array $allCenterIDs;
 
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance with the issues
      */
-    function __construct()
+    function __construct(\LORIS\LorisInstance $loris)
     {
-        $factory         = \NDB_Factory::singleton();
-        $user            = $factory->user();
-        $this->_siteList = array_keys(\Utility::getSiteList(false));
-        $userID          = $user->getUsername();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $this->allCenterIDs = array_map(
+            function ($center) {
+                return $center->getCenterID();
+            },
+            $loris->getAllSites()
+        );
+        $userID = $user->getUsername();
         //note that this needs to be in the same order as the headers array
         parent::__construct(
             "SELECT i.issueID,
@@ -102,22 +109,13 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 
         if (isset($row['centerId'])) {
             // convert the value from string to int array
-            $cids = [intval($row['centerId'])];
+            $cids = [new \CenterID($row['centerId'])];
 
-            // convert the value from string to string array
-            $row['centerId'] = [$row['centerId']];
         } else {
-            // set $cids to all centersID (int array)
-            $cids = $this->_siteList;
-
-            // set $row['centerId'] to all centersID
-            // Use getCenterIDs and convert values to string (string array)
-            $row['centerId'] = array_map(
-                "strval",
-                $this->_siteList
-            );
+            $cids = $this->allCenterIDs;
         }
 
+        $row['centerId']   = $cids;
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);
         return new IssueRow($row, $cids, $module);
     }

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -126,4 +126,23 @@ class LorisInstance
     {
         return $this->config;
     }
+
+    /**
+     * Returns a list of Site objects that are valid for this
+     * Loris instance
+     *
+     * @return \Site[]
+     */
+    public function getAllSites() : array
+    {
+        $DB      = $this->getDatabaseConnection();
+        $centers = $DB->pselectCol("SELECT CenterID FROM psc", []);
+
+        return array_map(
+            function ($center) {
+                return \Site::singleton(new \CenterID($center));
+            },
+            $centers
+        );
+    }
 }


### PR DESCRIPTION
Fix issue tracker to load the correct type, as required by the
MultiSiteHaver interface that it declares itself to implement.

phan was not able to track down the type incompatibilities because
the docblock was using the less specific "array" and not the typed
"\CenterID[]" array.

Resolves #7799