### PR TITLE
[imaging_browser] Use API for thumbnail and download

### DIFF
--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -648,15 +648,20 @@ class DownloadButton extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
-    if (!this.props.FileName || this.props.FileName === '') {
+    const empty = (prop) => {
+        return !prop || prop == '';
+    };
+    if (empty(this.props.FileName) && empty(this.props.URL)) {
       return <span/>;
     }
     let style = {
       margin: 6,
     };
+    const url = this.props.URL ||
+        (this.props.BaseURL
+           + '/mri/jiv/get_file.php?file=' + this.props.FileName);
     return (
-      <a href={this.props.BaseURL + '/mri/jiv/get_file.php?file=' +
-      this.props.FileName}
+      <a href={url}
          className="btn btn-default" style={style}>
         <span className="glyphicon glyphicon-download-alt"></span>
         <span className="hidden-xs">{this.props.Label}</span>
@@ -806,7 +811,7 @@ class ImageDownloadButtons extends Component {
         <ImageQCCommentsButton FileID={this.props.FileID}
                                BaseURL={this.props.BaseURL}
         />
-        <DownloadButton FileName={this.props.Fullname}
+        <DownloadButton URL={this.props.APIFile}
                         Label="Download Minc"
                         BaseURL={this.props.BaseURL}
         />
@@ -833,6 +838,7 @@ class ImageDownloadButtons extends Component {
 ImageDownloadButtons.propTypes = {
   FileID: PropTypes.string,
   BaseURL: PropTypes.string,
+  APIFile: PropTypes.string,
   Fullname: PropTypes.string,
   XMLProtocol: PropTypes.string,
   XMLReport: PropTypes.string,
@@ -877,7 +883,7 @@ class ImagePanelBody extends Component {
           <div className="col-xs-9 imaging_browser_pic">
             <a href="#noID" onClick={this.openWindowHandler}>
               <img className="img-checkpic img-responsive"
-                   src={this.props.Checkpic}/>
+                   src={this.props.APIFile + '/format/thumbnail'}/>
             </a>
           </div>
           <div className="col-xs-3 mri-right-panel">
@@ -897,7 +903,7 @@ class ImagePanelBody extends Component {
         <ImageDownloadButtons
           BaseURL={this.props.BaseURL}
           FileID={this.props.FileID}
-          Fullname={this.props.Fullname}
+          APIFile={this.props.APIFile}
           XMLProtocol={this.props.XMLProtocol}
           XMLReport={this.props.XMLReport}
           NrrdFile={this.props.NrrdFile}
@@ -920,12 +926,12 @@ ImagePanelBody.propTypes = {
   SeriesUID: PropTypes.string,
   BaseURL: PropTypes.string,
   Fullname: PropTypes.string,
+  APIFile: PropTypes.string,
   XMLProtocol: PropTypes.string,
   XMLReport: PropTypes.string,
   NrrdFile: PropTypes.string,
   OtherTimepoints: PropTypes.string,
   HeadersExpanded: PropTypes.string,
-  Checkpic: PropTypes.string,
   CaveatViolationsResolvedID: PropTypes.string,
 };
 
@@ -992,7 +998,7 @@ class ImagePanel extends Component {
 
               FileID={this.props.FileID}
               Filename={this.props.Filename}
-              Checkpic={this.props.Checkpic}
+              APIFile={this.props.APIFile}
               HeadersExpanded={!this.state.HeadersCollapsed}
 
               HeaderInfo={this.props.HeaderInfo}
@@ -1034,7 +1040,7 @@ ImagePanel.propTypes = {
   OtherTimepoints: PropTypes.string,
   HeaderInfo: PropTypes.string,
   HeadersExpanded: PropTypes.string,
-  Checkpic: PropTypes.string,
+  APIFile: PropTypes.string,
   CaveatViolationsResolvedID: PropTypes.string,
 };
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -193,7 +193,15 @@ class ViewSession extends \NDB_Form
                      files.File",
             $args
         );
+
         $this->tpl_data['files'] = [];
+
+        $timePoint = \TimePoint::singleton(
+            new \SessionID($this->sessionID),
+        );
+        $factory   = \NDB_Factory::singleton();
+        $baseurl   = $factory->settings()->getBaseURL();
+
         foreach ($files as $fileRow) {
             $FileObj = new \MRIFile(intval($fileRow['FileID']));
             if (empty($scannerID)) {
@@ -208,18 +216,15 @@ class ViewSession extends \NDB_Form
                 }
             }
 
-            $FullFilename     = $FileObj->getParameter('File') ?? '';
-            $checkPicFilename = $FileObj->getParameter(
-                'check_pic_filename'
-            ) ?? '';
-            $FileID           = intval($fileRow['FileID']);
-            $Filename         = $JivFilename = basename($FullFilename);
-            $CheckPic         = "/mri/jiv/get_file.php?file=pic/". $checkPicFilename;
-            $JivAddress       = str_replace(
-                '_check.jpg',
-                '',
-                $checkPicFilename
-            );
+            $FullFilename = $FileObj->getParameter('File') ?? '';
+            $FileID       = intval($fileRow['FileID']);
+            $Filename     = basename($FullFilename);
+            $APIFile      = $baseurl . "/api/v0.0.3/candidates/"
+                    . $timePoint->getCandID() . "/"
+                    . $timePoint->getVisitLabel()
+                    . "/images/"
+                    . $Filename;
+
             $New        = ($FileObj->getParameter('QCFirstChangeTime') == '') ?
                                          1 : 0;
             $Pipeline   = $FileObj->getParameter('Pipeline');
@@ -305,10 +310,8 @@ class ViewSession extends \NDB_Form
             $file   = [
                 'FileID'                     => $FileID,
                 'Filename'                   => $Filename,
-                'CheckPic'                   => $CheckPic,
+                'APIFile'                    => $APIFile,
                 'FullFilename'               => $FullFilename,
-                'JivFilename'                => $JivFilename,
-                'JivAddress'                 => $JivAddress,
                 'New'                        => $New,
                 'Pipeline'                   => $Pipeline,
                 'OutputType'                 => $OutputType,

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -25,7 +25,7 @@
                       'FileID'   : "{$files[file].FileID}",
                       'Filename' : "{$files[file].Filename}",
                       'QCStatus' : "{$files[file].QCStatus}",
-                      'Checkpic' : "{$files[file].CheckPic}",
+                      'APIFile' : "{$files[file].APIFile}",
 
                       'HasQCPerm': {if $has_qc_permission}true{else}false{/if},
                       'FileNew'  : {if $files[file].New}true{else}false{/if},


### PR DESCRIPTION
This updates the imaging browser to use the "thumbnail"
API which is specifically defined for that purpose. It
also updates the "Download Minc" button to use the API.