### PR TITLE
[NDB_BVL_Instrument] fix support for JSONData instruments

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -146,7 +146,12 @@ trait LorisFormDictionaryImpl
      */
     public function getDataDictionary() : iterable
     {
-        $subtests =$this->getSubtestList();
+        $subtests = array_merge(
+            [
+                ["Name"=>"","Description"=>""]
+            ],
+            $this->getSubtestList()
+        );
         foreach ($subtests as $subtest) {
             $this->page = $subtest['Name'];
 

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -32,6 +32,12 @@ trait LorisFormDictionaryImpl
     public $testName;
 
     /**
+     * Variable from NDB_Page. Must be included in trait
+     * to avoid PhanUndeclaredProperty errors.
+     */
+    protected $lorisinstance;
+
+    /**
      * Recursively extract non-group elements from $elements, and
      * return the dictionary of the items.
      *
@@ -146,27 +152,36 @@ trait LorisFormDictionaryImpl
      */
     public function getDataDictionary() : iterable
     {
-        $subtests = array_merge(
+        // Create new instance of the same instrument to avoid altering variables
+        // in $this instrument
+        $instrument = \NDB_BVL_Instrument::factory(
+            $this->lorisinstance,
+            $this->testName
+        );
+        $subtests   = array_merge(
             [
                 ["Name"=>"","Description"=>""]
             ],
-            $this->getSubtestList()
+            $instrument->getSubtestList()
         );
         foreach ($subtests as $subtest) {
-            $this->page = $subtest['Name'];
+            $instrument->page = $subtest['Name'];
 
             if (method_exists($this, '_setupForm')) {
                 // False positive from phan. We're inside a
                 // method_exists check
                 /* @phan-suppress-next-line PhanUndeclaredMethod */
-                $this->_setupForm();
+                $instrument->_setupForm();
             }
         }
 
-        $formElements = $this->form->toElementArray();
-        $cat          = new Category($this->testName, $this->getFullName());
-        return $this->_getDataDictionaryGroup(
-            $this->testName . "_",
+        $formElements = $instrument->form->toElementArray();
+        $cat          = new Category(
+            $instrument->testName,
+            $instrument->getFullName()
+        );
+        return $instrument->_getDataDictionaryGroup(
+            $instrument->testName . "_",
             $cat,
             $formElements["elements"],
             ''

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -451,7 +451,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $retVal
             );
             if ($retVal != 0) {
-                print "An error occurred while running the scoring 
+                print "An error occurred while running the scoring
                 algorithm of instrument ".$this->testName.".";
             }
         }
@@ -1403,12 +1403,17 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getFieldValue(string $field)
     {
-        $allValues = $this->getInstanceData();
+        $allValues  = $this->getInstanceData();
+        $dictionary = $this->getDataDictionary();
 
-        if (!array_key_exists($field, $allValues)) {
-            throw new \OutOfBoundsException("Invalid field for instrument");
+        foreach ($dictionary as $item) {
+            if ($field === $item->getName()) {
+                return $allValues[$field];
+            }
         }
-        return $allValues[$field];
+        throw new \OutOfBoundsException(
+            "Invalid field $field for instrument $this->testName"
+        );
     }
 
 
@@ -2517,10 +2522,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ['TN' => $this->testName]
         );
 
-        $Responses = $DB->pselectRow(
-            "SELECT * FROM " . $this->table . " WHERE CommentID=:CID",
-            ['CID' => $this->getCommentID()]
-        );
+        $Responses = $this->getInstanceData();
 
         foreach ($tpl_data['questions'] as &$row) {
             if (isset($Responses[$row['SourceField']])) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1307,7 +1307,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     echo "$rule[0] ";
                 }
 
-                //Handle select multiples who's controllre values are arrays.
+                //Handle select multiples who's controller values are arrays.
 
                 //explicitly cast the controller value as an array
                 if (!is_array($elements[$rule[0]])) {
@@ -1407,7 +1407,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $dictionary = $this->getDataDictionary();
 
         foreach ($dictionary as $item) {
-            if ($field === $item->getName()) {
+            // The Field name to compare to in the data dictionary is
+            // prefixed with the testname
+            $dictionaryFieldName = $this->testName."_".$field;
+            if ($dictionaryFieldName === $item->getName()) {
                 return $allValues[$field];
             }
         }

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -86,7 +86,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             $this->dictionary,
             [
                 new DictionaryItem(
-                    'Date_taken',
+                    $this->testName.'_Date_taken',
                     'Date of Administration',
                     $scope,
                     new \LORIS\Data\Types\DateType(),
@@ -105,7 +105,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->dictionary,
                     [
                         new DictionaryItem(
-                            'Candidate_age',
+                            $this->testName.'_Candidate_age',
                             'Candidate Age (Months)',
                             $scope,
                             new \LORIS\Data\Types\Duration(),
@@ -123,7 +123,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->dictionary,
                     [
                         new DictionaryItem(
-                            'Candidate_age',
+                            $this->testName.'_Candidate_age',
                             'Candidate Age At Death (Months)',
                             $scope,
                             new \LORIS\Data\Types\Duration(),
@@ -140,7 +140,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 $this->dictionary,
                 [
                     new DictionaryItem(
-                        'Window_Difference',
+                        $this->testName.'_Window_Difference',
                         'Window difference from test battery (days)',
                         $scope,
                         new \LORIS\Data\Types\Duration(),
@@ -164,7 +164,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             $this->dictionary,
             [
                 new DictionaryItem(
-                    'Examiner',
+                    $this->testName.'_Examiner',
                     'Examiner',
                     $scope,
                     // This should be an enum of examiners, but
@@ -595,7 +595,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
                     }
                     $this->dictionary[] = new DictionaryItem(
-                        $pieces[1],
+                        $this->testName."_".$pieces[1],
                         $pieces[2],
                         $scope,
                         new StringType(255),
@@ -620,7 +620,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
                     }
                     $this->dictionary[] = new DictionaryItem(
-                        $pieces[1],
+                        $this->testName."_".$pieces[1],
                         $pieces[2],
                         $scope,
                         new StringType(),
@@ -648,7 +648,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
 
                         $this->dictionary[] = new DictionaryItem(
-                            $pieces[1],
+                            $this->testName."_".$pieces[1],
                             $pieces[2],
                             $scope,
                             new DateType(),
@@ -716,7 +716,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     if ($addElements) {
                         $this->addNumericElement($pieces[1], $pieces[2]);
                         $this->dictionary[] = new DictionaryItem(
-                            $pieces[1],
+                            $this->testName."_".$pieces[1],
                             $pieces[2],
                             $scope,
                             new IntegerType(),
@@ -819,7 +819,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
                     $t  = new Enumeration(...$dictopts);
                     $it = new DictionaryItem(
-                        $pieces[1],
+                        $this->testName."_".$pieces[1],
                         $pieces[2],
                         $scope,
                         $t,
@@ -857,7 +857,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             = ['type' => 'score'];
 
                         $this->dictionary[] = new DictionaryItem(
-                            $pieces[1],
+                            $this->testName."_".$pieces[1],
                             $pieces[2],
                             $scope,
                             new StringType(255),

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -118,6 +118,15 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->quickForm = new \LorisForm();
 
+        $dictionaryItem = $this->getMockBuilder(
+            \LORIS\Data\Dictionary\DictionaryItem::class
+        )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dictionaryItem->method('getName')
+            ->willReturn('Test_Date_taken');
+        '@phan-var \LORIS\Data\Dictionary\DictionaryItem $dictionaryItem';
+
         $instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
             ->onlyMethods(
@@ -126,9 +135,10 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $instrument->method('getFullName')->willReturn("Test Instrument");
         $instrument->method('getSubtestList')->willReturn([]);
-        $instrument->method('getDataDictionary')->willReturn([]);
+        $instrument->method('getDataDictionary')->willReturn([$dictionaryItem]);
 
         '@phan-var \NDB_BVL_Instrument $instrument';
+
         $instrument->form     = $this->quickForm;
         $instrument->testName = "Test";
 
@@ -1140,8 +1150,8 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table     = 'medical_history';
         $this->assertEquals(
-            'Test Examiner1',
-            $this->_instrument->getFieldValue('Examiner')
+            '2010-05-05',
+            $this->_instrument->getFieldValue('Date_taken')
         );
     }
 
@@ -1252,7 +1262,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setTableData();
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table     = 'medical_history';
-        $this->_instrument->testName  = 'Test Name1';
+        $this->_instrument->testName  = 'Test';
         $values = ['Date_taken' => '2005-06-06'];
         $this->_instrument->_saveCandidateAge($values);
         $this->assertEquals(
@@ -1309,7 +1319,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setTableData();
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table     = 'medical_history';
-        $this->_instrument->testName  = 'TestName1';
+        $this->_instrument->testName  = 'Test';
         $this->_instrument->formType  = "XIN";
         $values = ['Date_taken' => '2005-06-06',
             'arthritis_age'        => 2,
@@ -1870,13 +1880,13 @@ class NDB_BVL_Instrument_Test extends TestCase
                     'CommentID'  => 'commentID1',
                     'UserID'     => '456',
                     'Examiner'   => 'Test Examiner1',
-                    'Date_taken' => '2010-05-05 00:00:01'
+                    'Date_taken' => '2010-05-05'
                 ],
                 [
                     'CommentID'  => 'commentID2',
                     'UserID'     => '457',
                     'Examiner'   => 'Test Examiner2',
-                    'Date_taken' => '2010-05-05 00:00:01'
+                    'Date_taken' => '2010-05-05'
                 ],
             ]
         );


### PR DESCRIPTION
## Brief summary of changes
Fix a couple instances where the Instrument class does not support JSONData instruments by either looking for a specific field in the not-yet-populated instrument data object or using the `$this->table` variable

Testing

1. choose a JSONData=true instrument (you can turn `false` into `true` in the `bmi.meta` file for an easy instruement)
2. set he `Data` column to `NULL` directly in the flag table in the database
3. try entering the "Date of Administration" and other required fields on the top page and save.

Without this PR the save will fail claiming the `Date_taken` field does not exist in the instrument. With this PR, issue should be solved