### PR TITLE
[NDB_BVL_Instrument] JSON Data support fix DECS field

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1652,7 +1652,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function getDataEntryCompletionStatus(): string
     {
         $data = NDB_BVL_Instrument::loadInstanceData($this);
-        return $data["Data_entry_completion_status"];
+        return $data["Data_entry_completion_status"] ?? '';
     }
 
 


### PR DESCRIPTION
## Brief summary of changes
When Data column is empty (before first save) this returns `NULL` which causes an issue since this method expects a string returned