### PR TITLE
[assign_missing_instruments] Error runing in confirm mode fix

### DIFF
--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -116,9 +116,17 @@ function populateVisitLabel($result, $visit_label)
         $timePoint->getVisitLabel()."\nMissing Instruments:\n";
         print_r($diff);
     }
+        $lorisinstance = new \LORIS\LorisInstance(
+            \NDB_Factory::singleton()->database(),
+            \NDB_Factory::singleton()->config(),
+            [
+                __DIR__ . "/../project/modules",
+                __DIR__ . "/../modules/",
+            ]
+        );
     if ($confirm === true) {
         foreach ($diff as $test_name) {
-            $battery->addInstrument($test_name);
+            $battery->addInstrument($lorisinstance, $test_name);
         }
     }
 


### PR DESCRIPTION
## Brief summary of changes
 
#### Testing instructions (if applicable)

1.  cd tools
2. run " php assign_missing_instruments confirm "

#### Link(s) to related issue(s)

https://github.com/aces/Loris/issues/7797