### PR TITLE
[DQT] Fix broken file link when querying using 'Add All'

### DIFF
--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -418,7 +418,7 @@ class FieldSelector extends Component {
         } else {
           isFile = (this.state.categoryFields[
             category
-            ][i].value.isFile)
+            ][i].value.IsFile)
             ? true
             : false;
           this.props.onFieldChange(fieldName, category, isFile);
@@ -447,7 +447,7 @@ class FieldSelector extends Component {
           ][i].key[0];
         if (this.props.selectedFields[category]
           && this.props.selectedFields[category][fieldName]) {
-          isFile = (this.state.categoryFields[category][i].value.isFile)
+          isFile = (this.state.categoryFields[category][i].value.IsFile)
             ? true
             : false;
           this.props.onFieldChange(fieldName, category, isFile);

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -63,7 +63,7 @@ class CouchDBMRIImporter
     function run()
     {
         $ScanTypes = $this->getScanTypes();
-        if (empty($scanTypes)) {
+        if (empty($ScanTypes)) {
             fwrite(STDERR, "No scan types found to import.\n");
             exit(1);
         }


### PR DESCRIPTION
## Brief summary of changes

Downloadable files i.e. minc files are missing their download links when the 'Add All' button is used to select a query.
This PR fixes that by fixing a typo found.
This PR also fixes a typo in the CouchDB MRI import script that fails to find any scan types to import

#### Testing instructions (if applicable)

1. On main, go to the new DQT module. Select mri_data category, filter for 'selected' string, and click on 'Add All'. Run the query and notice that the mri files appear as the correct path, but is not a downloadable link.
2. Repeat the above step, but only select one 'Selected_ ...' field without clicking on 'Add All'. Run the query and you will see that the mri files are downloadable links.
3. On this PR branch, repeat step 1 and confirm that the mri files are now downloadable links as seen in step 2.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
