### PR TITLE
[create_timepoint] Code refactor to display proper select options based on previous selections

### DIFF
--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -141,7 +141,6 @@ class CreateTimepoint extends React.Component {
             state.form.display.project = true;
           }
           // Populate the select options for visit.
-          console.log(data);
           if (data.visit) {
             // Store the (complete) visit selection information.
             state.storage.visit = data.visit;

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -210,16 +210,7 @@ class CreateTimepoint extends React.Component {
    */
   handleVisitLabel() {
     const state = Object.assign({}, this.state);
-    if (Array.isArray(state.storage.visit[state.form.value.subproject])) {
-      // Display error message to user.
-      const errorMessage = `No visit labels defined for subproject: ${
-        this.state.form.options.visit[
-          this.state.form.value.subproject
-      ]}`;
-      state.messages = [errorMessage];
-      swal.fire(errorMessage, '', 'error');
-      state.form.options.visit = {};
-    } else if (state.storage.visit[
+    if (state.storage.visit[
         state.form.value.project
       ] !== undefined) {
       if (Array.isArray(state.storage.visit[

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -178,12 +178,13 @@ class CreateTimepoint extends React.Component {
   handleSubproject() {
     const state = Object.assign({}, this.state);
     if (Array.isArray(state.storage.subproject[state.form.value.project])) {
-      // Display error message to user. show swal error.
-      state.messages = [
-        `No subprojects defined for project: ${this.state.form.options.project[
+      // Display error message to user.
+      const errorMessage = `No subprojects defined for project: ${
+        this.state.form.options.project[
           this.state.form.value.project
-        ]}`,
-      ];
+      ]}`;
+      state.messages = [errorMessage];
+      swal.fire(errorMessage, '', 'error');
       state.form.options.subproject = {};
       state.form.options.visit = {};
     } else {
@@ -210,13 +211,13 @@ class CreateTimepoint extends React.Component {
   handleVisitLabel() {
     const state = Object.assign({}, this.state);
     if (Array.isArray(state.storage.visit[state.form.value.subproject])) {
-      // Display error message to user. show swal error.
-      state.messages = [
-        `No visit labels defined for subproject:
-        ${this.state.form.options.visit[
+      // Display error message to user.
+      const errorMessage = `No visit labels defined for subproject: ${
+        this.state.form.options.visit[
           this.state.form.value.subproject
-        ]}`,
-      ];
+      ]}`;
+      state.messages = [errorMessage];
+      swal.fire(errorMessage, '', 'error');
       state.form.options.visit = {};
     } else if (state.storage.visit[
         state.form.value.project

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -222,10 +222,22 @@ class CreateTimepoint extends React.Component {
     } else if (state.storage.visit[
         state.form.value.project
       ] !== undefined) {
-      state.form.options.visit = state.storage.visit[
-        state.form.value.project
-      ][state.form.value.subproject];
-      state.form.value.visit = null;
+      if (Array.isArray(state.storage.visit[
+        state.form.value.project][state.form.value.subproject])
+      ) {
+        const errorMessage = `No visit labels defined for subproject: ${
+          this.state.form.options.subproject[
+            this.state.form.value.subproject
+        ]}`;
+        state.messages = [errorMessage];
+        swal.fire(errorMessage, '', 'error');
+        state.form.options.visit = {};
+      } else {
+        state.form.options.visit = state.storage.visit[
+          state.form.value.project
+        ][state.form.value.subproject];
+        state.form.value.visit = null;
+      }
     }
     state.form.display.visit = true;
     if (Array.isArray(state.storage.visit) && !state.storage.visit.length) {

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -216,11 +216,12 @@ class CreateTimepoint extends React.Component {
       if (Array.isArray(state.storage.visit[
         state.form.value.project][state.form.value.subproject])
       ) {
-        const errorMessage = `No visit labels defined for ${
+        const errorMessage = `No visit labels defined for 
+        combination of project: ${
           this.state.form.options.project[
             this.state.form.value.project
           ]
-        }-${
+        } and subproject: ${
           this.state.form.options.subproject[
             this.state.form.value.subproject
         ]}`;

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -141,6 +141,7 @@ class CreateTimepoint extends React.Component {
             state.form.display.project = true;
           }
           // Populate the select options for visit.
+          console.log(data);
           if (data.visit) {
             // Store the (complete) visit selection information.
             state.storage.visit = data.visit;
@@ -179,6 +180,9 @@ class CreateTimepoint extends React.Component {
       state.form.value.subproject
       ];
     state.form.display.visit = true;
+    if (Array.isArray(state.storage.visit) && !state.storage.visit.length) {
+      state.form.display.visit = false;
+    }
     this.setState(state);
   }
 

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -216,7 +216,11 @@ class CreateTimepoint extends React.Component {
       if (Array.isArray(state.storage.visit[
         state.form.value.project][state.form.value.subproject])
       ) {
-        const errorMessage = `No visit labels defined for subproject: ${
+        const errorMessage = `No visit labels defined for ${
+          this.state.form.options.project[
+            this.state.form.value.project
+          ]
+        }-${
           this.state.form.options.subproject[
             this.state.form.value.subproject
         ]}`;

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -435,7 +435,6 @@ class CreateTimepoint extends React.Component {
     );
   }
 }
-
 CreateTimepoint.propTypes = {
   baseURL: PropTypes.string.isRequired,
 };

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -125,11 +125,6 @@ class CreateTimepoint extends React.Component {
       if (response.ok) {
         response.json().then((data) => {
           const state = Object.assign({}, this.state);
-          // Populate the select options for subproject.
-          if (data.hasOwnProperty('subproject')) {
-            state.form.options.subproject = data.subproject;
-            state.form.display.subproject = true;
-          }
           // Populate the select options for psc.
           if (data.psc) {
             state.form.options.psc = data.psc;
@@ -140,10 +135,17 @@ class CreateTimepoint extends React.Component {
             state.form.options.project = data.project;
             state.form.display.project = true;
           }
-          // Populate the select options for visit.
-          if (data.visit) {
+          // Populate the select options for subproject.
+          if (data.hasOwnProperty('subprojectGroups')) {
             // Store the (complete) visit selection information.
-            state.storage.visit = data.visit;
+            state.storage.subproject = data.subprojectGroups;
+            // Handle subproject selection.
+            this.handleSubproject();
+          }
+          // Populate the select options for visit.
+          if (data.hasOwnProperty('visitGroups')) {
+            // Store the (complete) visit selection information.
+            state.storage.visit = data.visitGroups;
             // Handle visit selection.
             this.handleVisitLabel();
           }
@@ -171,13 +173,59 @@ class CreateTimepoint extends React.Component {
   }
 
   /**
+   * Subproject refreshes when Project changes.
+   */
+  handleSubproject() {
+    const state = Object.assign({}, this.state);
+    if (Array.isArray(state.storage.subproject[state.form.value.project])) {
+      // Display error message to user. show swal error.
+      state.messages = [
+        `No subprojects defined for project: ${this.state.form.options.project[
+          this.state.form.value.project
+        ]}`,
+      ];
+      state.form.options.subproject = {};
+      state.form.options.visit = {};
+    } else {
+      state.form.options.subproject = state.storage.subproject[
+        state.form.value.project
+      ];
+      state.form.value.subproject = null;
+      state.form.value.visit = null;
+      // Remove existing error messages.
+      state.messages = [];
+    }
+    state.form.display.subproject = true;
+    if (Array.isArray(state.storage.subproject)
+      && !state.storage.subproject.length
+    ) {
+      state.form.display.subproject = false;
+    }
+    this.setState(state);
+  }
+
+  /**
    * Visit Labels refreshes when Subproject changes.
    */
   handleVisitLabel() {
     const state = Object.assign({}, this.state);
-    state.form.options.visit = state.storage.visit[
-      state.form.value.subproject
+    if (Array.isArray(state.storage.visit[state.form.value.subproject])) {
+      // Display error message to user. show swal error.
+      state.messages = [
+        `No visit labels defined for subproject:
+        ${this.state.form.options.visit[
+          this.state.form.value.subproject
+        ]}`,
       ];
+      state.form.options.visit = {};
+    } else if (state.storage.visit[
+        state.form.value.project
+      ] !== undefined) {
+      state.form.options.visit = state.storage.visit[
+        state.form.value.project
+      ][state.form.value.subproject];
+      state.form.value.visit = null;
+    }
     state.form.display.visit = true;
     if (Array.isArray(state.storage.visit) && !state.storage.visit.length) {
       state.form.display.visit = false;
@@ -195,7 +243,9 @@ class CreateTimepoint extends React.Component {
     const state = Object.assign({}, this.state);
     state.form.value[formElement] = value;
     this.setState(state);
-    if (formElement === 'subproject') {
+    if (formElement === 'project') {
+      this.handleSubproject();
+    } else if (formElement === 'subproject') {
       this.handleVisitLabel();
     }
   }
@@ -369,9 +419,9 @@ class CreateTimepoint extends React.Component {
             label={'DCCID'}
             text={this.state.data.dccid}
           />
-          {subproject}
           {psc}
           {project}
+          {subproject}
           {visit}
           {languages}
           <ButtonElement

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -438,7 +438,6 @@ class CreateTimepoint extends React.Component {
 
 CreateTimepoint.propTypes = {
   baseURL: PropTypes.string.isRequired,
-  dataURL: PropTypes.string.isRequired,
 };
 
 /**
@@ -448,7 +447,6 @@ window.addEventListener('load', () => {
   ReactDOM.render(
     <CreateTimepoint
       baseURL={loris.BaseURL}
-      dataURL={`${loris.BaseURL}/create_timepoint/AjaxTimepoint`}
     />,
     document.getElementById('lorisworkspace')
   );

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -71,7 +71,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $userProjects   = $user->getProjects();
         $projectOptions = [];
         foreach ($userProjects as $project) {
-            $projectOptions[$project->getId()] = $project->getName();
+            $projectOptions[$project->getId()->__toString()] = $project->getName();
         }
         $values['project'] = $projectOptions;
         $values['psc']     = \Utility::getSiteNameListByIDs($user->getCenterIDs());
@@ -81,7 +81,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $subprojectGroups = [];
         foreach ($projectOptions as $pid=>$pname) {
             $subprojectGroups[$pid] = \Utility::getSubprojectList(
-                new \ProjectID($pid)
+                new \ProjectID(strval($pid))
             );
         }
         $values['subprojectGroups'] = $subprojectGroups;
@@ -91,7 +91,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         foreach ($subprojectGroups as $pid=>$subprojectList) {
             foreach ($subprojectList as $sid=>$title) {
                 $visitGroups[$pid][$sid] = \Utility::getVisitsForProjectSubproject(
-                    new \ProjectID($pid),
+                    new \ProjectID(strval($pid)),
                     $sid
                 );
             }

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -92,7 +92,10 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         // Retrieve visit labels.
         $visit_options = [];
         foreach ($allSubprojects as $sid=>$title) {
-            $visit_options[$sid] = \Utility::getVisitsForSubproject($sid);
+            $visit_option = \Utility::getVisitsForSubproject($sid);
+            if (!empty($visit_option)) {
+                $visit_options[$sid] = $visit_option;
+            }
         }
         $values['visit'] = $visit_options;
 

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -64,46 +64,39 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         }
 
         // Setup variables
-        $conflict       = []; // conflict messages.
-        $candidate      = \Candidate::singleton(new CandID($values['candID']));
-        $allSubprojects = \Utility::getSubprojectList();
+        $conflict = []; // conflict messages.
 
-        // All subprojects from config file (error).
-        if (empty($allSubprojects)) {
-            $conflict['subprojectID'] = 'No subprojects have been defined
-            for this study. If you are an administrator, please use the
-            Configuration module to add new subprojects.';
+        //Projects and sites should be limited to the logged in user's affiliations
+        $user           = $request->getAttribute("user");
+        $userProjects   = $user->getProjects();
+        $projectOptions = [];
+        foreach ($userProjects as $project) {
+            $projectOptions[$project->getId()] = $project->getName();
         }
+        $values['project'] = $projectOptions;
+        $values['psc']     = \Utility::getSiteNameListByIDs($user->getCenterIDs());
 
-        // List of valid subprojects for a given project
-        $subprojList    = $candidate->getValidSubprojects();
-        $allSubprojects = \Utility::getSubprojectList();
-        if (empty($subprojList)) {
-            $conflict['subprojectID'] = 'No subprojects have been
-            defined for the project this candidate is affiliated with.
-            If you are an administrator, please use the Configuration module to
-            add new subprojects and associate them with projects.';
+        //Subprojects should be determined by project options
+        //Nested array of valid suprojects grouped by projects
+        $subprojectGroups = [];
+        foreach ($projectOptions as $pid=>$pname) {
+            $subprojectGroups[$pid] = \Utility::getSubprojectList(
+                new \ProjectID($pid)
+            );
         }
-        $values['subproject'] = array_intersect_key(
-            $allSubprojects,
-            $candidate->getValidSubprojects()
-        );
+        $values['subprojectGroups'] = $subprojectGroups;
 
-        // Retrieve visit labels.
-        $visit_options = [];
-        foreach ($allSubprojects as $sid=>$title) {
-            $visit_option = \Utility::getVisitsForSubproject($sid);
-            if (!empty($visit_option)) {
-                $visit_options[$sid] = $visit_option;
+        //Visits are determined by subproject-project associations.
+        $visitGroups = [];
+        foreach ($subprojectGroups as $pid=>$subprojectList) {
+            foreach ($subprojectList as $sid=>$title) {
+                $visitGroups[$pid][$sid] = \Utility::getVisitsForProjectSubproject(
+                    new \ProjectID($pid),
+                    $sid
+                );
             }
         }
-        $values['visit'] = $visit_options;
-
-        // List sites
-        $values['psc'] = array_intersect(
-            \Utility::getSiteList(),
-            \User::singleton()->getSiteNames()
-        );
+        $values['visitGroups'] = $visitGroups;
 
         // List languages
         $languages = \Utility::getLanguageList();
@@ -111,16 +104,6 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             $languages = [null] + $languages;
         }
         $values['languages'] = $languages;
-
-        // List projects
-        $user = \User::singleton();
-        $user_list_of_projects = $user->getProjectIDs();
-        $projectOptions        = [];
-        foreach ($user_list_of_projects as $projectID) {
-            $project = \Project::getProjectFromID($projectID);
-            $projectOptions["$projectID"] = $project->getName();
-        }
-        $values['project'] = $projectOptions;
 
         if (!empty($conflict)) {
             return new \LORIS\Http\Response\JSON\Conflict(

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -351,6 +351,41 @@ class Utility
     }
 
     /**
+     * Returns a list of visits associated with the supplied Project AND subproject.
+     * The visits are in an associative array format [VisitName=>VisitLabel]
+     *
+     * @param \ProjectID $projectID    ID of the project
+     * @param int        $subprojectID ID of the subproject
+     *
+     * @return array list of visits for supplied project-subproject combination
+     *
+     * @note This function should be moved to a visits class when it is created
+     */
+    static function getVisitsForProjectSubproject(
+        \ProjectID $projectID,
+        int $subprojectID
+    ): array {
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
+
+        $result = $DB->pselectColWithIndexKey(
+            "SELECT DISTINCT VisitID, VisitLabel
+            FROM visit v
+                JOIN visit_project_subproject_rel vpsr USING(VisitID)
+                JOIN project_subproject_rel psr USING(ProjectSubprojectRelID)
+	    WHERE SubprojectID = :sid
+		AND ProjectID = :pid
+            ORDER BY VisitLabel",
+            ["sid"=>$subprojectID, "pid"=>$projectID],
+            "VisitID"
+        );
+
+        return $result;
+    }
+
+
+
+    /**
      * Returns a list of bvl instruments
      *
      * Returns a list of instruments for a timepoint's stage ($stage).


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a few long-standing issues exacerbated by the addition of user-multisites and user-multiprojects. Below is the list of changes:
 - Cleanup of code duplication and inefficiencies
 - Reorganization of the fields in a more logical order on the front end
 - conditional display of options based on previous selections
 - swal prompts when study configurations are missing preventing the creation of a timepoint

#### Link(s) to related issue(s)

* Resolves #7602
