### PR TITLE
[bvl_feedback] Fix Permissions for Feedback Summary & Thread List

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -475,25 +475,38 @@ class NDB_BVL_Feedback
             $query .= " LEFT JOIN flag as f ON (ft.CommentID = f.CommentID)";
         }
         $query .= " WHERE ft.Active ='Y'";
+
+        $query .= " AND Public = 'Y' AND Status <> 'closed'";
+        if (!empty($this->_feedbackObjectInfo['CandID'])) {
+            $query            .= " AND ft.CandID = :CaID";
+            $qparams['CaID']   = $this->_feedbackObjectInfo['CandID'];
+            $candidate         = Candidate::singleton(new CandID($qparams['CaID']));
+            $hasReadPermission = (
+                $hasReadPermission ||
+                $candidate->isAccessibleBy($user)
+            );
+        }
+        if (!empty($this->_feedbackObjectInfo['SessionID'])) {
+            $query            .= " AND ft.SessionID = :SID";
+            $qparams['SID']    = $this->_feedbackObjectInfo['SessionID'];
+            $timepoint         = Timepoint::singleton(
+                new SessionID($qparams['SID'])
+            );
+            $hasReadPermission = (
+                $hasReadPermission ||
+                $timepoint->isAccessibleBy($user)
+            );
+        }
+        if (!empty($this->_feedbackObjectInfo['CommentID'])) {
+            $query           .= " AND ft.CommentID = :ComID";
+            $qparams['ComID'] = $this->_feedbackCandidateProfileInfo['CommentID'];
+        }
+
         if (!$hasReadPermission===true) {
             $query            .= " AND FIND_IN_SET(s.CenterID, :CentID)";
             $qparams['CentID'] = implode(',', $user->getCenterIDs());
         }
 
-        $query .= " AND Public = 'Y' AND Status <> 'closed'";
-        if (!empty($this->_feedbackObjectInfo['CandID'])) {
-            $query          .= " AND ft.CandID = :CaID";
-            $qparams['CaID'] = $this->_feedbackObjectInfo['CandID'];
-        }
-
-        if (!empty($this->_feedbackObjectInfo['SessionID'])) {
-            $query         .= " AND ft.SessionID = :SID";
-            $qparams['SID'] = $this->_feedbackObjectInfo['SessionID'];
-        }
-        if (!empty($this->_feedbackObjectInfo['CommentID'])) {
-            $query          .= " AND ft.SessionID = :CSID";
-            $qparams['CSID'] = $this->_feedbackCandidateProfileInfo['SessionID'];
-        }
         $query .= " GROUP BY ft.CandID, ft.Feedback_level, ft.SessionID";
         if (empty($this->_feedbackObjectInfo['CandID'])) {
             $query .= ", ft.CommentID";
@@ -565,13 +578,25 @@ class NDB_BVL_Feedback
             $qparams['SID']   = $this->_feedbackCandidateProfileInfo['SessionID'];
             $qparams['ComID'] = $this->_feedbackObjectInfo['CommentID'];
         } elseif (!empty($this->_feedbackObjectInfo['SessionID'])) {
-            $query         .= " AND ft.SessionID = :SID AND ft.CommentID is null";
-            $qparams['SID'] = $this->_feedbackObjectInfo['SessionID'];
+            $query            .= " AND ft.SessionID = :SID AND ft.CommentID is null";
+            $qparams['SID']    = $this->_feedbackObjectInfo['SessionID'];
+            $timepoint         = Timepoint::singleton(
+                new SessionID($qparams['SID'])
+            );
+            $hasReadPermission = (
+                $hasReadPermission ||
+                $timepoint->isAccessibleBy($user)
+            );
         } elseif (!empty($this->_feedbackObjectInfo['CandID'])) {
-            $query          .= " AND ft.CandID = :CaID
+            $query            .= " AND ft.CandID = :CaID
                                  AND ft.SessionID IS NULL
                                  AND ft.CommentID IS NULL";
-            $qparams['CaID'] = $this->_feedbackObjectInfo['CandID'];
+            $qparams['CaID']   = $this->_feedbackObjectInfo['CandID'];
+            $candidate         = Candidate::singleton(new CandID($qparams['CaID']));
+            $hasReadPermission = (
+                $hasReadPermission ||
+                $candidate->isAccessibleBy($user)
+            );
         } else {
             throw new Exception(
                 "You need to pass at least one of the following to retrieve the"

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -502,7 +502,7 @@ class NDB_BVL_Feedback
             $qparams['ComID'] = $this->_feedbackCandidateProfileInfo['CommentID'];
         }
 
-        if (!$hasReadPermission===true) {
+        if (!$hasReadPermission) {
             $query            .= " AND FIND_IN_SET(s.CenterID, :CentID)";
             $qparams['CentID'] = implode(',', $user->getCenterIDs());
         }
@@ -606,7 +606,7 @@ class NDB_BVL_Feedback
 
         // DCC users should be able to see THEIR OWN inactive threads,
         // other users should see only active threads
-        if ($hasReadPermission===true) {
+        if ($hasReadPermission) {
             $query .= " AND (ft.Active='Y' OR
                 (ft.Active='N' AND ft.UserID=:Username)
             )";


### PR DESCRIPTION
## Brief summary of changes

Currently, only users with the `access_all_profiles` permission can see Feedback Threads and Open Thread Summary at the profile level. Even if a user adds a feedback entry, they won't be able to see their own feedback thread unless they have the `access_all_profiles` permission.

This PR allows users to see threads and the summary that exists for candidates that they have access to (i.e., if a user is affiliated with MTL, they can now see the feedback threads & summary of MTL candidates).


- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Ensure that your user DOES NOT have the `access_all_profiles` permission and DOES have the `bvl_feedback` permission
2. Go to Candidate --> Access Profile
3. Click on any candidate 
4. Click the notepad icon in the top right-hand corner of the page (next to the question mark icon). This will open the feedback panel from the right side of the screen
5. Create a new feedback entry by typing in the large text field under "New profile level feedback", selecting a feedback type, then clicking the "Save data" button
6. The "Feedback Threads" card should populate with your newly created feedback entry, and the "Open Thread Summary" card should increment 
7. Log out and switch to a different user, and visit the same candidate to check if you can view the feedback thread 


#### Link(s) to related issue(s)

* Resolves  https://github.com/aces/Loris/issues/7190
