### PR TITLE
[EEG Browser] Add ability to view annotations in event panel and overlaid on signal viewer

### DIFF
--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -193,7 +193,6 @@ class ElectrophysiologySessionView extends Component {
       return resp.json();
     })
       .then((data) => {
-        console.log(data);
           const database = data.database.map((dbEntry) => ({
             ...dbEntry,
             // EEG Visualisation parameters

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -192,10 +192,11 @@ class ElectrophysiologySessionView extends Component {
       }
       return resp.json();
     })
-        .then((data) => {
+      .then((data) => {
+        console.log(data);
           const database = data.database.map((dbEntry) => ({
             ...dbEntry,
-            // EEG Visualisation urls
+            // EEG Visualisation parameters
             chunksURLs:
                 dbEntry
                 && dbEntry.file.chunks_urls.map(
@@ -222,6 +223,9 @@ class ElectrophysiologySessionView extends Component {
                       + '/electrophysiology_browser/file_reader/?file='
                       + group.links[1].file
                 ),
+            annotations:
+                dbEntry
+                && dbEntry.file.annotations,
           }));
 
           this.setState({
@@ -321,6 +325,7 @@ class ElectrophysiologySessionView extends Component {
           chunksURLs,
           epochsURL,
           electrodesURL,
+          annotations,
         } = this.state.database[i];
         const file = this.state.database[i].file;
         const splitPagination = [];
@@ -349,7 +354,8 @@ class ElectrophysiologySessionView extends Component {
           chunksURLs?.[file.splitData?.splitIndex] || chunksURLs
       }
         epochsURL={epochsURL}
-        electrodesURL={electrodesURL}
+                  electrodesURL={electrodesURL}
+                  annotations={annotations}
             >
             <Panel
         id='channel-viewer'

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -17,8 +17,7 @@ import {setDomain, setInterval} from '../series/store/state/bounds';
 import {updateFilteredEpochs} from '../series/store/logic/filterEpochs';
 import {setElectrodes} from '../series/store/state/montage';
 import {Channel} from '../series/store/types';
-import {Annotation} from '../series/store/types';
-import {composeWithDevTools} from 'redux-devtools-extension';
+import {AnnotationMetadata} from '../series/store/types';
 
 declare global {
   interface Window {
@@ -30,7 +29,7 @@ type CProps = {
   chunksURL: string,
   epochsURL: string,
   electrodesURL: string,
-  annotations: Annotation,
+  annotations: AnnotationMetadata,
   limit: number,
 };
 
@@ -53,7 +52,7 @@ class EEGLabSeriesProvider extends Component<CProps> {
 
     this.store = createStore(
       rootReducer,
-      composeWithDevTools(applyMiddleware(thunk, epicMiddleware))
+      applyMiddleware(thunk, epicMiddleware)
     );
 
     this.state = {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
@@ -32,6 +32,12 @@ export type Epoch = {
   channels: number[] | "all",
 };
 
+export type Annotation = {
+  instances: any[],
+  labels: any[],
+  metadata: any[]
+}
+
 export type RightPanel = 'annotationForm' | 'epochList' | null;
 
 export type Electrode = {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
@@ -32,7 +32,7 @@ export type Epoch = {
   channels: number[] | "all",
 };
 
-export type Annotation = {
+export type AnnotationMetadata = {
   instances: any[],
   labels: any[],
   metadata: any[]

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -461,7 +461,6 @@ class Sessions extends \NDB_Page
         $fileSummary['downloads']   = $this->getDownloadLinks($physioFileObj);
         $fileSummary['chunks_urls'] = $physioFileObj->getChunksURLs();
 
-
         //Get the annotation data
         $annotations = new ElectrophysioAnnotations(
             intval($physioFileID)

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -461,24 +461,13 @@ class Sessions extends \NDB_Page
         $fileSummary['downloads']   = $this->getDownloadLinks($physioFileObj);
         $fileSummary['chunks_urls'] = $physioFileObj->getChunksURLs();
 
-        $fileOutput = $db->pselectone(
-            'SELECT pot.OutputTypeName
-                FROM physiological_output_type pot
-                INNER JOIN physiological_file AS pf
-                ON pf.PhysiologicalFileID=:PFID
-                AND pf.PhysiologicalOutputTypeID=pot.PhysiologicalOutputTypeID',
-            ['PFID' => $physioFileID]
+
+        //Get the annotation data
+        $annotations = new ElectrophysioAnnotations(
+            intval($physioFileID)
         );
 
-        //Get the annotation data if the output type is derivative
-        //Get the annotation data if the output type is derivative
-        if (strcmp($fileOutput, 'derivative') == 0) {
-            $annotations = new ElectrophysioAnnotations(
-                intval($physioFileID)
-            );
-            $fileSummary['annotations'] = $annotations->getData();
-        }
-
+        $fileSummary['annotations'] = $annotations->getData();
         $fileSummary['output_type'] = $fileOutput;
         $fileSummary['splitData']   = $physioFileObj->getSplitData(0);
 


### PR DESCRIPTION
## Brief summary of changes
_**Disclaimer:**_ This PR is blocked by #7811 and will need to be rebased after its merge.

The changes in this PR fill in a few gaps in the code and allow for annotation data to be viewed in the EEG Browser. Annotations are displayed in orange in the `Events / Annotation Panel` and when selected are shown as an overlay in the signal viewer.

<img width="1440" alt="Screen Shot 2021-11-12 at 1 27 09 PM" src="https://user-images.githubusercontent.com/34260251/141516652-d77b5af9-7f60-4329-9c40-e38546dff364.png">

#### Testing instructions (if applicable)

1. Reach out to @jesscall on slack to get access to annotation data / SQL patches
2. Insert the SQL into your DB and place the files on your VM.
3. Navigate to the `EEG Browser`
4. Make sure that you can see and interact with annotations data.

