### PR TITLE
[EEG Browser][Feature] Ability to add new annotations from module

### DIFF
--- a/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
+++ b/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
@@ -91,7 +91,7 @@ class DownloadPanel extends Component {
                           >Not Available</a>
                         : <a
                             className='btn btn-primary download col-xs-6'
-                            href={this.state.outputType == 'derivative' &&
+                            href={
                               (download.type ==
                               'physiological_annotation_files' ||
                               download.type == 'all_files') ?

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -193,7 +193,6 @@ class ElectrophysiologySessionView extends Component {
       return resp.json();
     })
       .then((data) => {
-        console.log(data);
           const database = data.database.map((dbEntry) => ({
             ...dbEntry,
             // EEG Visualisation parameters

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -192,10 +192,11 @@ class ElectrophysiologySessionView extends Component {
       }
       return resp.json();
     })
-        .then((data) => {
+      .then((data) => {
+        console.log(data);
           const database = data.database.map((dbEntry) => ({
             ...dbEntry,
-            // EEG Visualisation urls
+            // EEG Visualisation parameters
             chunksURLs:
                 dbEntry
                 && dbEntry.file.chunks_urls.map(
@@ -222,6 +223,9 @@ class ElectrophysiologySessionView extends Component {
                       + '/electrophysiology_browser/file_reader/?file='
                       + group.links[1].file
                 ),
+            annotations:
+                dbEntry
+                && dbEntry.file.annotations,
           }));
 
           this.setState({
@@ -321,6 +325,7 @@ class ElectrophysiologySessionView extends Component {
           chunksURLs,
           epochsURL,
           electrodesURL,
+          annotations,
         } = this.state.database[i];
         const file = this.state.database[i].file;
         const splitPagination = [];
@@ -349,7 +354,8 @@ class ElectrophysiologySessionView extends Component {
           chunksURLs?.[file.splitData?.splitIndex] || chunksURLs
       }
         epochsURL={epochsURL}
-        electrodesURL={electrodesURL}
+                  electrodesURL={electrodesURL}
+                  annotations={annotations}
             >
             <Panel
         id='channel-viewer'

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -17,8 +17,7 @@ import {setDomain, setInterval} from '../series/store/state/bounds';
 import {updateFilteredEpochs} from '../series/store/logic/filterEpochs';
 import {setElectrodes} from '../series/store/state/montage';
 import {Channel} from '../series/store/types';
-import {Annotation} from '../series/store/types';
-import {composeWithDevTools} from 'redux-devtools-extension';
+import {AnnotationMetadata} from '../series/store/types';
 
 declare global {
   interface Window {
@@ -30,7 +29,7 @@ type CProps = {
   chunksURL: string,
   epochsURL: string,
   electrodesURL: string,
-  annotations: Annotation,
+  annotations: AnnotationMetadata,
   limit: number,
 };
 
@@ -53,7 +52,7 @@ class EEGLabSeriesProvider extends Component<CProps> {
 
     this.store = createStore(
       rootReducer,
-      composeWithDevTools(applyMiddleware(thunk, epicMiddleware))
+      applyMiddleware(thunk, epicMiddleware)
     );
 
     this.state = {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
@@ -5,7 +5,7 @@ import {setTimeSelection} from '../store/state/timeSelection';
 import {setRightPanel} from '../store/state/rightPanel';
 import {setEpochs} from '../store/state/dataset';
 import * as R from 'ramda';
-import {toggleEpoch, updateActiveEpoch, updateFilteredEpochs} from '../store/logic/filterEpochs';
+import {toggleEpoch, updateActiveEpoch} from '../store/logic/filterEpochs';
 import {RootState} from '../store';
 
 type CProps = {
@@ -14,6 +14,7 @@ type CProps = {
   filteredEpochs: number[],
   setTimeSelection: (_: [number, number]) => void,
   setRightPanel: (_: RightPanel) => void,
+  setEpochs: (_: EpochType[]) => void,
   toggleEpoch: (_: number) => void,
   updateActiveEpoch: (_: number) => void,
   interval: [number, number],
@@ -25,6 +26,7 @@ const AnnotationForm = ({
   filteredEpochs,
   setTimeSelection,
   setRightPanel,
+  setEpochs,
   toggleEpoch,
   updateActiveEpoch,
   interval,
@@ -289,10 +291,6 @@ export default connect(
     setEpochs: R.compose(
       dispatch,
       setEpochs
-    ),
-    updateFilteredEpochs: R.compose(
-      dispatch,
-      updateFilteredEpochs
     ),
     toggleEpoch: R.compose(
       dispatch,

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
@@ -104,12 +104,6 @@ const AnnotationForm = ({
         channels: 'all',
         description: comment,
       },
-      // TODO: Figure out data that should go here
-      metadata: {
-        description: 'An annotation',
-        sources: 'LORIS',
-        author: 'LORIS user',
-      },
     };
 
     const newAnnotation : EpochType = {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -600,6 +600,23 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                     }
                   </button>
                 }
+                {
+                  <button
+                  className={'btn btn-primary'
+                    + (rightPanel === 'annotationForm' ? ' active' : '')
+                  }
+                  onClick={() => {
+                    rightPanel === 'annotationForm'
+                      ? setRightPanel(null)
+                      : setRightPanel('annotationForm');
+                  }}
+                >
+                  {rightPanel === 'annotationForm'
+                    ? 'Close Annotation Form'
+                    : 'New Annotation'
+                  }
+                </button>
+                }
 
                 <div
                   className='pull-right col-xs-7'

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
@@ -32,6 +32,12 @@ export type Epoch = {
   channels: number[] | "all",
 };
 
+export type Annotation = {
+  instances: any[],
+  labels: any[],
+  metadata: any[]
+}
+
 export type RightPanel = 'annotationForm' | 'epochList' | null;
 
 export type Electrode = {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/types.tsx
@@ -32,7 +32,7 @@ export type Epoch = {
   channels: number[] | "all",
 };
 
-export type Annotation = {
+export type AnnotationMetadata = {
   instances: any[],
   labels: any[],
   metadata: any[]

--- a/modules/electrophysiology_browser/php/annotations.class.inc
+++ b/modules/electrophysiology_browser/php/annotations.class.inc
@@ -27,14 +27,14 @@ class Annotations extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $factory    = \NDB_Factory::singleton();
-        $user       = $factory->user();
-        $db         = $factory->database();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $db      = $factory->database();
 
         switch ($request->getMethod()) {
         case 'GET':
             $parameters = $request->getQueryParams();
-            $sessionID = $db->pselectOne(
+            $sessionID  = $db->pselectOne(
                 'SELECT SessionID
                     FROM physiological_file
                     WHERE PhysiologicalFileID=:PFID',

--- a/modules/electrophysiology_browser/php/annotations.class.inc
+++ b/modules/electrophysiology_browser/php/annotations.class.inc
@@ -27,13 +27,13 @@ class Annotations extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $parameters = $request->getQueryParams();
         $factory    = \NDB_Factory::singleton();
         $user       = $factory->user();
         $db         = $factory->database();
 
         switch ($request->getMethod()) {
         case 'GET':
+            $parameters = $request->getQueryParams();
             $sessionID = $db->pselectOne(
                 'SELECT SessionID
                     FROM physiological_file
@@ -78,6 +78,8 @@ class Annotations extends \NDB_Page
                 $request->withAttribute('filename', $filename)
             );
         case 'DELETE':
+            $parameters = $request->getQueryParams();
+
             if (!$user->hasPermission('electrophysiology_browser_edit_annotations')
             ) {
                 return (new \LORIS\Http\Response\JSON\Unauthorized());
@@ -94,12 +96,25 @@ class Annotations extends \NDB_Page
 
             return (new \LORIS\Http\Response\JSON\OK());
         case 'POST':
+            $parameters = json_decode((string) $request->getBody(), true);
+
             if (!$user->hasPermission('electrophysiology_browser_edit_annotations')
             ) {
                 return (new \LORIS\Http\Response\JSON\Unauthorized());
             }
 
-            if (!isset($parameters['physioFileID'])) {
+            if (!isset($parameters['sessionID'])) {
+                return (new \LORIS\Http\Response\JSON\BadRequest());
+            }
+
+            $physioFileID = $db->pselectOne(
+                'SELECT PhysiologicalFileID
+                    FROM physiological_file
+                    WHERE SessionID=:SID',
+                ['SID' => $parameters['sessionID']]
+            );
+
+            if (!isset($physioFileID)) {
                 return (new \LORIS\Http\Response\JSON\BadRequest());
             }
 
@@ -108,7 +123,7 @@ class Annotations extends \NDB_Page
             $instance_id   = $parameters['instance_id'] ?? null;
             $parameter_id  = $parameters['parameter_id'] ?? null;
 
-            (new ElectrophysioAnnotations(intval($parameters['physioFileID'])))
+            (new ElectrophysioAnnotations(intval($physioFileID)))
                 ->update($instance_data, $metadata, $instance_id, $parameter_id);
 
             return (new \LORIS\Http\Response\JSON\OK());

--- a/modules/electrophysiology_browser/php/annotations.class.inc
+++ b/modules/electrophysiology_browser/php/annotations.class.inc
@@ -119,7 +119,11 @@ class Annotations extends \NDB_Page
             }
 
             $instance_data = $parameters['instance'];
-            $metadata      = $parameters['metadata'];
+            $metadata      = [
+                'description' => 'An annotation',
+                'sources'     => 'EEGNet LORIS',
+                'author'      => $user->getFullname()
+            ];
             $instance_id   = $parameters['instance_id'] ?? null;
             $parameter_id  = $parameters['parameter_id'] ?? null;
 

--- a/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
@@ -73,10 +73,10 @@ class ElectrophysioAnnotations
      * Will add new derivative files if none exist for the given instance.
      * Will either add new annotations or update existing ones.
      *
-     * @param array $instance_data Instance data
-     * @param array $metadata      Metadata
-     * @param int|null   $instance_id   InstanceID
-     * @param int|null   $parameter_id  ParameterID
+     * @param array    $instance_data Instance data
+     * @param array    $metadata      Metadata
+     * @param int|null $instance_id   InstanceID
+     * @param int|null $parameter_id  ParameterID
      *
      * @return void
      */

--- a/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
@@ -75,16 +75,16 @@ class ElectrophysioAnnotations
      *
      * @param array $instance_data Instance data
      * @param array $metadata      Metadata
-     * @param int   $instance_id   InstanceID
-     * @param int   $parameter_id  ParameterID
+     * @param int|null   $instance_id   InstanceID
+     * @param int|null   $parameter_id  ParameterID
      *
      * @return void
      */
     function update(
         array $instance_data,
         array $metadata,
-        int $instance_id,
-        int $parameter_id
+        ?int $instance_id,
+        ?int $parameter_id
     ): void {
 
         $factory = \NDB_Factory::singleton();
@@ -135,7 +135,6 @@ class ElectrophysioAnnotations
                 'Duration'          => $instance_data['duration'],
                 'AnnotationLabelID' => $labelID,
                 'Channels'          => $instance_data['channels'],
-                'AbsoluteTime'      => $instance_data['abs_time'],
                 'Description'       => $instance_data['description']
             ];
 

--- a/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
@@ -292,7 +292,7 @@ class ElectrophysioAnnotations
         );
 
         $tsv_entries = [
-            'onset', 'duration', 'label', 'channels', 'aboslute_time', 'description'
+            'onset', 'duration', 'label', 'channels', 'absolute_time', 'description'
         ];
 
         $tsv = $db->pselect(

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -461,7 +461,6 @@ class Sessions extends \NDB_Page
         $fileSummary['downloads']   = $this->getDownloadLinks($physioFileObj);
         $fileSummary['chunks_urls'] = $physioFileObj->getChunksURLs();
 
-
         //Get the annotation data
         $annotations = new ElectrophysioAnnotations(
             intval($physioFileID)

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -461,24 +461,13 @@ class Sessions extends \NDB_Page
         $fileSummary['downloads']   = $this->getDownloadLinks($physioFileObj);
         $fileSummary['chunks_urls'] = $physioFileObj->getChunksURLs();
 
-        $fileOutput = $db->pselectone(
-            'SELECT pot.OutputTypeName
-                FROM physiological_output_type pot
-                INNER JOIN physiological_file AS pf
-                ON pf.PhysiologicalFileID=:PFID
-                AND pf.PhysiologicalOutputTypeID=pot.PhysiologicalOutputTypeID',
-            ['PFID' => $physioFileID]
+
+        //Get the annotation data
+        $annotations = new ElectrophysioAnnotations(
+            intval($physioFileID)
         );
 
-        //Get the annotation data if the output type is derivative
-        //Get the annotation data if the output type is derivative
-        if (strcmp($fileOutput, 'derivative') == 0) {
-            $annotations = new ElectrophysioAnnotations(
-                intval($physioFileID)
-            );
-            $fileSummary['annotations'] = $annotations->getData();
-        }
-
+        $fileSummary['annotations'] = $annotations->getData();
         $fileSummary['output_type'] = $fileOutput;
         $fileSummary['splitData']   = $physioFileObj->getSplitData(0);
 


### PR DESCRIPTION
## Brief summary of changes

**_Disclaimer_**: This PR is blocked by #7828 and will need to be rebased after its merge.

This PR fills in some gaps in the code relating to EEG annotations. It connects the front-end architecture from #7433 to the annotation form that was added in #7387. The result is that a user can now add new annotations from the EEG Browser.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Will add details shortly.


#### Discussion Items:
- Figure out metadata
- Determine if annotation labels in form are sufficient
- Talk about derivatives vs normal annotations