### PR TITLE
[EEG Broswer] Bugfix for Filtered Epochs

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -175,15 +175,10 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
   };
 
   const EpochsLayer = () => {
-    const fEpochs = [...Array(epochs.length).keys()].filter((i) =>
-      epochs[i].onset + epochs[i].duration > interval[0]
-      && epochs[i].onset < interval[1]
-    );
-
     return (
       <Group>
-        {fEpochs.length < MAX_RENDERED_EPOCHS &&
-          fEpochs.map((index) => {
+        {filteredEpochs.length < MAX_RENDERED_EPOCHS &&
+          filteredEpochs.map((index) => {
             return (
               <Epoch
                 {...epochs[index]}


### PR DESCRIPTION
## Brief summary of changes
Epochs should not be highlighted (in blue) in the Signal Viewer unless they are marked as visible using the eye button. This PR fixes bug where all epochs were being shown.

This fix was done by @laemtl on iEEG ATLAS, just pushing it to LORIS

**What it should look like (notice the eye button on first 3 epochs):**
<img width="1440" alt="Screen Shot 2021-11-17 at 11 22 52 AM" src="https://user-images.githubusercontent.com/34260251/142240512-35b0c074-5e79-48eb-9b27-4db8a6c576d7.png">


**What it looks like currently (notice no epochs are marked as visible):**
<img width="1440" alt="Screen Shot 2021-11-17 at 11 31 35 AM" src="https://user-images.githubusercontent.com/34260251/142241469-6e0ee474-18cc-4b99-8d9a-d1c9a9fd0fd5.png">


#### Testing instructions (if applicable)

1. Go EEG Browser
2. Notice that the signal viewer highlights all epochs before checking this PR out (second screenshot)
3. Checkout this PR, notice the behaviour from first screenshot

