### PR TITLE
[imaging_browser] Remove jQuery from imaging browser

### DIFF
--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -20,13 +20,6 @@ class ImagePanelHeader extends Component {
   }
 
   /**
-   * Called by React when the component has been rendered on the page.
-   */
-  componentDidMount() {
-    $('.panel-title').tooltip();
-  }
-
-  /**
    * Renders the React component.
    *
    * @return {JSX} - React markup for the component
@@ -117,23 +110,6 @@ class ImagePanelHeadersTable extends Component {
    */
   constructor(props) {
     super(props);
-  }
-
-  /**
-   * Called by React when the component has been rendered on the page.
-   */
-  componentDidMount() {
-    $(ReactDOM.findDOMNode(this)).DynamicTable();
-  }
-
-  /**
-   * Invoked immediately before a component is unmounted and destroyed.
-   */
-  componentWillUnmount() {
-    // Remove wrapper nodes so React is able to remove component
-    $(ReactDOM.findDOMNode(this)).DynamicTable({
-      removeDynamicTable: true,
-    });
   }
 
   /**


### PR DESCRIPTION
This removes the couple references to jQuery in the imaging_browser
so that the errors:

```
/home/runner/work/Loris/Loris/modules/imaging_browser/jsx/ImagePanel.js
26:5  warning  The jQuery constructor is not allowed  no-jquery/no-jquery-constructor
26:5  warning  .tooltip is not allowed                no-jquery/no-other-methods
126:5  warning  The jQuery constructor is not allowed  no-jquery/no-jquery-constructor
126:5  warning  .DynamicTable is not allowed           no-jquery/no-other-methods
134:5  warning  The jQuery constructor is not allowed  no-jquery/no-jquery-constructor
134:5  warning  .DynamicTable is not allowed           no-jquery/no-other-methods
```

are not displayed. The first error was a call to ".tooltip" which was
unnecessary. The value of the tooltip is the same as the text being
hovered over and serves no purpose.

The second was a call to .DyanmicTable on the panels. This is cosmetic
and should have little effect (I don't think I've ever seen the DynamicTable
rendered in the imaging browser.)

The third call was just undoing the second call to prevent errors when
the page is unmounted.