### PR TITLE
[instruments] Fix warning when no sessionID set

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2888,9 +2888,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         // Disable form if data entry is complete
         $user      = $request->getAttribute("user");
-        $sessionID = $request->getQueryParams()["sessionID"];
+        $sessionID = $this->getSessionID();
         if ($sessionID !== null) {
-            $timepoint = \Timepoint::singleton(new SessionID($sessionID));
+            $timepoint = \Timepoint::singleton($sessionID);
         }
 
         // create an instrument status object


### PR DESCRIPTION
Fix the warning:

```
b>Warning</b>:  Undefined array key "sessionID" in <b>/home/driusan/Code/Loris/php/libraries/NDB_BVL_Instrument.class.inc</b> on line <b>2891</b><br />
```

when an instrument is accessed without a sessionID set in the URL (such
as through the candidate profile), by using the instrument's getSessionID()
instead of trusting the request query param.