### PR TITLE
[Meta] Add PHP 8.1 and remove PHP 7.4 from GitHub actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "squizlabs/php_codesniffer" : "^3.5",
         "phpunit/phpunit" : "9.4.4",
         "phan/phan": "^5.0",
-        "phpstan/phpstan": "0.12.58",
+        "phpstan/phpstan": "^1.4",
         "slevomat/coding-standard": "^6.4",
         "php-webdriver/webdriver" : "dev-main"
 

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
             "LORIS\\": "src/"
         },
         "classmap": ["project/libraries", "php"]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd17062ad69f700715d9abdaeb192607",
+    "content-hash": "69011d30db3454f5e1f30d9705586ed8",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -2441,16 +2441,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.58",
+            "version": "1.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "2a4847df6047b30af28854ed9dc95304cdb56ae5"
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2a4847df6047b30af28854ed9dc95304cdb56ae5",
-                "reference": "2a4847df6047b30af28854ed9dc95304cdb56ae5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8a7761f1c520e0dad6e04d862fdc697445457cfe",
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe",
                 "shasum": ""
             },
             "require": {
@@ -2466,7 +2466,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -2481,11 +2481,15 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.58"
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
                     "type": "github"
                 },
                 {
@@ -2497,7 +2501,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-29T13:32:03+00:00"
+            "time": "2022-02-06T12:56:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5078,5 +5082,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/php/libraries/CenterID.php
+++ b/php/libraries/CenterID.php
@@ -46,7 +46,7 @@ class CenterID extends ValidatableIdentifier implements \JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return $this->value;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -730,7 +730,13 @@ class Database implements LoggerAwareInterface
             return [];
         }
 
-        $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
+        $rows = array_map(function($row) {
+            $strrow = [];
+            foreach($row as $key => $val) {
+                $strrow[$key] = strval($val);
+            }
+            return $strrow;
+        }, $prepared->fetchAll(PDO::FETCH_ASSOC));
         // The fetchAll function will return an empty set if no results are
         // found and FALSE on "failure". We don't expect this case so an
         // exception is thrown.
@@ -997,7 +1003,7 @@ class Database implements LoggerAwareInterface
         if (is_array($result) && count($result)) {
             $result = array_values($result)[0];
         }
-        return $result;
+        return strval($result);
     }
 
     /**
@@ -1026,7 +1032,7 @@ class Database implements LoggerAwareInterface
             return null;
         }
 
-        return $result;
+        return intval($result);
     }
 
     /**

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -67,7 +67,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
             );
         }
         //Use basename to remove path traversal characters.
-        $filename = basename($request->getAttribute('filename'));
+        $filename = basename(strval($request->getAttribute('filename')));
 
         if (empty($filename)) {
             return new \LORIS\Http\Response\JSON\BadRequest(

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -191,6 +191,7 @@ abstract class IdentifierGenerator
         $this->checkIDRangeFull();
 
         $id = '';
+        assert(count($this->alphabet) >= 1);
         while (strlen($id) < $this->length) {
             $id .= $this->alphabet[random_int(0, count($this->alphabet) - 1)];
         }

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -46,7 +46,7 @@ class ProjectID extends ValidatableIdentifier implements \JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return $this->value;
     }

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -155,18 +155,20 @@ class SiteIDGenerator extends IdentifierGenerator
     private function _getIDSetting(
         string $setting
     ) {
+        $config = \NDB_Factory::singleton()->config();
+        $kind   = $config->getSetting($this->kind);
+
+        if (!is_array($kind)) {
+            throw new \LorisException("Invalid config for $this->kind");
+        };
         // The generation setting can be easily extracted and returned.
         if ($setting == 'generation') {
-            return \NDB_Factory::singleton()
-                ->config()
-                ->getSetting($this->kind)['generation'];
+            return $kind['generation'];
         }
 
         // Values other than 'generation' are found within 'seq' elements and
         // require more complex processing.
-        $idStructure = \NDB_Factory::singleton()
-            ->config()
-            ->getSetting($this->kind)['structure']['seq'];
+        $idStructure = $kind['structure']['seq'];
 
         if (!$idStructure[0]) {
             // There's only one seq tag so the param format
@@ -230,10 +232,12 @@ class SiteIDGenerator extends IdentifierGenerator
      * configured. Do error handling to make sure that there is exactly one
      * value corresponding to the requested setting.
      *
-     * @param array<array> $idStructure Settings concerning ID structure
-     *                                  extracted from project/config.sml
-     * @param string       $setting     The name of the variable for which we
-     *                                  want the value.
+     * @param array<array<array<string>>> $idStructure Settings concerning ID
+     *                                                 structure extracted from
+     *                                                 project/config.sml
+     * @param string                      $setting     The name of the variable
+     *                                                 for which we want the
+     *                                                 value.
      *
      * @throws \ConfigurationException
      *
@@ -285,17 +289,19 @@ class SiteIDGenerator extends IdentifierGenerator
                 'Too many values found for config setting: ' . $setting
             );
         }
-        return array_pop($seqAttributes);
+        return strval(array_pop($seqAttributes));
     }
 
     /**
      * Traverse the $idStructure array and collect all values that exist
      * for $setting.
      *
-     * @param array<array> $idStructure Settings concerning ID structure
-     *                                  extracted from project/config.xml
-     * @param string       $setting     The name of the variable for which
-     *                                  we want the value.
+     * @param array<array<array<string>>> $idStructure Settings concerning ID
+     *                                                 structure extracted from
+     *                                                 project/config.xml
+     * @param string                      $setting     The name of the variable
+     *                                                 for which we want the
+     *                                                 value.
      *
      * @return array<int,mixed> The value(s) corresponding to $setting.
      */

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -88,7 +88,7 @@ class CandID extends ValidatableIdentifier implements \JsonSerializable
      * @see https://www.php.net/manual/en/jsonserializable.jsonserialize.php
      * @return mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return $this->value;
     }

--- a/test/phpstan-loris.neon
+++ b/test/phpstan-loris.neon
@@ -1,10 +1,4 @@
 parameters:
-    autoload_directories:
-        - %currentWorkingDirectory%/php/
-        - %currentWorkingDirectory%/src/
-        - %currentWorkingDirectory%/modules/
-        - %currentWorkingDirectory%/test/integrationtests/
-        - %currentWorkingDirectory%/test/unittests/
     excludes_analyse:
         - %currentWorkingDirectory%/modules/*/ajax/*
         - %currentWorkingDirectory%/modules/*/test/*


### PR DESCRIPTION
PHP 8.1 is set to be released in a week. We should have our tests run with it.