### PR TITLE
[PHPCS] Allow autofixing of control structures

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -92,7 +92,7 @@ try {
     $m = Module::factory($Module);
 
     $public = $m->isPublicModule();
-} catch(LorisModuleMissingException $e) {
+} catch (LorisModuleMissingException $e) {
     $public = false;
 }
 if ($anonymous === true && $m->isPublicModule() === false) {

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -93,7 +93,7 @@ $tpl_data = [];
 // Page 3: Help, prompt for new username/password (include defaults)
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //     2. Update config.xml if write access, otherwise download copy
-switch(isset($_POST['formname']) ? $_POST['formname'] : '') {
+switch (isset($_POST['formname']) ? $_POST['formname'] : '') {
 case 'validaterootaccount':
     // This will connect to MySQL, check the permissions of the
     // account provided, check that the database doesn't already

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -87,7 +87,7 @@ if (strpos($FileBase, "DCM_") === 0) {
  * name based on its extension.
  */
 $DownloadFilename = '';
-switch($FileExt) {
+switch ($FileExt) {
 case 'mnc':
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = "application/x-minc";

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -228,7 +228,7 @@ class DirectDataEntryMainPage
         try {
             $this->initialize();
             $this->display();
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->displayError($e);
         }
     }
@@ -259,8 +259,7 @@ class DirectDataEntryMainPage
      */
     function displayError($e)
     {
-        switch($e->getCode())
-        {
+        switch ($e->getCode()) {
         case 404:
             header("HTTP/1.1 404 Not Found");
             break;

--- a/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
@@ -134,7 +134,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
         );
 
         $version = $request->getAttribute('LORIS-API-Version');
-        switch($version) {
+        switch ($version) {
         case "v0.0.3":
             $view = (new \LORIS\api\Views\Visit\Dicoms(
                 $this->_visit,

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -113,7 +113,7 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $subendpoint = array_shift($pathparts);
-        switch($subendpoint) {
+        switch ($subendpoint) {
         case 'metadata':
             $handler = new Metadata($this->_visit, $recording);
             break;

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -113,7 +113,7 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $subendpoint = array_shift($pathparts);
-        switch($subendpoint) {
+        switch ($subendpoint) {
         case 'format':
             $handler = new Format($image);
             break;

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -134,7 +134,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
         );
 
         $version = $request->getAttribute('LORIS-API-Version');
-        switch($version) {
+        switch ($version) {
         case 'v0.0.3':
             $view = (new \LORIS\api\Views\Visit\Images(
                 $this->_visit,

--- a/modules/api/php/endpoints/candidate/visit/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/qc.class.inc
@@ -160,7 +160,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         try {
             $candid = new CandID($data['Meta']['CandID']);
-        } catch(\DomainException $e) {
+        } catch (\DomainException $e) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 'CandID is invalid'
             );

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -124,7 +124,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         // Delegate to sub-endpoints
         $subendpoint = array_shift($pathparts);
-        switch($subendpoint) {
+        switch ($subendpoint) {
         case 'instruments':
             $handler = new Instruments($this->_visit);
             break;

--- a/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
@@ -139,7 +139,7 @@ class Visit_0_0_4_Dev extends Endpoint implements \LORIS\Middleware\ETagCalculat
 
         // Delegate to sub-endpoints
         $subendpoint = array_shift($pathparts);
-        switch($subendpoint) {
+        switch ($subendpoint) {
         case 'instruments':
             $handler = new Instruments($this->_visit);
             break;

--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -100,7 +100,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         // Delegate to sub-endpoints
         $subendpoint = array_shift($pathparts);
-        switch($subendpoint) {
+        switch ($subendpoint) {
         case 'candidates':
             $handler = new Candidates($this->_project);
             break;

--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -99,7 +99,7 @@ class Module extends \Module
 
         $handlername = $pathparts[0];
 
-        switch($handlername) {
+        switch ($handlername) {
         case 'candidates':
             $handler = new \LORIS\api\Endpoints\Candidates();
             break;

--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -104,7 +104,7 @@ class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
         $this->user = $request->getAttribute('user');
         $method     = $request->getMethod();
 
-        switch($method) {
+        switch ($method) {
         case 'GET':
             return $this->_getInstances();
         case 'POST':

--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -43,7 +43,7 @@ class TestOptionsEndpoint extends \NDB_Page
     {
         $method = $request->getMethod();
 
-        switch($method) {
+        switch ($method) {
         case 'GET':
             return new \LORIS\Http\Response\JSON\OK($this->_getOptions());
         }

--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -60,7 +60,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options)
     {
-        switch($type) {
+        switch ($type) {
         case 'dashboard':
             $factory = \NDB_Factory::singleton();
             $baseURL = $factory->settings()->getBaseURL();

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -28,7 +28,7 @@ if ($tab === '') {
 
 $db = \Database::singleton();
 
-switch($tab) {
+switch ($tab) {
 case 'candidateInfo':
     editCandInfoFields($db);
     break;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -36,7 +36,7 @@ if ($data == '') {
     exit;
 }
 
-switch($data) {
+switch ($data) {
 case 'candidateInfo':
     echo json_encode(getCandInfoFields());
     exit;

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -35,7 +35,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case 'candidate':
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -66,7 +66,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case 'candidate':
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -104,7 +104,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case 'usertasks':
             $factory = \NDB_Factory::singleton();
             $baseURL = $factory->settings()->getBaseURL();

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -48,7 +48,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options)
     {
-        switch($type) {
+        switch ($type) {
         case 'dashboard':
             $factory = \NDB_Factory::singleton();
             $DB      = $factory->database();

--- a/modules/data_release/php/permissions.class.inc
+++ b/modules/data_release/php/permissions.class.inc
@@ -83,7 +83,7 @@ class Permissions extends \NDB_Page
         if (empty($action)) {
             return new \LORIS\Http\Response\JSON\BadRequest("Missing action");
         }
-        switch($action) {
+        switch ($action) {
         case 'add':
             return $this->_addPermission($request);
         case 'manage':

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -259,7 +259,7 @@ class ViewDetails extends \NDB_Form
                 mri_protocol";
             $this->protocols = $this->DB->pselect($query, []);
             return true;
-        } catch(\LorisException $e) {
+        } catch (\LorisException $e) {
             return false;
         }
     }

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -343,7 +343,7 @@ class Files extends \NDB_Page
 
         $targetdir = new \SplFileInfo($path);
 
-        try{
+        try {
             $uploader = (new \LORIS\FilesUploadHandler($targetdir))
                 ->withPermittedMIMETypes(
                     'application/pdf',

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -76,7 +76,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options)
     {
-        switch($type) {
+        switch ($type) {
         case 'dashboard':
             $factory = \NDB_Factory::singleton();
             $baseURL = $factory->settings()->getBaseURL();

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -83,7 +83,7 @@ class Sessions extends \NDB_Page
                 new \SessionID(strval($session_id))
             );
             $this->sessionID = $session_id;
-        } catch(\LorisException $e) {
+        } catch (\LorisException $e) {
             throw new \NotFound("Session not found");
         }
 

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -189,7 +189,7 @@ class Genomicfile
             ) {
                 $this->reportProgress(99, 'File successfully copied!');
             }
-        } catch (\Exception $ex){
+        } catch (\Exception $ex) {
             error_log("Cannot move file: $ex");
             $this->endWithFailure();
         }

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -68,7 +68,7 @@ class Module extends \Module
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
         $baseURL = $factory->settings()->getBaseURL();
-        switch($type) {
+        switch ($type) {
         case 'usertasks':
             return [
                 new \LORIS\dashboard\TaskQueryWidget(

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -468,7 +468,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
             if ($name == 'Examiner') {
                 continue;
             }
-            switch($type) {
+            switch ($type) {
             case 'page':
             case 'table':
             case 'title':
@@ -552,7 +552,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                             " FROM instrument_subtests".
                             " WHERE Test_name=:testname".
                             " AND Description=:testdesc";
-            switch($type) {
+            switch ($type) {
             case 'page':
                 $exists = $db->pselectOne(
                     $sqlSelectOne,

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -111,7 +111,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case "usertasks":
             $factory = \NDB_Factory::singleton();
             $DB      = $factory->database();

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -82,7 +82,7 @@ class Module extends \Module
         $DB      = $factory->database();
         $baseURL = $factory->settings()->getBaseURL();
 
-        switch($type) {
+        switch ($type) {
         case 'usertasks':
             $url = 'assignee=' . $user->getUsername() . '&status=acknowledged&'.
                    'status=assigned&status=feedback&status=new&status=resolved';

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -106,7 +106,7 @@ class Media extends \DataFrameworkMenu
                     $this->lorisinstance,
                     $instrument["Test_name"],
                 )->getFullname();
-            } catch (\Exception $e){
+            } catch (\Exception $e) {
                 $instrumentName = $instrument['Full_name'];
             }
 

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -54,7 +54,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case 'candidate':
             $factory   = \NDB_Factory::singleton();
             $baseurl   = $factory->settings()->getBaseURL();

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -210,7 +210,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case "usertasks":
             $factory = \NDB_Factory::singleton();
             $DB      = $factory->database();

--- a/modules/server_processes_manager/php/abstractserverprocess.class.inc
+++ b/modules/server_processes_manager/php/abstractserverprocess.class.inc
@@ -472,8 +472,7 @@ abstract class AbstractServerProcess
                 $setValues,
                 $whereValues
             );
-        }
-        catch(\DatabaseException $exception) {
+        } catch (\DatabaseException $exception) {
             error_log(
                 "Failed to update task (pid=" . $this->getPid() . ") status: "
                 . $exception->getMessage()

--- a/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
+++ b/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
@@ -121,9 +121,8 @@ class ServerProcessesMonitor
         // Try to fetch the requested processes
         try {
             $rows = $db->pselect($query, $params);
-        }
-        // If this fails, log the error and return the exception to the caller
-        catch(\DatabaseException $exception) {
+        } catch (\DatabaseException $exception) {
+            // If this fails, log the error and return the exception to the caller
             error_log(
                 "Failed to retrieve processes to monitor: "
                 . (is_null($idsToMonitor) ? "All ids "      : "IDs in ($idInClause)")

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -84,7 +84,7 @@ class Charts extends \NDB_Page
         if (count($pathparts) != 2) {
             return new \LORIS\Http\Response\JSON\NotFound();
         }
-        switch($pathparts[1]){
+        switch ($pathparts[1]) {
         case 'siterecruitment_pie':
             return $this->_handleSitePieData();
         case 'siterecruitment_bysex':

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -70,7 +70,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case 'dashboard':
             $factory = \NDB_Factory::singleton();
             $config  = $factory->config();

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -56,7 +56,7 @@ class Statistics_Mri_Site extends Statistics_Site
      */
     function _getIssueName(string $issue)
     {
-        switch($issue) {
+        switch ($issue) {
         case "Tarchive_Missing":
             return "MRI Parameter Form Completed but Missing tarchive entry";
         case "PF_Missing":

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -241,7 +241,7 @@ class AddSurvey extends \NDB_Form
                     'CommentID'       => $commentID,
                 ]
             );
-        } catch(\DatabaseException $e) {
+        } catch (\DatabaseException $e) {
             error_log($e->getMessage());
             $this->tpl_data['success'] = false;
         }

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -74,7 +74,7 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
-        switch($type) {
+        switch ($type) {
         case "usertasks":
             $factory = \NDB_Factory::singleton();
             $DB      = $factory->database();

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -179,7 +179,7 @@ class Database
             $this->PDO->exec("CREATE DATABASE $database");
             $this->PDO->exec("USE $database");
             return true;
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return false;
         }
     }
@@ -228,7 +228,7 @@ class Database
             }
             $this->PDO->exec("USE $database");
             return true;
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             error_log($e->getMessage());
             $this->lastErr = $e->getMessage();
             return false;
@@ -248,7 +248,7 @@ class Database
             }
             $this->PDO->query("SELECT 'x'");
             return true;
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return false;
         }
     }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -101,7 +101,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         // store user data in object property
         foreach ($row as $key=>$value) {
-            switch ($key){
+            switch ($key) {
             case 'Sex':
                 $this->candidateInfo[$key] = empty($value) ? null : new Sex($value);
                 break;
@@ -968,7 +968,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         foreach ($seqs AS $seq) {
             $unit = "";
 
-            switch($seq['@']['type']) {
+            switch ($seq['@']['type']) {
             case 'alpha':
                 $unit .= '[a-z]';
                 break;

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -244,7 +244,7 @@ class Database implements LoggerAwareInterface
             }
             $this->_PDO->query("SELECT 'x'");
             return true;
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             return false;
         }
     }

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -323,7 +323,7 @@ class File_Upload
         //If there is already a file with this name in the target directory either
         //overwrite, rename, or reject.
         if (file_exists($dest_dir.$safe_name)) {
-            switch($this->overwriteMode){
+            switch ($this->overwriteMode) {
             case "rename":
                 if ($this->renameMode=="incremental") {
                     $safe_name =$this->nameToIncremental($dest_dir, $safe_name);

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -410,7 +410,7 @@ class LorisForm
         $customs=[]
     ) {
         $el = null;
-        switch($type)  {
+        switch ($type) {
         case 'select':
             $el = $this->addSelect($name, $label, $options, $attribs);
             break;
@@ -1512,7 +1512,7 @@ class LorisForm
      */
     function renderElement(&$el)
     {
-        switch($el['type']) {
+        switch ($el['type']) {
         case 'date':
             return $this->dateHTML($el);
         case 'select':
@@ -1985,7 +1985,7 @@ class LorisForm
         $attribs=[],
         $customs=[]
     ) {
-        switch($type) {
+        switch ($type) {
         case 'text':
             return $this->createText($elname, $label, $attribs);
         case 'select':

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -81,7 +81,7 @@ trait LorisFormDictionaryImpl
 
             $t = null;
 
-            switch($element['type']) {
+            switch ($element['type']) {
             case 'select':
                 // The values of the enumeration are the keys of the
                 // options, but when the key is something like "0" or

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -61,7 +61,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         foreach ($mnames as $name) {
             try {
                 $modules[] = self::factory($name);
-            } catch(\LorisModuleMissingException $e) {
+            } catch (\LorisModuleMissingException $e) {
                 error_log($e->getMessage() . " " . $e->getTraceAsString());
             }
         }
@@ -368,7 +368,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
 
         try {
             $page = $this->loadPage($loris, $pagename);
-        } catch(\NotFound $e) {
+        } catch (\NotFound $e) {
             $this->logger->debug("Page $pagename not found");
             return $resp->withStatus(404);
         }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -104,7 +104,7 @@ class NDB_BVL_Feedback
                     $sessionID,
                     $commentID
                 );
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 unset($feedbackList[$objectName]);
                 throw new Exception(
                     "Could not instantiate feedback object",

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -418,7 +418,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         try {
             $candidate = \Candidate::singleton($timePoint->getCandID());
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             throw new LorisException($e->getMessage());
         }
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -516,7 +516,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     }
                     continue;
                 }
-                switch($type) {
+                switch ($type) {
                 case 'page':
                     $pageDescription  = trim($pieces[2]);
                     $pageName         = "page_$subtestCount";
@@ -958,7 +958,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     // of replaced.
                     $q['UserRules'] = true;
 
-                    switch($q['type']) {
+                    switch ($q['type']) {
                     case 'select':
                         // Selects are the only type of rules that aren't part
                         // of a group, the rest include a _status element

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -265,7 +265,7 @@ class NDB_Config
     function getSettingFromDB(string $name, ?int $id = null)
     {
         // These should never come from the DB
-        switch($name) {
+        switch ($name) {
         case 'database':
         case 'sandbox':
         case 'showDatabaseQueries':
@@ -402,7 +402,7 @@ class NDB_Config
             if ($XMLValue !== null) {
                 return $XMLValue;
             }
-        } catch(ConfigurationException $e) {
+        } catch (ConfigurationException $e) {
             // There was no config in the database with this
             // name. It may exist in the XML, so we handle this
             // silently.

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -643,7 +643,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function display()
     {
-        switch($this->format) {
+        switch ($this->format) {
         case 'json':
             return $this->toJSON();
         }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -775,7 +775,7 @@ class NDB_Page implements RequestHandlerInterface
     function display()
     {
         $this->logger->debug("Rendering page via display function");
-        switch($this->format) {
+        switch ($this->format) {
         case 'json':
             return $this->toJSON();
         }

--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -26,7 +26,7 @@ class Site implements
             try {
                 $siteList[$cidS] = new Site();
                 $siteList[$cidS]->select($centerID);
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 $message = $e->getMessage();
                 unset($siteList[$cidS]);
                 throw new Exception("Could not select site ($message)", 0, $e);

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -247,7 +247,7 @@ class SiteIDGenerator extends IdentifierGenerator
          * 'type' attributes within 'seq' elements. See project/config.xml for
          * examples.
          */
-        switch($setting) {
+        switch ($setting) {
         case 'alphabet':
             $seqAttributes = array_filter(
                 self::_getSeqAttribute($idStructure, 'type'),

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -807,7 +807,7 @@ class Utility
         $val  = trim($val);
         $last = strtolower($val[strlen($val)-1]);
 
-        switch($last) {
+        switch ($last) {
         case 'g':
             return (int)$val * 1024 * 1024 * 1024;
         case 'm':

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -11,12 +11,17 @@
         <exclude name="PEAR.Commenting.ClassComment.MissingVersion"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
         <exclude name="PEAR.NamingConventions.ValidVariableName"/>
+        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
+        <!-- handled by Squiz.ControlStructures.ControlSignature, which
+             can be autofixed -->
+        <exclude name="PEAR.ControlStructures.ControlSignature"/>
     </rule>
 
     <!-- Pieces of other standards to include... -->
 
     <!-- Make sure there's no weird spacing for array brackets -->
     <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
+    <rule ref="Squiz.ControlStructures.ControlSignature" />
 
     <!-- Pick up any calls to deprecated functions. -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -572,9 +572,9 @@ abstract class LorisIntegrationTest extends TestCase
         try {
             $webElement->click();
             $clickException = null;
-        } catch(ElementNotVisibleException $e) {
+        } catch (ElementNotVisibleException $e) {
             $clickException = $e;
-        } catch(StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceException $e) {
             $clickException = $e;
         }
 

--- a/tools/configuration_check.php
+++ b/tools/configuration_check.php
@@ -151,7 +151,7 @@ if (! $config->settingEnabled('usePwnedPasswordsAPI')) {
     $response = $client->sendRequest(
         new Request('GET', "/range/21BD1")
     );
-    switch ($response->getStatusCode()){
+    switch ($response->getStatusCode()) {
     case 200:
         $helper->printSuccess('Connection successful.');
         break;

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -104,7 +104,7 @@ foreach ($instruments AS $instrument) {
     foreach ($items AS $item) {
         $paramId = "";
         $bits    = explode("{@}", trim($item));
-        switch($bits[0]){
+        switch ($bits[0]) {
         case "testname":
             break;
         case "table":

--- a/tools/manage_modules.php
+++ b/tools/manage_modules.php
@@ -53,7 +53,7 @@ if (isset($flags['remove'])) {
     foreach ($currentModules as $module) {
         try {
             Module::factory($module);
-        } catch(\LorisNoSuchModuleException | \LorisModuleMissingException $e) {
+        } catch (\LorisNoSuchModuleException | \LorisModuleMissingException $e) {
             print "Removing $module\n";
             if ($dryrun) {
                 continue;
@@ -92,7 +92,7 @@ function addDir(string $moduledir): void
             if (is_dir("$moduledir/$module")) {
                 try {
                     Module::factory($module);
-                } catch(\LorisNoSuchModuleException
+                } catch (\LorisNoSuchModuleException
                     | \LorisModuleMissingException $e
                 ) {
                     // Wasn't a valid module, so don't add it.


### PR DESCRIPTION
This changes the rule set to use the Squizlabs ControlStructure
sniff instead of the PEAR one. The primary differences between
these are that:
1. There must now be a space after `switch`, similarly to `if`
2. They are auto-fixable using phpcbf, so that, for instance
   `if(` no longer needs to be manually fixed to `if (` when
   an error is flagged.