### PR TITLE
[Access Profile (Beta)] remove Minimizing boxes

### DIFF
--- a/jsx/CSSGrid.js
+++ b/jsx/CSSGrid.js
@@ -110,7 +110,7 @@ function CSSGrid(props) {
         style.alignSelf = 'stretch';
         return (
             <Card title={value.Title} id={cardID} key={cardID} style={style}
-                cardSize={pSize}>
+                cardSize={pSize} collapsing={value.collapsing}>
             {value.Content}
             </Card>
         );

--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -63,6 +63,7 @@ class Card extends Component {
           initCollapsed={this.props.initCollapsed}
             style={{overflow: 'auto'}}
            panelSize={this.props.cardSize}
+          collapsing={this.props.collapsing}
         >
           <div
             onClick={this.handleClick}

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -39,7 +39,9 @@ class Panel extends Component {
    * Toggle whether this Panel is displayed as collapsed
    */
   toggleCollapsed() {
-    this.setState({collapsed: !this.state.collapsed});
+    if (this.props.collapsing) {
+      this.setState({collapsed: !this.state.collapsed});
+    }
   }
 
   /**
@@ -66,7 +68,7 @@ class Panel extends Component {
       <div
         className="panel-heading"
         onClick={this.toggleCollapsed}
-        data-toggle="collapse"
+        data-toggle={this.props.collapsing ? 'collapse' : null}
         data-target={'#' + this.props.id}
         data-parent={this.props.parentId ?
           '#'+this.props.parentId :

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -52,7 +52,8 @@ window.addEventListener('load', () => {
             Content: React.createElement(
                 {$widget->getComponentName()},
                 allprops
-            )
+            ),
+            collapsing: false
             {if $widget->getWidth()},Width: {$widget->getWidth()}{/if}
             {if $widget->getOrder()},Order: {$widget->getOrder()}{/if}
             {if $widget->getHeight()},Height: {$widget->getHeight()}{/if}


### PR DESCRIPTION
## Brief summary of changes

Past discussion came to conclusion of removing minimizing from cards displayed at candidate_profile.

#### Testing instructions (if applicable)

1. Checkout PR
2. Visit Access Profile (Beta)
3. Visit a candidate and the cards should not be able to be minimized.

#### Link(s) to related issue(s) https://github.com/aces/Loris/issues/7536
