### PR TITLE
[User Accounts] Users request are allowed to be created with "incorrect" email address via "user request" UI

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1213,6 +1213,137 @@ TextboxElement.defaultProps = {
 };
 
 /**
+ * EmailElement Component
+ * React wrapper for a <input type="email"> element.
+ */
+class EmailElement extends Component {
+  /**
+   * @constructor
+   * @param {object} props - React Component properties
+   */
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+  }
+
+  /**
+   * Handle change
+   *
+   * @param {object} e - Event
+   */
+  handleChange(e) {
+    this.props.onUserInput(
+      this.props.name,
+      e.target.value,
+      e.target.id, 'textbox',
+    );
+  }
+
+  /**
+   * Handle blur
+   *
+   * @param {object} e - Event
+   */
+  handleBlur(e) {
+    this.props.onUserBlur(this.props.name, e.target.value);
+  }
+
+  /**
+   * Renders the React component.
+   *
+   * @return {JSX} - React markup for the component
+   */
+  render() {
+    let disabled = this.props.disabled ? 'disabled' : null;
+    let required = this.props.required ? 'required' : null;
+    let errorMessage = null;
+    let requiredHTML = null;
+    let elementClass = 'row form-group';
+
+    // Add required asterix
+    if (required) {
+      requiredHTML = <span className="text-danger">*</span>;
+    }
+
+    // Add error message
+    if (this.props.errorMessage) {
+      errorMessage = <span>{this.props.errorMessage}</span>;
+      elementClass = 'row form-group has-error';
+    }
+
+
+    // Label prop needs to be provided to render label
+    // (including empty label i.e. <TextboxElement label='' />)
+    // and retain formatting. If label prop is not provided at all, the input
+    // element will take up the whole row.
+    let label = null;
+    let inputClass = this.props.class;
+    if (this.props.label || this.props.label == '') {
+      label = (
+        <label className="col-sm-3 control-label" htmlFor={this.props.id}>
+          {this.props.label}
+          {requiredHTML}
+        </label>
+      );
+      inputClass = 'col-sm-9';
+    }
+
+    return (
+      <div className={elementClass}>
+        {label}
+        <div className={inputClass}>
+          <input
+            type="email"
+            className="form-control"
+            name={this.props.name}
+            id={this.props.id}
+            value={this.props.value || ''}
+            required={required}
+            disabled={disabled}
+            onChange={this.handleChange}
+            onBlur={this.handleBlur}
+            autoComplete={this.props.autoComplete}
+            placeholder={this.props.placeholder}
+          />
+          {errorMessage}
+        </div>
+      </div>
+    );
+  }
+}
+EmailElement.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  value: PropTypes.string,
+  id: PropTypes.string,
+  class: PropTypes.string,
+  placeholder: PropTypes.string,
+  autoComplete: PropTypes.string,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  onUserInput: PropTypes.func,
+  onUserBlur: PropTypes.func,
+};
+EmailElement.defaultProps = {
+  name: '',
+  value: '',
+  id: null,
+  class: 'col-sm-12',
+  placeholder: '',
+  autoComplete: null,
+  disabled: false,
+  required: false,
+  errorMessage: '',
+  onUserInput: function() {
+    console.warn('onUserInput() callback is not set');
+  },
+  onUserBlur: function() {
+  },
+};
+
+/**
  * Password Component
  * React wrapper for a <input type="password"> element.
  */
@@ -2287,6 +2418,9 @@ class LorisElement extends Component {
       case 'text':
         elementHtml = (<TextboxElement {...elementProps} />);
         break;
+      case 'email':
+       elementHtml = (<EmailElement {...elementProps} />);
+       break;
       case 'password':
        elementHtml = (<PasswordElement {...elementProps} />);
        break;
@@ -2656,6 +2790,7 @@ window.TagsElement = TagsElement;
 window.SearchableDropdown = SearchableDropdown;
 window.TextareaElement = TextareaElement;
 window.TextboxElement = TextboxElement;
+window.EmailElement = EmailElement;
 window.PasswordElement = PasswordElement;
 window.DateElement = DateElement;
 window.TimeElement = TimeElement;

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -176,7 +176,7 @@ class RequestAccount extends Component {
             type={'text'}
             placeholder={'Last name'}
           />
-          <TextboxElement
+          <EmailElement
             name={'email'}
             value={this.state.form.value.email}
             onUserInput={this.setForm}

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -110,6 +110,14 @@ class Signup extends \NDB_Page implements ETagCalculator
             'account_request_date' => date('Y-m-d'),
         ];
 
+        // Check if email address is valid.
+        if (!filter_var($from, FILTER_VALIDATE_EMAIL)) {
+            // Invalid email address.
+            return new \LORIS\Http\Response\JSON\Conflict(
+                'Please provide a valid email address!'
+            );
+        }
+
         // Check email address' uniqueness
         $result = $DB->pselectOne(
             "SELECT COUNT(*) FROM users WHERE Email=:VEmail OR UserID=:VEmail",


### PR DESCRIPTION
## Brief summary of changes

Created an EmailElement that uses type="email" (see [here for specs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email)). The user's browser will prevent the form being completed if the user has not entered a valid email when type="email".

#### Testing instructions (if applicable)

1. Checkout PR.
2. Request account with invalid email

#### Link(s) to related issue(s)

* Resolves #7827
