### PR TITLE
[Issue tracker] No space before user in Comments & History

### DIFF
--- a/modules/issue_tracker/css/issue_tracker.css
+++ b/modules/issue_tracker/css/issue_tracker.css
@@ -84,5 +84,6 @@ h3 {
 }
 
 .history-item-user {
-    font-weight: bold;
+  font-weight: bold;
+  margin: 0 4px;
 }


### PR DESCRIPTION
## Brief summary of changes

Adds a space between the "user" in comments & history using css.

#### Testing instructions (if applicable)

1. Checkout PR.
2. Visit issue tracker module
3. See if there's a space before and after user.

#### Link(s) to related issue(s)

* Resolves #7800
