### PR TITLE
[NDB_BVL_Instrument] Add null value to examiner array

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1085,7 +1085,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'examinerID'
             );
         }
-        $examiners = [];
+        $examiners = [
+            null => ''
+        ];
         if (is_array($results) && !empty($results)) {
             foreach ($results AS $eid => $row) {
                 $name = $row['full_name'];


### PR DESCRIPTION
## Brief summary of changes
This PR adds an empty value to the array of examiner names. This was mistakenly taken out in #7462, and is causing the first value to be selected by default in instruments.

#### Testing instructions (if applicable)

1. Check that there is an empty option in the examiner drop down of instruments, and make sure that no value is selected by default.
