### PR TITLE
[bvl_feedback][dashboard] Add project/site specs to widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ changes in the following format: PR #1234***
 - Rename subproject to Cohort (PR #7817)
 - Create new CohortData and CohortController classes to use as data access model 
   and transfer object (PR #7817)
-- 
+- BVL Feedback widget only shows notifications for the users sites / projects (PR #7848)
 
 #### Bug Fixes
 - placeholder
@@ -121,7 +121,6 @@ multi-echo aquisitions (PR #7515).
 from the `psc` table. The default value of `CenterID` is `NULL`. Previously, the 
 default for `Center_name` was `AAAA` or `ZZZZ`. (PR #7525)
 - The statistics displayed in the dashboard was changed to only show the data relevant to the user's site(s). (PR #8132)
-- BVL Feedback widget only shows notifications for the users sites / projects (PR #7848)
 
 #### Bug Fixes
 - A LINST instrument Date field name now appears correctly (not truncated) on the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ multi-echo aquisitions (PR #7515).
 from the `psc` table. The default value of `CenterID` is `NULL`. Previously, the 
 default for `Center_name` was `AAAA` or `ZZZZ`. (PR #7525)
 - The statistics displayed in the dashboard was changed to only show the data relevant to the user's site(s). (PR #8132)
+- BVL Feedback widget only shows notifications for the users sites / projects (PR #7848)
 
 #### Bug Fixes
 - A LINST instrument Date field name now appears correctly (not truncated) on the 

--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -79,18 +79,18 @@ class Module extends \Module
 
             // Add centerID restriction if needed
             if (!$user->hasPermission('access_all_profiles')) {
-                $site_arr = implode(",",$user->getCenterIDs());
-                $query .= " AND s.CenterID IN ({$site_arr}) ";
+                $site_arr = implode(",", $user->getCenterIDs());
+                $query   .= " AND s.CenterID IN ({$site_arr}) ";
             }
 
             // Add project restriction & order BY
-            $project_arr = implode(",",$user->getProjectIDs());
-            $query .= " AND s.ProjectID IN ({$project_arr}) 
+            $project_arr = implode(",", $user->getProjectIDs());
+            $query      .= " AND s.ProjectID IN ({$project_arr}) 
                 ORDER BY Testdate DESC LIMIT 4";
 
-            $bvl_feedback      = $DB->pselect(
+            $bvl_feedback = $DB->pselect(
                 $query,
-                array()
+                []
             );
 
             $frontend_feedback = [];

--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -68,16 +68,31 @@ class Module extends \Module
 
             $last_login = $user->getLastLogin($DB);
 
-            $bvl_feedback      = $DB->pselect(
-                "SELECT fbt.Name, fbe.Testdate, fbe.Comment, fbth.FieldName,
+            // Base query
+            $query = "SELECT fbt.Name, fbe.Testdate, fbe.Comment, fbth.FieldName,
                 fbth.CommentID, fbth.SessionID, fbth.CandID, fbth.Feedback_level
                 FROM feedback_bvl_entry fbe
                 JOIN feedback_bvl_thread fbth USING (FeedbackID)
                 JOIN feedback_bvl_type fbt USING (Feedback_type)
-                WHERE fbth.Status='opened' AND fbth.Active='Y'
-                ORDER BY Testdate DESC LIMIT 4",
-                []
+                JOIN session s ON s.ID=fbth.SessionID
+                WHERE fbth.Status='opened' AND fbth.Active='Y'";
+
+            // Add centerID restriction if needed
+            if (!$user->hasPermission('access_all_profiles')) {
+                $site_arr = implode(",",$user->getCenterIDs());
+                $query .= " AND s.CenterID IN ({$site_arr}) ";
+            }
+
+            // Add project restriction & order BY
+            $project_arr = implode(",",$user->getProjectIDs());
+            $query .= " AND s.ProjectID IN ({$project_arr}) 
+                ORDER BY Testdate DESC LIMIT 4";
+
+            $bvl_feedback      = $DB->pselect(
+                $query,
+                array()
             );
+
             $frontend_feedback = [];
             foreach ($bvl_feedback as $row) {
                 if (new \DateTime($row['Testdate']) > $last_login) {


### PR DESCRIPTION
## Brief summary of changes

This PR changes the getWidget code so that a user only sees behavioural feedback notifications relevant to their own sites (unless they have the access all sites permission) / projects.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Login with a user who only has some sites / projects but not all
2. Check that the bvl feedback widget on the dashboard only includes notifications for that users sites / projects
3. Give the user the access_all_profiles permission, and check that the notifications no longer have the site restriction
