### PR TITLE
[user_accounts] Fix Access when only own site permission is set

### DIFF
--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -20,9 +20,9 @@ class UserAccountRow implements
      /**
       * Create a new ModuleRow Instance.
       *
-      * @param array $row  The ModuleRow Instance
-      * @param array $cids The CenterIDs
-      * @param array $pids The ProjectIDs
+      * @param array        $row  The ModuleRow Instance
+      * @param \CenterID[]  $cids The CenterIDs
+      * @param \ProjectID[] $pids The ProjectIDs
       */
     public function __construct(array $row, array $cids, array $pids)
     {
@@ -35,7 +35,7 @@ class UserAccountRow implements
     /**
      * Returns the CenterIDs for this row.
      *
-     * @return array The CenterIDs
+     * @return \CenterID[] The CenterIDs
      */
     public function getCenterIDs() : array
     {

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -44,13 +44,18 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        $cids = explode(',', $row['centerIds'] ?? '');
-
         $pids = array_map(
             function (string $pid) : \ProjectID {
                 return new \ProjectID($pid);
             },
             explode(',', $row['projectIds']),
+        );
+
+        $cids = array_map(
+            function (string $cid) : \CenterID{
+                return new \CenterID($cid);
+            },
+            explode(',', $row['centerIds']),
         );
 
         $row['centerIds']  = $cids;

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -52,7 +52,7 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
         );
 
         $cids = array_map(
-            function (string $cid) : \CenterID{
+            function (string $cid) : \CenterID {
                 return new \CenterID($cid);
             },
             explode(',', $row['centerIds']),


### PR DESCRIPTION
Fix access to the user accounts module when the user has only the
"own site" permission. The user_accounts module was returning
strings of CenterIDs instead of objects, this updates it to return
CenterID objects.

Resolves #7642
Replaces/Closes #7764