### PR TITLE
[conflict_resolver] Bar graph in candidate profile widget not working correctly

### DIFF
--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -108,7 +108,7 @@ class ResolvedFilterableDataTable extends Component {
         options: options.site,
       }},
       {label: 'CandID', show: true, filter: {
-        name: 'CandID',
+        name: 'candidateID',
         type: 'text',
         value: '300001',
       }},
@@ -117,7 +117,7 @@ class ResolvedFilterableDataTable extends Component {
         type: 'text',
       }},
       {label: 'Visit Label', show: true, filter: {
-        name: 'VisitLabel',
+        name: 'visitLabel',
         type: 'select',
         options: options.visitLabel,
       }},

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -120,7 +120,7 @@ class UnresolvedFilterableDataTable extends Component {
         options: options.site,
       }},
       {label: 'CandID', show: true, filter: {
-        name: 'CandID',
+        name: 'candidateID',
         type: 'text',
         value: '300001',
       }},
@@ -129,7 +129,7 @@ class UnresolvedFilterableDataTable extends Component {
         type: 'text',
       }},
       {label: 'Visit Label', show: true, filter: {
-        name: 'VisitLabel',
+        name: 'visitLabel',
         type: 'select',
         options: options.visitLabel,
       }},

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -28,8 +28,8 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
     //filter location on conflict_resolver page
     static $ForSite    = 'select[name="Site"]';
     static $Instrument = 'select[name="instrument"]';
-    static $VisitLabel = 'select[name="VisitLabel"]';
-    static $CandID     = 'input[name="CandID"]';
+    static $VisitLabel = 'select[name="visitLabel"]';
+    static $CandID     = 'input[name="candidateID"]';
     static $PSCID      = 'input[name="PSCID"]';
     static $Question   = 'input[name="Question"]';
     static $Project    = 'select[name="Project"]';


### PR DESCRIPTION
## Brief summary of changes

Bar graph in candidate profile widget will now link to the conflict_resolver module correctly and where the filters of the conflict_resolver will be correctly displayed for the user.

#### Testing instructions (if applicable)

See issue for testing instructions.

#### Link(s) to related issue(s)

* Resolves #7703
