### PR TITLE
[fatal_errors php 8.1]  Fatal error: Uncaught TypeError

### DIFF
--- a/php/libraries/CenterID.php
+++ b/php/libraries/CenterID.php
@@ -44,9 +44,9 @@ class CenterID extends ValidatableIdentifier implements \JsonSerializable
     /**
      * Specify how the data should be serialized to JSON.
      *
-     * @return mixed
+     * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : string
     {
         return $this->value;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -792,8 +792,8 @@ class Database implements LoggerAwareInterface
 
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
-                "The pselectWithIndexKey() function expects the uniqueKey parameter 
-                to not be null or empty. If re-indexing on the primary key is 
+                "The pselectWithIndexKey() function expects the uniqueKey parameter
+                to not be null or empty. If re-indexing on the primary key is
                 not necessary please use the pselect() function instead."
             );
         }
@@ -810,9 +810,9 @@ class Database implements LoggerAwareInterface
             // Check first that the row contains the primary key supplied
             if (!array_key_exists($uniqueKey, $row)) {
                 throw new DatabaseException(
-                    "The query supplied to pselectWithIndexKey() does not contain 
-                    the unique key to re-index on. Make sure to supply the 
-                    appropriate key in the SELECT statement to match the supplied 
+                    "The query supplied to pselectWithIndexKey() does not contain
+                    the unique key to re-index on. Make sure to supply the
+                    appropriate key in the SELECT statement to match the supplied
                     parameter of this function",
                     $query
                 );
@@ -823,7 +823,7 @@ class Database implements LoggerAwareInterface
             if (isset($filteredResult[$row[$uniqueKey]])) {
                 throw new DatabaseException(
                     "The uniqueKey supplied to pselectWithIndexKey() does not appear
-                     to be unique or is nullable. This function expects the key to 
+                     to be unique or is nullable. This function expects the key to
                      be both UNIQUE and NOT NULL.",
                     $query
                 );
@@ -885,7 +885,7 @@ class Database implements LoggerAwareInterface
             $colNumber = count($row);
             if ($colNumber !== 1) {
                 throw new DatabaseException(
-                    "The pselectCol() function expects only one column in the 
+                    "The pselectCol() function expects only one column in the
                     SELECT clause of the query, $colNumber were passed.",
                     $query
                 );
@@ -926,7 +926,7 @@ class Database implements LoggerAwareInterface
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
                 "The pselectColWithIndexKey() function expects the uniqueKey
-                 parameter to not be null or empty. If re-indexing on the primary 
+                 parameter to not be null or empty. If re-indexing on the primary
                  key is not necessary please use the pselectCol() function instead."
             );
         }
@@ -944,9 +944,9 @@ class Database implements LoggerAwareInterface
             // Check first that the row contains the primary key supplied
             if (!array_key_exists($uniqueKey, $row) || $colNumber !== 2) {
                 throw new DatabaseException(
-                    "The query supplied to pselectColWithIndexKey() should only 
-                    contain the unique key and one other column in the SELECT 
-                    clause. Make sure to supply the appropriate key in the SELECT 
+                    "The query supplied to pselectColWithIndexKey() should only
+                    contain the unique key and one other column in the SELECT
+                    clause. Make sure to supply the appropriate key in the SELECT
                     statement to match the supplied parameter of this function.",
                     $query
                 );
@@ -956,8 +956,8 @@ class Database implements LoggerAwareInterface
             // in the result array
             if (isset($filteredResult[$row[$uniqueKey]])) {
                 throw new DatabaseException(
-                    "The uniqueKey supplied to pselectColWithIndexKey() does not 
-                    appear to be unique or is nullable. This function expects the 
+                    "The uniqueKey supplied to pselectColWithIndexKey() does not
+                    appear to be unique or is nullable. This function expects the
                     key to be both UNIQUE and NOT NULL.",
                     $query
                 );
@@ -997,7 +997,7 @@ class Database implements LoggerAwareInterface
         if (is_array($result) && count($result)) {
             $result = array_values($result)[0];
         }
-        return $result;
+        return strval($result);
     }
 
     /**

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -44,9 +44,9 @@ class ProjectID extends ValidatableIdentifier implements \JsonSerializable
     /**
      * Specify how the data should be serialized to JSON.
      *
-     * @return mixed
+     * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : string
     {
         return $this->value;
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -100,7 +100,7 @@ class User extends UserPermissions implements
         $sitenames = [];
         foreach ($user_centerID_query as $key=>$val) {
             // Convert string representation of ID to int
-            $user_cid[$key] = new \CenterID($val['CenterID']);
+            $user_cid[$key] = new \CenterID(strval($val['CenterID']));
             $sitenames[]    = $val['Name'];
         }
         $row['Sites'] = implode(';', $sitenames);
@@ -110,7 +110,7 @@ class User extends UserPermissions implements
             ['uid' => $row['ID']]
         );
         foreach ($user_pid as $k=>$pid) {
-            $user_pid[$k] = new ProjectID($pid);
+            $user_pid[$k] = new ProjectID(strval($pid));
         }
 
         // Get examiner information


### PR DESCRIPTION
## Brief summary of changes

Fixes the following:

```
Fatal error: Uncaught TypeError: Database::pselectOne(): Return value must be of type ?string, int returned in /Loris/php/libraries/Database.class.inc:1000 Stack trace: #0 /Loris/php/libraries/UserPermissions.class.inc(55): Database->pselectOne('SELECT ID FROM ...', Array) #1 /Loris/php/libraries/User.class.inc(61): UserPermissions->select('admin') #2 /Loris/php/libraries/User.class.inc(169): User::factory('admin') #3 /Loris/php/libraries/NDB_Client.class.inc(184): User::singleton('admin') #4 /Loris/htdocs/index.php(34): NDB_Client->initialize() #5 {main} thrown in /Loris/php/libraries/Database.class.inc on line 1000
```

```
Deprecated: Return type of CenterID::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Loris/php/libraries/CenterID.php on line 49
```

```
Fatal error: Uncaught TypeError: ValidatableIdentifier::__construct(): Argument #1 ($value) must be of type string, int given, called in /Loris/php/libraries/User.class.inc on line 103 and defined in /Loris/php/libraries/ValidatableIdentifier.php:57 Stack trace: #0 /Loris/php/libraries/User.class.inc(103): ValidatableIdentifier->__construct(2) #1 /Loris/php/libraries/User.class.inc(169): User::factory('admin') #2 /Loris/php/libraries/NDB_Client.class.inc(184): User::singleton('admin') #3 /Loris/htdocs/index.php(34): NDB_Client->initialize() #4 {main} thrown in /Loris/php/libraries/ValidatableIdentifier.php on line 57
```


```
Deprecated: Return type of ProjectID::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Loris/php/libraries/ProjectID.php on line 49

: ValidatableIdentifier::__construct(): Argument #1 ($value) must be of type string, int given, called in Loris/php/libraries/User.class.inc on line 113 and defined in Loris/php/libraries/ValidatableIdentifier.php:57 Stack trace: #0 Loris/php/libraries/User.class.inc(113): ValidatableIdentifier->__construct(1) #1 Loris/php/libraries/User.class.inc(169): User::factory('admin') #2 Loris/php/libraries/NDB_Client.class.inc(184): User::singleton('admin') #3 Loris/htdocs/index.php(34): NDB_Client->initialize() #4 {main} thrown in Loris/php/libraries/ValidatableIdentifier.php on line 57
```

