### PR TITLE
Remove install instructions from the README so that users go to the WIKI page that is more complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,75 +27,8 @@ Deploy and log in with username *admin* and the password that's set up during de
 
 ## Installation
 
-#### System Requirements
-
- * Apache **2.4** or higher
- * MySQL >= 5.7 (or MariaDB >= 10.3)
- * PHP <b>7.4</b> or higher
- * [Composer](https://getcomposer.org/) <b>1.4</b> or higher
- * NodeJS <b>10.13.0</b> or higher
- * NPM
- * make
-
-These dependencies are subject to change so be sure to verify your version of MySQL and PHP when updating LORIS. Installing some dependencies may require `sudo` privileges.
-
-### Install Steps
-
 Consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information.
 
-1. Set up LINUX user and group lorisadmin and create LORIS base directory:
-
-```bash
-# Create lorisadmin user and group
-# Give lorisadmin `sudo` permission. This is required for the install process
-# in order to automatically generate Apache configuration files.
-# Sudo privileges can be revoked once the install is completed.
-sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-# Add apache to the lorisadmin group
-sudo usermod -a -G lorisadmin www-data
-# Set the password for the lorisadmin account
-sudo passwd lorisadmin
-sudo mkdir -m 755 -p /var/www/$projectname
-sudo chown lorisadmin.lorisadmin /var/www/$projectname
-su - lorisadmin
-```
-
- <i>$projectname ⇾ "loris" or one-word project name</i>
-
-2. Get the code:
-Download the latest release from the [releases page](https://github.com/aces/Loris/releases) and extract it to `/var/www/$projectname`
-
-3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
-
-For more information, please read the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md).
-
- ```bash
- cd /var/www/$projectname/tools
- ./install.sh
- ```
-
-4. Run the makefile (use `make dev` if you are setting up a development sandbox)
- ```bash
- cd /var/www/$projectname
- make
- ```
-
-5. Apache configuration
-
-If your apache configuration was not completed by the Install script, run the following enable rewriting of LORIS, enable your `$projectname` site, and restart apache:  (run by user who has root privileges)
-
-```bash
-sudo a2enmod rewrite
-sudo a2dissite default
-sudo a2ensite $projectname
-sudo service apache2 reload
-```
-
-6. Open your browser and go to: `<loris-url>/installdb.php`. This web page will prompt you for your mysql connection information. Follow the instructions to finalize LORIS installation, then restart apache.
-
-If you use MySQL 8, please read [this link](https://www.php.net/manual/en/mysqli.requirements.php) and also [this](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password-compatible-connectors).
-
-7. Follow the [Setup Guide in the LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) to complete your post-installation setup and configuration, and for more documentation.
 
 ## Community
 


### PR DESCRIPTION
## Brief summary of changes

Removes the install steps from the README.md file since there is already a link to the proper WIKI install pages. The WIKI install description is more up to date than what was present in the README. Would avoid the users the same confusion I encountered while testing the install process (aka: missing tons of packages as they were not specified in the README).

