### PR TITLE
Remove dataquery from the modules table in the default schema

### DIFF
--- a/SQL/0000-00-01-Modules.sql
+++ b/SQL/0000-00-01-Modules.sql
@@ -21,7 +21,6 @@ INSERT INTO modules (Name, Active) VALUES ('create_timepoint', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('dashboard', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('data_release', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('datadict', 'Y');
-INSERT INTO modules (Name, Active) VALUES ('dataquery', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('dicom_archive', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('dictionary', 'Y');
 INSERT INTO modules (Name, Active) VALUES ('document_repository', 'Y');


### PR DESCRIPTION
## Brief summary of changes

This removes the `dataquery` module from the `modules` database table. Note: there is already a [patch](https://github.com/aces/Loris/blob/main/SQL/New_patches/2021-09-07_dqt_drop_old_dataquery.sql) taking care of that but the default schema was not up to date.

Note: RB `modules` table does not contain `dataquery` so no need to update RB data here.