### PR TITLE
Update install order and add npm dependency to the list of dependencies

### DIFF
--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -24,6 +24,8 @@ Additionally, the following package manager are required to build LORIS:
 
 * NodeJS 16.10.0 (or higher)
 
+* NPM
+
 * composer
 
 This guide does not cover installation of these requirements.

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -59,6 +59,30 @@ The following Ubuntu packages are required and should be installed using
 * libapache2-mod-php7.4  
 
 
+## Creating the lorisadmin user
+Create the _lorisadmin_ user and group and give _lorisadmin_ `sudo` permission. 
+This is required for the install process in order to automatically generate
+Apache configuration files. Sudo priviledges can be revoked once the install
+is completed. 
+
+## Creating the lorisadmin user
+
+```bash
+# Create lorisadmin user and group
+# Give lorisadmin `sudo` permission. This is required for the install process
+# in order to automatically generate Apache configuration files.
+# 
+# Sudo privileges should be revoked once the install is completed.
+sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+# Add apache to the lorisadmin group
+sudo usermod -a -G lorisadmin www-data
+# Set the password for the lorisadmin account
+sudo passwd lorisadmin
+sudo mkdir -m 755 -p /var/www/$projectname
+sudo chown lorisadmin.lorisadmin /var/www/$projectname
+su - lorisadmin
+```
+
 ## Getting the source code
 
 Visit the [releases](https://github.com/aces/loris/releases) page and download the zipped file of the latest LORIS
@@ -105,29 +129,6 @@ make      # For production environments
 make dev  # For development environments
 ```
 
-## Creating the lorisadmin user
-Create the _lorisadmin_ user and group and give _lorisadmin_ `sudo` permission. 
-This is required for the install process in order to automatically generate
-Apache configuration files. Sudo priviledges can be revoked once the install
-is completed. 
-
-## Creating the lorisadmin user
-
-```bash
-# Create lorisadmin user and group
-# Give lorisadmin `sudo` permission. This is required for the install process
-# in order to automatically generate Apache configuration files.
-# 
-# Sudo privileges should be revoked once the install is completed.
-sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-# Add apache to the lorisadmin group
-sudo usermod -a -G lorisadmin www-data
-# Set the password for the lorisadmin account
-sudo passwd lorisadmin
-sudo mkdir -m 755 -p /var/www/$projectname
-sudo chown lorisadmin.lorisadmin /var/www/$projectname
-su - lorisadmin
-```
 
 ## Running the install script
 


### PR DESCRIPTION
## Brief summary of changes

While testing the install, I noticed the order in the installation instructions were off. Should first create the `lorisadmin` user and `/var/www/loris` and then download the source code to move it to `/var/www/loris`.

Also, NPM is missing in the prerequisites. 