### PR TITLE
[data_release] Version column sort - fix

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -230,7 +230,8 @@ class DataTable extends Component {
       if (val === '.') {
         // hack to handle non-existent items in DQT
         val = null;
-      } else if (isNumber) {
+      } else if (isNumber && this.state.sort.column === -1) {
+        // only No. column will conver to number, otherwise string
         // perform type conversion (from string to int/float)
         val = Number(val);
       } else if (isString) {
@@ -269,8 +270,8 @@ class DataTable extends Component {
         if (b.Value === null || typeof b.Value === 'undefined') return 1;
 
         // Sort by value
-        if (String(a.Value) < String(b.Value)) return -1;
-        if (String(a.Value) > String(b.Value)) return 1;
+        if (a.Value < b.Value) return -1;
+        if (a.Value > b.Value) return 1;
       } else {
         if (a.Value === b.Value) {
           // If all values are equal, sort by rownum
@@ -282,8 +283,8 @@ class DataTable extends Component {
         if (b.Value === null || typeof b.Value === 'undefined') return -1;
 
         // Sort by value
-        if (String(a.Value) < String(b.Value)) return 1;
-        if (String(a.Value) > String(b.Value)) return -1;
+        if (a.Value < b.Value) return 1;
+        if (a.Value > b.Value) return -1;
       }
       // They're equal..
       return 0;

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -236,6 +236,7 @@ class DataTable extends Component {
       } else if (isString) {
         // if string with text convert to lowercase
         val = val.toLowerCase();
+        console.log(val);
       } else if (Array.isArray(val)) {
         val = val.join(', ');
       } else {
@@ -258,6 +259,9 @@ class DataTable extends Component {
     }
 
     index.sort((a, b) => {
+console.log(a);
+console.log('__');
+console.log(b);
       if (this.state.sort.ascending) {
         if (a.Value === b.Value) {
           // If all values are equal, sort by rownum
@@ -269,8 +273,8 @@ class DataTable extends Component {
         if (b.Value === null || typeof b.Value === 'undefined') return 1;
 
         // Sort by value
-        if (a.Value < b.Value) return -1;
-        if (a.Value > b.Value) return 1;
+        if (String(a.Value) < String(b.Value)) return -1;
+        if (String(a.Value) > String(b.Value)) return 1;
       } else {
         if (a.Value === b.Value) {
           // If all values are equal, sort by rownum
@@ -282,8 +286,8 @@ class DataTable extends Component {
         if (b.Value === null || typeof b.Value === 'undefined') return -1;
 
         // Sort by value
-        if (a.Value < b.Value) return 1;
-        if (a.Value > b.Value) return -1;
+        if (String(a.Value) < String(b.Value)) return 1;
+        if (String(a.Value) > String(b.Value)) return -1;
       }
       // They're equal..
       return 0;

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -236,7 +236,6 @@ class DataTable extends Component {
       } else if (isString) {
         // if string with text convert to lowercase
         val = val.toLowerCase();
-        console.log(val);
       } else if (Array.isArray(val)) {
         val = val.join(', ');
       } else {
@@ -259,9 +258,6 @@ class DataTable extends Component {
     }
 
     index.sort((a, b) => {
-console.log(a);
-console.log('__');
-console.log(b);
       if (this.state.sort.ascending) {
         if (a.Value === b.Value) {
           // If all values are equal, sort by rownum

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -120,9 +120,6 @@ class DataReleaseIndex extends Component {
           );
         }
         break;
-      case 'Version':
-        result = <td>{cell || 'Unversioned'}</td>;
-        break;
     }
     return result;
   }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -61,7 +61,7 @@ class Data_Release extends \NDB_Menu_Filter
         // set the class variables
         $this->columns = [
             'file_name AS fileName',
-            'version',
+            'IF(version is null or version ="","Unversioned", version) AS version',
             'upload_date AS uploadDate',
             'dr.id as dataReleaseID',
         ];


### PR DESCRIPTION
## Brief summary of changes
transfer the int value to string to sort the mix type column. { 1 , version2 , v3}
add Unversioned into sorting.
#### Testing instructions (if applicable)
sort the version column 
#### Link(s) to related issue(s)

[data_release] Version column only sorts in 1 direction #7894
