### PR TITLE
[Login] Request account with bad email UI seems to work

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1295,6 +1295,10 @@ class EmailElement extends Component {
         <div className={inputClass}>
           <input
             type="email"
+            pattern={'/^[a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[' +
+              'a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-' +
+              ']{0,61}[a-zA-Z0-9])?)*$/'}
+            title="Please provide a valid email address!"
             className="form-control"
             name={this.props.name}
             id={this.props.id}

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
+import swal from 'sweetalert2';
 
 /**
  * Request account form.
@@ -96,7 +97,11 @@ class RequestAccount extends Component {
           response.json().then((data) => {
             if (data.error) {
               console.error(data.error);
-              this.setState({request: true});
+              if (data.error === 'Please provide a valid email address!') {
+                swal.fire('Error!', data.error, 'error');
+              } else {
+                this.setState({request: true});
+              }
             }
           });
         }


### PR DESCRIPTION
## Brief summary of changes

Updates the email component to use the pattern property for the email input. Also using the type property for the message to displayed to the user when email isn't matching the pattern property. See here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email

edit: I added frontend logic for if by any chance the php validation finds an error not caught by the frontend and so the user will get a notification that email is invalid.

#### Testing instructions (if applicable)

1. Checkout PR
2. Attempt request account with bad email ex. "bad@email"
3. User should not be able to use bad email.

#### Link(s) to related issue(s)

* Resolves #7897
