### PR TITLE
[user_accounts] Random "none" on the page when adding new user

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -659,8 +659,9 @@ class Edit_User extends \NDB_Form
             // It is an existing user:
             //     display user name and account request date
             $this->addScoreColumn('UserID', 'User name');
-            $this->addScoreColumn('account_request_date', 'Account Request Date');
         }
+        // Account Request Date - always displayed
+        $this->addScoreColumn('account_request_date', 'Account Request Date');
 
         // password
         if ($this->isCreatingNewUser()) {

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -397,6 +397,7 @@
                 {/if}
             </div>
       {/if}
+      {if $form.Active|default}
       <div class="row form-group form-inline">
            <label class="col-sm-2">
                {$form.Active.label|default}
@@ -408,6 +409,7 @@
               {$form.Active.html|default}
           </div>
       </div>
+      {/if}
 
 	{if $form.errors.active_timeWindows|default}
 	    <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
## Brief summary of changes

Updates the logic for `Account Request Date` to always be displayed. Unsure if we want to hide it for administrators. @ridz1208 ?

#### Testing instructions (if applicable)

1. See issue.

#### Link(s) to related issue(s)

* Resolves #7912
