### PR TITLE
[User Accounts] A user with the permission "View/Create/Edit User Accounts - Own Sites" could be unintentionally restrict the access of other users to the sites it doesn't have access to.

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -298,7 +298,7 @@ class Edit_User extends \NDB_Form
             }
 
             $DB->delete('user_psc_rel', ["UserID" => $uid]);
-            foreach ($us_curr_sites as $site) {
+            foreach ($userNewCenterIDs as $CenterID) {
                 $DB->insert(
                     'user_psc_rel',
                     [

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -273,16 +273,18 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getId();
         $us_curr_sites = $values['CenterIDs'];
         $userNewCenterIDs = array_map(
-            function($val) {return new \CenterID($val);},
+            function ($val) {
+                return new \CenterID($val);
+            },
             $values['CenterIDs']
         );
         if (!$this->isCreatingNewUser()) {
             // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
-                $userCenterIDs       = $user->getCenterIDs();
+                $userCenterIDs = $user->getCenterIDs();
                 // Collect CenterID(s) of the editor modifying sites.
-                $editorCenterIDs       = $editor->getCenterIDs();
+                $editorCenterIDs = $editor->getCenterIDs();
                 // If the editor does not have access to all of the
                 // user's sites the difference between the two arrays
                 // will be the sites we additionally need to add to
@@ -290,14 +292,14 @@ class Edit_User extends \NDB_Form
                 $differenceOfCenterIDs = array_udiff(
                     $userCenterIDs,
                     $editorCenterIDs,
-                    function($userCenterID, $editorCenterID) {
+                    function ($userCenterID, $editorCenterID) {
                         return strcmp(
                             $userCenterID,
                             $editorCenterID
                         );
                     }
                 );
-                $userNewCenterIDs         = array_merge(
+                $userNewCenterIDs      = array_merge(
                     $userNewCenterIDs,
                     $differenceOfCenterIDs
                 );

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -288,8 +288,8 @@ class Edit_User extends \NDB_Form
                 // will be the sites we additionally need to add to
                 // the user being modified.
                 $differenceOfCenterIDs = array_diff(
-                    $userCenterIDsValues,
-                    $editorCenterIDsValues
+                    $userCenterIDs,
+                    $editorCenterIDs
                 );
                 $us_curr_sites         = array_merge(
                     $us_curr_sites,

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -273,6 +273,29 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getId();
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
+            // Prevent deletion of rules current user may not have access to edit.
+            if (!$editor->hasPermission('user_accounts_multisite')) {
+                // Collect CenterID(s) of user being modified.
+                $userCenterIDs = array_values($DB->pselect('SELECT CenterID FROM user_psc_rel WHERE UserID=:uid', [
+                    'uid' => $uid
+                ]));
+                // Collect CenterID(s) of the editor modifying sites.
+                $editorCenterIDs = $editor->getCenterIDs();
+                $userCenterIDsValues   = [];
+                $editorCenterIDsValues = [];
+                foreach ($userCenterIDs as $userCenterID) {
+                    $userCenterIDsValues[] = $userCenterID['CenterID'];
+                }
+                foreach ($editorCenterIDs as $editorCenterID) {
+                    $editorCenterIDsValues[] = (string) $editorCenterID;
+                }
+                // If the editor does not have access to all of the user's sites
+                // the difference between the two arrays will be the sites we additionally
+                // need to add to the user.
+                $differenceOfCenterIDs = array_diff($userCenterIDsValues, $editorCenterIDsValues);
+                $us_curr_sites = array_merge($us_curr_sites, $differenceOfCenterIDs);
+            }
+
             $DB->delete('user_psc_rel', ["UserID" => $uid]);
             foreach ($us_curr_sites as $site) {
                 $DB->insert(

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -278,7 +278,7 @@ class Edit_User extends \NDB_Form
         );
         if (!$this->isCreatingNewUser()) {
             // Prevent deletion of rules/sites editor may not have access to edit.
-            if (!$editor->hasPermission('user_accounts_multisite')) {
+//            if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
                 $userCenterIDs       = $user->getCenterIDs();
                 // Collect CenterID(s) of the editor modifying sites.
@@ -287,23 +287,29 @@ class Edit_User extends \NDB_Form
                 // user's sites the difference between the two arrays
                 // will be the sites we additionally need to add to
                 // the user being modified.
-                $differenceOfCenterIDs = array_diff(
+                $differenceOfCenterIDs = array_udiff(
                     $userCenterIDs,
-                    $editorCenterIDs
+                    $editorCenterIDs,
+                    function($userCenterID, $editorCenterID) {
+                        return strcmp(
+                            (string) $userCenterID,
+                            (string) $editorCenterID
+                        );
+                    }
                 );
                 $userNewCenterIDs         = array_merge(
                     $userNewCenterIDs,
                     $differenceOfCenterIDs
                 );
-            }
+//            }
 
             $DB->delete('user_psc_rel', ["UserID" => $uid]);
-            foreach ($userNewCenterIDs as $CenterID) {
+            foreach ($userNewCenterIDs as $centerID) {
                 $DB->insert(
                     'user_psc_rel',
                     [
                         "UserID"   => $uid,
-                        "CenterID" => $site,
+                        "CenterID" => $centerID,
                     ]
                 );
             }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -294,11 +294,18 @@ class Edit_User extends \NDB_Form
                 foreach ($editorCenterIDs as $editorCenterID) {
                     $editorCenterIDsValues[] = (string) $editorCenterID;
                 }
-                // If the editor does not have access to all of the user's sites
-                // the difference between the two arrays will be the sites we additionally
-                // need to add to the user being modified.
-                $differenceOfCenterIDs = array_diff($userCenterIDsValues, $editorCenterIDsValues);
-                $us_curr_sites         = array_merge($us_curr_sites, $differenceOfCenterIDs);
+                // If the editor does not have access to all of the
+                // user's sites the difference between the two arrays
+                // will be the sites we additionally need to add to
+                // the user being modified.
+                $differenceOfCenterIDs = array_diff(
+                    $userCenterIDsValues,
+                    $editorCenterIDsValues
+                );
+                $us_curr_sites         = array_merge(
+                    $us_curr_sites,
+                    $differenceOfCenterIDs
+                );
             }
 
             $DB->delete('user_psc_rel', ["UserID" => $uid]);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -280,14 +280,7 @@ class Edit_User extends \NDB_Form
             // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
-                $userCenterIDs = array_values(
-                    $DB->pselect(
-                        'SELECT CenterID FROM user_psc_rel WHERE UserID=:uid',
-                        [
-                            'uid' => $uid
-                        ]
-                    )
-                );
+                $userCenterIDs       = $user->getCenterIDs();
                 // Collect CenterID(s) of the editor modifying sites.
                 $editorCenterIDs       = $editor->getCenterIDs();
                 $userCenterIDsValues   = [];

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -289,15 +289,9 @@ class Edit_User extends \NDB_Form
                 // user's sites the difference between the two arrays
                 // will be the sites we additionally need to add to
                 // the user being modified.
-                $differenceOfCenterIDs = array_udiff(
+                $differenceOfCenterIDs = array_diff(
                     $userCenterIDs,
-                    $editorCenterIDs,
-                    function ($userCenterID, $editorCenterID) {
-                        return strcmp(
-                            $userCenterID,
-                            $editorCenterID
-                        );
-                    }
+                    $editorCenterIDs
                 );
                 $userNewCenterIDs      = array_merge(
                     $userNewCenterIDs,

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -272,6 +272,10 @@ class Edit_User extends \NDB_Form
         // multi-site UPDATE
         $uid           = $user->getId();
         $us_curr_sites = $values['CenterIDs'];
+        $userNewCenterIDs = array_map(
+            function($val) {return new \CenterID($val);},
+            $values['CenterIDs']
+        );
         if (!$this->isCreatingNewUser()) {
             // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -294,7 +294,7 @@ class Edit_User extends \NDB_Form
                     $editorCenterIDs
                 );
                 $userNewCenterIDs      = array_merge(
-                    $userNewCenterIDs,
+                    array_intersect($userNewCenterIDs, $editorCenterIDs),
                     $differenceOfCenterIDs
                 );
             }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -291,7 +291,7 @@ class Edit_User extends \NDB_Form
                     $userCenterIDs,
                     $editorCenterIDs
                 );
-                $us_curr_sites         = array_merge(
+                $userNewCenterIDs         = array_merge(
                     $userNewCenterIDs,
                     $differenceOfCenterIDs
                 );

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -273,7 +273,7 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getId();
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
-            // Prevent deletion of rules current user may not have access to edit.
+            // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
                 $userCenterIDs = array_values($DB->pselect('SELECT CenterID FROM user_psc_rel WHERE UserID=:uid', [
@@ -291,7 +291,7 @@ class Edit_User extends \NDB_Form
                 }
                 // If the editor does not have access to all of the user's sites
                 // the difference between the two arrays will be the sites we additionally
-                // need to add to the user.
+                // need to add to the user being modified.
                 $differenceOfCenterIDs = array_diff($userCenterIDsValues, $editorCenterIDsValues);
                 $us_curr_sites = array_merge($us_curr_sites, $differenceOfCenterIDs);
             }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -278,7 +278,7 @@ class Edit_User extends \NDB_Form
         );
         if (!$this->isCreatingNewUser()) {
             // Prevent deletion of rules/sites editor may not have access to edit.
-//            if (!$editor->hasPermission('user_accounts_multisite')) {
+            if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
                 $userCenterIDs       = $user->getCenterIDs();
                 // Collect CenterID(s) of the editor modifying sites.
@@ -292,8 +292,8 @@ class Edit_User extends \NDB_Form
                     $editorCenterIDs,
                     function($userCenterID, $editorCenterID) {
                         return strcmp(
-                            (string) $userCenterID,
-                            (string) $editorCenterID
+                            $userCenterID,
+                            $editorCenterID
                         );
                     }
                 );
@@ -301,7 +301,7 @@ class Edit_User extends \NDB_Form
                     $userNewCenterIDs,
                     $differenceOfCenterIDs
                 );
-//            }
+            }
 
             $DB->delete('user_psc_rel', ["UserID" => $uid]);
             foreach ($userNewCenterIDs as $centerID) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -283,14 +283,6 @@ class Edit_User extends \NDB_Form
                 $userCenterIDs       = $user->getCenterIDs();
                 // Collect CenterID(s) of the editor modifying sites.
                 $editorCenterIDs       = $editor->getCenterIDs();
-                $userCenterIDsValues   = [];
-                $editorCenterIDsValues = [];
-                foreach ($userCenterIDs as $userCenterID) {
-                    $userCenterIDsValues[] = $userCenterID['CenterID'];
-                }
-                foreach ($editorCenterIDs as $editorCenterID) {
-                    $editorCenterIDsValues[] = (string) $editorCenterID;
-                }
                 // If the editor does not have access to all of the
                 // user's sites the difference between the two arrays
                 // will be the sites we additionally need to add to

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -276,11 +276,16 @@ class Edit_User extends \NDB_Form
             // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
-                $userCenterIDs = array_values($DB->pselect('SELECT CenterID FROM user_psc_rel WHERE UserID=:uid', [
-                    'uid' => $uid
-                ]));
+                $userCenterIDs = array_values(
+                    $DB->pselect(
+                        'SELECT CenterID FROM user_psc_rel WHERE UserID=:uid',
+                        [
+                            'uid' => $uid
+                        ]
+                    )
+                );
                 // Collect CenterID(s) of the editor modifying sites.
-                $editorCenterIDs = $editor->getCenterIDs();
+                $editorCenterIDs       = $editor->getCenterIDs();
                 $userCenterIDsValues   = [];
                 $editorCenterIDsValues = [];
                 foreach ($userCenterIDs as $userCenterID) {
@@ -293,7 +298,7 @@ class Edit_User extends \NDB_Form
                 // the difference between the two arrays will be the sites we additionally
                 // need to add to the user being modified.
                 $differenceOfCenterIDs = array_diff($userCenterIDsValues, $editorCenterIDsValues);
-                $us_curr_sites = array_merge($us_curr_sites, $differenceOfCenterIDs);
+                $us_curr_sites         = array_merge($us_curr_sites, $differenceOfCenterIDs);
             }
 
             $DB->delete('user_psc_rel', ["UserID" => $uid]);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -292,7 +292,7 @@ class Edit_User extends \NDB_Form
                     $editorCenterIDs
                 );
                 $us_curr_sites         = array_merge(
-                    $us_curr_sites,
+                    $userNewCenterIDs,
                     $differenceOfCenterIDs
                 );
             }


### PR DESCRIPTION
## Brief summary of changes

Here's an attempt at solving the bug of when a user has permissions to edit users for "Own Sites" and where the editor can possibly remove sites from a user that has additional sites that the editor modifying does not.

#### Testing instructions (if applicable)

See issue created for testing instructions if not clear from summary.

#### Link(s) to related issue(s)

* Resolves #7855
