### PR TITLE
[document_repository] simplify notification permission restrictions to view only

### DIFF
--- a/modules/document_repository/README.md
+++ b/modules/document_repository/README.md
@@ -30,7 +30,7 @@ uploaded file system where new files will be written.
 
 ## Interactions with LORIS
 
-Users can enable notifications for the document_repository in the My Preferences module. Once activated, users receive an email each time one of the following events occurs:
+Users can enable notifications for the document_repository in the "My Preferences" module. Permissions required in order to be able to change notification settings for this module are dictated by the `notification_modules_perm_rel` table of the database. Once activated, users receive an email each time one of the following events occurs:
 * Addition, deletion or modification of a file (by another user)
 * Addition of a category (by another user)
 

--- a/raisinbread/RB_files/RB_notification_modules_perm_rel.sql
+++ b/raisinbread/RB_files/RB_notification_modules_perm_rel.sql
@@ -5,10 +5,6 @@ INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (4,35);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (5,35);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (6,35);
-INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (3,36);
-INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (4,36);
-INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (5,36);
-INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (6,36);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (1,43);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (2,43);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (1,44);


### PR DESCRIPTION
## Brief summary of changes
Change necessary permissions to document_repository_view only in order to be able to toggle the doc repo notification settings in "my preferences"

Add info to the readme to know where the notification permission control can be found


#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #7867
