### PR TITLE
[document_repository] Edit/Upload permissions fixes

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -265,7 +265,11 @@ class DocIndex extends React.Component {
         type: 'text',
       }},
       {label: 'Date Uploaded', show: true},
-      {label: 'Edit', show: true},
+      {
+        label: 'Edit',
+        show: this.props.hasPermission('superUser')
+        || this.props.hasPermission('document_repository_edit')
+      },
       {
         label: 'Delete File',
         show: this.props.hasPermission('superUser')
@@ -281,13 +285,14 @@ class DocIndex extends React.Component {
     ];
     let uploadDoc;
     let uploadCategory;
-    if (loris.userHasPermission('document_repository_view')) {
+    if (loris.userHasPermission('document_repository_edit')) {
       tabList.push(
         {
           id: 'upload',
           label: 'Upload',
         },
       );
+
       tabList.push(
         {
           id: 'category',
@@ -309,6 +314,24 @@ class DocIndex extends React.Component {
 
       uploadCategory = (
         <TabPane TabId={tabList[2].id}>
+          <DocCategoryForm
+            dataURL={`${loris.BaseURL}/document_repository/?format=json`}
+            action={`${loris.BaseURL}/document_repository/UploadCategory`}
+            refreshPage={this.fetchData}
+            newCategoryState={this.newCategoryState}
+          />
+        </TabPane>
+      );
+    } else if (loris.userHasPermission('document_repository_view')) {
+      tabList.push(
+        {
+          id: 'category',
+          label: 'Category',
+        },
+      );
+
+      uploadCategory = (
+        <TabPane TabId={tabList[1].id}>
           <DocCategoryForm
             dataURL={`${loris.BaseURL}/document_repository/?format=json`}
             action={`${loris.BaseURL}/document_repository/UploadCategory`}

--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -268,7 +268,7 @@ class DocIndex extends React.Component {
       {
         label: 'Edit',
         show: this.props.hasPermission('superUser')
-        || this.props.hasPermission('document_repository_edit')
+        || this.props.hasPermission('document_repository_edit'),
       },
       {
         label: 'Delete File',

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -46,6 +46,7 @@ class DocTree extends \NDB_Page
             [
                 'document_repository_view',
                 'document_repository_delete',
+                'document_repository_edit'
             ]
         );
     }

--- a/modules/document_repository/php/edit.class.inc
+++ b/modules/document_repository/php/edit.class.inc
@@ -32,7 +32,7 @@ class Edit extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('document_repository_view');
+        return $user->hasPermission('document_repository_edit');
     }
 
     /**

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -37,6 +37,7 @@ class Files extends \NDB_Page
             [
                 'document_repository_view',
                 'document_repository_delete',
+                'document_repository_edit'
             ]
         );
     }

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -40,6 +40,7 @@ class Module extends \Module
                 [
                     'document_repository_view',
                     'document_repository_delete',
+                    'document_repository_edit'
                 ]
             );
     }


### PR DESCRIPTION
## Brief summary of changes
There are 2 changes made in this PR. 
1. Users with the document repository edit/upload permission but no view/delete permissions can access the document repository module
2. Users without edit/upload permission cannot access the edit and upload pages of the module. The `Edit` button and `Upload` tab are not visible for users without the edit/upload permission.

#### Testing instructions (if applicable)
To test module access:
1. Give a non-superuser only the Document Repository Edit/Upload permission
2. Log in as this user and see that the document repository is accessible 

To test edit/upload permissions:
1. Give a non-superuser the Document Repository View or Delete permissions
2. Log in as this user and see that the `Upload` tab is not visible or accessible
3. Navigate to a file in the document tree and see that it cannot be edited by this user and the edit button is not displayed

#### Links to related issues
* Resolves #7863
* Resolves #7864 

