### PR TITLE
[next_stage] Help text for next_stage module

### DIFF
--- a/modules/next_stage/help/next_stage.md
+++ b/modules/next_stage/help/next_stage.md
@@ -1,0 +1,5 @@
+# Next Stage
+
+This module prompts for the date of the current visit to start the Visit Stage of the session and populate the instrument list page with the relevant instruments. 
+
+Once the date of the visit is entered and the user clicks on "Start Visit", the user will be redirected to a page with a success message and a link to the updated instrument list page.


### PR DESCRIPTION
This PR adds help text for users in the frontend of the next stage module

#### Testing instructions (if applicable)
1. Create a new timepoint for a candidate and go to the next stage page
2. Click on the `?` icon and see help text

#### Link to related issue
* Resolves #7871 
