### PR TITLE
[LINST] Fix standard dates always required bug

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -657,6 +657,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // Set date format
                         $dateFormat = isset($pieces[5]) ? trim($pieces[5]) : "";
 
+                        // The question should be added to the LinstQuestions in this
+                        // order, before the _date is stripped below for standard
+                        // dates to allow XINValidation to recognize the field name
+                        $this->LinstQuestions[$pieces[1]] = ['type' => 'date'];
+
                         if ($dateFormat === 'MonthYear') {
                             // Shows date without day of month
                             $this->addMonthYear(
@@ -710,7 +715,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $this->_requiredElements[] = $fieldname;
                         $firstFieldOfPage          = false;
                     }
-                    $this->LinstQuestions[$pieces[1]] = ['type' => 'date'];
                     break;
                 case 'numeric':
                     if ($addElements) {


### PR DESCRIPTION
## Brief summary of changes
XIN rules always required Standard Date elements to be completed, even when user tries to override rules from the `.rules` file. The bug is caused by the stripping of the `_date` suffix for datefields (the suffix is later added in the Instrument class to make LINST and PHP instruments compatible) which means the incorrect question name was being passed to validation without the `_date` suffix.

This PR moves the addition of the question to the validated array to BEFORE the `_date` is stripped

#### Testing instructions (if applicable)

1. create or use an existing instrument having a standard date field
2. load the instrument for a candidate and try to save it without any data in the date field (the form should return an error as all fields are required by default)
3. add a rule to the `.rules` file for the linst instrument to make the date field not required
4. try saving without any value in the date field (without this PR, the form will still return an error. With this PR the issue is fixed)


To simplify testing, I am providing here the necessary addition you need to make to the following files to add a date field as well as the rule that should make the field not required
 - `.linst` file:
   ```
   date{@}somedate_date{@}DATE FOR TESTING{@}1900{@}1923{@}Date
   select{@}somedate_date_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
   ```
 - `.rules` file:
   ```
   somedate_date{-}Required{-}somedate_date{@}=={@}NEVER_REQUIRED
   ```
You can add these to any LINST instrument, including the RB BMI to test this PR easily


#### Link(s) to related issue(s)

* Resolves #7650
