### PR TITLE
[Battery] Fix error when multiple rows of the same instrument match

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -318,14 +318,14 @@ class NDB_BVL_Battery
         $this->_assertBatterySelected();
 
         // craft the select query
-        $query = "SELECT DISTINCT f.Test_name,
+        $query = "SELECT f.Test_name,
                       t.Full_name,
                       f.CommentID,
                       CONCAT('DDE_', f.CommentID) AS DDECommentID,
                       ts.Subgroup_name as Sub_group,
                       ts.group_order as Subgroup_order,
                       t.isDirectEntry,
-                      b.instr_order as instrument_order
+                      MAX(b.instr_order) as instrument_order
                   FROM flag f
             	      JOIN test_names t ON (f.Test_name=t.Test_name)
             	      JOIN test_subgroups ts ON (ts.ID = t.Sub_group)
@@ -336,7 +336,14 @@ class NDB_BVL_Battery
        	                AND (s.Visit_label=b.Visit_label OR b.Visit_label IS NULL)
        	                AND (s.CenterID=b.CenterID OR b.CenterID IS NULL))
        	          WHERE f.SessionID=:SID
-                      AND LEFT(f.CommentID, 4) != 'DDE_' ";
+                      AND LEFT(f.CommentID, 4) != 'DDE_'
+                  GROUP BY f.Test_name,
+                           t.Full_name,
+                           f.CommentID,
+                           DDECommentID,
+                           Sub_group,
+                           Subgroup_order,
+                           isDirectEntry";
         if (\Utility::columnsHasNull('test_subgroups', 'group_order')) {
             $query .= " ORDER BY Subgroup_name";
         } else {
@@ -431,13 +438,13 @@ class NDB_BVL_Battery
             $this->age = $age;
         }
         $qparams = [
-            'vAge'      => $this->age,
+            'vAge'      => $age,
             'SubprojID' => $SubprojectID,
         ];
         // The query to lookup the battery uses the min/max age ranges
         // if they are not 0
         $query = "
-            SELECT t.Test_name
+            SELECT DISTINCT t.Test_name
                 FROM test_battery AS b, test_names AS t
                 WHERE
                     t.Test_name=b.Test_name


### PR DESCRIPTION
## Brief summary of changes
2 Issues are fixed By the following changes, both related to the fact that when multiple entries exist in the test_battery that have different attributes (not duplicates) but all match the lookup at a specific timepoint the next_stage and instrument_list modules fail.

Issue 1: The next stage module calls on the battery class to populate the flag table when the visit is started. When multiple entries of the same instrument are returned from the lookup query, the battery class attempts to create both which triggers a duplicate error in MySQL

Issue 2: The instrument_list module uses the battery class' `getBatteryVerbose` function to list the instruments properly grouped and ordered. the issue occurs when multiple entries of the same instrument are found in the lookup results. This PR removes the duplication of the instrument in the front end when that happens


#### Testing instructions (if applicable)

1. Choose a battery entry and duplicate it
2. change a few parameters which still allow the entry to overlap with another (change age range for example)
3. create a new timepoint with paramters that match the battery entry (subproject, visit_label,...) and start it
4. Without this PR, the next stage module will give a 500 error when populating the battery
5. navigate to the instrument_list of the new timepoint. notice that without these changes, the instrument is displayed twice on the page.

#### Link(s) to related issue(s)

* Resolves #7130