### PR TITLE
[instruments] The examiner dropdown in the Top page of the instruments in taking by default the value of the firth alphabetical available.

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -801,6 +801,7 @@ class LorisForm
                     . $el['requireMsg']
                     . "' : '')\"";
             }
+            $retVal .= '><option value="" selected="true"';
         }
         $retVal .= ">$strOptions</select>";
 


### PR DESCRIPTION
## Brief summary of changes

When starting filling a brand new instrument the examiner dropdown in the Top page of the instruments is showing by default the value of the firth alphabetical examiner available. The fix for this issue is to modify the LorisForm.class.inc to insert an empty select option with selected="true" for required select html elements.

#### Testing instructions (if applicable)

1. See the issue for instructions. 

#### Link(s) to related issue(s)

* Resolves #7885
