### PR TITLE
[dqt] critical fix remove old dataquery include

### DIFF
--- a/modules/dqt/php/dqt.class.inc
+++ b/modules/dqt/php/dqt.class.inc
@@ -63,7 +63,6 @@ class Dqt extends \NDB_Form
                 $baseURL . '/dqt/js/react.tabs.js',
                 $baseURL . '/dqt/js/react.sidebar.js',
                 $baseURL . '/dqt/js/react.app.js',
-                $baseURL . '/dataquery/js/jstat.js',
                 $baseURL . '/js/flot/jquery.flot.min.js',
                 $baseURL . '/js/components/PaginationLinks.js',
                 $baseURL . '/js/jszip/jszip.min.js',


### PR DESCRIPTION
## Brief summary of changes

Removes an old reference that somehow wasn't caught in previous merged PR. Note: We're getting the removed include from node_modules/package.json.

