### PR TITLE
[user_accounts] Prevent password autofill in chrome when editing or creating an account

### DIFF
--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -71,7 +71,7 @@
             <span class="pwd-star password {if isset($form.Password_hash.required) && $form.Password_hash.required} required{/if}" style="color: red">*</span>
         </label>
         <div class="col-sm-3">
-            <input type="password" name="{$form.Password_hash.name}" />
+            <input type="password" name="{$form.Password_hash.name}" autocomplete="new-password"/>
         </div>
         <div class="col-sm-4">{$form.NA_Password.html}</div>
         {if $form.errors.Password|default}


### PR DESCRIPTION
## Brief summary of changes
I was getting tired of chrome autofilling the password field when editing a user in the user accounts module. I followed the instructions [here](https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off) to get rid of that and it seems to work

Issue:
Using chrome, if you have a password saved for user **X** on the loris instance you are using and you navigate to the user_accounts module and edit user **X**, Chrome decides to autofill the "password" field (I think simply because it's called password). If you are not mindful of the autofill and try to modify some permission of other parameter and hit save you get an error (see images)

Autofill on page load:
![image](https://user-images.githubusercontent.com/15268287/147964666-888f0a46-3688-4412-9447-4bcab8a616e8.png)

Error after saving without clearing the password field:
![image](https://user-images.githubusercontent.com/15268287/147964723-76cbcf2e-a6b8-4d7e-ab4d-52004680dd35.png)

This PR should simply prevent chrome from being annoying

~#firstPRin2022~ #secondPRin2022 (@maltheism beat me by 38 seconds)
