### PR TITLE
[DQT] Prevent Autofill in chrome

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -296,35 +296,5 @@
         {if $FormAction}
         </form>
         {/if}
-
-        <a id="login-modal-button" href="#" data-toggle="modal" data-target="#login-modal" style="display: none;">Login</a>
-
-        <div class="modal fade" id="login-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" style="display: none;">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        Login to Your Account
-                    </div>
-                    <div class="modal-body">
-                        <div class="row">
-                            <div class="col-xs-12">
-                                <font color="red" align="middle" id="login-modal-error" style="display: none;">
-                                    Incorrect username or password
-                                </font>
-                            </div>
-                            <div class="form-group col-xs-12">
-                                <input id="modal-username" name="username" class="form-control" type="text" value="" placeholder="User">
-                            </div>
-                            <div class="form-group col-xs-12">
-                                <input id="modal-password" name="password" class="form-control" type="password" placeholder="Password">
-                            </div>
-                            <div class="form-group col-xs-12">
-                                <input class="btn btn-primary col-xs-12" id="modal-login" name="login" type="submit" value="Login">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </body>
 </html>


### PR DESCRIPTION
## Brief summary of changes

Prevents autofill in chrome being incorrectly applied throughout LORIS like in the DQT module.

#### Testing instructions (if applicable)

1. Checkout PR.
2. make clean && make dev
3. Visit the DQT and examine fields in chrome if passwords are being autofilled.

#### Link(s) to related issue(s)

* Resolves #7938
