### PR TITLE
[DQT] Results header is stuck on initial query run when scrolling down and won't update when changing display modality (Cross sectional vs Longitudinal)

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -72,7 +72,6 @@ class StaticDataTable extends Component {
         $('#dynamictable').find('tbody td:eq(0)').hide();
       }
     }
-
     if (!this.props.DisableFilter) {
       // Retrieve module preferences
       let modulePrefs = JSON.parse(localStorage.getItem('modulePrefs'));
@@ -106,16 +105,16 @@ class StaticDataTable extends Component {
    * @param {object} prevState - Previous React Component state
    */
   componentDidUpdate(prevProps, prevState) {
-    if (!this.props.DisableFilter) {
-      if (jQuery.fn.DynamicTable) {
-        if (this.props.freezeColumn) {
-          $('#dynamictable').DynamicTable({
-            freezeColumn: this.props.freezeColumn,
-          });
-        } else {
-          $('#dynamictable').DynamicTable();
-        }
+    if (jQuery.fn.DynamicTable) {
+      if (this.props.freezeColumn) {
+        $('#dynamictable').DynamicTable({
+          freezeColumn: this.props.freezeColumn,
+        });
+      } else {
+        $('#dynamictable').DynamicTable();
       }
+    }
+    if (!this.props.DisableFilter) {
       if (this.props.onSort &&
         (this.state.SortColumn !== prevState.SortColumn ||
           this.state.SortOrder !== prevState.SortOrder)


### PR DESCRIPTION
## Brief summary of changes

Fixed the issue where the component update wasn't refreshing the dynamictable's floating headers. The dynamictable's floating headers visible to the user when scrolling.

#### Testing instructions (if applicable)

1. Checkout PR
2. make clean && make dev
3. visit the DQT module
4. run a query and see if the floating headers when scrolling update after changing back & forth from (Cross sectional vs Longitudinal).

#### Link(s) to related issue(s)

* Resolves #7929
