### PR TITLE
[tools] fix strftime

### DIFF
--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -26,7 +26,7 @@ $dir = __DIR__ . "/../logs/";
 if (!is_dir($dir)) {
     mkdir($dir);
 }
-$date = date("Y-m-d_h:i");
+$date    = date("Y-m-d_h:i");
 $logPath = "$dir/score_instrument.$date.log";
 $logfp   = fopen($logPath, 'a');
 

--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -26,8 +26,7 @@ $dir = __DIR__ . "/../logs/";
 if (!is_dir($dir)) {
     mkdir($dir);
 }
-$today   = getdate();
-$date    = strftime("%Y-%m-%d_%H:%M");
+$date = date("Y-m-d_h:i");
 $logPath = "$dir/score_instrument.$date.log";
 $logfp   = fopen($logPath, 'a');
 
@@ -258,7 +257,7 @@ function logMessage($message)
         //use print instead
         print_r($message);
     }
-    $now_string = strftime("%Y-%m-%d %H:%M:%S");
+    $now_string = date("Y-m-d h:i:s");
     fwrite($logfp, "[$now_string] $message\n");
 }
 

--- a/tools/single_use/instrument_double_escape_report.php
+++ b/tools/single_use/instrument_double_escape_report.php
@@ -19,8 +19,7 @@ $dir = __DIR__ . "/../logs/";
 if (!is_dir($dir)) {
     mkdir($dir);
 }
-$today   = getdate();
-$date    = strftime("%Y-%m-%d_%H:%M");
+$date = date("Y-m-d_h:i");
 $logPath = "$dir/instrument_double_escape_report_$date.log";
 $logfp   = fopen($logPath, 'a');
 


### PR DESCRIPTION
## Brief summary of changes
 strftime() missing a parameter. 
 strftime and gmstrftime functions will are deprecated on php 8.1
remove deprecated functions
#### Testing instructions (if applicable)
run this file under tools folder
"php tools/data_integrity/score_instrument.php"

#### Link(s) to related issue(s)

