### PR TITLE
[DQT] Fix crash when last update time is not set.

### DIFF
--- a/modules/dqt/php/dqt_setup.class.inc
+++ b/modules/dqt/php/dqt_setup.class.inc
@@ -121,7 +121,7 @@ class Dqt_Setup extends \NDB_Form implements RequestHandlerInterface
                 "descending" => "true",
             ]
         );
-        $data['updatetime'] = $update[0]['key'];
+        $data['updatetime'] = $update[0]['key'] ?? 'unknown';
 
         $categories = $couch->queryView(
             "DQG-2.0",


### PR DESCRIPTION
This fixes an issue where the DQT crashes if the last update time
is not set. The key indexed from PHP is not set, causing it to print
a warning resulting in invalid JSON being returned to the browser.

This can happen if, for instance, CouchDB_Import_Demographics is
run for testing without the other import scripts (the last update
time is only set by the instruments import script.)