### PR TITLE
[create_timepoint] Require project for validation

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -287,6 +287,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
         try {
             \TimePoint::isValidVisitLabel(
                 new CandID($visitinfo['CandID']),
+                $project->getId(),
                 $subprojectid,
                 $visitinfo['Visit']
             );

--- a/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
@@ -326,6 +326,7 @@ class Visit_0_0_4_Dev extends Endpoint implements \LORIS\Middleware\ETagCalculat
         try {
             \TimePoint::isValidVisitLabel(
                 new CandID($visitinfo['CandID']),
+                $this->_project->getId(),
                 $subprojectid,
                 $visitinfo['Visit']
             );

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -253,13 +253,15 @@ class Timepoint extends \NDB_Page implements ETagCalculator
 
         $candid       = $values['candID'];
         $subprojectID = intval($values['subproject']);
+        $projectID    = new \ProjectID($values['project']);
         $visitLabel   = $values['visit'] ?? '';
 
         try {
             \TimePoint::isValidVisitLabel(
                 new CandID($candid),
+                $projectID,
                 $subprojectID,
-                $visitLabel
+                $visitLabel,
             );
         } catch (\LorisException $exception) {
             $conflict['visitLabel'] = $exception->getMessage();

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -301,9 +301,10 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      * Validates if a given visit_label follows the study's config settings
      * and if that same visit label can be created for the given candidate.
      *
-     * @param CandID  $candid       The candidate identifier
-     * @param integer $subprojectID The subprojectID
-     * @param string  $visitLabel   The visit label
+     * @param CandID     $candid       The candidate identifier
+     * @param \ProjectID $projectID    The Project identifier
+     * @param integer    $subprojectID The subprojectID
+     * @param string     $visitLabel   The visit label
      *
      * @throws LorisException
      *
@@ -311,6 +312,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     static function isValidVisitLabel(
         CandID $candid,
+        \ProjectID $projectID,
         int $subprojectID,
         string $visitLabel
     ): void {
@@ -327,7 +329,10 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         // Check if visit label exists for this subproject
         if (!array_key_exists(
             $visitLabel,
-            \Utility::getVisitsForSubproject($subprojectID)
+            \Utility::getVisitsForProjectSubproject(
+                $projectID,
+                $subprojectID
+            )
         )
         ) {
             throw new \LorisException(


### PR DESCRIPTION
## Brief summary of changes
Create timepoint logic now uses a combination of project/subproject to validate the visit label selected (and displayed). in this case the validation code needs to be passed the projectID to do the validation.

#### Testing instructions (if applicable)

1. try creating a timepoint

#### Link(s) to related issue(s)

* Resolves #7959
