### PR TITLE
Add S3 Support to LORIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ changes in the following format: PR #1234***
 - Added ability for scripts to bulk load instrument data (PR #6869)
 - Multiple classes of errors flagged by phan are now fixed (various PRs)
 - A PSR3 compatible logging interface was added (PR #7509)
+- Added support for Amazon S3 (PR #7963)
 
 #### Features
 - Data tables may now stream data as they're loading rather than waiting

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -166,6 +166,12 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, Or
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'database_log_level', 'Verbosity of database logging', 1, 0, 'log_level', ID, 'Database Log Level', 3 FROM ConfigSettings WHERE Name='logs';
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'request_log_level', 'Verbosity of HTTP request logs', 1, 0, 'log_level', ID, 'HTTP Request Log Level', 3 FROM ConfigSettings WHERE Name='logs';
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'exception_log_level', 'Verbosity of PHP exception logging', 1, 0, 'log_level', ID, 'Exception Log Level', 3 FROM ConfigSettings WHERE Name='logs';
+
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('aws', 'Settings related to AWS services', 1, 0, 'AWS Settings', 13);
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Endpoint', 'Endpoint to use for accessing files stored in S3. Endpoint or region are required for S3 support.', 1, 0, 'text', ID, 'AWS S3 Endpoint', 3 FROM ConfigSettings WHERE Name='aws';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Region', 'AWS Region to use for accessing files stored in S3. Endpoint or region are required for S3 support.', 1, 0, 'text', ID, 'AWS S3 Region', 3 FROM ConfigSettings WHERE Name='aws';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Default_Bucket', 'Default bucket for LORIS to use for accessing files in S3.', 1, 0, 'text', ID, 'AWS S3 Default Bucket', 3 FROM ConfigSettings WHERE Name='aws';
+
 --
 -- Filling Config table with default values
 --

--- a/SQL/New_patches/2022-01-26-S3Support.sql
+++ b/SQL/New_patches/2022-01-26-S3Support.sql
@@ -1,0 +1,6 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('aws', 'Settings related to AWS services', 1, 0, 'AWS Settings', 13);
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Endpoint', 'Endpoint to use for accessing files stored in S3. Endpoint or region are required for S3 support.', 1, 0, 'text', ID, 'AWS S3 Endpoint', 3 FROM ConfigSettings WHERE Name='aws';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Region', 'AWS Region to use for accessing files stored in S3. Endpoint or region are required for S3 support.', 1, 0, 'text', ID, 'AWS S3 Region', 3 FROM ConfigSettings WHERE Name='aws';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'AWS_S3_Default_Bucket', 'Default bucket for LORIS to use for accessing files in S3.', 1, 0, 'text', ID, 'AWS S3 Default Bucket', 3 FROM ConfigSettings WHERE Name='aws';
+
+

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "psr/http-server-middleware" : "*",
         "laminas/laminas-diactoros" : "^2.5",
         "ext-json": "*",
-        "bjeavons/zxcvbn-php": "^1.0"
+        "bjeavons/zxcvbn-php": "^1.0",
+        "aws/aws-sdk-php": "^3.209"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : "^3.5",
@@ -31,5 +32,10 @@
             "LORIS\\": "src/"
         },
         "classmap": ["project/libraries", "php"]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,149 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c59fc96cd078073baaf4d654e1e8ec3a",
+    "content-hash": "ae00d8d76bd64eb3e0823f6a64e71919",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "3942776a8c99209908ee0b287746263725685732"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/3942776a8c99209908ee0b287746263725685732",
+                "reference": "3942776a8c99209908ee0b287746263725685732",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.0.2"
+            },
+            "time": "2021-09-03T22:57:30+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.209.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "22bbcc0b25578d4c496756d9f46fcd4c27cffd5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/22bbcc0b25578d4c496756d9f46fcd4c27cffd5d",
+                "reference": "22bbcc0b25578d4c496756d9f46fcd4c27cffd5d",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.0.2",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
+                "guzzlehttp/promises": "^1.4.0",
+                "guzzlehttp/psr7": "^1.7.0|^2.0",
+                "mtdowling/jmespath.php": "^2.6",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
+                "nette/neon": "^2.3",
+                "paragonie/random_compat": ">= 2",
+                "phpunit/phpunit": "^4.8.35|^5.4.3",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.7"
+            },
+            "time": "2022-01-18T19:16:05+00:00"
+        },
         {
             "name": "bjeavons/zxcvbn-php",
             "version": "1.2.0",
@@ -478,6 +619,67 @@
                 "zf"
             ],
             "time": "2020-09-14T14:23:00+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "9b87907a81b87bc76d19a7fb2d61e61486ee9edb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9b87907a81b87bc76d19a7fb2d61e61486ee9edb",
+                "reference": "9b87907a81b87bc76d19a7fb2d61e61486ee9edb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^7.5.15"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.6.1"
+            },
+            "time": "2021-06-14T00:11:39+00:00"
         },
         {
             "name": "php-http/guzzle7-adapter",

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -33,6 +33,15 @@ ini_set('session.use_strict_mode', '1');
 $client = new \NDB_Client;
 $client->initialize();
 
+$client = new Aws\S3\S3Client([
+    'region' => 'us-west-2',
+    'version' => '2006-03-01',
+    // 'endpoint' => 'hosted.domain.com',
+    ]);
+
+// Register the stream wrapper from an S3Client object
+$client->registerStreamWrapper();
+
 // Middleware that happens on every request. This doesn't include
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -33,15 +33,6 @@ ini_set('session.use_strict_mode', '1');
 $client = new \NDB_Client;
 $client->initialize();
 
-$client = new Aws\S3\S3Client([
-    'region' => 'us-west-2',
-    'version' => '2006-03-01',
-    // 'endpoint' => 'hosted.domain.com',
-    ]);
-
-// Register the stream wrapper from an S3Client object
-$client->registerStreamWrapper();
-
 // Middleware that happens on every request. This doesn't include
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.

--- a/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
@@ -113,7 +113,13 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $filename = $info->getFilename();
-        $body     = new \LORIS\Http\FileStream($info->getRealPath(), 'r');
+
+        $realpath = $info->getRealPath();
+        if($realpath === false) {
+            $realpath = $info->getPath() . "/" . $info->getFilename();
+        }
+
+        $body = new \LORIS\Http\FileStream($realpath, 'r');
 
         return new \LORIS\Http\Response(
             $body,

--- a/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
@@ -115,7 +115,7 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $filename = $info->getFilename();
 
         $realpath = $info->getRealPath();
-        if($realpath === false) {
+        if ($realpath === false) {
             $realpath = $info->getPath() . "/" . $info->getFilename();
         }
 

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -158,6 +158,7 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $info = $image->getFileInfo();
 
+/*
         if (!$info->isFile()) {
             error_log('file in database but not in file system');
             return new \LORIS\Http\Response\JSON\NotFound();
@@ -167,8 +168,19 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
             error_log('file exist but is not readable by webserver');
             return new \LORIS\Http\Response\JSON\NotFound();
         }
+        */
 
-        $body = new \LORIS\Http\FileStream($info->getRealPath(), 'r');
+/*
+var_dump($info->getPath());
+var_dump($info->getFilename());
+var_dump($info);
+*/
+$realpath = $info->getRealPath();
+if($realpath === false) {
+    $realpath = $info->getPath() . "/" . $info->getFilename();
+}
+
+        $body = new \LORIS\Http\FileStream($realpath, 'r');
 
         return (new \LORIS\Http\Response())
             ->withHeader('Content-Type', $mimetype)

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -168,7 +168,7 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $realpath = $info->getRealPath();
-        if($realpath === false) {
+        if ($realpath === false) {
             $realpath = $info->getPath() . "/" . $info->getFilename();
         }
 

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -158,27 +158,19 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $info = $image->getFileInfo();
 
-/*
         if (!$info->isFile()) {
             error_log('file in database but not in file system');
             return new \LORIS\Http\Response\JSON\NotFound();
         }
-
         if (!$info->isReadable()) {
             error_log('file exist but is not readable by webserver');
             return new \LORIS\Http\Response\JSON\NotFound();
         }
-        */
 
-/*
-var_dump($info->getPath());
-var_dump($info->getFilename());
-var_dump($info);
-*/
-$realpath = $info->getRealPath();
-if($realpath === false) {
-    $realpath = $info->getPath() . "/" . $info->getFilename();
-}
+        $realpath = $info->getRealPath();
+        if($realpath === false) {
+            $realpath = $info->getPath() . "/" . $info->getFilename();
+        }
 
         $body = new \LORIS\Http\FileStream($realpath, 'r');
 

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -250,19 +250,7 @@ class Image
      */
     public function getFileInfo(): \SplFileInfo
     {
-        if (strpos($this->_filelocation, '://') !== false) {
-            // It represents a URI, not a local path
-            return new \SplFileInfo($this->_filelocation);
-        }
-        $imagepath = \NDB_factory::singleton()
-            ->config()
-            ->getSetting('imagePath');
-
-        $fullpath = $imagepath . $this->_filelocation;
-
-        $info = new \SplFileInfo($fullpath);
-
-        return $info;
+        return $this->getFullPath($this->_filelocation);
     }
 
     /**
@@ -272,17 +260,23 @@ class Image
      */
     public function getThumbnailFileInfo(): \SplFileInfo
     {
+        return $this->getFullPath('/pic/'. $this->getHeader('check_pic_filename'));
+    }
+
+    private function getFullPath(string $relpath) : \SplFileInfo
+    {
+        if (strpos($this->_filelocation, '://') !== false) {
+            // It represents a URI, not a local path
+            return new \SplFileInfo($this->_filelocation);
+        }
         $imagepath = \NDB_factory::singleton()
             ->config()
             ->getSetting('imagePath');
 
-        $fullpath = $imagepath . '/pic/'. $this->getHeader('check_pic_filename');
+        $fullpath = $imagepath . $relpath;
 
-        $info = new \SplFileInfo($fullpath);
-
-        return $info;
+        return new \SplFileInfo($fullpath);
     }
-
     /**
      * Creates an immutable object representation of this Image
      *

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -250,6 +250,10 @@ class Image
      */
     public function getFileInfo(): \SplFileInfo
     {
+        if (strpos($this->_filelocation, '://') !== false) {
+            // It represents a URI, not a local path
+            return new \SplFileInfo($this->_filelocation);
+        }
         $imagepath = \NDB_factory::singleton()
             ->config()
             ->getSetting('imagePath');

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -260,14 +260,19 @@ class Image
      */
     public function getThumbnailFileInfo(): \SplFileInfo
     {
-        return $this->getFullPath('/pic/'. $this->getHeader('check_pic_filename'));
+        $picfile = $this->getHeader('check_pic_filename');
+        if (strpos($picfile, '://') !== false) {
+            // It represents a URI, not a local path
+            return new \SplFileInfo($picfile);
+    }
+    return $this->getFullPath('/pic/'. $this->getHeader('check_pic_filename'));
     }
 
     private function getFullPath(string $relpath) : \SplFileInfo
     {
-        if (strpos($this->_filelocation, '://') !== false) {
+        if (strpos($relpath, '://') !== false) {
             // It represents a URI, not a local path
-            return new \SplFileInfo($this->_filelocation);
+            return new \SplFileInfo($relpath);
         }
         $imagepath = \NDB_factory::singleton()
             ->config()

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -250,7 +250,7 @@ class Image
      */
     public function getFileInfo(): \SplFileInfo
     {
-        return $this->getFullPath($this->_filelocation);
+        return $this->_getFullPath($this->_filelocation);
     }
 
     /**
@@ -264,11 +264,20 @@ class Image
         if (strpos($picfile, '://') !== false) {
             // It represents a URI, not a local path
             return new \SplFileInfo($picfile);
-    }
-    return $this->getFullPath('/pic/'. $this->getHeader('check_pic_filename'));
+        }
+
+        return $this->_getFullPath('/pic/'. $this->getHeader('check_pic_filename'));
     }
 
-    private function getFullPath(string $relpath) : \SplFileInfo
+    /**
+     * Returns the full path to the file after adding
+     * imagePath if applicable.
+     *
+     * @param string $relpath The relative pathname
+     *
+     * @return \SplFileInfo
+     */
+    private function _getFullPath(string $relpath) : \SplFileInfo
     {
         if (strpos($relpath, '://') !== false) {
             // It represents a URI, not a local path

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -74,8 +74,8 @@ class NDB_Client
                 'version' => '2006-03-01',
             ];
             $endpoint = $config->getSetting('S3_Endpoint');
-            if(!empty($endpoint)) {
-                $s3config['region'] = '';
+            if (!empty($endpoint)) {
+                $s3config['region']   = '';
                 $s3config['endpoint'] = $endpoint;
             } else {
                 $s3config['region'] = $config->getSetting('AWS_Region');

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -73,12 +73,12 @@ class NDB_Client
             $s3config = [
                 'version' => '2006-03-01',
             ];
-            $endpoint = $config->getSetting('S3_Endpoint');
+            $endpoint = $config->getSetting('AWS_S3_Endpoint');
             if (!empty($endpoint)) {
                 $s3config['region']   = '';
                 $s3config['endpoint'] = $endpoint;
             } else {
-                $s3config['region'] = $config->getSetting('AWS_Region');
+                $s3config['region'] = $config->getSetting('AWS_S3_Region');
             }
 
             $s3client = new Aws\S3\S3Client($s3config);

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -83,7 +83,8 @@ class NDB_Client
 
             $s3client = new Aws\S3\S3Client($s3config);
 
-            // Register the stream wrapper from an S3Client object
+            // Register the stream wrapper so that s3:// urls can be
+            // treated as regular files.
             $s3client->registerStreamWrapper();
         }
 

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -66,6 +66,27 @@ class NDB_Client
             set_include_path($extLibs.":".get_include_path());
         }
 
+        // Register S3 stream wrapper if configured
+        if (getenv('AWS_ACCESS_KEY_ID') !== false) {
+            // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+            // should both be set as environment variables
+            $s3config = [
+                'version' => '2006-03-01',
+            ];
+            $endpoint = $config->getSetting('S3_Endpoint');
+            if(!empty($endpoint)) {
+                $s3config['region'] = '';
+                $s3config['endpoint'] = $endpoint;
+            } else {
+                $s3config['region'] = $config->getSetting('AWS_Region');
+            }
+
+            $s3client = new Aws\S3\S3Client($s3config);
+
+            // Register the stream wrapper from an S3Client object
+            $s3client->registerStreamWrapper();
+        }
+
         // This must be done after the extra includes, as those may
         // include Smarty
         include_once "Smarty_hook.class.inc";


### PR DESCRIPTION
This adds support for accessing files via S3 to LORIS. The AWS SDK is used so that `s3://` URLs can be accessed as normal files within PHP if the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set (which roughly correspond to AWS username and passport). One of the LORIS config settings `AWS_S3_Region` or `AWS_S3_Endpoint` must be set for the SDK to work (the latter for AWS hosted instances, and the latter for self-hosted.)

In this PR the LORIS API for imaging is updated (for both thumbnails and the mnc files). The imaging_browser and brainbrowser have already been updated to use the LORIS API, so should work transparently.

Other modules that deal with files (document_repository, media, issue_tracker, etc) will need to be tested separately. (The most likely cause of bugs is that a path config option is concatenated to the filename at some point, invalidating the url.)