### PR TITLE
[Instrument] Add blank option to list of examiners

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -911,7 +911,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'Window Difference (+/- Days)'
             );
         }
-        $examiners = $this->_getExaminerNames();
+        $examiners = ['' => ''] + $this->_getExaminerNames();
         $this->addSelect('Examiner', 'Examiner', $examiners);
 
         $this->addRule(
@@ -1016,8 +1016,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $centerID = null;
         }
 
-        $candID    = $_REQUEST['candID'] ?? '';
         $sessionID = $this->getSessionID();
+        $timepoint = \TimePoint::singleton($sessionID);
+        $candID    = $timepoint->getCandID();
 
         $project = $db->pselectOne(
             "SELECT ProjectID from session where CandID =:cnd_id AND ID=:sid",

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -911,7 +911,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'Window Difference (+/- Days)'
             );
         }
-        $examiners = ['' => ''] + $this->_getExaminerNames();
+        $examiners = $this->_getExaminerNames();
         $this->addSelect('Examiner', 'Examiner', $examiners);
 
         $this->addRule(
@@ -1072,7 +1072,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'examinerID'
             );
         }
-        $examiners = [];
+        $examiners = ['' => ''];
         if (is_array($results) && !empty($results)) {
             foreach ($results AS $eid => $row) {
                 $name = $row['full_name'];


### PR DESCRIPTION
This adds a blank option to the list of examiners on
data entry in order to prevent the first alphabetical
one from being automatically selected, potentially
resulting in data entry errors.

Resolves #7885
Replaces/Closes #7928