### PR TITLE
Filter dqt results on project and site

### DIFF
--- a/modules/dqt/ajax/retrieveCategoryDocs.php
+++ b/modules/dqt/ajax/retrieveCategoryDocs.php
@@ -39,7 +39,32 @@ $keys        = array_map(
     },
     $sessions
 );
-$results     = $cdb->queryView(
+
+$docs = $cdb->postView(
+    'DQG-2.0',
+    'instruments',
+    [
+        "reduce"       => "false",
+        "include_docs" => "true",
+    ],
+    $keys
+);
+
+$results = ['rows'=>[]];
+foreach ($docs as $doc) {
+    if (!isset($doc['doc']['Meta']['ProjectID'])) {
+        var_dump($doc);
+        exit;
+    }
+    $projectid = new \ProjectID($doc['doc']['Meta']['ProjectID'] ?? '');
+    $centerid  = new \CenterID($doc['doc']['Meta']['CenterID']);
+    if ($user->hasProject($projectid) && $user->hasCenter($centerid)) {
+        $results['rows'][] = $doc;
+    }
+}
+echo json_encode($results);
+exit;
+$results = $cdb->queryView(
     "DQG-2.0",
     "instruments",
     [
@@ -49,9 +74,9 @@ $results     = $cdb->queryView(
     ],
     true
 );
-$keys        = null;
-$cdb         = null;
-$client      = null;
+$keys    = null;
+$cdb     = null;
+$client  = null;
 //print $results;
 /*
 $justTheDocs = array_map(function($row) {

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -417,6 +417,71 @@ class CouchDB
     }
 
     /**
+     * Executes the specified view function from the specified design document.
+     * Same as GET but will set keys in the body of the request instead of the
+     * query parameters.
+     *
+     * Note: This yields an array per document intead of a complete array of docs.
+     *
+     * @param string $design      The design document
+     * @param string $view        The view name
+     * @param array  $queryparams An associative array of param_name and values
+     * @param array  $keys        The target document keys
+     *
+     * @return A traversable of documents objects
+     */
+    public function postView(
+        string $design,
+        string $view,
+        array $queryparams,
+        array $keys
+    ): \Traversable {
+        $params = http_build_query($queryparams);
+        $url    = $this->_constructURL(
+            'POST',
+            "_design/$design/_view/$view/?$params"
+        );
+
+        $dockeys = json_encode(['keys' => $keys]);
+
+        $handler = $this->SocketHandler;
+        $handler->setHost($this->_host);
+        $handler->setPort($this->_port);
+
+        $handler->open();
+        $handler->write($url . " HTTP/1.0\r\n");
+        $handler->write("Content-Length: " . strlen($dockeys) . "\r\n");
+        $handler->write("Content-type: application/json\r\n");
+
+        $handler->write(
+            "Authorization: Basic "
+            . base64_encode(
+                $this->_user . ":" . $this->_password
+            )
+            . "\r\n"
+        );
+
+        $handler->write("\r\n");
+        $handler->write($dockeys);
+
+        $finishedHeaders = false;
+        while (!$handler->eof()) {
+            $line = $handler->gets();
+            if ($finishedHeaders === false) {
+                if ($line == "\r\n") {
+                    $finishedHeaders = true;
+                }
+            } else {
+                $doc = json_decode(substr(trim($line), 0, -1), true);
+                if (is_array($doc)) {
+                    yield $doc;
+                }
+            }
+        }
+        $handler->close();
+    }
+
+    /**
      * Internal function to make a low level HTTP POST request to the CouchDB
      * server, not relative to the CouchDB server (not database). This is useful
      * for posting to other CouchDB databases on the same server (ie. the users

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -186,6 +186,8 @@ class CouchDBDemographicsImporter
                                 c.PSCID, 
                                 s.Visit_label, 
                                 s.SubprojectID, 
+                                s.ProjectID,
+                                s.CenterID,
                                 p.Alias as Site, 
                                 c.Sex,
                                 s.Current_stage, 
@@ -381,6 +383,9 @@ class CouchDBDemographicsImporter
             $demographics['Cohort']
                 = $this->_getSubproject($demographics['SubprojectID']);
             unset($demographics['SubprojectID']);
+            $centerid = $demographics['CenterID'];
+            unset($demographics['CenterID']);
+            $projectid = $demographics['ProjectID'];
             if (isset($demographics['ProjectID'])) {
                 $demographics['Project']
                     = $this->_getProject($demographics['ProjectID']);
@@ -451,6 +456,8 @@ class CouchDBDemographicsImporter
                             $demographics['PSCID'],
                             $demographics['Visit_label'],
                         ],
+                        'ProjectID'  => $projectid,
+                        'CenterID'   => $centerid
                     ],
                     'data' => $demographics,
                 ]

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -129,6 +129,8 @@ class CouchDBInstrumentImporter
         $select = "SELECT
             c.PSCID,
             s.Visit_label,
+            s.ProjectID,
+            s.CenterID,
             f.Administration,
             f.Data_entry,
             f.Validity,
@@ -217,7 +219,6 @@ class CouchDBInstrumentImporter
             $preparedStatement->execute(['inst' => $instrument]);
             while ($row = $preparedStatement->fetch(PDO::FETCH_ASSOC)) {
                 $CommentID = $row['CommentID'];
-
                 if ($JSONData) {
                     //Transform JSON object into an array and add treat it the
                     //same as SQL
@@ -235,6 +236,11 @@ class CouchDBInstrumentImporter
                 unset($docdata['city_of_birth']);
                 unset($docdata['city_of_birth_status']);
 
+                $projectid = $row['ProjectID'];
+                $centerid  = $row['CenterID'];
+                unset($row['ProjectID']);
+                unset($row['CenterID']);
+
                 if (isset($docdata['Examiner'])
                     && is_numeric($docdata['Examiner'])
                 ) {
@@ -251,6 +257,8 @@ class CouchDBInstrumentImporter
                             $row['PSCID'],
                             $row['Visit_label'],
                         ],
+                        'ProjectID'  => $projectid,
+                        'CenterID'   => $centerid
                     ],
                     'data' => $docdata,
                 ];

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -117,7 +117,7 @@ class CouchDBMRIImporter
     {
 
         $s     = $ScanTypes;
-        $Query = "SELECT c.PSCID, s.Visit_label, s.ID as SessionID, fmric.Comment
+        $Query = "SELECT c.PSCID, s.Visit_label, s.ProjectID, s.CenterID, s.ID as SessionID, fmric.Comment
           as QCComment";
 
         foreach ($s as $scan) {
@@ -438,6 +438,12 @@ class CouchDBMRIImporter
                 $row['PSCID'],
                 $row['Visit_label'],
             ];
+
+            $projectid = $row['ProjectID'];
+            unset($row['ProjectID']);
+            $centerid  = $row['CenterID'];
+            unset($row['CenterID']);
+
             $docid      = 'MRI_Files:' . join($identifier, '_');
             unset($doc['PSCID']);
             unset($doc['Visit_label']);
@@ -449,6 +455,8 @@ class CouchDBMRIImporter
                     'Meta' => [
                         'DocType'    => 'mri_data',
                         'identifier' => $identifier,
+                        'ProjectID'  => $projectid,
+                        'CenterID'   => $centerid,
                     ],
                     'data' => $doc,
                 ]


### PR DESCRIPTION
This add filtering on DQT results based on user's project(s) and site(s).

proof of concept. 

I think there should be a CouchDBRowProvisioner which would take Filters and Mappers instead of highjacking the CouchDB class and do the filtering adhoc. 