### PR TITLE
Remove drop table statements that should not be in the release patch for 24.0

### DIFF
--- a/SQL/Archive/24.0/Cleanup/2022-02-03-remove_CenterName_from_mri_protocol.sql
+++ b/SQL/Archive/24.0/Cleanup/2022-02-03-remove_CenterName_from_mri_protocol.sql
@@ -1,0 +1,3 @@
+-- Drop the Center_name table (CenterID will be replacing it)
+-- Before droping the column, ensure the relevant data have been ported into the CenterID column
+ALTER TABLE mri_protocol DROP COLUMN `Center_name`;

--- a/SQL/Archive/24.0/Cleanup/2022-02-03-remove_password_expiry_from_users.sql
+++ b/SQL/Archive/24.0/Cleanup/2022-02-03-remove_password_expiry_from_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN Password_expiry;

--- a/SQL/Release_patches/23.0_To_24.0_upgrade.sql
+++ b/SQL/Release_patches/23.0_To_24.0_upgrade.sql
@@ -293,13 +293,6 @@ UPDATE permissions SET description='LORIS API Manual', moduleID=(SELECT ID FROM 
 
 SELECT 'Running: SQL/Archive/24.0/2021-02-19_electrophysiology_annotation_tables.sql';
 
--- SQL tables for BIDS derivative file structure
-DROP TABLE IF EXISTS `physiological_annotation_instance`;
-DROP TABLE IF EXISTS `physiological_annotation_parameter`;
-DROP TABLE IF EXISTS `physiological_annotation_archive`;
-DROP TABLE IF EXISTS `physiological_annotation_file`;
-DROP TABLE IF EXISTS `physiological_annotation_file_type`;
-DROP TABLE IF EXISTS `physiological_annotation_label`;
 -- Create physiological_annotation_file_type table
 CREATE TABLE `physiological_annotation_file_type` (
     `FileType`        VARCHAR(20)   NOT NULL UNIQUE,

--- a/SQL/Release_patches/23.0_To_24.0_upgrade.sql
+++ b/SQL/Release_patches/23.0_To_24.0_upgrade.sql
@@ -10,7 +10,6 @@ SELECT 'Running: SQL/Archive/24.0/2019-12-17-RemovePasswordExpiry.sql';
 
 ALTER TABLE users ADD COLUMN PasswordChangeRequired TINYINT(1) NOT NULL DEFAULT 0;
 UPDATE users SET PasswordChangeRequired=1 WHERE Password_expiry < CURDATE();
-ALTER TABLE users DROP COLUMN Password_expiry;
 
 SELECT 'Running: SQL/Archive/24.0/2020-01-07-publication_users_edit_perm_rel_pk.sql';
 
@@ -1016,9 +1015,6 @@ ALTER TABLE mri_protocol ADD FOREIGN KEY (`CenterID`) REFERENCES psc(`CenterID`)
 UPDATE mri_protocol 
 INNER JOIN psc ON (Center_name = MRI_alias) 
 SET mri_protocol.CenterID = psc.CenterID;
-
--- Drop the Center_name table (CenterID will be replacing it)
-ALTER TABLE mri_protocol DROP COLUMN `Center_name`;
 
 SELECT 'Running: SQL/Archive/24.0/2021-07-29-physiological_task_event_columns_types.sql';
 


### PR DESCRIPTION
## Brief summary of changes

Some `DROP table` statements were inserted into the release patch and should be removed to avoid the deletion of tables with potential data if projects already had those table set up.

