### PR TITLE
[EEG] Modify physiological_annotation_parameter `Description` datatype

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -265,7 +265,7 @@ CREATE TABLE `physiological_annotation_archive` (
 CREATE TABLE `physiological_annotation_parameter` (
     `AnnotationParameterID` INT(10)      UNSIGNED NOT NULL AUTO_INCREMENT,
     `AnnotationFileID`      INT(10)      UNSIGNED NOT NULL,
-    `Description`           TEXT         NOT NULL,
+    `Description`           TEXT         DEFAULT NULL,
     `Sources`               VARCHAR(255),
     `Author`                VARCHAR(255),
     PRIMARY KEY (`AnnotationParameterID`),

--- a/SQL/New_patches/2022-02-03-physiological_annotation_parameter_fix_description_default.sql
+++ b/SQL/New_patches/2022-02-03-physiological_annotation_parameter_fix_description_default.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `physiological_annotation_parameter`
+  MODIFY COLUMN `Description` text DEFAULT NULL
+;


### PR DESCRIPTION
## Brief summary of changes
The `Description` field of the annotation.json sidecar is recommended but not required. 

Ran into this issue with the bids_import:

```
Traceback (most recent call last):
  File "/opt/eegnet/bin/mri/python/bids_import.py", line 464, in <module>
    main()
  File "/opt/eegnet/bin/mri/python/bids_import.py", line 76, in main
    read_and_insert_bids(bids_dir, config_file, verbose, createcand, createvisit)
  File "/opt/eegnet/bin/mri/python/bids_import.py", line 230, in read_and_insert_bids
    loris_bids_root_dir    = loris_bids_root_dir
  File "/opt/eegnet/bin/mri/python/lib/eeg.py", line 155, in __init__
    self.register_data()
  File "/opt/eegnet/bin/mri/python/lib/eeg.py", line 284, in register_data
    derivatives
  File "/opt/eegnet/bin/mri/python/lib/eeg.py", line 757, in fetch_and_insert_annotation_files
    annotation_metadata, annotation_metadata_path, physiological_file_id, blake2
  File "/opt/eegnet/bin/mri/python/lib/physiological.py", line 612, in insert_annotation_metadata
    annotation_metadata['Author']
  File "/opt/eegnet/bin/mri/python/lib/database_lib/physiologicalannotationparameter.py", line 40, in insert
    values       = (annotation_file_id, sources, author)
  File "/opt/eegnet/bin/mri/python/lib/database.py", line 190, in insert
    raise Exception("Insert query failure: " + format(err))
Exception: Insert query failure: (1364, "Field 'Description' doesn't have a default value")
```

This PR makes assigns a NULL default value to the `Description` field. 
See also https://github.com/aces/Loris-MRI/pull/759

