### PR TITLE
[Tools] use table name in Set_Required_elements_completed_flag.php

### DIFF
--- a/tools/single_use/Set_Required_elements_completed_flag.php
+++ b/tools/single_use/Set_Required_elements_completed_flag.php
@@ -82,7 +82,7 @@ foreach ($flagData as $cmid => $data) {
     if (!$instrument->usesJSONData()) {
         $instrDECS = $DB->pselectOne(
             "SELECT Data_entry_completion_status 
-            FROM {$data['Test_name']} WHERE CommentID=:cmid",
+            FROM {$instrument->table} WHERE CommentID=:cmid",
             ["cmid" => $cmid]
         );
     }


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a bug where the Set_Required_elements_completed_flag.php script was using the test_name where it should have been using the table name.

#### Testing instructions (if applicable)

1. Test the script with an instrument whose table name is different than the test_name
