### PR TITLE
[create_timepoint] validate on visit label not ID

### DIFF
--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -266,7 +266,13 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $candid       = $values['candID'];
         $subprojectID = intval($values['subproject']);
         $projectID    = new \ProjectID($values['project']);
-        $visitLabel   = $values['visit'] ?? '';
+
+        //Visit - Get all visits to map ID back to label for session table
+        $visits     = \Utility::getVisitsForProjectSubproject(
+            $projectID,
+            intval($values['subproject'])
+        );
+        $visitLabel = $visits[$values['visit']];
 
         try {
             \TimePoint::isValidVisitLabel(

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -273,13 +273,16 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             intval($values['subproject'])
         );
         $visitLabel = $visits[$values['visit']];
+        $visitName  = (new VisitController(
+            $this->lorisinstance->getDatabaseConnection()
+        ))->getVisitFromVisitLabel($visitLabel)->getName();
 
         try {
             \TimePoint::isValidVisitLabel(
                 new CandID($candid),
                 $projectID,
                 $subprojectID,
-                $visitLabel,
+                $visitName,
             );
         } catch (\LorisException $exception) {
             $conflict['visitLabel'] = $exception->getMessage();

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -13,7 +13,6 @@
  */
 use \LORIS\StudyEntities\Candidate\CandID;
 use \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
-use LORIS\VisitController;
 
 /**
  * The Loris TimePoint class
@@ -305,7 +304,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      * @param CandID     $candid       The candidate identifier
      * @param \ProjectID $projectID    The Project identifier
      * @param integer    $subprojectID The subprojectID
-     * @param string     $visitLabel   The visit label
+     * @param string     $visitName    The visit name
      *
      * @throws LorisException
      *
@@ -315,27 +314,23 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         CandID $candid,
         \ProjectID $projectID,
         int $subprojectID,
-        string $visitLabel
+        string $visitName
     ): void {
-
-        $db = \NDB_Factory::singleton()->database();
         // This can happen if the user quickly clicks "Create Time Point" before the
         // page has loaded and the Visit Label dropdown hasn't been selected yet.
         // The page will create "V1" when this is the case without this check.
-        if (empty($visitLabel)) {
+        if (empty($visitName)) {
             throw new \LorisException(
                 'A visit label is required.'
             );
         }
 
         // Check if visit label exists for this subproject
-        if (!in_array(
-            $visitLabel,
-            \Utility::getVisitsForProjectSubproject(
-                $projectID,
+        if (!array_key_exists(
+            $visitName,
+            \Utility::getVisitsForSubproject(
                 $subprojectID
-            ),
-            true
+            )
         )
         ) {
             throw new \LorisException(
@@ -347,10 +342,6 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         // The function below gets a list of VisitNames from the DB, not real labels
         $timePointArray = $candidate->getListOfVisitLabels();
-
-        $visitName = (new VisitController($db))
-            ->getVisitFromVisitLabel($visitLabel)
-            ->getName();
 
         //If the visitLabel is already in use then let the user pick another
         foreach ($timePointArray AS $used_name) {

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -13,6 +13,7 @@
  */
 use \LORIS\StudyEntities\Candidate\CandID;
 use \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
+use LORIS\VisitController;
 
 /**
  * The Loris TimePoint class
@@ -317,6 +318,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         string $visitLabel
     ): void {
 
+        $db = \NDB_Factory::singleton()->database();
         // This can happen if the user quickly clicks "Create Time Point" before the
         // page has loaded and the Visit Label dropdown hasn't been selected yet.
         // The page will create "V1" when this is the case without this check.
@@ -327,12 +329,13 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         }
 
         // Check if visit label exists for this subproject
-        if (!array_key_exists(
+        if (!in_array(
             $visitLabel,
             \Utility::getVisitsForProjectSubproject(
                 $projectID,
                 $subprojectID
-            )
+            ),
+            true
         )
         ) {
             throw new \LorisException(
@@ -342,11 +345,16 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $candidate =& \Candidate::singleton($candid);
 
+        // The function below gets a list of VisitNames from the DB, not real labels
         $timePointArray = $candidate->getListOfVisitLabels();
 
+        $visitName = (new VisitController($db))
+            ->getVisitFromVisitLabel($visitLabel)
+            ->getName();
+
         //If the visitLabel is already in use then let the user pick another
-        foreach ($timePointArray AS $used_label) {
-            if (strcasecmp($visitLabel, $used_label) == 0) {
+        foreach ($timePointArray AS $used_name) {
+            if (strcasecmp($visitName, $used_name) == 0) {
                 throw new \LorisException(
                     'This visit label is not unique.'
                 );


### PR DESCRIPTION
## Brief summary of changes
This addresses the issue where duplicate visit labels were being created. 

This is yet another patch to fix the ID vs NAME vs LABEL confusion that is happening since the reactification of create_timepoiint without the normalization. this should all become much cleaner in the next release