### PR TITLE
[SQL] Drop foreign keys before making ProjectID not nullable

### DIFF
--- a/SQL/Archive/24.0/2019-07-01_fix_project_in_session.sql
+++ b/SQL/Archive/24.0/2019-07-01_fix_project_in_session.sql
@@ -1,6 +1,12 @@
 -- Populate new session field with pre recorded candidate project
+ALTER TABLE candidate DROP FOREIGN KEY `FK_candidate_RegistrationProjectID`;
 ALTER TABLE candidate CHANGE `RegistrationProjectID` `RegistrationProjectID` int(10) unsigned NOT NULL;
+ALTER TABLE candidate ADD CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE;
+
 UPDATE session s JOIN candidate c ON s.CandID=c.CandID SET ProjectID=c.RegistrationProjectID WHERE ProjectID IS NULL;
+
+ALTER TABLE `session` DROP FOREIGN KEY `FK_session_ProjectID`;
 ALTER TABLE `session` CHANGE `ProjectID` `ProjectID` int(10) unsigned NOT NULL;
+ALTER TABLE `session` ADD CONSTRAINT `FK_session_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`);
 
 

--- a/SQL/Release_patches/23.0_To_24.0_upgrade.sql
+++ b/SQL/Release_patches/23.0_To_24.0_upgrade.sql
@@ -1,9 +1,15 @@
 SELECT 'Running: SQL/Archive/24.0/2019-07-01_fix_project_in_session.sql';
 
 -- Populate new session field with pre recorded candidate project
+ALTER TABLE candidate DROP FOREIGN KEY `FK_candidate_RegistrationProjectID`;
 ALTER TABLE candidate CHANGE `RegistrationProjectID` `RegistrationProjectID` int(10) unsigned NOT NULL;
+ALTER TABLE candidate ADD CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE;
+
 UPDATE session s JOIN candidate c ON s.CandID=c.CandID SET ProjectID=c.RegistrationProjectID WHERE ProjectID IS NULL;
+
+ALTER TABLE `session` DROP FOREIGN KEY `FK_session_ProjectID`;
 ALTER TABLE `session` CHANGE `ProjectID` `ProjectID` int(10) unsigned NOT NULL;
+ALTER TABLE `session` ADD CONSTRAINT `FK_session_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`);
 
 SELECT 'Running: SQL/Archive/24.0/2019-09-18_DocRepoEdit.sql';
 


### PR DESCRIPTION
## Brief summary of changes

Make MariaDB happy by dropping foreign key contraints before modifying the ProjectId fields to `NOT NULL`. otherwise MariaDB throws an error
