### PR TITLE
[document_repository] make directory with proper permissions for writing

### DIFF
--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -340,7 +340,9 @@ class Files extends \NDB_Page
             $config->getSetting("documentRepositoryPath"),
             $name
         );
-        mkdir($path, 0600);
+        if (!is_dir($path)) {
+            mkdir($path, 0770);
+        }
 
         $targetdir = new \SplFileInfo($path);
 


### PR DESCRIPTION
## Brief summary of changes

1. Change mkdir parameters to make the new directory executable. a non-executable directory is technically not writable as well causing the issue linked below
2. added an if statement around mkdir to avoid warnings when directory already exists for the user.


 #### Testing instructions (if applicable)
1. try uploading a file from the document_repository module
2. make sure the upload goes through successfully
3. make sure the directory created for you user has permissions 770

#### Link(s) to related issue(s)

* Resolves #8035
