### PR TITLE
[survey] Fix saving functionality using LorisFormDictionaryImpl trait

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -35,7 +35,7 @@ trait LorisFormDictionaryImpl
      * Variable from NDB_Page. Must be included in trait
      * to avoid PhanUndeclaredProperty errors.
      */
-    protected $lorisinstance;
+    protected $loris;
 
     /**
      * Recursively extract non-group elements from $elements, and
@@ -155,7 +155,7 @@ trait LorisFormDictionaryImpl
         // Create new instance of the same instrument to avoid altering variables
         // in $this instrument
         $instrument = \NDB_BVL_Instrument::factory(
-            $this->lorisinstance,
+            $this->loris,
             $this->testName
         );
         $subtests   = array_merge(


### PR DESCRIPTION
## Brief summary of changes
The LorisFormDictionaryImpl trait for instruments was using the `$this->lorisinstance` variable which happens to be null in survey instruments, replaced with `$this->loris` instanciated in the constructor of NDB_Page and now it works


#### Link(s) to related issue(s)

* Resolves #8021 and #8020
