### PR TITLE
[survey_accounts] Survey email being sent for both "Create survey" and "Email survey" - fix 

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -247,7 +247,7 @@ class AddSurvey extends \NDB_Form
         }
         $this->tpl_data['success'] = true;
 
-        if ($email) {
+        if ($email && ($_REQUEST['fire_away'] !== 'Create survey')) {
             $config   = \NDB_Config::singleton();
             $baseURL  = \NDB_Factory::singleton()->settings()->getBaseURL();
             $msg_data = [


### PR DESCRIPTION
## Brief summary of changes
add a "Create survey" check into the function.
https://github.com/aces/Loris/issues/8041

Describe the bug
When I click "Create survey" instead of "Email survey", a survey email is still sent to the participant.

To Reproduce
Steps to reproduce the behavior (attach screenshots if applicable):

Go to survey accounts module and click "Add survey"
Fill out information to add a survey, add your own email as the participant email
Click "Create survey" instead of "Email survey"
See that you receive an email
What did you expect to happen?
No email to be sent when "Create survey" is selected.
