### PR TITLE
[media] Caching instrument names

### DIFF
--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -82,7 +82,7 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        $testname = $row['testName'] ?? null;
+        $testname = $row['testName'] ?? '';
         unset($row['testName']);
 
         if (!isset($this->_instrumentnames[$testname])) {

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -32,6 +32,8 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     protected $lorisinstance;
 
+    private $_instrumentnames = [];
+
     /**
      * Create a MediaFileProvisioner, which gets files for the meida
      * menu table.
@@ -80,22 +82,20 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        static $instrumentnames = [];
-
         $testname = $row['testName'] ?? null;
         unset($row['testName']);
 
-        if (!isset($instrumentnames[$testname])) {
+        if (!isset($this->_instrumentnames[$testname])) {
             try {
-                $instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
+                $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
                     $this->lorisinstance,
                     $row['testName'],
                 )->getFullname();
             } catch (\Exception $e) {
-                $instrumentnames[$testname] = null;
+                $this->_instrumentnames[$testname] = null;
             }
         }
-        $row['fullName'] = $instrumentnames[$testname] ?? null;
+        $row['fullName'] = $this->_instrumentnames[$testname] ?? null;
 
         return new MediaFile($row);
     }

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -93,14 +93,10 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         unset($row['testName']);
 
         if (!isset($this->_instrumentnames[$testname])) {
-            try {
-                $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
-                    $this->lorisinstance,
-                    $testname,
-                )->getFullname();
-            } catch (\Exception $e) {
-                $this->_instrumentnames[$testname] = null;
-            }
+            $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
+                $this->lorisinstance,
+                $testname,
+            )->getFullname();
         }
         $row['fullName'] = $this->_instrumentnames[$testname] ?? null;
 

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -89,7 +89,7 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             try {
                 $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
                     $this->lorisinstance,
-                    $row['testName'],
+                    $testname,
                 )->getFullname();
             } catch (\Exception $e) {
                 $this->_instrumentnames[$testname] = null;

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -32,7 +32,14 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     protected $lorisinstance;
 
-    private $_instrumentnames = [];
+    /**
+     * Cache of instrument->getFullname returned value.
+     * Initializing empty keys to prevent instanciation of empty testnames.
+     */
+    private $_instrumentnames = [
+        null => '',
+        ''   => ''
+    ];
 
     /**
      * Create a MediaFileProvisioner, which gets files for the meida

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -80,17 +80,22 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        if (!is_null($row['testName'])) {
+        static $instrumentnames = [];
+
+        $testname = $row['testName'] ?? null;
+        unset($row['testName']);
+
+        if (!isset($instrumentnames[$testname])) {
             try {
-                $instrumentName  = \NDB_BVL_Instrument::factory(
+                $instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
                     $this->lorisinstance,
                     $row['testName'],
                 )->getFullname();
-                $row['fullName'] = $instrumentName;
             } catch (\Exception $e) {
+                $instrumentnames[$testname] = null;
             }
         }
-        unset($row['testName']);
+        $row['fullName'] = $instrumentnames[$testname] ?? null;
 
         return new MediaFile($row);
     }


### PR DESCRIPTION
## Brief summary of changes
This adds a static variable in the getInstance function of the provisioner to load each instrument only once instead of for each rows.

#### Testing instructions (if applicable)

1. Access `/media`
2. Check if datatable loads. (There should be no timeout)

#### Link(s) to related issue(s)
Resolves https://github.com/aces/Loris/issues/8033
