### PR TITLE
[Timepoint] Fix timepoint permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ scanner candidates. This prevents an error from being thrown in the candidate pa
 - Download CSV fix to remove duplicates and entries that partially match the filtering criteria (PR #7242)
 - Partially fix instrument escaping issues by reloading instrument and its data upon successful save (PR #7776)
 - Fix recognition of null sessionID in NDB_BVL_Instrument (PR #8031)
-- Fix bug where users with `access_all_profiles` permission can not see profiles of candidates with visits from different sites (PR TODO)
+- Fix bug where users with `access_all_profiles` permission can not see profiles of candidates with visits from different sites (PR #8067)
 
 
 ### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ scanner candidates. This prevents an error from being thrown in the candidate pa
 - Download CSV fix to remove duplicates and entries that partially match the filtering criteria (PR #7242)
 - Partially fix instrument escaping issues by reloading instrument and its data upon successful save (PR #7776)
 - Fix recognition of null sessionID in NDB_BVL_Instrument (PR #8031)
+- Fix bug where users with `access_all_profiles` permission can not see profiles of candidates with visits from different sites (PR TODO)
 
 
 ### Modules

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1229,7 +1229,8 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers);
-        return $projMatch && $centerMatch;
+        return ($projMatch && $centerMatch)
+            || $user->hasPermission('access_all_profiles');
     }
 }
 

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1229,8 +1229,8 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers);
-        return ($projMatch && $centerMatch)
-            || $user->hasPermission('access_all_profiles');
+        return $projMatch && ($centerMatch
+            || $user->hasPermission('access_all_profiles'));
     }
 }
 


### PR DESCRIPTION
## Brief summary of changes
This PR changes the `isAccessibleBy` function of TimePoint to give access to users with the `access_all_profiles` permission. This fixes a bug where some candidate profiles were not loading, and also where users with this permission could still only see the visits of their own sites.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Give yourself the `access_all_profiles` permission, and access to one but not all sites.
2. Go to the `candidate_profile` (beta) of a candidate that has visits from both the site that you belong to and the site that you do not belong to
3. Make sure the profile loads
4. Go to the timepoint list of that candidate
5. Make sure that you can see the visits from your site and from other sites.

#### Link(s) to related issue(s)

* Resolves #8040
