### PR TITLE
[candidate_profile] Error handling when loading widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ scanner candidates. This prevents an error from being thrown in the candidate pa
 - Partially fix instrument escaping issues by reloading instrument and its data upon successful save (PR #7776)
 - Fix recognition of null sessionID in NDB_BVL_Instrument (PR #8031)
 - Fix bug where server_processes_manager had a timeout (PR #8071)
+- Candidate profile page loads with only the visits listed that a user has access to 
+if a candidate has some visits that the user should not see. Fixes error where page was not loading for this use case (PR #8072)
 
 
 ### Modules

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -73,6 +73,12 @@ window.addEventListener('load', () => {
         );
     }
 
-    loadCandidate().then(loadVisits).then(loadCards).then(displayCards);
+    loadCandidate()
+      .then(loadVisits)
+      .then(loadCards)
+      .then(displayCards)
+      .catch(function (error) {
+        console.error(error);
+      });
 });
 </script>

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -21,10 +21,20 @@ window.addEventListener('load', () => {
         let visits = candidate.Visits.map(async function(visit) {
             // FIXME: This shouldn't use the dev version. See #6058
             let response = await fetch(loris.BaseURL + '/api/v0.0.3/candidates/' + candidate.Meta.CandID + '/' + visit);
-            let data = await response.json();
-            return data;
+            if (!response.ok) {
+              return new Error('Permission denied');
+            } else {
+              let data = await response.json();
+              return data;
+            }
         });
         return Promise.all(visits);
+    }
+
+    async function filterVisits(visits) {
+      return visits.filter(function(v) {
+        return !(v instanceof Error);
+      });
     }
 
     async function loadCards(visits) {
@@ -73,12 +83,6 @@ window.addEventListener('load', () => {
         );
     }
 
-    loadCandidate()
-      .then(loadVisits)
-      .then(loadCards)
-      .then(displayCards)
-      .catch(function (error) {
-        console.error(error);
-      });
+    loadCandidate().then(loadVisits).then(filterVisits).then(loadCards).then(displayCards);
 });
 </script>


### PR DESCRIPTION
## Brief summary of changes
This PR changes the candidate_profile template that loads the widgets of the candidate_profile page so that it catches the errors when loading candidate visit information. Specifically, this handles the issue where a candidate is affiliated with multiple sites and the user only has access to one of those sites and the candidate_profile page does not load. 

- [x] Have you updated related documentation?

## Testing instructions
1. Create a user with `access_all_profiles` permission and only give them permission for one site
2. Find a candidate that has some of its visits at the site your user is affiliated with and some of its visits at other sites your user should not have permission for
3. Go to the candidate_profile page of this candidate
4. See that the page loads correctly
5. See that the list of visits does not include any of the visits that your user doesn't have permission to view.

#### Link(s) to related issue(s)

* Resolves #8040
