### PR TITLE
Move DB credentials to environment

### DIFF
--- a/htdocs/acknowledgements/acknowledgements.php
+++ b/htdocs/acknowledgements/acknowledgements.php
@@ -19,7 +19,7 @@ $client->makeCommandLine();
 $client->initialize();
 
 $config = NDB_Config::singleton();
-$db     = Database::singleton();
+$db     = \NDB_Factory::singleton()->database();
 
 $publication_date = $_GET["date"];
 

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -19,7 +19,7 @@ if ($client->initialize() == false) {
 }
 
 // create DB object
-$DB = \Database::singleton();
+$DB = \NDB_Factory::singleton()->database();
 
 // user is logged in, let's continue with the show...
 $user = \User::singleton($_SESSION['State']->getUsername());

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -81,7 +81,7 @@ class DirectDataEntryMainPage
         }
         $this->key = $_REQUEST['key'];
 
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $this->loris     = new \LORIS\LorisInstance(
             $DB,
@@ -167,7 +167,7 @@ class DirectDataEntryMainPage
 
         $nextPage = $currentPage+1;
         return intval(
-            \Database::singleton()->pselectOne(
+            \NDB_Factory::singleton()->database()->pselectOne(
                 "SELECT Order_number FROM instrument_subtests
                 WHERE Test_name=:TN AND Order_number=:PN",
                 [
@@ -188,7 +188,7 @@ class DirectDataEntryMainPage
      */
     function getPrevPageNum($currentPage): ?string
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         if ($currentPage === null) {
             // On the top page or no page specified, do not include link
             return null;
@@ -240,7 +240,7 @@ class DirectDataEntryMainPage
      */
     function getCommentID(): ?string
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         return $DB->pselectOne(
             "SELECT CommentID FROM participant_accounts
             WHERE OneTimePassword=:key AND Status <> 'Complete'",
@@ -285,7 +285,7 @@ class DirectDataEntryMainPage
      */
     function updateStatus($status): bool
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $currentStatus = $DB->pselectOne(
             'SELECT Status FROM participant_accounts
@@ -320,7 +320,7 @@ class DirectDataEntryMainPage
      */
     function updateComments($ease, $comments)
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         $DB->update(
             "participant_accounts",
             [
@@ -338,7 +338,7 @@ class DirectDataEntryMainPage
      */
     function display()
     {
-        $DB       = Database::singleton();
+        $DB       = \NDB_Factory::singleton()->database();
         $nextpage = null;
 
         if (isset($_REQUEST['nextpage'])) {

--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -100,7 +100,7 @@ class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $this->db   = \Database::singleton();
+        $this->db   = $this->loris->getDatabaseConnection();
         $this->user = $request->getAttribute('user');
         $method     = $request->getMethod();
 

--- a/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
@@ -24,8 +24,9 @@ class IncompleteProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
     {
         $config         =& \NDB_Config::singleton();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
+        $db = \NDB_Factory::singleton()->database();
         for ($i=0; $i<count($ddeInstruments); ++$i) {
-            $ddeInstruments[$i] = \Database::singleton()->quote($ddeInstruments[$i]);
+            $ddeInstruments[$i] = $db->quote($ddeInstruments[$i]);
         }
         $where = "
                 AND (f.commentid NOT LIKE 'DDE_%')

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -26,7 +26,7 @@ if ($tab === '') {
     exit;
 }
 
-$db = \Database::singleton();
+$db = \NDB_Factory::singleton()->database();
 
 switch ($tab) {
 case 'candidateInfo':

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -73,7 +73,7 @@ function getCandInfoFields()
 {
     $candID = new CandID($_GET['candID']);
 
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     // get caveat options
     $caveat_options = [];
@@ -153,7 +153,7 @@ function getProbandInfoFields()
 {
     $candID = new CandID($_GET['candID']);
 
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     // get pscid
     $pscid = $db->pselectOne(
@@ -233,7 +233,7 @@ function getFamilyInfoFields()
 {
     $candID = new CandID($_GET['candID']);
 
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     // get pscid
     $pscid = $db->pselectOne(
@@ -305,7 +305,7 @@ function getParticipantStatusFields()
     \Module::factory('candidate_parameters');
     $candID = new CandID($_GET['candID']);
 
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     // get pscid
     $pscid = $db->pselectOne(
@@ -385,7 +385,7 @@ function getParticipantStatusFields()
  */
 function getParticipantStatusHistory(CandID $candID)
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
     $unformattedComments = $db->pselect(
         "SELECT entry_staff, data_entry_date,
             (SELECT Description 
@@ -511,7 +511,7 @@ function getConsentStatusHistory($pscid)
 function getDOBFields(): array
 {
     $candID = new CandID($_GET['candID']);
-    $db     = \Database::singleton();
+    $db     = \NDB_Factory::singleton()->database();
     // Get PSCID
     $candidateData = $db->pselectRow(
         'SELECT PSCID,DoB FROM candidate where CandID =:candid',
@@ -535,7 +535,7 @@ function getDOBFields(): array
 function getDODFields(): array
 {
     $candID = new CandID($_GET['candID']);
-    $db     = \Database::singleton();
+    $db     = \NDB_Factory::singleton()->database();
 
     $candidateData = $db->pselectRow(
         'SELECT PSCID,DoD, DoB FROM candidate where CandID =:candid',

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -212,7 +212,7 @@ function getPathIDs(string $table): array
             . "WHERE DataType = 'web_path';";
         break;
     }
-    return \Database::singleton()->pselectCol($query, []);
+    return \NDB_Factory::singleton()->database()->pselectCol($query, []);
 }
 
 /**

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -48,7 +48,7 @@ class Configuration extends \NDB_Form
     {
         parent::setup();
         $config = \NDB_Config::singleton();
-        $DB     = \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
 
         $scans      = $DB->pselect(
             "SELECT Scan_type
@@ -103,7 +103,7 @@ class Configuration extends \NDB_Form
      */
     function _getParentConfigLabels()
     {
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         $parentConfigItems = $DB->pselect(
             "SELECT Label, Name 
@@ -126,7 +126,7 @@ class Configuration extends \NDB_Form
     function _getConfigSettingTree()
     {
         $config = \NDB_Config::singleton();
-        $DB     = \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
 
         // Get the names and meta-information for the config settings in the database
         $configs = $DB->pselect(

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -56,7 +56,7 @@ class Data_Release extends \NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& \User::singleton();
-        $DB   = \Database::singleton();
+        $DB   = $this->loris->getDatabaseConnection();
 
         // set the class variables
         $this->columns = [
@@ -87,7 +87,7 @@ class Data_Release extends \NDB_Menu_Filter
     {
         parent::setup();
 
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         $this->fieldOptions = [
             'users'     => $this->getUsersList($db),

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -135,7 +135,7 @@ class Files extends \NDB_Page
         bool $overwrite
     ) : ?ResponseInterface {
         // Check if file is duplicate
-        $DB            = \Database::singleton();
+        $DB            = $this->loris->getDatabaseConnection();
         $duplicateFile = $DB->pselectRow(
             "SELECT id, file_name FROM data_release WHERE file_name=:f",
             ['f' => $fileName]
@@ -199,7 +199,7 @@ class Files extends \NDB_Page
         ?string $version,
         bool $overwrite
     ) : ResponseInterface {
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         if ($version !== null) {
             $version = strtolower($version);
         }
@@ -262,7 +262,7 @@ class Files extends \NDB_Page
             return new \LORIS\Http\Response\JSON\NotFound("Not found");
         }
 
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         if (isset($matches[1])) {
             $fileID   = substr($matches[1], 1);
             $filename = $DB->pselectOne(

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -61,7 +61,7 @@ class ViewDetails extends \NDB_Form
      */
     function setup()
     {
-        $this->DB = \Database::singleton();
+        $this->DB = $this->loris->getDatabaseConnection();
 
         $user = \User::singleton();
         if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess($user))) {
@@ -157,7 +157,7 @@ class ViewDetails extends \NDB_Form
     function _validateNamesIds()
     {
         $config =& \NDB_Config::singleton();
-        $db     = \Database::singleton();
+        $db     = $this->loris->getDatabaseConnection();
         $dicomArchiveSettings = $config->getSetting('imaging_modules');
 
         // escape any forward slashes

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -80,7 +80,7 @@ class DocTree extends \NDB_Page
      */
     public function getTreeData()
     {
-        return \Database::singleton()->pselect(
+        return $this->loris->getDatabaseConnection()->pselect(
             "SELECT * FROM document_repository_categories",
             []
         );

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -52,7 +52,7 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     {
         parent::setup();
         $user  = \User::singleton();
-        $db    = \Database::singleton();
+        $db    = $this->loris->getDatabaseConnection();
         $query = $db->pselect(
             "SELECT * FROM document_repository_categories",
             []
@@ -118,7 +118,7 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     function parseCategory($value): array
     {
         $id = $value['id'];
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
             $categoryName = $value['category_name'];
         do {
             if ($value['parent_id'] != 0) {

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -206,7 +206,7 @@ class Files extends \NDB_Page
      */
     function getUploadDocFields(string $id): array
     {
-        $db    = \Database::singleton();
+        $db    = $this->loris->getDatabaseConnection();
         $query = $db->pselect(
             "SELECT * FROM document_repository_categories",
             []
@@ -261,7 +261,7 @@ class Files extends \NDB_Page
     function parseCategory(array $value): array
     {
         $id           = $value['id'];
-        $DB           = \Database::singleton();
+        $DB           = $this->loris->getDatabaseConnection();
         $categoryName = $value['category_name'];
         do {
             if ($value['parent_id'] != 0) {
@@ -423,7 +423,7 @@ class Files extends \NDB_Page
      */
     function existFilename(string $filename): bool
     {
-        $DB        = \Database::singleton();
+        $DB        = $this->loris->getDatabaseConnection();
         $fileCount =  $DB->pselectOne(
             "SELECT COUNT(*) FROM document_repository
              WHERE File_Name=:name",

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -79,7 +79,7 @@ class UploadCategory extends \NDB_Page
      */
     function uploadDocCategory($request): bool
     {
-        $DB  = \Database::singleton();
+        $DB  = $this->loris->getDatabaseConnection();
         $req = $request->getParsedBody();
         if (!is_array($req)) {
             throw new \LorisException("Invalid JSON");

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -41,7 +41,7 @@ class EditExaminer extends \NDB_Form
                 "Incorrect URL: No examiner ID provided."
             );
         }
-        $DB     = \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
         $config = \NDB_Config::singleton();
 
         $certification = $config->getSetting('Certification');
@@ -80,7 +80,7 @@ class EditExaminer extends \NDB_Form
      */
     function _getDefaults()
     {
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         // get the certification results for the given examiner
         $result = $DB->pselect(
@@ -110,7 +110,7 @@ class EditExaminer extends \NDB_Form
      */
     function _process($values)
     {
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         // get the examinerID
         $examinerID = $this->identifier;
@@ -277,7 +277,7 @@ class EditExaminer extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         // Get the certification history from the database
         $certification_history = $DB->pselect(
@@ -377,7 +377,7 @@ class EditExaminer extends \NDB_Form
      */
     function _validateEditExaminer($values)
     {
-        $DB     = \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
         $errors = [];
 
         // check that there is both a status and a date (neither can be null)
@@ -416,7 +416,7 @@ class EditExaminer extends \NDB_Form
     function getCertificationInstruments(): array
     {
         $config = \NDB_Config::singleton();
-        $DB     = \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
 
         // Get the instruments requiring certification from the config
         $certificationConfig      = $config->getSetting("Certification");

--- a/modules/genomic_browser/php/cnvbrowser.class.inc
+++ b/modules/genomic_browser/php/cnvbrowser.class.inc
@@ -83,7 +83,7 @@ class CnvBrowser extends \DataFrameworkMenu implements ETagCalculator
         $user = \NDB_Factory::singleton()->user();
 
         // Platform
-        $DB = \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         $platform_results = $DB->pselect(
             "SELECT distinct Name FROM genotyping_platform",
             []

--- a/modules/genomic_browser/php/snpbrowser.class.inc
+++ b/modules/genomic_browser/php/snpbrowser.class.inc
@@ -80,7 +80,7 @@ class SnpBrowser extends \DataFrameworkMenu implements ETagCalculator
     function getFieldOptions() : array
     {
         $user = \NDB_Factory::singleton()->user();
-        $DB   = \Database::singleton();
+        $DB   = $this->loris->getDatabaseConnection();
         $platform_results
             = $DB->pselect(
                 "SELECT distinct Name FROM genotyping_platform ",

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -127,7 +127,7 @@ class Genomicfile
      */
     function begin() : void
     {
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         $DB->beginTransaction();
     }
 
@@ -138,7 +138,7 @@ class Genomicfile
      */
     function endWithFailure() : void
     {
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         $DB->rollBack();
     }
 
@@ -149,7 +149,7 @@ class Genomicfile
      */
     function endWithSuccess() : void
     {
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         $DB->commit();
     }
 
@@ -221,7 +221,7 @@ class Genomicfile
      */
     function createCandidateFileRelations(&$fileToUpload) : void
     {
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $f = fopen(
             $fileToUpload->tmp_name,
@@ -285,7 +285,7 @@ class Genomicfile
         // Assuming genomic_cpg_annotation have already been created.
         // see: /module/genomic_browser/tool/human...
 
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $f = fopen(
             $fileToUpload->tmp_name,
@@ -376,7 +376,7 @@ class Genomicfile
     {
         $this->reportProgress(85, 'Creating sample-candidate relations');
 
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $f = fopen(
             $fileToUpload->tmp_name,
@@ -448,7 +448,7 @@ class Genomicfile
      */
     function candidateExists($pscid) : bool
     {
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $CandID = $DB->pselectOne(
             "SELECT CandID from candidate WHERE PSCID = :pscid",
@@ -495,7 +495,7 @@ class Genomicfile
      */
     function registerFile(&$fileToUpload) : void
     {
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $values = [
             'FileName'         => $fileToUpload->full_path,

--- a/modules/genomic_browser/php/views/file.class.inc
+++ b/modules/genomic_browser/php/views/file.class.inc
@@ -65,7 +65,7 @@ class File
      */
     function _getDistinctValues(string $table, string $column)
     {
-        $DB      = \Database::singleton();
+        $DB      = \NDB_Factory::singleton()->database();
         $results = $DB->pselect(
             "SELECT DISTINCT $column FROM $table ",
             []

--- a/modules/genomic_browser/php/views/methylation.class.inc
+++ b/modules/genomic_browser/php/views/methylation.class.inc
@@ -82,7 +82,7 @@ class Methylation
      */
     private function _getDistinctValues($table, $column)
     {
-        $DB      = \Database::singleton();
+        $DB      = \NDB_Factory::singleton()->database();
         $results = $DB->pselect(
             "SELECT DISTINCT $column FROM $table ",
             []

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -55,7 +55,7 @@ class HelpFile
     static function &factory($helpID)
     {
         // create DB object
-        $DB =& \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $obj = new HelpFile;
 

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -64,7 +64,7 @@ class Imaging_Session_ControlPanel
      */
     function getData()
     {
-        $DB        = \Database::singleton();
+        $DB        = \NDB_Factory::singleton()->database();
         $config    = \NDB_Config::singleton();
         $timePoint = \TimePoint::singleton(
             new \SessionID(strval($_REQUEST['sessionID']))

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -101,7 +101,7 @@ class ViewSession extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $this->_DB = \Database::singleton();
+        $this->_DB = $this->loris->getDatabaseConnection();
 
         $this->sessionID = $_REQUEST['sessionID'];
 

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -51,7 +51,7 @@ class Imaging_QC extends \NDB_Menu_Filter
     function _getScanTypes(): array
     {
         $config = \NDB_Config::singleton();
-        $db     = \Database::singleton();
+        $db     = $this->loris->getDatabaseConnection();
 
         $toTable_scan_types = $config->getSetting('tblScanTypes');
 
@@ -182,7 +182,7 @@ class Imaging_QC extends \NDB_Menu_Filter
 
         $this->skipTemplate = true;
         $user      = \User::singleton();
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         $siteList  = [];
         $visitList = \Utility::getVisitList();
         // allow to view all sites data through filter

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -32,7 +32,7 @@ $summary  = $_POST['summary'] === 'true';
 /* Fetch columns Inserting and InsertionComplete from table mri_upload
  * create Database object
  */
-$DB    =& Database::singleton();
+$DB    = \NDB_Factory::singleton()->database();
 $query = "SELECT Inserting, InsertionComplete 
           FROM mri_upload
           WHERE UploadId =:uploadId";

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -150,7 +150,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             // MRI archive is now in the mri_upload table. If there are existing
             // records in table notification_spool for that upload (i.e a re-upload
             // of a scan that the MRI pipeline failed to process), inactivate them
-            $db = \Database::singleton();
+            $db = $this->loris->getDatabaseConnection();
             $db->update(
                 'notification_spool',
                 ['Active' => 'N'],
@@ -275,7 +275,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     {
         //make sure the file-name is  valid
         $temp_file = $file->fileInfo['tmp_name'];
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         // creates associative array to store error messages for each form element
         $errors = [
             'IsPhantom'  => [],
@@ -475,7 +475,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      */
     function importFile($file, $args)
     {
-        $db         = \Database::singleton();
+        $db         = $this->loris->getDatabaseConnection();
         $pname      = '';
         $IsPhantom  = $args['values']['IsPhantom'];
         $updateFile = isset($args['values']['overwrite'])

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -33,7 +33,7 @@ if (isset($_GET['action'])) {
  */
 function editFile()
 {
-    $db   =& Database::singleton();
+    $db   = \NDB_Factory::singleton()->database();
     $user =& User::singleton();
     if (!$user->hasPermission('media_write')) {
         showMediaError("Permission Denied", 403);
@@ -85,7 +85,7 @@ function uploadFile()
         "upload"
     );
 
-    $db     =& Database::singleton();
+    $db     = \NDB_Factory::singleton()->database();
     $config = NDB_Config::singleton();
     $user   =& User::singleton();
     if (!$user->hasPermission('media_write')) {
@@ -428,7 +428,7 @@ function toSelect($options, $item, $item2)
  */
 function getFilesList()
 {
-    $db       =& Database::singleton();
+    $db       = \NDB_Factory::singleton()->database();
     $fileList = $db->pselect("SELECT id, file_name FROM media", []);
 
     $mediaFiles = [];

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -35,7 +35,7 @@ class Edit extends \NDB_Form
     {
         parent::setup();
 
-        $db      =& \Database::singleton();
+        $db      = $this->loris->getDatabaseConnection();
         $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -76,7 +76,7 @@ class Media extends \DataFrameworkMenu
     protected function getFieldOptions() : array
     {
         $user = \User::singleton();
-        $db   = \Database::singleton();
+        $db   = $this->loris->getDatabaseConnection();
 
         $siteList  = [];
         $visitList = \Utility::getVisitList();

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -41,8 +41,9 @@ class Module extends \Module
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
         $siteClauseElements = [];
+        $db = \NDB_Factory::singleton()->database();
         foreach (array_keys($accessibleSites) as $siteID) {
-            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+            $siteClauseElements[] = $db->quote($siteID);
         }
         $siteClause = sprintf(
             "(v.Site IS NULL OR v.Site IN (%s))",

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -62,8 +62,9 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
         $siteClauseElements = [];
+        $db = $this->loris->getDatabaseConnection();
         foreach (array_keys($accessibleSites) as $siteID) {
-            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+            $siteClauseElements[] = $db->quote($siteID);
         }
         $siteClause = sprintf(
             "(p.CenterID IS NULL OR p.CenterID IN (%s))",

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -165,7 +165,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
      */
     function getMRIProtocolData()
     {
-        $db =& \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
         // select all except Objective from mri_protocol
         // and add Scan_type from mri_scan_type
         // to mri_protocol's Scan_type

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -56,7 +56,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         if (!is_array($values) || count($values) ==0) {
             return true;
         }
-        $DB   = \Database::singleton();
+        $DB   = $this->loris->getDatabaseConnection();
         $user = \User::singleton();
         foreach ($values['resolvable'] AS $key=>$val) {
             $hash = $key;
@@ -302,7 +302,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         // create user object
         $user    =& \User::singleton();
         $config  =& \NDB_Config::singleton();
-        $db      =& \Database::singleton();
+        $db      = $this->loris->getDatabaseConnection();
         $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
         $maxYear = $config->getSetting('endYear');
 

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -56,7 +56,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         if (!is_array($values) || count($values) ==0) {
             return true;
         }
-        $DB   =& \Database::singleton();
+        $DB   = $this->loris->getDatabaseConnection();
         $user =& \User::singleton();
 
         foreach ($values AS $key=>$val) {
@@ -201,8 +201,9 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
         $siteClauseElements = [];
+        $db = $this->loris->getDatabaseConnection();
         foreach (array_keys($accessibleSites) as $siteID) {
-            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+            $siteClauseElements[] = $db->quote($siteID);
         }
         $siteClause = sprintf(
             "(v.Site IS NULL OR v.Site IN (%s))",

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -203,7 +203,7 @@ function insertCollaborators(int $pubID) : void
     if (!isset($_POST['collaborators'])) {
         return;
     }
-    $db = Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     $collaborators = json_decode($_POST['collaborators'], true);
     foreach ($collaborators as $c) {
@@ -255,7 +255,7 @@ function insertEditors(int $pubID) : void
         return;
     }
 
-    $db = Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
     $usersWithEditPerm = json_decode($_POST['usersWithEditPerm']);
     foreach ($usersWithEditPerm as $uid) {
         $insert = [
@@ -282,7 +282,7 @@ function insertKeywords(int $pubID) : void
     if (empty($_POST['keywords'])) {
         return;
     }
-    $db       = Database::singleton();
+    $db       = \NDB_Factory::singleton()->database();
     $keywords = json_decode($_POST['keywords']);
     foreach ($keywords as $kw) {
         // check if keyword exists
@@ -329,7 +329,7 @@ function insertVOIs(int $pubID) : void
     if (empty($_POST['voiFields'])) {
         return;
     }
-    $db        = Database::singleton();
+    $db        = \NDB_Factory::singleton()->database();
     $testNames = $db->pselectColWithIndexKey(
         'SELECT ID, Test_name FROM test_names',
         [],
@@ -379,7 +379,7 @@ function insertVOIs(int $pubID) : void
  */
 function cleanup(int $pubID) : void
 {
-    $db    = Database::singleton();
+    $db    = \NDB_Factory::singleton()->database();
     $where = ['PublicationID' => $pubID];
 
     $tables = [
@@ -498,7 +498,7 @@ function notify($pubID, $type) : void
  */
 function editProject() : void
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
     $id = isset($_REQUEST['id']) ? intval($_REQUEST['id']) : null;
 
     if (isset($id)) {
@@ -611,7 +611,7 @@ function editProject() : void
  */
 function editEditors($id) : void
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
     $usersWithEditPerm = isset($_POST['usersWithEditPerm'])
         ? json_decode($_POST['usersWithEditPerm']) : null;
 
@@ -654,7 +654,7 @@ function editEditors($id) : void
  */
 function editCollaborators($id) : void
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
     $submittedCollaborators = isset($_POST['collaborators'])
         ? json_decode($_POST['collaborators'], true) : null;
 
@@ -739,7 +739,7 @@ function editCollaborators($id) : void
  */
 function editKeywords($id) : void
 {
-    $db       = \Database::singleton();
+    $db       = \NDB_Factory::singleton()->database();
     $keywords = isset($_POST['keywords'])
         ? json_decode($_POST['keywords']) : null;
 
@@ -788,7 +788,7 @@ function editKeywords($id) : void
  */
 function editVOIs($id) : void
 {
-    $db  = \Database::singleton();
+    $db  = \NDB_Factory::singleton()->database();
     $voi = isset($_POST['voiFields'])
         ? json_decode($_POST['voiFields']) : null;
 
@@ -858,7 +858,7 @@ function editVOIs($id) : void
  */
 function editUploads($id) : void
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     $pubUploads = $db->pselectWithIndexKey(
         'SELECT * FROM publication_upload WHERE PublicationID=:pid',

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -207,7 +207,7 @@ function getProjectData($db, $user, $id) : array
  */
 function getVOIs($id) : array
 {
-    $db        = \Database::singleton();
+    $db        = \NDB_Factory::singleton()->database();
     $fields    = $db->pselectCol(
         'SELECT pt.Name AS field ' .
         'FROM parameter_type pt '.
@@ -236,7 +236,7 @@ function getVOIs($id) : array
  */
 function getKeywords($id) : array
 {
-    $db  = \Database::singleton();
+    $db  = \NDB_Factory::singleton()->database();
     $kws = $db->pselectCol(
         'SELECT pk.Label FROM publication_keyword pk '.
         'LEFT JOIN publication_keyword_rel pkr '.
@@ -257,7 +257,7 @@ function getKeywords($id) : array
  */
 function getCollaborators($id) : array
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     $collaborators = $db->pselect(
         'SELECT Name as name, Email as email FROM publication_collaborator pc '.
@@ -279,7 +279,7 @@ function getCollaborators($id) : array
  */
 function getFiles($id) : array
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     $files = $db->pselect(
         'SELECT * FROM publication_upload WHERE PublicationID=:pid',
@@ -301,7 +301,7 @@ function getFiles($id) : array
  */
 function getStatusOptions() : array
 {
-    $db        = \Database::singleton();
+    $db        = \NDB_Factory::singleton()->database();
     $rawStatus = $db->pselect(
         'SELECT * FROM publication_status',
         []
@@ -322,7 +322,7 @@ function getStatusOptions() : array
  */
 function getUploadTypes() : array
 {
-    $db = \Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     return $db->pselectColWithIndexKey(
         'SELECT PublicationUploadTypeID, Label FROM publication_upload_type',

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -157,7 +157,7 @@ class Publication extends \NDB_Menu_Filter_Form
     {
         parent::setup();
 
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         $rawStatus = $db->pselectCol(
             'SELECT Label FROM publication_status',
             []

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -64,7 +64,7 @@ class View_Project extends \NDB_Form
      */
     function _setupPage() : void
     {
-        $db      = \Database::singleton();
+        $db      = $this->loris->getDatabaseConnection();
         $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
 

--- a/modules/server_processes_manager/php/defaultdatabaseprovider.class.inc
+++ b/modules/server_processes_manager/php/defaultdatabaseprovider.class.inc
@@ -33,7 +33,7 @@ class DefaultDatabaseProvider implements IDatabaseProvider
      */
     public function getDatabase()
     {
-        return \Database::singleton();
+        return \NDB_Factory::singleton()->database();
     }
 }
 

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -46,7 +46,7 @@ class Statistics extends \NDB_Form
     {
         parent::setup();
 
-        $DB =& \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         $this->tpl_data['StatsTabs'] = $DB->pselect(
             "SELECT ModuleName, SubModuleName, Description
                  FROM StatisticsTabs

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -77,7 +77,7 @@ class Statistics_DD_Site extends statistics_site
     function _completeCount($centerID, $projectID, $instrument): ?string
     {
         $this->_checkCriteria($centerID, $projectID);
-        $DB =& \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         $safe_instrument = $DB->escape($instrument);
 
@@ -108,7 +108,7 @@ class Statistics_DD_Site extends statistics_site
     function _getResults($centerID, $projectID, $instrument)
     {
         $this->_checkCriteria($centerID, $projectID);
-        $DB =& \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         $safe_instrument = $DB->escape($instrument);
         $result          = $DB->pselect(
             "SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID,

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -92,7 +92,7 @@ class Statistics_Mri_Site extends Statistics_Site
     function _getResults($centerID, $projectID, $issue)
     {
         $this->_checkCriteria($centerID, $projectID);
-        $DB =& \Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         $scan_types = $DB->pselect("SELECT Scan_type from mri_scan_type", []);
         $where      = "WHERE (";
@@ -197,7 +197,7 @@ class Statistics_Mri_Site extends Statistics_Site
             "PF_Missing",
         ];
 
-        $DB     =& \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
         $sqlRow = "SELECT CenterID as ID,".
                   " PSCArea as Name FROM psc WHERE CenterID=:cid";
         $center = $DB->pselectRow($sqlRow, ['cid' => $_REQUEST['CenterID']]);

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -188,7 +188,7 @@ class Statistics_Site extends \NDB_Menu
     {
 
         $this->_checkCriteria($centerID, $projectID);
-        $DB    =& \Database::singleton();
+        $DB    = $this->loris->getDatabaseConnection();
         $count = $DB->pselectOne(
             "SELECT count(s.CandID)  FROM session s,
                 candidate c, flag f, {$instrument} i
@@ -218,7 +218,7 @@ class Statistics_Site extends \NDB_Menu
     function _getResults($centerID, $projectID, $instrument)
     {
         $this->_checkCriteria($centerID, $projectID);
-        $DB     =& \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
         $result = $DB->pselect(
             "SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID,
                 s.Visit_label
@@ -243,7 +243,7 @@ class Statistics_Site extends \NDB_Menu
      */
     function setup()
     {
-        $DB     =& \Database::singleton();
+        $DB     = $this->loris->getDatabaseConnection();
         $sqlRow = "SELECT CenterID as ID, PSCArea as Name".
                   " FROM psc WHERE CenterID =:cid";
         if (!empty($_REQUEST['CenterID'])) {

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -206,7 +206,7 @@ class Stats_Demographic extends \NDB_Form
     {
         parent::setup();
         $visits = \Utility::getVisitList();
-        $db     = \Database::singleton();
+        $db     = $this->loris->getDatabaseConnection();
         //This boolean is for optional use by project if the demographics table
         // queries any information from the mri_parameter_form table
         $this->tpl_data['mri_table_exists'] = true;

--- a/modules/survey_accounts/ajax/GetEmailContent.php
+++ b/modules/survey_accounts/ajax/GetEmailContent.php
@@ -30,7 +30,7 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
 
-$DB = Database::singleton();
+$DB = \NDB_Factory::singleton()->database();
 
 $result = $DB->pselectOne(
     "SELECT DefaultEmail FROM participant_emails WHERE Test_name=:TN",

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -29,7 +29,7 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
 
-$db = Database::singleton();
+$db = \NDB_Factory::singleton()->database();
 
 
 $numCandidates = $db->pselectOne(

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -59,7 +59,7 @@ class AddSurvey extends \NDB_Form
      */
     function _validateAddSurvey($values)
     {
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         // Check that all required fields are present.
         if (!empty($values['Email']) ) {
@@ -188,7 +188,7 @@ class AddSurvey extends \NDB_Form
      */
     function _process($values)
     {
-        $db    = \Database::singleton();
+        $db    = $this->loris->getDatabaseConnection();
         $email = $values['Email'];
         unset($values['Email']);
         $SessionID = $db->pselectOne(

--- a/php/libraries/CandIDGenerator.php
+++ b/php/libraries/CandIDGenerator.php
@@ -53,6 +53,7 @@ class CandIDGenerator extends IdentifierGenerator
      */
     public function generate(): CandID
     {
+        $db = \NDB_Factory::singleton()->database();
         do {
             $this->checkIDRangeFull();
             $id = new CandID(
@@ -62,11 +63,10 @@ class CandIDGenerator extends IdentifierGenerator
             );
             // Check if the ID is in use. If so, the loop will continue and a new
             // ID will be generated.
-            $validID = \Database::singleton()
-                ->pselectOne(
-                    "SELECT count(CandID) FROM candidate WHERE CandID=:id",
-                    ['id' => (string) $id]
-                ) == 0;
+            $validID = $db->pselectOne(
+                "SELECT count(CandID) FROM candidate WHERE CandID=:id",
+                ['id' => (string) $id]
+            ) == 0;
         } while (! $validID);
 
         return $id;
@@ -81,7 +81,7 @@ class CandIDGenerator extends IdentifierGenerator
     {
         // CandIDs have no prefix so the result of the query can be returned
         // immediately.
-        return \Database::singleton()->pselectCol(
+        return \NDB_Factory::singleton()->database()->pselectCol(
             'SELECT CandID from candidate',
             []
         );

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -307,6 +307,8 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $generator = new \CandIDGenerator();
         // declare the variable to avoid static analysis warnings
         $attemptcount = 0;
+
+        $db = \NDB_Factory::singleton()->database();
         do {
             // Reset on each iteration
             $invalidID = false;
@@ -314,7 +316,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             $candID = $generator->generate();
             $setArray['CandID'] = (string) $candID;
             try {
-                \Database::singleton()->insert('candidate', $setArray);
+                $db->insert('candidate', $setArray);
             } catch (\DatabaseException | \DomainException $e) {
                 // Occurs in the case of a race condition where another CandID
                 // with the same value has been inserted into the DB before this
@@ -844,7 +846,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     static function getParticipantStatusOptions(): array
     {
-        $DB           =& Database::singleton();
+        $DB           = \NDB_Factory::singleton()->database();
         $options      = $DB->pselect(
             "SELECT ID,Description
             FROM participant_status_options
@@ -868,7 +870,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     static function getParticipantStatusSubOptions(int $parentID): array
     {
-        $DB           =& Database::singleton();
+        $DB           = \NDB_Factory::singleton()->database();
         $options      = $DB->pselect(
             "SELECT ID,Description
             FROM participant_status_options

--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -90,8 +90,9 @@ class ConflictDetector
      */
     static function recordUnresolvedConflicts(array $diffResult): void
     {
+        $db = \NDB_Factory::singleton()->database();
         foreach ($diffResult as $diffLine) {
-            \Database::singleton()->replace('conflicts_unresolved', $diffLine);
+            $db->replace('conflicts_unresolved', $diffLine);
         }
 
     }
@@ -118,7 +119,8 @@ class ConflictDetector
             'CommentId2'     => $diffLine['CommentId2'],
         ];
 
-        \Database::singleton()->delete('conflicts_unresolved', $deleteWhere);
+        \NDB_Factory::singleton()->database()
+            ->delete('conflicts_unresolved', $deleteWhere);
     }
 
     /**
@@ -131,7 +133,7 @@ class ConflictDetector
      */
     static function clearConflictsForInstance(string $commentId): void
     {
-        \Database::singleton()->delete(
+        \NDB_Factory::singleton()->database()->delete(
             'conflicts_unresolved',
             ['CommentId1' => $commentId]
         );
@@ -146,7 +148,7 @@ class ConflictDetector
      */
     static function isInstrumentInstanceInConflictState(string $commentId): bool
     {
-        $conflictCount = \Database::singleton()->pselectOne(
+        $conflictCount = \NDB_Factory::singleton()->database()->pselectOne(
             "SELECT COUNT(*) FROM conflicts_unresolved WHERE CommentId1=:CID",
             ['CID' => $commentId]
         );

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -68,14 +68,16 @@ class Database implements LoggerAwareInterface
     /**
      * Singleton design pattern implementation - creates the object
      * and also connects to the database if necessary.
-     * NOTE There is no return type declaration for this function as it returns
-     * the type `Database` which is not supported by PHPs built in return types.
+     *
+     * To avoid credentials being displayed in stack traces,
+     * credentials must be passed in environment variables.
+     *
+     * The caller must ensure there are variables named
+     * LORIS_$dbname_USERNAME, LORIS_$dbname_PASSWORD, and
+     * LORIS_$dbname_HOST with their respective values. This
+     * is usually done by NDB_Factory.
      *
      * @param string $database     the database to select
-     * @param string $username     the username with which to log into
-     *                             the database server
-     * @param string $password     the password that matches the username
-     * @param string $host         the name of the database server
      * @param bool   $trackChanges boolean determining if changes should be
      *                             logged to the history table
      *
@@ -84,12 +86,12 @@ class Database implements LoggerAwareInterface
      * @access public
      */
     static function &singleton(
-        string $database     = '',
-        string $username     = '',
-        string $password     = '',
-        string $host         = '',
+        string $database,
         bool $trackChanges = true
     ): \Database {
+        $username = getenv("LORIS_{$database}_USERNAME");
+        $password = getenv("LORIS_{$database}_PASSWORD");
+        $host     = getenv("LORIS_{$database}_HOST");
 
         static $connections = [];
 

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -70,7 +70,7 @@ class FeedbackMRI
     function clearAllComments(): bool
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = NDB_Factory::singleton()->database();
 
         $DB->delete('feedback_mri_comments', $this->_buildWhereAssoc());
         return true;
@@ -141,7 +141,7 @@ class FeedbackMRI
     function getComments(): ?array
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // start building the query
         $query = "SELECT CommentTypeID, PredefinedCommentID, Comment
@@ -181,7 +181,7 @@ class FeedbackMRI
     function getAllPredefinedComments(int $commentTypeID): array
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // build the query
         $query = "SELECT PredefinedCommentID, Comment
@@ -221,7 +221,7 @@ class FeedbackMRI
         }
 
         // create DB object
-        $DB =& Database::singleton();
+        $DB =& \NDB_Factory::singleton()->database();
 
         // get the parameter type id
         $query = "SELECT ParameterTypeID FROM parameter_type WHERE Name=:FName";
@@ -267,7 +267,7 @@ class FeedbackMRI
         }
 
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // get the parameter type id
         $query = "SELECT ParameterTypeID FROM parameter_type WHERE Name=:FName";
@@ -326,7 +326,7 @@ class FeedbackMRI
     function getAllCommentTypes(): array
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // build the array
         $query = "SELECT CommentTypeID, CommentName, CommentStatusField
@@ -409,7 +409,7 @@ class FeedbackMRI
         }
 
         // create DB object
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // object identifier
         $set = [];

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -70,7 +70,7 @@ class FeedbackMRI
     function clearAllComments(): bool
     {
         // create DB object
-        $DB = NDB_Factory::singleton()->database();
+        $DB = \NDB_Factory::singleton()->database();
 
         $DB->delete('feedback_mri_comments', $this->_buildWhereAssoc());
         return true;

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -29,6 +29,13 @@
 trait LegacyInstrumentTrait
 {
     /**
+     * The LorisInstance that this page was created to serve.
+     *
+     * @var \LORIS\LorisInstance
+     */
+    protected $loris;
+
+    /**
      * The testName being accessed. Not that this is set in
      * NDB_BVL_Instrument but needs to be redeclared here so
      * that static analysis tools know that it exists within
@@ -44,7 +51,7 @@ trait LegacyInstrumentTrait
      */
     public function getFullName(): ?string
     {
-        return \NDB_Factory::singleton()->database()->pselectOne(
+        return $this->loris->getDatabaseConnection()->pselectOne(
             "SELECT Full_name FROM test_names WHERE Test_name=:TN",
             ['TN' => $this->testName]
         );
@@ -61,7 +68,7 @@ trait LegacyInstrumentTrait
     function getSubtestList(): array
     {
         // get a database connection
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         $query = "SELECT Subtest_name AS Name, Description
             FROM instrument_subtests

--- a/php/libraries/MRIFile.class.inc
+++ b/php/libraries/MRIFile.class.inc
@@ -35,7 +35,7 @@ class MRIFile
      */
     function __construct(int $fileID)
     {
-        $db     = \Database::singleton();
+        $db     = \NDB_Factory::singleton()->database();
         $params = ['FID' => $fileID];
 
         $query    = "SELECT * FROM files WHERE FileID=:FID";
@@ -115,7 +115,7 @@ class MRIFile
             return null;
         }
 
-        return \Database::singleton()->pselectOne(
+        return \NDB_Factory::singleton()->database()->pselectOne(
             'SELECT Scan_type FROM mri_scan_type WHERE ID=:ProtoID',
             ['ProtoID' => $this->fileData['AcquisitionProtocolID']]
         );

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -192,7 +192,7 @@ class NDB_BVL_Battery
      */
     function addInstrument($loris, $testName)
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         // assert that a battery has already been selected
         $this->_assertBatterySelected();
 
@@ -281,7 +281,7 @@ class NDB_BVL_Battery
      */
     function getBattery()
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         // assert that a battery has already been selected
         $this->_assertBatterySelected();
 
@@ -313,7 +313,7 @@ class NDB_BVL_Battery
      */
     function getBatteryVerbose()
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         // assert that a battery has already been selected
         $this->_assertBatterySelected();
 
@@ -433,7 +433,7 @@ class NDB_BVL_Battery
         $center_ID=null,
         $firstVisit=null
     ) {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         if (empty($this->age)) {
             $this->age = $age;
         }
@@ -571,7 +571,7 @@ class NDB_BVL_Battery
      */
     static function generateCommentID($SessionID, $Test_name)
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $SessionID = $SessionID->__toString();
 
@@ -624,7 +624,7 @@ class NDB_BVL_Battery
      */
     function _assertValidInstrument($testName)
     {
-        $DB    = Database::singleton();
+        $DB    = \NDB_Factory::singleton()->database();
         $query = "SELECT COUNT(*) AS counter FROM test_names WHERE Test_name=:TN";
         $row   = $DB->pselectRow($query, ['TN' => $testName]);
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -380,7 +380,7 @@ class NDB_BVL_Feedback
     function getMaxThreadStatus($select_inactive_threads): ?string
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db =& \NDB_Factory::singleton()->database();
 
         $query   = "SELECT MAX(Status) FROM feedback_bvl_thread WHERE";
         $qparams = [];
@@ -454,7 +454,7 @@ class NDB_BVL_Feedback
     function getSummaryOfThreads()
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // get User object
         $user =& User::singleton($this->_username);
@@ -517,7 +517,7 @@ class NDB_BVL_Feedback
     function getThreadList()
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // create user object
         $user =& User::singleton($this->_username);
@@ -617,7 +617,7 @@ class NDB_BVL_Feedback
     static function getThreadEntries($feedbackID)
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         //select the entries (details) for the thread
         $query
@@ -659,7 +659,7 @@ class NDB_BVL_Feedback
     function createThread($level, $type, $comment, $public=null,$fieldname=null)
     {
         // new DB Object
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // public threads are inactive by default
         if ($public == 'Y') {
@@ -763,7 +763,7 @@ class NDB_BVL_Feedback
     function createEntry($feedbackID, $comment, $username): array
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // create SET array for the INSERT
         $setArray = [
@@ -802,7 +802,7 @@ class NDB_BVL_Feedback
         $fieldname =''
     ) {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // create the new entry - every update need to be follow up with a comment
         // FIXME: I don't think the third parameter is correct, but I'm not sure
@@ -854,7 +854,7 @@ class NDB_BVL_Feedback
     function deleteThread($feedbackID)
     {
         // new DB Object
-        $db = \Database::singleton();
+        $db = \NDB_factory::singleton()->database();
 
         // DELETE the thread's entries
         $db->delete(
@@ -880,7 +880,7 @@ class NDB_BVL_Feedback
     function deleteEntry($entryID)
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db =& \NDB_Factory::singleton()->database();
 
         // DELETE the thread entries
         $db->delete('feedback_bvl_entry', ["ID" => $entryID]);
@@ -896,7 +896,7 @@ class NDB_BVL_Feedback
     function activateThread($feedbackID=null)
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         $setArray = [
             "Active"   => 'Y',
@@ -947,7 +947,7 @@ class NDB_BVL_Feedback
     function closeThread(?int $feedbackID = null): int
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         $whereStr = 'Public = \'Y\' AND Active = \'Y\' ';
         if (!empty($feedbackID)) {
@@ -1001,7 +1001,7 @@ class NDB_BVL_Feedback
      */
     function openThread(int $feedbackID): int
     {
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         $whereStr = 'Public = \'Y\' AND Active = \'Y\' ';
 
@@ -1039,7 +1039,7 @@ class NDB_BVL_Feedback
             );
         }
         // new DB Object
-        $db = Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // StatusID is passed in as an integer, but the field in the database
         // is an enum, so we need to do WHERE Status+0= .. to convert it to

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -645,7 +645,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _saveCandidateAge(array &$values): void
     {
         if (!empty($values['Date_taken'])) {
-            $DB  = Database::singleton();
+            $DB  = $this->loris->getDatabaseConnection();
             $age = $this->getCandidateAge($values['Date_taken']);
             if (empty($age)) {
                 throw new LorisException("Candidate age could not be found.");
@@ -823,7 +823,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _save(array $values): void
     {
-        $db = Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         // clear any fields starting with __
         foreach (array_keys($values) AS $key) {
@@ -1005,7 +1005,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             return [];
         }
 
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         $centerID = $db->pselectOne(
             "SELECT session.CenterID FROM session, flag
@@ -1543,7 +1543,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getRequiredElementsCompletedFlag(): string
     {
-        $db     = Database::singleton();
+        $db     = $this->loris->getDatabaseConnection();
         $status = $db->pselectOne(
             "SELECT Required_elements_completed FROM flag WHERE CommentID=:CID",
             ['CID' => $this->getCommentID()]
@@ -1574,7 +1574,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 . "'Y' or 'N'<br>\n"
             );
         }
-        $DB = Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
         $DB->update(
             "flag",
             ["Required_elements_completed" => $status],
@@ -2108,7 +2108,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             return $this->instanceData;
         }
 
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         if ($this->jsonData) {
             $jsondata = $db->pselectOne(
@@ -2145,7 +2145,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             'Warning: loadInstanceData($inst) is deprecated and will be removed'
             . ' in a future version of LORIS. Use $inst->getInstanceData() instead.'
         );
-        $db = \Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         if ($instrumentInstance->jsonData) {
             $jsondata = $db->pselectOne(
@@ -2180,7 +2180,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "Must bulk load from instrument loaded without commentID"
             );
         }
-        $db = \Database::singleton();
+        $db = $this->loris->getDatabaseConnection();
 
         $prepBindings = [];
         $prepValues   = [];
@@ -2273,7 +2273,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getDoB(): ?string
     {
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         $CommentID = $this->getCommentID();
 
         $dob = $db->pselectOne(
@@ -2293,7 +2293,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getDoD(): ?string
     {
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         $CommentID = $this->getCommentID();
         $dod       = $db->pselectOne(
             "SELECT c.DoD FROM flag f
@@ -2312,7 +2312,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getPSCID(): ?string
     {
-        $db        = \Database::singleton();
+        $db        = $this->loris->getDatabaseConnection();
         $CommentID = $this->getCommentID();
 
         $pscid = $db->pselectOne(
@@ -2333,7 +2333,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function clearInstrument(): void
     {
         $config   = NDB_Config::singleton();
-        $db       = Database::singleton();
+        $db       = $this->loris->getDatabaseConnection();
         $dbconfig = $config->getSetting('database');
 
         if (!$this->jsonData) {
@@ -2741,7 +2741,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function determineDataEntryAllowed(): bool
     {
-        $DB    = Database::singleton();
+        $DB    = $this->loris->getDatabaseConnection();
         $entry = $DB->pselectOne(
             "SELECT Data_entry FROM flag WHERE CommentID=:CID",
             ['CID' => $this->getCommentId()]

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -104,7 +104,7 @@ class NDB_BVL_InstrumentStatus
         // set the _commentID property
         $this->_commentID = $commentID;
 
-        $db = Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // get candidate data from database
         $query = "SELECT SessionID, Data_entry, Administration, Validity, Exclusion

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -165,13 +165,23 @@ class NDB_Factory
 
         $settings = $this->settings();
 
+        // Pass the credentials in environment variables, so that they
+        // don't potentially show up in a stack trace if something goes
+        // wrong.
+        $dbname = $settings->dbName();
+        putenv("LORIS_{$dbname}_USERNAME=" . $settings->dbUserName());
+        putenv("LORIS_{$dbname}_PASSWORD=" . $settings->dbPassword());
+        putenv("LORIS_{$dbname}_HOST=" . $settings->dbHost());
+
         $db_ref = \Database::singleton(
             $settings->dbName(),
-            $settings->dbUserName(),
-            $settings->dbPassword(),
-            $settings->dbHost(),
             true
         );
+
+        // Unset the variables now that they're no longer needed.
+        putenv("LORIS_{$dbname}_USERNAME=");
+        putenv("LORIS_{$dbname}_PASSWORD=");
+        putenv("LORIS_{$dbname}_HOST=");
 
         self::$db = $db_ref;
 

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -433,7 +433,7 @@ class NDB_Menu_Filter extends NDB_Menu
     function _getList()
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = $this->loris->getDatabaseConnection();
 
         // add the base query
         $query  = '';

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -197,7 +197,7 @@ abstract class NDB_Notifier_Abstract
      */
     private function _getAdminUser(): array
     {
-        $result = \Database::singleton()->pselectRow(
+        $result = \NDB_Factory::singleton()->database()->pselectRow(
             "SELECT ID, Real_name, Email, UserID FROM users WHERE UserID='admin'",
             []
         );
@@ -258,7 +258,7 @@ abstract class NDB_Notifier_Abstract
 
         }
 
-        $result = \Database::singleton()->pselect($query, $params);
+        $result = \NDB_Factory::singleton()->database()->pselect($query, $params);
 
         //parse $result and create 2D array
         $n_list = [];
@@ -281,7 +281,7 @@ abstract class NDB_Notifier_Abstract
      */
     private function _hasNotificationPermission(int $uid): bool
     {
-        $DB      = Database::singleton();
+        $DB      = \NDB_Factory::singleton()->database();
         $current = $DB->pselect(
             "SELECT * FROM user_perm_rel WHERE userID=:uid",
             ["uid" => $uid]
@@ -319,7 +319,7 @@ abstract class NDB_Notifier_Abstract
      */
     protected function getEmail(int $uid): ?string
     {
-        return \Database::singleton()->pselectOne(
+        return \NDB_Factory::singleton()->database()->pselectOne(
             "SELECT Email FROM users WHERE ID=:uid",
             ["uid" => $uid]
         );
@@ -334,7 +334,7 @@ abstract class NDB_Notifier_Abstract
      */
     protected function getPhone(int $uid): ?string
     {
-        return \Database::singleton()->pselectOne(
+        return \NDB_Factory::singleton()->database()->pselectOne(
             "SELECT Phone FROM users WHERE ID=:uid",
             ["uid" => $uid]
         );
@@ -363,7 +363,7 @@ abstract class NDB_Notifier_Abstract
         string $service
     ): void {
 
-        \Database::singleton()->insert(
+        \NDB_Factory::singleton()->database()->insert(
             'notification_history',
             [
                 "module_id"    => $this->getNotificationModuleID(
@@ -387,7 +387,7 @@ abstract class NDB_Notifier_Abstract
      */
     public static function getNotificationModuleServices(): array
     {
-        $DB = Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $query  = "
             SELECT 
@@ -430,7 +430,7 @@ abstract class NDB_Notifier_Abstract
      */
     public static function getNotificationServices(): array
     {
-        $result = \Database::singleton()->pselect(
+        $result = \NDB_Factory::singleton()->database()->pselect(
             'SELECT * FROM notification_services',
             []
         );
@@ -450,7 +450,7 @@ abstract class NDB_Notifier_Abstract
      */
     public static function getNotificationModules() :array
     {
-        $result = \Database::singleton()->pselect(
+        $result = \NDB_Factory::singleton()->database()->pselect(
             'SELECT * FROM notification_modules',
             []
         );
@@ -488,7 +488,10 @@ abstract class NDB_Notifier_Abstract
             "mn" => $module,
             "ot" => $operation_type,
         ];
-        return intval(\Database::singleton()->pselectOne($query, $params));
+        return intval(
+            \NDB_Factory::singleton()->database()
+                ->pselectOne($query, $params)
+        );
     }
 
     /**
@@ -505,7 +508,10 @@ abstract class NDB_Notifier_Abstract
                   WHERE service=:serv
                     ";
         $params = ["serv" => $service];
-        return intval(\Database::singleton()->pselectOne($query, $params));
+        return intval(
+            \NDB_Factory::singleton()->database()
+                ->pselectOne($query, $params)
+        );
     }
 
     /**
@@ -534,7 +540,7 @@ abstract class NDB_Notifier_Abstract
                                                       )
                       ";
         $params = ["uid" => $uid];
-        $result = \Database::singleton()->pselect($query, $params);
+        $result = \NDB_Factory::singleton()->database()->pselect($query, $params);
 
         $user_n_list =[];
         foreach ($result as $row) {

--- a/php/libraries/Notify.class.inc
+++ b/php/libraries/Notify.class.inc
@@ -52,7 +52,9 @@ class Notify
             'Message'            => $message,
             'CenterID'           => $centerID,
         ];
-        \Database::singleton()->insert('notification_spool', $setArray);
+
+        $db = \NDB_Factory::singleton()->database();
+        $db->insert('notification_spool', $setArray);
     }
 
     /**

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -571,7 +571,7 @@ class SinglePointLogin
     function insertFailedDetail(string $description, array $setArray): void
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $setArray['Success']     = 'N';
         $setArray['Fail_detail'] = $description;
@@ -595,7 +595,7 @@ class SinglePointLogin
         int $maximumDaysInactive
     ): bool {
 
-        $DB    =& Database::singleton();
+        $DB    = \NDB_Factory::singleton()->database();
         $query = "SELECT MAX(Login_timestamp) as Login_timestamp
                   FROM user_login_history 
                   WHERE UserID = :username";

--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -49,7 +49,7 @@ class Site implements
         $this->_siteInfo['CenterID'] = $centerID;
 
         // make a local reference to the Database object
-        $db = \Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         $query  = "SELECT Name, PSCArea, Alias, MRI_alias, Account, Study_site
                       FROM psc

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -128,7 +128,7 @@ class SiteIDGenerator extends IdentifierGenerator
      */
     protected function getExistingIDs(): array
     {
-        $ids = \Database::singleton()->pselectCol(
+        $ids = \NDB_Factory::singleton()->database()->pselectCol(
             "SELECT substring($this->kind, LENGTH('{$this->prefix}') +1)
             from candidate
             WHERE {$this->kind} LIKE '{$this->prefix}%'",

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -400,7 +400,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             );
         }
 
-        \Database::singleton()->update(
+        \NDB_Factory::singleton()->database()->update(
             'session',
             $newData,
             [
@@ -741,7 +741,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function setCurrentStage(): void
     {
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // this class does not handle Subject & Recycling Bin stage at the moment
         if (in_array($this->getCurrentStage(), ['Subject', 'Recycling Bin'])) {
@@ -838,7 +838,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function setBVLQCType(string $type): void
     {
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         if (!in_array($type, $this->bvlQcTypes)) {
             throw new Exception("You need to specify a valid BVL QC Type");
@@ -867,7 +867,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function setBVLQCStatus(string $status): void
     {
-        $db =& Database::singleton();
+        $db =& \NDB_Factory::singleton()->database();
 
         if (!in_array($status, $this->bvlQcStatuses)) {
             throw new Exception("You need to specify a valid BVL QC Type");
@@ -904,7 +904,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function setBVLQCExclusion(string $status): bool
     {
-        $db =& Database::singleton();
+        $db = \NDB_Factory::singleton()->database();
 
         // check the status
         if (!in_array($status, $this->bvlQcExclusionStatuses)) {

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -64,7 +64,7 @@ class User extends UserPermissions implements
         };
 
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // get user data from database
         $query = "SELECT * FROM users WHERE UserID = :UID";
@@ -183,7 +183,7 @@ class User extends UserPermissions implements
      */
     public static function insert(array $set): void
     {
-        \Database::singleton()->insert('users', $set);
+        \NDB_Factory::singleton()->database()->insert('users', $set);
     }
 
 
@@ -197,7 +197,7 @@ class User extends UserPermissions implements
      */
     public function update(array $set): void
     {
-        \Database::singleton()->update(
+        \NDB_Factory::singleton()->database()->update(
             'users',
             $set,
             ['UserID' => $this->userInfo['UserID']]

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -52,7 +52,7 @@ class UserPermissions
         $query  = "SELECT ID FROM users WHERE UserID =:UName";
         $params = ['UName' => $username];
 
-        $userID = \Database::singleton()->pselectOne($query, $params);
+        $userID = \NDB_Factory::singleton()->database()->pselectOne($query, $params);
         if ($userID === null) {
             return false;
         }
@@ -74,7 +74,7 @@ class UserPermissions
     function setPermissions(): void
     {
         // create DB object
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // get all the permissions for this user
         $query = "SELECT p.code, pr.userID FROM permissions p
@@ -195,7 +195,7 @@ class UserPermissions
     function addPermissions(array $set): void
     {
         // create DB object
-        $DB = \Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // add the permissions
         foreach ($set as $value) {
@@ -224,7 +224,7 @@ class UserPermissions
     function removePermissions(?array $set = null): void
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
         if (is_null($set)) {
             // remove all permissions
             $DB->delete(
@@ -258,7 +258,7 @@ class UserPermissions
     function getPermissionIDs(): array
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         // get all the permissions for this user
         $query = "SELECT permissions.permID
@@ -287,7 +287,7 @@ class UserPermissions
     function getPermissionsVerbose(): array
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \NDB_Factory::singleton()->database();
 
         $query = "SELECT
                 p.permID,
@@ -343,7 +343,7 @@ class UserPermissions
     ): void {
 
         // create DB object
-        $DB =& Database::singleton();
+        $DB =& \NDB_Factory::singleton()->database();
 
         //insert into the login_history
         $DB->insert(

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -627,7 +627,7 @@ class Utility
         $query    = "SELECT count(*)
             FROM {$table_name}
             WHERE {$column} is NULL";
-        $DB       =& \Database::singleton();
+        $DB       = \NDB_Factory::singleton()->database();
         $num_null = $DB->pselectOne(
             $query,
             []

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -38,7 +38,7 @@ class NDB_BVL_Battery_Test extends TestCase
         $client->makeCommandLine();
         $client->initialize();
 
-        $this->DB = Database::singleton();
+        $this->DB = \NDB_Factory::singleton()->database();
 
         $this->DB->setFakeTableData(
             "test_names",

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -70,7 +70,7 @@ abstract class LorisIntegrationTest extends TestCase
 
         $database = $this->config->getSetting('database');
 
-        $this->DB = Database::singleton(
+        $this->DB = $this->factory->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -1328,7 +1328,7 @@ class CandidateTest extends TestCase
         $this->_factoryForDB->reset();
         $this->_config = $this->_factoryForDB->Config(CONFIG_XML);
         $database      = $this->_config->getSetting('database');
-        $this->_DB     = Database::singleton(
+        $this->_DB     = $this->_factoryForDB->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -93,7 +93,7 @@ class Database_Test extends TestCase
         $this->factory->reset();
         $this->config = $this->factory->Config(CONFIG_XML);
         $database     = $this->config->getSetting('database');
-        $this->DB     = Database::singleton(
+        $this->DB     = $this->factory->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/Loris_PHPUnit_Database_TestCase.php
+++ b/test/unittests/Loris_PHPUnit_Database_TestCase.php
@@ -82,11 +82,21 @@ abstract class Loris_PHPUnit_Database_TestCase extends TestCase
      */
     protected function createLorisDBConnection()
     {
+        $dbname = $this->factory->settings()->dbName();
+        putenv(
+            "LORIS_{$dbname}_USERNAME="
+            . $this->factory->settings()->dbUserName()
+        );
+        putenv(
+            "LORIS_{$dbname}_PASSWORD="
+            . $this->factory->settings()->dbPassword()
+        );
+        putenv(
+            "LORIS_{$dbname}_HOST="
+            . $this->factory->settings()->dbHost()
+        );
         $this->database = Database::singleton(
             $this->factory->settings()->dbName(),
-            $this->factory->settings()->dbUserName(),
-            $this->factory->settings()->dbPassword(),
-            $this->factory->settings()->dbHost()
         );
     }
 

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -142,6 +142,21 @@ class NDB_BVL_Instrument_Test extends TestCase
         $instrument->form     = $this->quickForm;
         $instrument->testName = "Test";
 
+        // Use reflection to set the internal
+        // loris object that should have been
+        // set by the instrument constructor,
+        // if PHPunit hadn't disabled the constructor
+        $ref = new \ReflectionProperty(get_class($instrument), 'loris');
+        $ref->setAccessible(true);
+        $ref->setValue(
+            $instrument,
+            new \LORIS\LorisInstance(
+                $mockDB,
+                $mockConfig,
+                [],
+            )
+        );
+
         $this->_instrument = $instrument;
     }
 
@@ -1934,7 +1949,7 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->_config = $this->_factoryForDB->Config(CONFIG_XML);
         $database      = $this->_config->getSetting('database');
-        $this->_DB     = \Database::singleton(
+        $this->_DB     = $this->_factoryForDB->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1597,6 +1597,22 @@ class NDB_BVL_Instrument_Test extends TestCase
             ->onlyMethods(
                 ["getFullName", "getSubtestList", "getDataDictionary"]
             )->getMock();
+
+        // Use reflection to set the internal
+        // loris object that should have been
+        // set by the instrument constructor,
+        // if PHPunit hadn't disabled the constructor
+        $ref = new \ReflectionProperty(get_class($otherInstrument), 'loris');
+        $ref->setAccessible(true);
+        $ref->setValue(
+            $otherInstrument,
+            new \LORIS\LorisInstance(
+                $this->_DB,
+                $this->_mockConfig,
+                [],
+            )
+        );
+
         '@phan-var \NDB_BVL_Instrument $otherInstrument';
         $otherInstrument->commentID = 'commentID2';
         $otherInstrument->table     = 'medical_history';
@@ -1959,5 +1975,16 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->_factoryForDB->setDatabase($this->_DB);
         $this->_factoryForDB->setConfig($this->_config);
+
+        $ref = new \ReflectionProperty(get_class($this->_instrument), 'loris');
+        $ref->setAccessible(true);
+        $ref->setValue(
+            $this->_instrument,
+            new \LORIS\LorisInstance(
+                $this->_DB,
+                $this->_config,
+                [],
+            )
+        );
     }
 }

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -40,7 +40,7 @@ class NDB_Factory_Test extends TestCase
 
         $this->_config = $this->_factory->Config(CONFIG_XML);
         $database      = $this->_config->getSetting('database');
-        $this->_DB     = Database::singleton(
+        $this->_DB     = $this->_factory->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -307,7 +307,7 @@ class UserTest extends TestCase
         $this->_mockDB      = $mockdb;
         $this->_mockConfig  = $mockconfig;
         $this->_mockFactory = \NDB_Factory::singleton();
-        $this->_mockFactory->setDatabase($mockdb);
+        $this->_mockFactory->setDatabase($this->_dbMock);
 
         $this->_factory->setConfig($this->_mockConfig);
 
@@ -742,6 +742,7 @@ class UserTest extends TestCase
                 $this->stringContains("FROM user_login_history")
             )
             ->willReturn($count);
+        $this->_factory->setDatabase($this->_mockDB);
 
         $this->assertTrue($this->_user->hasLoggedIn());
     }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -290,7 +290,7 @@ class UserTest extends TestCase
         $this->_factory->reset();
         $this->_configMock = $this->_factory->Config(CONFIG_XML);
         $database          = $this->_configMock->getSetting('database');
-        $this->_dbMock     = \Database::singleton(
+        $this->_dbMock     = $this->_factory->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -1234,7 +1234,7 @@ class UtilityTest extends TestCase
         $this->_mockFactory->reset();
         $this->_mockConfig = $this->_mockFactory->Config(CONFIG_XML);
         $database          = $this->_mockConfig->getSetting('database');
-        $this->_mockDB     = \Database::singleton(
+        $this->_mockDB     = $this->_mockFactory->database(
             $database['database'],
             $database['username'],
             $database['password'],

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -12,8 +12,6 @@
  */
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../../php/libraries/VisitController.class.inc';
-require_once __DIR__ . '/../../php/libraries/Visit.class.inc';
 
 use \LORIS\Visit;
 //use \LORIS\VisitController;
@@ -57,11 +55,12 @@ class VisitTest extends TestCase
         $this->factory->reset();
         $this->config = $this->factory->Config(CONFIG_XML);
         $database     = $this->config->getSetting('database');
-        $this->DB     = Database::singleton(
+        putenv("LORIS_{$database['database']}_USERNAME={$database['username']}");
+        putenv("LORIS_{$database['database']}_PASSWORD={$database['password']}");
+        putenv("LORIS_{$database['database']}_HOST={$database['host']}");
+
+        $this->DB = \Database::singleton(
             $database['database'],
-            $database['username'],
-            $database['password'],
-            $database['host'],
             true,
         );
         $this->visitController = new \Loris\VisitController($this->DB);

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../php/libraries/VisitController.class.inc';
+require_once __DIR__ . '/../../php/libraries/Visit.class.inc';
 
 use \LORIS\Visit;
 //use \LORIS\VisitController;


### PR DESCRIPTION
This prevents the possibility of PHP printing a stack trace
with database credentials if an exception is thrown from the
database constructor, by moving the credentials from function
arguments to environment variables.

Since the function signature changed, all calls to \Database::singleton
were (finally) updated to use LorisInstance->getDatabaseConnection (if
available) or NDB_Factory->database (if no LorisInstance available in
the current context) in order to centralize the change to one place.

Resolves #8014