### PR TITLE
[LINST/Instruments] Backporting fixes from 24 + group errors

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -36,6 +36,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
     public $LinstLines = array();
 
+    // array of the format "field_name" => "group_name"
+    protected $GroupElements = [];
+
     /**
      * Sets up the variables required for a LINST instrument to load
      *
@@ -263,7 +266,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 } else if (substr($elname, -7) != "_status"
                     && !in_array($elname, array("page", "subtest"))
                 ) {
-                    $errors[$elname] = "Required.";
+                    // Check if element part of a group.
+                    // If so, the error should be on the group to show up
+                    $errorEl          = $this->GroupElements[$elname] ?? $elname;
+                    $errors[$errorEl] = "$elname is required.";
+
                     if ($this->XINDebug) {
                         echo "Required by default";
                     }
@@ -481,7 +488,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     break;
                 case 'begingroup':
                     if ($addElements) {
-                        $Group['Name']      = $pieces[1] . '_group';
+                        $Group['Name']      = trim($pieces[1]) . '_group';
                         $Group['Delimiter'] = trim($pieces[2]);
 
                         if (empty($Group['Delimiter'])) {
@@ -499,6 +506,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $Group['Delimiter'],
                             false
                         );
+
+                        // Track elements and their groups for XIN errors proper
+                        // higlighting in the browser
+                        foreach ($Group['Elements'] as $el) {
+                            if (isset($el['name'])) {
+                                $this->GroupElements[$el['name']] = $Group['Name'];
+                            }
+                        }
 
                         $Group['Name']     = null;
                         $Group['Elements'] = array();

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -579,6 +579,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // Set date format
                         $dateFormat = isset($pieces[5]) ? trim($pieces[5]) : "";
 
+                        $this->LinstQuestions[$pieces[1]] = array('type' => 'date');
+
                         if ($dateFormat === 'MonthYear') {
                             // Shows date without day of month
                             $this->addMonthYear(
@@ -632,7 +634,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $this->_requiredElements[] = $fieldname;
                         $firstFieldOfPage          = false;
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'date');
                     break;
                 case 'numeric':
                     if ($addElements) {
@@ -683,7 +684,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                         $pieces[1],
                                         $pieces[2],
                                         $opt,
-                                        "multiple"
+                                        [ "multiple" => "multiple" ]
                                     );
                             } else {
                                 $Group['Elements'][]
@@ -729,7 +730,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->_doubleDataEntryDiffIgnoreColumns[] = $pieces[1];
                     if ($addElements) {
                         if ($Group['Name'] != null) {
-                            print "Creating $pieces[1] with label: $pieces[2]";
                             $Group['Elements'][]
                                 = $this->form->createElement(
                                     'static',


### PR DESCRIPTION
## Brief summary of changes
This PR cherry picks a few key bugfixes already merged into 24 back into the 23 branch for projects not looking to upgrade immediately and are using LINST

1. Print out (debugging) showing up on the front end of instruments: https://github.com/aces/Loris/commit/a6e1744bc642a0413d2e27bd10f832ee32f4da3e#diff-1d18bbc27ba2cabe74bdf1a067307ce735f0f84fd29c735010eb122abc370c14L843
2. Date elements are always required even when a rule is explicitly added to make them not required: https://github.com/aces/Loris/pull/7925/files#diff-1d18bbc27ba2cabe74bdf1a067307ce735f0f84fd29c735010eb122abc370c14R660
3. The `multiple` parameter should be passed as an array, not a string: https://github.com/aces/Loris/commit/137f1fb5fa19d8934a2d80c340477e1e1b9bee90#diff-1d18bbc27ba2cabe74bdf1a067307ce735f0f84fd29c735010eb122abc370c14R665

4. NEW: This PR also fixes the problem where table rows (rows using `begingroup` and `endgroup` elements) are not highlighted in red when an element within the group breaks XIN rules. the reason for that is the XIN validation in LINST assumes all elements are purely linear, no group logic.