### PR TITLE
[timepoint_list] Update error message when no access to timepoints

### DIFF
--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -155,7 +155,7 @@
             </td>
         </tr>
     {sectionelse}
-        <tr><td colspan="10">No timepoints have been registered yet.</td></tr>
+        <tr><td colspan="10">You do not have access to any timepoints registered for this candidate.</td></tr>
     {/section}
     </tbody>
 </table>


### PR DESCRIPTION
This updates the error message when attempting to access a candidate for which the user doesn't have permission to access any timepoints.

The previous message claimed that there was no timepoints registered, which was not the case if the list is empty for permission related reasons.