### PR TITLE
Do not filter sites with access_all_profiles permission

### DIFF
--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -100,12 +100,14 @@ class Timepoint_List extends \NDB_Menu
             $listOfSessionIDs,
         );
 
-        $listOfTimePoints = array_filter(
-            $listOfTimePoints,
-            function ($timePoint) use ($user) {
-                return $timePoint->isAccessibleBy($user);
-            }
-        );
+        if ($user->hasPermission('access_all_profiles') === false) {
+            $listOfTimePoints = array_filter(
+                $listOfTimePoints,
+                function ($timePoint) use ($user) {
+                    return $timePoint->isAccessibleBy($user);
+                }
+            );
+        }
 
         /*
          * List of visits


### PR DESCRIPTION
Do not filter the sites in the timepoint_list page if the
user has the access_all_profiles permission since the permission
says it gives access to all profiles *and* visits.

