### PR TITLE
[installation] fix bug on Loris 24.1-release

### DIFF
--- a/src/Log/ErrorLogLogger.php
+++ b/src/Log/ErrorLogLogger.php
@@ -62,7 +62,7 @@ class ErrorLogLogger implements LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         // LogLevel consts are strings, not integers, so we need to
         // be explicit about which are used instead of doing a < or >


### PR DESCRIPTION
## Brief summary of changes
PHP Fatal error:  Declaration of LORIS\\Log\\ErrorLogLogger::log($level, $message, array $context = []) must be compatible with Psr\\Log\\LoggerTrait::log($level, Stringable|string $message, array $context = []): void in /var/www/Loris/src/Log/ErrorLogLogger.php on line 65

Testing instructions (if applicable)
install Loris 24.1-release
Test Enviorment:
Ubuntu:22
php 8.1
npm -v 8.12.1
node v14.19.3
Composer version 2.3.7
