### PR TITLE
[instrument_builder] ADDED: field warnings for maximum length in Instrument Builder module

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -1007,7 +1007,7 @@ class AddElement extends Component {
       });
       hasError = true;
     } else if (this.state.error) {
-      // No error, remove the elememt's questionName error flag if set
+      // No error, remove the element's questionName error flag if set
       let temp = this.state.error;
       delete temp.questionName;
       this.setState({

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -1020,7 +1020,7 @@ class AddElement extends Component {
       return;
     }
 
-    if (questionText.length > 64) {
+    if (questionText.length > 64 && selected !=='label') {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionText with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -996,30 +996,6 @@ class AddElement extends Component {
       });
     }
 
-    if (questionName.length > 64 && selected !== 'textbox'
-        && selected !== 'textarea' && selected !== 'date'
-        && selected !== 'numeric') {
-      // Error, question name is needed for the desired type. Set the element
-      // error flag for the questionName with message. Set the hasError flag
-      let temp = (this.state.error) ? this.state.error : {};
-      temp.questionName = 'Please shorten to 64 characters maximum';
-      this.setState({
-        error: temp,
-      });
-      hasError = true;
-    } else if (this.state.error) {
-      // No error, remove the element's questionName error flag if set
-      let temp = this.state.error;
-      delete temp.questionName;
-      this.setState({
-        error: temp,
-      });
-    }
-    if (hasError) {
-      // An error is present, return
-      return;
-    }
-
     if (questionText.length > 64 && selected !=='label') {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionText with message. Set the hasError flag
@@ -1033,30 +1009,6 @@ class AddElement extends Component {
       // No error, remove the elememt's questionText error flag if set
       let temp = this.state.error;
       delete temp.questionText;
-      this.setState({
-        error: temp,
-      });
-    }
-    if (hasError) {
-      // An error is present, return
-      return;
-    }
-
-    if (questionName.length > 57 && (selected === 'textbox'
-      || selected === 'textarea' || selected === 'date'
-      || selected === 'numeric')) {
-      // Error, question name is needed for the desired type. Set the element
-      // error flag for the questionName with message. Set the hasError flag
-      let temp = (this.state.error) ? this.state.error : {};
-      temp.questionName = 'Please shorten to 57 characters maximum';
-      this.setState({
-        error: temp,
-      });
-      hasError = true;
-    } else if (this.state.error) {
-      // No error, remove the elememt's questionName error flag if set
-      let temp = this.state.error;
-      delete temp.questionName;
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -1023,7 +1023,7 @@ class AddElement extends Component {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionText with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
-      temp.questionText = 'Field length should be strictly less than 65 characters';
+      temp.questionText = 'Please shorten to 64 characters maximum';
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -995,20 +995,46 @@ class AddElement extends Component {
         error: temp,
       });
     }
-
-    if (questionText.length > 64 && selected !=='label') {
+    
+    if (questionName.length > 64 && selected !== 'textbox'
+        && selected !== 'textarea' && selected !== 'date'
+        && selected !== 'numeric') {
       // Error, question name is needed for the desired type. Set the element
-      // error flag for the questionText with message. Set the hasError flag
+      // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
-      temp.questionText = 'Please shorten to 64 characters maximum';
+      temp.questionName = 'Please shorten to 64 characters maximum';
       this.setState({
         error: temp,
       });
       hasError = true;
     } else if (this.state.error) {
-      // No error, remove the elememt's questionText error flag if set
+      // No error, remove the element's questionName error flag if set
       let temp = this.state.error;
-      delete temp.questionText;
+      delete temp.questionName;
+      this.setState({
+        error: temp,
+      });
+    }
+    if (hasError) {
+      // An error is present, return
+      return;
+    }
+    
+    if (questionName.length > 57 && (selected === 'textbox'
+      || selected === 'textarea' || selected === 'date'
+      || selected === 'numeric')) {
+      // Error, question name is needed for the desired type. Set the element
+      // error flag for the questionName with message. Set the hasError flag
+      let temp = (this.state.error) ? this.state.error : {};
+      temp.questionName = 'Please shorten to 57 characters maximum';
+      this.setState({
+        error: temp,
+      });
+      hasError = true;
+    } else if (this.state.error) {
+      // No error, remove the elememt's questionName error flag if set
+      let temp = this.state.error;
+      delete temp.questionName;
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -996,8 +996,9 @@ class AddElement extends Component {
       });
     }
 
-    if(questionName.length > 64 && selected !== 'textbox' && selected !== 'textarea' &&
-      selected !== 'date' && selected !== 'numeric') {
+    if (questionName.length > 64 && selected !== 'textbox' 
+        && selected !== 'textarea' && selected !== 'date' 
+        && selected !== 'numeric') {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
@@ -1018,8 +1019,8 @@ class AddElement extends Component {
       // An error is present, return
       return;
     }
-    
-    if(questionText.length > 64) {
+
+    if (questionText.length > 64) {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionText with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
@@ -1041,8 +1042,9 @@ class AddElement extends Component {
       return;
     }
 
-    if(questionName.length > 57 && (selected === 'textbox' || selected === 'textarea' || 
-      selected === 'date' || selected === 'numeric')) {
+    if (questionName.length > 57 && (selected === 'textbox' 
+      || selected === 'textarea' || selected === 'date' 
+      || selected === 'numeric')) {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -1046,7 +1046,7 @@ class AddElement extends Component {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
-      temp.questionName = 'Field length should be strictly less than 58 characters';
+      temp.questionName = 'Please shorten to 57 characters maximum';
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -1001,7 +1001,7 @@ class AddElement extends Component {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
-      temp.questionName = 'Field length should be strictly less than 65 characters';
+      temp.questionName = 'Please shorten to 64 characters maximum';
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -996,12 +996,80 @@ class AddElement extends Component {
       });
     }
 
+    if(questionName.length > 64 && selected !== 'textbox' && selected !== 'textarea' &&
+      selected !== 'date' && selected !== 'numeric') {
+      // Error, question name is needed for the desired type. Set the element
+      // error flag for the questionName with message. Set the hasError flag
+      let temp = (this.state.error) ? this.state.error : {};
+      temp.questionName = 'Field length should be strictly less than 65 characters';
+      this.setState({
+        error: temp,
+      });
+      hasError = true;
+    } else if (this.state.error) {
+      // No error, remove the elememt's questionName error flag if set
+      let temp = this.state.error;
+      delete temp.questionName;
+      this.setState({
+        error: temp,
+      });
+    }
+    if (hasError) {
+      // An error is present, return
+      return;
+    }
+    
+    if(questionText.length > 64) {
+      // Error, question name is needed for the desired type. Set the element
+      // error flag for the questionText with message. Set the hasError flag
+      let temp = (this.state.error) ? this.state.error : {};
+      temp.questionText = 'Field length should be strictly less than 65 characters';
+      this.setState({
+        error: temp,
+      });
+      hasError = true;
+    } else if (this.state.error) {
+      // No error, remove the elememt's questionText error flag if set
+      let temp = this.state.error;
+      delete temp.questionText;
+      this.setState({
+        error: temp,
+      });
+    }
+    if (hasError) {
+      // An error is present, return
+      return;
+    }
+
+    if(questionName.length > 57 && (selected === 'textbox' || selected === 'textarea' || 
+      selected === 'date' || selected === 'numeric')) {
+      // Error, question name is needed for the desired type. Set the element
+      // error flag for the questionName with message. Set the hasError flag
+      let temp = (this.state.error) ? this.state.error : {};
+      temp.questionName = 'Field length should be strictly less than 58 characters';
+      this.setState({
+        error: temp,
+      });
+      hasError = true;
+    } else if (this.state.error) {
+      // No error, remove the elememt's questionName error flag if set
+      let temp = this.state.error;
+      delete temp.questionName;
+      this.setState({
+        error: temp,
+      });
+    }
+    if (hasError) {
+      // An error is present, return
+      return;
+    }
+
     if (questionName === '' && selected !== 'header' && selected !== 'label' &&
       selected !== 'line' && selected !== 'page-break') {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
       let temp = (this.state.error) ? this.state.error : {};
-      temp.questionName = 'Must specifiy name for database to save value into';
+      temp.questionName = 'Must specify name for database to save value into';
       this.setState({
         error: temp,
       });

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -995,7 +995,7 @@ class AddElement extends Component {
         error: temp,
       });
     }
-    
+
     if (questionName.length > 64 && selected !== 'textbox'
         && selected !== 'textarea' && selected !== 'date'
         && selected !== 'numeric') {
@@ -1019,7 +1019,7 @@ class AddElement extends Component {
       // An error is present, return
       return;
     }
-    
+
     if (questionName.length > 57 && (selected === 'textbox'
       || selected === 'textarea' || selected === 'date'
       || selected === 'numeric')) {

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -996,8 +996,8 @@ class AddElement extends Component {
       });
     }
 
-    if (questionName.length > 64 && selected !== 'textbox' 
-        && selected !== 'textarea' && selected !== 'date' 
+    if (questionName.length > 64 && selected !== 'textbox'
+        && selected !== 'textarea' && selected !== 'date'
         && selected !== 'numeric') {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag
@@ -1042,8 +1042,8 @@ class AddElement extends Component {
       return;
     }
 
-    if (questionName.length > 57 && (selected === 'textbox' 
-      || selected === 'textarea' || selected === 'date' 
+    if (questionName.length > 57 && (selected === 'textbox'
+      || selected === 'textarea' || selected === 'date'
       || selected === 'numeric')) {
       // Error, question name is needed for the desired type. Set the element
       // error flag for the questionName with message. Set the hasError flag

--- a/modules/instrument_builder/test/TestPlan.md
+++ b/modules/instrument_builder/test/TestPlan.md
@@ -4,21 +4,32 @@ Instrument builder Test Plan
   * 1.a Add Header 
   * 1.b Add Label 
   * 1.c Add Scored Field 
-    * 1.c.1 Validate that this requires both QuestionName and QuestionText 
+    * 1.c.1 Validate that this requires both QuestionName and QuestionText
+    * 1.c.2 Validate that both QuestionName and QuestionText require less than 65 characters
   * 1.d Add Textbox 
-    * 1.d.1 Validate that this requires both QuestionName and QuestionText 
+    * 1.d.1 Validate that this requires both QuestionName and QuestionText
+    * 1.d.2 Validate that QuestionName requires less than 58 characters
+    * 1.d.3 Validate that QuestionText requires less than 65 characters 
   * 1.e Add Textarea  
-    * 1.e.1 Validate that this requires both QuestionName and QuestionText 
+    * 1.e.1 Validate that this requires both QuestionName and QuestionText
+    * 1.e.2 Validate that QuestionName requires less than 58 characters
+    * 1.e.3 Validate that QuestionText requires less than 65 characters 
   * 1.f Add Dropdown   
-    * 1.f.1 Validate that this requires both QuestionName and QuestionText 
+    * 1.f.1 Validate that this requires both QuestionName and QuestionText
+    * 1.f.2 Validate that both QuestionName and QuestionText require less than 65 characters 
   * 1.g Add Multiselect 
-    * 1.g.1 Validate that this requires both QuestionName and QuestionText 
+    * 1.g.1 Validate that this requires both QuestionName and QuestionText
+    * 1.g.2 Validate that both QuestionName and QuestionText require less than 65 characters
   * 1.h Add Date 
     * 1.h.1 Validate that this requires both QuestionName and QuestionText 
     * 1.h.2 Validate adding range (startyear-endyear) 
+    * 1.h.3 Validate that QuestionName requires less than 58 characters
+    * 1.h.4 Validate that QuestionText requires less than 65 characters
   * 1.i Add Numeric 
     * 1.i.1 Validate that this requires both QuestionName and QuestionText 
     * 1.i.2 Validate adding range 
+    * 1.i.3 Validate that QuestionName requires less than 58 characters
+    * 1.i.4 Validate that QuestionText requires less than 65 characters
   * 1.j Add Blank Line 
   * 1.k Add Page break
 2.  Edit Question Name and Question Text in the table directly and check if it sticks.


### PR DESCRIPTION
…t Builder

## Brief summary of changes
* Added field warnings for length for `_status` fields: 
* Added field warnings for length for all the fields
* Minor spelling mistake fix

#### Testing instructions (if applicable)
1. Go to /instrument_builder/#Build 
2. Check for warnings for input length greater than 57 for the following fields by clicking Add Row 
    1. Data entry->Textbox->Question Name
    2. Data entry->Textarea->Question Name
    3. Data entry->Date->Question Name
    4. Data entry->Numeric->Question Name
3. Check for warnings for input length greater than 64 for the rest of the Question Name and Question Text fields by clicking Add Row

#### Link(s) to related issue(s) 

* Resolves #7582 
