### PR TITLE
[DQT] v23 - Fix dictionary builder and dictionary display issues

### DIFF
--- a/modules/dataquery/jsx/react.fieldselector.js
+++ b/modules/dataquery/jsx/react.fieldselector.js
@@ -199,6 +199,7 @@ class FieldList extends Component {
     // Display the fields using the FieldItem component
     for (let i = start; i < filteredItems.length; i += 1) {
       fieldName = filteredItems[i].key[1];
+      desc = filteredItems[i].value.Description;
       type = filteredItems[i].value.Type || 'varchar(255)';
 
       // Check if field is a file, if so set flag to true

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -73,14 +73,14 @@ $DB->run(
 );
 
 $DB->delete("parameter_type_category", array("Type" => "Instrument"));
-   
+
 print "Cleared data from BVL instruments\n";
 
 print "Reading instruments\n";
 //Read the ip_output.txt staging file.
 $fp = fopen(__DIR__."/../ip_output.txt", "r");
 if (!$fp) {
-    print "There was an issue opening the ip_output file. Ensure the 
+    print "There was an issue opening the ip_output file. Ensure the
     file exists and the permissions are properly set.\n";
     die();
 }
@@ -100,16 +100,26 @@ $parameterNames = array();
 foreach ($instruments AS $instrument) {
     $catId = "";
     $table = "";
+    $testname = "";
     $items = explode("\n", trim($instrument));
     foreach ($items AS $item) {
         $paramId = "";
         $bits    = explode("{@}", trim($item));
         switch($bits[0]){
-	          case "testname":
-		          break;
+	        case "testname":
+                  $testname = $bits[1];
+                  print "Instrument: $testname\n";
+                  break;
             case "table":
                 $table = $bits[1];
-                print "Instrument: $table\n";
+                //`testname` was only recently added to the lorisform parser, for
+                //backwards compatibility, instruments with no testname parameter
+                //should assume the testname from the `table` name (to maintain
+                //status quo) although it might be incorrect since instrument names
+                //and table names could be different by design.
+                if (empty($testname)) {
+                    $testname = $table;
+                }
                 break;
 
             case "title":
@@ -117,7 +127,7 @@ foreach ($instruments AS $instrument) {
                 // Check if there's already an entry with the same name and reuse same ID
                 // insertIgnore does not work here since name is not a Unique key in the database
                 $catId = $DB->pselectOne(
-                    "SELECT ParameterTypeCategoryID 
+                    "SELECT ParameterTypeCategoryID
                        FROM parameter_type_category
                        WHERE Name=:name AND Type=:type",
                     array(
@@ -153,7 +163,7 @@ foreach ($instruments AS $instrument) {
                     // the name from the examiner id
                     $bits[0] = "varchar(255)";
                 } else if ($bits[0]=="select") {
-                    $bits[0] = enumizeOptions($bits[3], $table, $bits[1]);
+                    $bits[0] = enumizeOptions($bits[3], $testname, $bits[1]);
                 } else if ($bits[0]=="textarea") {
                     $bits[0] ="text";
                 } else if ($bits[0]=="text") {
@@ -171,10 +181,10 @@ foreach ($instruments AS $instrument) {
                     continue;
                 }
 
-                print "\tInserting $table $bits[1]\n";
+                print "\tInserting $testname $bits[1]\n";
                 $bits[2] = htmlspecialchars($bits[2]);
                 //find values to insert
-                $Name = $table . "_" . $bits[1];
+                $Name = $testname . "_" . $bits[1];
                 if (in_array($Name, $parameterNames, true)) {
                     // this specific table_field combination was already inserted, skip.
                     continue;
@@ -185,7 +195,7 @@ foreach ($instruments AS $instrument) {
                     "Type"        => $bits[0],
                     "Description" => $bits[2],
                     "SourceField" => $bits[1],
-                    "SourceFrom"  => $table,
+                    "SourceFrom"  => $testname,
                     "Queryable"   => "1",
                 );
 
@@ -225,13 +235,13 @@ foreach ($instruments AS $instrument) {
         }
     }
 
-    if (empty($table)) {
+    if (empty($testname)) {
         continue;
     }
 
     // INSTRUMENT VALIDITY
-    print "\tInserting validity for $table\n";
-    $Name = $table . "_Validity";
+    print "\tInserting validity for $testname\n";
+    $Name = $testname . "_Validity";
 
     if (in_array($Name, $parameterNames, true)) {
         // this specific table_validity combination was already inserted, skip.
@@ -243,9 +253,9 @@ foreach ($instruments AS $instrument) {
     $query_params = array(
         "Name"        => $Name,
         "Type"        => $_type_enum,
-        "Description" => "Validity of $table",
+        "Description" => "Validity of $testname",
         "SourceField" => "Validity",
-        "SourceFrom"  => $table,
+        "SourceFrom"  => $testname,
         "Queryable"   => "1",
     );
 
@@ -275,8 +285,8 @@ foreach ($instruments AS $instrument) {
     );
 
     // INSTRUMENT ADMINISTRATION
-    print "\tInserting administration for $table\n";
-    $Name = $table . "_Administration";
+    print "\tInserting administration for $testname\n";
+    $Name = $testname . "_Administration";
     if (in_array($Name, $parameterNames, true)) {
         // this specific table__Administration combination was already inserted, skip.
         continue;
@@ -286,9 +296,9 @@ foreach ($instruments AS $instrument) {
     $query_params = array(
         "Name"        => $Name,
         "Type"        => $_type_enum,
-        "Description" => "Administration for $table",
+        "Description" => "Administration for $testname",
         "SourceField" => "Administration",
-        "SourceFrom"  => $table,
+        "SourceFrom"  => $testname,
         "Queryable"   => "1",
     );
 
@@ -346,12 +356,12 @@ echo "\n\nData Dictionary generation complete:  $tblCount new categories added"
  * enums
  *
  * @param string $options The line of the ip_output.txt to enumize
- * @param string $table   The table containing this line
+ * @param string $testname   The table containing this line
  * @param string $name    The name of the field being enumized
  *
  * @return string A valid MySQL format enum field string
  */
-function enumizeOptions($options, $table, $name)
+function enumizeOptions($options, $testname, $name)
 {
     $options =explode("{-}", $options);
     foreach ($options as $option) {
@@ -361,7 +371,7 @@ function enumizeOptions($options, $table, $name)
         }
     }
     if (!is_array($enum)) {
-        echo "$table $name $options\n";
+        echo "$testname $name $options\n";
     }
     $enum =implode(",", $enum);
     return "enum($enum)";


### PR DESCRIPTION
## Brief summary of changes
This PR is 2 parts:

1. backporting fix for the display of the dictionary in the DQT module (#7098)
2. in the data_dictionary_builder script, reference the `tesname` value in parsed instruments (lorisform parser output format) instead of `table` while keeping it backwards compatible. This is needed because JSONdata instruments do not define a `table` variable and since [23.0.3] (https://github.com/aces/Loris/pull/7153/files#diff-962394c093e5275dcfa7cc6eca8927b2f8f592f42b7b95ec5921cb7fc0dc8453R88) the lorisform parser exports the test name in its output for this specific reason.
