### PR TITLE
fixes getDataDictionary() not support the 'file' type

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -111,6 +111,9 @@ trait LorisFormDictionaryImpl
                 break;
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);
+		break;
+	    case 'file':
+                $t = new \LORIS\Data\Types\URI();
                 break;
             case 'textarea':
                 $t = new \LORIS\Data\Types\StringType();


### PR DESCRIPTION
This PR fixes getDataDictionary() that doesn't support the 'file' type (which is getting called indirectly while saveValues() calls getCandidateAge).