### PR TITLE
fixes getDataDictionary() not support the 'file' type

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -112,7 +112,7 @@ trait LorisFormDictionaryImpl
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);
 		        break;
-	        case 'file':
+            case 'file':
                 $t = new \LORIS\Data\Types\URI();
                 break;
             case 'textarea':

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -111,8 +111,8 @@ trait LorisFormDictionaryImpl
                 break;
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);
-		break;
-	    case 'file':
+		        break;
+	        case 'file':
                 $t = new \LORIS\Data\Types\URI();
                 break;
             case 'textarea':

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -111,6 +111,9 @@ trait LorisFormDictionaryImpl
                 break;
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);
+		break;
+	    case 'file':
+                $t = new \LORIS\Data\Types\URI();
                 break;
             case 'textarea':
                 $t = new \LORIS\Data\Types\StringType();

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -111,7 +111,7 @@ trait LorisFormDictionaryImpl
                 break;
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);
-		        break;
+                break;
             case 'file':
                 $t = new \LORIS\Data\Types\URI();
                 break;


### PR DESCRIPTION
This PR fixes getDataDictionary() that doesn't support the 'file' type (which is getting called indirectly while saveValues() calls getCandidateAge()).