### PR TITLE
[Readthedocs] Updating requirements file to fix RTD build

### DIFF
--- a/readthedocs/requirements.txt
+++ b/readthedocs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.1
+jinja2<3.1.0
 ./readthedocs/plugins/mkdocs-root-plugin


### PR DESCRIPTION
A new version of the "jinja" package is causing the Read the Docs build to fail, so the Read the Docs page cannot be updated to the latest version of the documentation. This PR adds a line to the `readthedocs/requirements.txt` file specifying the version of jinja to use that will not cause errors in the build.

Testing:
This change has been tested on my forked version of the Loris Read the docs and correctly builds the latest (24.0) version of the documentation