### PR TITLE
[dashboard][Study Progression] Add tooltip visualising of Total in line chart

### DIFF
--- a/htdocs/css/c3.css
+++ b/htdocs/css/c3.css
@@ -86,10 +86,6 @@
     stroke-width: 1px;
 }
 
-.c3-target-Total{
-    display: none;
-}
-
 /*-- Point --*/
 
 .c3-circle._expanded_ {

--- a/htdocs/css/c3.css
+++ b/htdocs/css/c3.css
@@ -86,6 +86,10 @@
     stroke-width: 1px;
 }
 
+.c3-target-Total{
+    display: none;
+}
+
 /*-- Point --*/
 
 .c3-circle._expanded_ {

--- a/modules/statistics/css/recruitment.css
+++ b/modules/statistics/css/recruitment.css
@@ -11,3 +11,8 @@
     background-color: #2FA4E7;
 }
 
+.c3-chart-line.c3-target.c3-target-Total{
+    display: none !important;
+}
+
+

--- a/modules/statistics/css/recruitment.css
+++ b/modules/statistics/css/recruitment.css
@@ -14,4 +14,3 @@
 .c3-chart-line.c3-target.c3-target-Total{
     display: none !important;
 }
-

--- a/modules/statistics/css/recruitment.css
+++ b/modules/statistics/css/recruitment.css
@@ -15,4 +15,3 @@
     display: none !important;
 }
 
-

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -38,7 +38,27 @@ $(document).ready(function() {
             dataset.push(data.datasets[i].name);
             processedData.push(dataset.concat(data.datasets[i].data));
         }
+        var totals = new Array();
+        totals.push("Total");
+        for(var j=0; j<data.datasets[0].data.length; j++){
+            var total=0;
+            for(var i=0;i<data.datasets.length;i++){
+                total+=parseInt(data.datasets[i].data[j]);
+            }
+            totals.push(total);
+        }
+        processedData.push(totals);
         return processedData;
+    }
+
+    function maxY(data){
+        var maxi=0;
+        for(var j=0; j<data.datasets[0].data.length; j++){
+            for(var i=0;i<data.datasets.length;i++){
+                maxi=Math.max(maxi,parseInt(data.datasets[i].data[j]));
+            }
+        }
+        return maxi;
     }
 
 
@@ -74,6 +94,7 @@ $(document).ready(function() {
                         }
                     },
                     y: {
+                        max: maxY(data),
                         label: 'Scans'
                     }
                 },
@@ -146,6 +167,7 @@ $(document).ready(function() {
                         }
                     },
                     y: {
+                        max: maxY(data),
                         label: 'Candidates registered'
                     }
                 },

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -67,9 +67,9 @@ $(document).ready(function() {
         url: loris.BaseURL + '/statistics/charts/scans_bymonth',
         type: 'get',
         success: function(data) {
-            let lengendNames = [];
+            let legendNames = [];
             for (let j=0; j<data.datasets.length; j++) {
-                lengendNames.push(data.datasets[j].name);
+                legendNames.push(data.datasets[j].name);
             }
             let scanLineData = formatLineData(data);
             scanLineChart = c3.generate({
@@ -108,7 +108,7 @@ $(document).ready(function() {
             d3.select('.scanChartLegend')
               .insert('div', '.scanChart')
               .attr('class', 'legend')
-              .selectAll('div').data(lengendNames).enter()
+              .selectAll('div').data(legendNames).enter()
               .append('div')
               .attr('data-id', function(id) {
                 return id;
@@ -140,9 +140,9 @@ $(document).ready(function() {
         url: loris.BaseURL + '/statistics/charts/siterecruitment_line',
         type: 'get',
         success: function(data) {
-            let lengendNames = [];
+            let legendNames = [];
             for (let j=0; j<data.datasets.length; j++) {
-                lengendNames.push(data.datasets[j].name);
+                legendNames.push(data.datasets[j].name);
             }
             let recruitmentLineData = formatLineData(data);
             recruitmentLineChart = c3.generate({
@@ -181,7 +181,7 @@ $(document).ready(function() {
             d3.select('.recruitmentChartLegend')
               .insert('div', '.recruitmentChart')
               .attr('class', 'legend')
-              .selectAll('div').data(lengendNames).enter()
+              .selectAll('div').data(legendNames).enter()
               .append('div')
               .attr('data-id', function(id) {
                 return id;


### PR DESCRIPTION
## Brief summary of changes
* Added total scan and recruitment data in their respective chart visualisations
* Added total calculation
* Updated related CSS
* Updated scale of chart appropriately
* Minor Spelling mistake fixes

#### Testing instructions (if applicable)

1. Check the dashboards for Study Progression Data

#### Link(s) to related issue(s)

* Resolves #8122 

Here's how the changes look:
![Screenshot from 2022-06-17 19-50-35](https://user-images.githubusercontent.com/64309880/174331750-9725626a-7e87-4a54-884b-9774acad3548.png)
![Screenshot from 2022-06-17 21-12-21](https://user-images.githubusercontent.com/64309880/174331939-571c5bc1-3df3-4927-a4d6-e099f3ce10c3.png)

