### PR TITLE
Fix broken tool's generic_includes.php 

### DIFF
--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -23,7 +23,7 @@ $configFile = __DIR__."/../project/config.xml";
 $client     = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize($configFile);
-$DB            = Database::singleton();
+$DB            = NDB_Factory::singleton()->database();
 $config        = NDB_Config::singleton();
 $lorisInstance = new \LORIS\LorisInstance(
     $DB,


### PR DESCRIPTION
## Brief summary of changes

`tools/generic_includes.php` missed the #8074 refactoring boat where all `Database::singleton` have been replaced by `NDB_Factory::singleton()->database()`

This fixes the `generic_includes.php` file to use the new way of loading the DB object.

