### PR TITLE
[Documentation] Small formatting fixes for ReadTheDocs

### DIFF
--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -63,7 +63,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
  > Example PSCID generated: PREFIX3994
  
  Options for the `type` element of the `<seq>` tag are:
- 
+
   - `siteAbbrev`: A string value that will be used as a dynamic prefix. Value drawn from the `Alias` 
   field of the `psc` table in the database.
   - `projectAbbrev`: A string value that will be used as a dynamic prefix. Value drawn from the `Alias` 
@@ -72,11 +72,11 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
   - `numeric`: An integer value generated dynamically in accordance to the generation method defined.
   - `alphanumeric`: An alphanumeric string value generated dynamically in accordance to the generation method defined. 
   - `alpha`: An alphabetic string value generated dynamically in accordance to the generation method defined.
- 
-  > Note: The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
+  
+ **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
   a `length` attribute. The length defaults to `4` when not specified.
   
-  > Note: The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
+ **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
   minimum `min` and maximum `max` values for sequentially and randomly generated PSCIDs. 
   By default sequence will start at the lowest possible values (i.e.: 0000, AAAA).
 

--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -51,7 +51,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
 
 3. ***random*** generates PSCIDs with a random numerical value for each new participant registered.
 
-```
+```xml
 <PSCID>
     <generation>random</generation> 
     <structure>
@@ -73,7 +73,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
   - `alphanumeric`: An alphanumeric string value generated dynamically in accordance to the generation method defined. 
   - `alpha`: An alphabetic string value generated dynamically in accordance to the generation method defined.
 
- Note: The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
+ **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
   a `length` attribute. The length defaults to `4` when not specified.
   
  **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 

--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -63,6 +63,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
  > Example PSCID generated: PREFIX3994
  
  Options for the `type` element of the `<seq>` tag are:
+ 
   - `siteAbbrev`: A string value that will be used as a dynamic prefix. Value drawn from the `Alias` 
   field of the `psc` table in the database.
   - `projectAbbrev`: A string value that will be used as a dynamic prefix. Value drawn from the `Alias` 

--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -51,15 +51,15 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
 
 3. ***random*** generates PSCIDs with a random numerical value for each new participant registered.
 
- ```xml
- <PSCID>
-     <generation>random</generation> 
-     <structure>
-         <seq type="static">PREFIX</seq>
-         <seq type="numeric" length="4" min="1" max="9999"/>
-     </structure>
- </PSCID>
- ```
+    ```xml
+    <PSCID>
+        <generation>random</generation> 
+        <structure>
+             <seq type="static">PREFIX</seq>
+            <seq type="numeric" length="4" min="1" max="9999"/>
+        </structure>
+    </PSCID>
+    ```
  > Example PSCID generated: PREFIX3994
  
  Options for the `type` element of the `<seq>` tag are:
@@ -72,7 +72,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
   - `numeric`: An integer value generated dynamically in accordance to the generation method defined.
   - `alphanumeric`: An alphanumeric string value generated dynamically in accordance to the generation method defined. 
   - `alpha`: An alphabetic string value generated dynamically in accordance to the generation method defined.
-  
+
  **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
   a `length` attribute. The length defaults to `4` when not specified.
   

--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -51,15 +51,15 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
 
 3. ***random*** generates PSCIDs with a random numerical value for each new participant registered.
 
-    ```xml
-    <PSCID>
-        <generation>random</generation> 
-        <structure>
-             <seq type="static">PREFIX</seq>
-            <seq type="numeric" length="4" min="1" max="9999"/>
-        </structure>
-    </PSCID>
-    ```
+```
+<PSCID>
+    <generation>random</generation> 
+    <structure>
+        <seq type="static">PREFIX</seq>
+        <seq type="numeric" length="4" min="1" max="9999"/>
+    </structure>
+</PSCID>
+```
  > Example PSCID generated: PREFIX3994
  
  Options for the `type` element of the `<seq>` tag are:
@@ -73,7 +73,7 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
   - `alphanumeric`: An alphanumeric string value generated dynamically in accordance to the generation method defined. 
   - `alpha`: An alphabetic string value generated dynamically in accordance to the generation method defined.
 
- **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
+ Note: The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 
   a `length` attribute. The length defaults to `4` when not specified.
   
  **Note:** The last 3 types above (`numeric`,`alphanumeric`,`alpha`) can be associated with 

--- a/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
+++ b/docs/wiki/01_STUDY_PARAMETERS_SETUP/01_Study_Variables/01_Identifiers.md
@@ -25,28 +25,28 @@ PSCIDs can be created for new subjects in one of 3 ways: *sequentially generated
 
 1. ***sequential*** generates PSCIDs sequentially for each new candiddate registered. **(default)**
 
- ```xml
- <PSCID>
-     <generation>sequential</generation> 
-     <structure>
-         <seq type="siteAbbrev"/>
-         <seq type="numeric" length="4" min="10" max="9999"/>
-     </structure>
- </PSCID>
- ```
+```xml
+<PSCID>
+    <generation>sequential</generation> 
+    <structure>
+        <seq type="siteAbbrev"/>
+        <seq type="numeric" length="4" min="10" max="9999"/>
+    </structure>
+</PSCID>
+```
  > Example PSCID generated: MTL1234
  > Where the site's alias is MTL
 
 2. ***manual*** asks the user to enter the PSCID when registering a new candidate.
 
- ```xml
- <PSCID> 
-     <generation>user</generation> 
-     <structure>
-         <seq type="alphanumeric" length="2"/>
-     </structure>
- </PSCID>
- ```
+```xml
+<PSCID> 
+    <generation>user</generation> 
+    <structure>
+        <seq type="alphanumeric" length="2"/>
+    </structure>
+</PSCID>
+```
   > Example PSCID accepted: A1
 
 3. ***random*** generates PSCIDs with a random numerical value for each new participant registered.

--- a/docs/wiki/99_Developers/Help_Style_Guide.md
+++ b/docs/wiki/99_Developers/Help_Style_Guide.md
@@ -50,19 +50,19 @@ LORIS is used by scientific community members worldwide, which means it's possib
 This means using more direct language and tone to get information across to the user in the least amount of time, with the least amount of friction. The quicker a user understands something, the happier they are. Easily understandable documentation also builds trust in the software, in addition to decreasing the amount of support questions we get.
 
 * Use second person point of view rather than third
-  * e.g. “This module allows *you* to browse…” (rather than “This module allows *users* to browse…”)
-* Keep it concise. Avoid unnecessary information.
-  * Try not to be repetitive. 
-  * e.g. the Help text for the Imaging Browser module begins with the title Imaging Browser. You don’t need to start text with “In the Imaging Browser module...”, because the user already knows the module based on the title. Instead, keep it short and say “In this module…”
-* Assume the user is tech-savvy enough to know about features that are intuitive or common across modern platforms, so you don’t need to repeat in every Help text
-  * e.g. clicking the column headers to re-sort a table
-  * e.g. clicking a Download button to download something
-  * e.g. navigate pages of a table using the arrows provided
-* Use Plain Language
-  * Avoid words that you wouldn't use in everyday speech
-* Where relevant introduce an abbreviation once and then use that abbreviation for the rest of the copy in that help text (e.g. introduce Quality Control = QC in a Help text title, then only call it QC throughout the text)
-  * e.g. DO: “The Imaging Quality Control (QC) module allows you to view the QC status of images in your LORIS.”
-  * e.g. DON’T: “The Imaging Quality Control (QC) module allows you to view the Quality Control status of images in your LORIS.”
+    * e.g. “This module allows *you* to browse…” (rather than “This module allows *users* to browse…”)
+* Keep it concise. Avoid unnecessary information. 
+    * Try not to be repetitive. 
+    * e.g. the Help text for the Imaging Browser module begins with the title Imaging Browser. You don’t need to start text with “In the Imaging Browser module...”, because the user already knows the module based on the title. Instead, keep it short and say “In this module…”
+* Assume the user is tech-savvy enough to know about features that are intuitive or common across modern platforms, so you don’t need to repeat in every Help text 
+    * e.g. clicking the column headers to re-sort a table
+    * e.g. clicking a Download button to download something
+    * e.g. navigate pages of a table using the arrows provided
+* Use Plain Language 
+    * Avoid words that you wouldn't use in everyday speech
+* Where relevant introduce an abbreviation once and then use that abbreviation for the rest of the copy in that help text (e.g. introduce Quality Control = QC in a Help text title, then only call it QC throughout the text) 
+    * e.g. DO: “The Imaging Quality Control (QC) module allows you to view the QC status of images in your LORIS.”
+    * e.g. DON’T: “The Imaging Quality Control (QC) module allows you to view the Quality Control status of images in your LORIS.”
 * Break up large blocks of text. It's more visually pleasing and less intimidating.
 
 For more information, including research studies conducted, on the use and value of Plain Language, please see [this article](https://www.nngroup.com/articles/plain-language-experts/) and feel free to browse the rest of this website for further helpful details, tips, and tricks. 

--- a/docs/wiki/99_Developers/LORIS-REST-API-0.0.3-dev.md
+++ b/docs/wiki/99_Developers/LORIS-REST-API-0.0.3-dev.md
@@ -1,1 +1,0 @@
-../../../modules/api/docs/LorisRESTAPI_v0.0.3.md

--- a/docs/wiki/99_Developers/LORIS-REST-API-0.0.4-dev.md
+++ b/docs/wiki/99_Developers/LORIS-REST-API-0.0.4-dev.md
@@ -1,0 +1,1 @@
+../../../modules/api/docs/LorisRESTAPI_v0.0.4-dev.md

--- a/readthedocs/mkdocs.yml
+++ b/readthedocs/mkdocs.yml
@@ -40,7 +40,7 @@ nav:
     - Help and Troubleshooting: 'docs/wiki/03_HELP_AND_TROUBLESHOOTING/README.md'
     - REST API:
         - 'Stable' : 'docs/wiki/99_Developers/LORIS-REST-API-0.0.2.md'
-        - 'Dev' : 'docs/wiki/99_Developers/LORIS-REST-API-0.0.3-dev.md'
+        - 'Dev' : 'docs/wiki/99_Developers/LORIS-REST-API-0.0.4-dev.md'
     - Developers:
         - Overview: 'docs/wiki/99_Developers/README.md'
         - 'Coding Standards': 'docs/CodingStandards.md'

--- a/readthedocs/mkdocs.yml
+++ b/readthedocs/mkdocs.yml
@@ -31,8 +31,8 @@ nav:
                 - PHP: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/02_instrument_format/PHP_instrument.md
             - Installation: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/03_instrument_install.md
             - Additional Configurations: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/04_instrument_additional_configurations.md
-            - Testing and Troubleshooting: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/05_instrument_testing_and_troubleshooting.md
-            - Quality Asssurance: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/06_instrument_quality_assurance.md
+            - Testing and Troubleshooting: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/06_instrument_testing_and_troubleshooting.md
+            - Quality Asssurance: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/05_instrument_quality_assurance.md
             - Test Batteries: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/07_clinical_test_battery.md
             - Annexe A - XIN Rules: docs/wiki/01_STUDY_PARAMETERS_SETUP/02_Clinical_Instruments/Annexe_A_XIN-Rules.md
         - Modules: 'docs/wiki/01_STUDY_PARAMETERS_SETUP/03_Loris_Modules/README.md'


### PR DESCRIPTION
Small formatting changes to a few of the markdowns so that they appear correctly in Read the docs. Updated the `mkdocs.yml` file to point to the correct document links. Updated the API documentation symlink `docs/wiki/99_Developers/LORIS-REST-API-0.0.3-dev.md` to point to the updated v0.0.4 version. Not shown here but multiple wiki links were updated to point to RTD.

#### Testing instructions 

Checkout this branch on your fork and test how it appears on RTD. Please check that all the links are pointing to the correct document and that all formatting changes are appearing correctly. See [this document](https://docs.google.com/document/d/19JAcogjb9mam6goD3p0KhgGIWq_G1KxXUc37mwAeqTU/edit?usp=sharing) for more information on setting up RTD and testing.
