### PR TITLE
[dashboard] Use user site permissions for dashboard charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ multi-echo aquisitions (PR #7515).
 - The `Center_name` field in the `mri_protocol` table has been replaced by `CenterID` 
 from the `psc` table. The default value of `CenterID` is `NULL`. Previously, the 
 default for `Center_name` was `AAAA` or `ZZZZ`. (PR #7525)
+- The statistics displayed in the dashboard was changed to only show the data relevant to the user's site(s). (PR #8132)
 
 #### Bug Fixes
 - A LINST instrument Date field name now appears correctly (not truncated) on the 

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -108,7 +108,8 @@ class Charts extends \NDB_Page
         $DB = \NDB_Factory::singleton()->database();
 
         $recruitmentBySiteData = [];
-        $list_of_sites         = \Utility::getSiteList(true, false);
+        $user          = \NDB_Factory::singleton()->user();
+        $list_of_sites = $user->getStudySites();
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $totalRecruitment = $DB->pselectOne(
@@ -138,7 +139,8 @@ class Charts extends \NDB_Page
     {
         $DB            = \NDB_Factory::singleton()->database();
         $sexData       = [];
-        $list_of_sites = \Utility::getSiteList(true, false);
+        $user          = \NDB_Factory::singleton()->user();
+        $list_of_sites = $user->getStudySites();
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $sexData['labels'][] = $siteName;
@@ -203,7 +205,8 @@ class Charts extends \NDB_Page
         $scanData['labels'] = array_keys($labels);
 
         // Massage the data into the appropriate format per site.
-        $list_of_sites = \Utility::getSiteList(true, false);
+        $user          = \NDB_Factory::singleton()->user();
+        $list_of_sites = $user->getStudySites();
         foreach ($list_of_sites as $siteID => $siteName) {
             $scanData['datasets'][] = [
                 "name" => $siteName,
@@ -281,7 +284,8 @@ class Charts extends \NDB_Page
             );
         }
 
-        $list_of_sites = \Utility::getSiteList(true, false);
+        $user          = \NDB_Factory::singleton()->user();
+        $list_of_sites = $user->getStudySites();
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $recruitmentData['datasets'][] = [


### PR DESCRIPTION
## Brief summary of changes
This PR uses the user sites instead of a full site list in the visualizations of statistics displayed on the dashboard. 

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Test the dashboard charts with a user who only has access to some but not all sites
2. Make sure that the numbers are correct
3. Repeat steps 1 and 2 but with a user who has all sites
4. Repeat steps 1 and 2 but with a user who has the "all sites" permission

