### PR TITLE
[user_accounts] Revert #2018 - Sanitization before validation of email falsifies validity

### DIFF
--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -135,6 +135,12 @@ class RequestAccount extends \NDB_Form
             $errors['from'] = "Please provide a valid email!";
         } else if (!filter_var($_REQUEST['from'], FILTER_VALIDATE_EMAIL) ) {
             $errors['from'] = 'Please provide a valid email!';
+        } else if (preg_match('[<|>|"|&]', $_REQUEST['from'])) {
+            // Although some of these characters are legal in emails, due to the
+            // current HTML escaping method, it is better to reject email
+            // addresses containing them
+            $errors['from'] =  'Email address can not contain any the following' .
+                ' characters: <, >, & and "';
         }
 
         if (empty($values['site'])) {

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -133,14 +133,14 @@ class RequestAccount extends \NDB_Form
         }
         if (empty($values['from'])) {
             $errors['from'] = "Please provide a valid email!";
-        } else if (!filter_var($_REQUEST['from'], FILTER_VALIDATE_EMAIL) ) {
-            $errors['from'] = 'Please provide a valid email!';
-        } else if (preg_match('[<|>|"|&]', $_REQUEST['from'])) {
+        } else if (preg_match('/(<|>|"|&)/', $_REQUEST['from'])) {
             // Although some of these characters are legal in emails, due to the
             // current HTML escaping method, it is better to reject email
             // addresses containing them
-            $errors['from'] =  'Email address can not contain any the following' .
-                ' characters: <, >, & and "';
+            $errors['from'] =  'Email address can not contain the following' .
+                ' characters: <,>,& and "';
+        } else if (!filter_var($_REQUEST['from'], FILTER_VALIDATE_EMAIL) ) {
+            $errors['from'] = 'Please provide a valid email!';
         }
 
         if (empty($values['site'])) {
@@ -148,22 +148,6 @@ class RequestAccount extends \NDB_Form
         }
         if (empty($values['project'])) {
             $errors['project'] = "Please choose a project!";
-        }
-
-        // I don't think this is required because insert uses prepared statements,
-        // but I'm keeping it for now because it doesn't do any harm (unlike the
-        // len > 3 check). Little Bobby Tables will just have to sign
-        // up using a table alias. - Dave
-        //
-        // For each fields, check if quotes or if some HTML/PHP
-        // tags have been entered
-        foreach ($values as $field => $value) {
-            if (preg_match('/["]/', html_entity_decode($value))) {
-                $errors[$field] = "You can't use quotes in $field";
-            }
-            if (strlen($value) > strlen(strip_tags($value))) {
-                $errors[$field] = "You can't use tags in $field";
-            }
         }
 
         return $errors;

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1290,7 +1290,7 @@ class Edit_User extends \NDB_Form
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             // If email not syntactically valid
             return "Invalid email address";
-        } elseif (preg_match('[<|>|"|&]', $email)) {
+        } elseif (preg_match('/(<|>|"|&)/', $email)) {
             // Although some of these characters are legal in emails, due to the
             // current HTML escaping method, it is better to reject email
             // addresses containing them

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1287,15 +1287,15 @@ class Edit_User extends \NDB_Form
      */
     private function _getEmailError(\Database $DB, string $email): ?string
     {
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            // If email not syntactically valid
-            return "Invalid email address";
-        } elseif (preg_match('/(<|>|"|&)/', $email)) {
+        if (preg_match('/(<|>|"|&)/', $email)) {
             // Although some of these characters are legal in emails, due to the
             // current HTML escaping method, it is better to reject email
             // addresses containing them
             return 'Email address can not contain any the following '.
                 'characters: <, >, & and "';
+        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            // If email not syntactically valid
+            return "Invalid email address";
         }
 
         // check email address' uniqueness

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1287,8 +1287,6 @@ class Edit_User extends \NDB_Form
      */
     private function _getEmailError(\Database $DB, string $email): ?string
     {
-        // remove illegal characters
-        $email = filter_var($email, FILTER_SANITIZE_EMAIL);
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             // If email not syntactically valid
             return "Invalid email address";

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1289,7 +1289,13 @@ class Edit_User extends \NDB_Form
     {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             // If email not syntactically valid
-            return "Invalid email address";
+            return "Invalid email addrezz";
+        } elseif (preg_match('[<|>|"|&]', $email)) {
+            // Although some of these characters are legal in emails, due to the
+            // current HTML escaping method, it is better to reject email
+            // addresses containing them
+            return 'Email address can not contain any the following '.
+                'characters: <, >, & and "';
         }
 
         // check email address' uniqueness


### PR DESCRIPTION
## Brief summary of changes

The issue came up when registering a user using the User Accounts -> add user functionality. If you select the "Make user name match email address" checkbox and your email address contains HTML special characters, you end up with a 500 error.

The email address failing here is: `test@gmail.com>` This address does not pass `FILTER_VALIDATE_EMAIL` check but because of the sanitization step removed in this PR, the email actually being validated is `test@gmail.com` which is valid.


This PR also removes an old check for < > and " because the new check offers a clearer error message and covers a broader range of characters we don't want in emails (because of escaping issues)
