### PR TITLE
[user_accounts] Prevent crash when one user has no site/project affiliations

### DIFF
--- a/modules/user_accounts/jsx/userAccountsIndex.js
+++ b/modules/user_accounts/jsx/userAccountsIndex.js
@@ -77,15 +77,25 @@ class UserAccountsIndex extends Component {
             .join(', ')}
           </td>
         );
+        if (cell.length === 0) {
+          result = (
+            <td>This user has no site affiliations</td>
+          );
+        }
         break;
       case 'Project':
-        // If user has multiple projectss, join array of sites into string
+        // If user has multiple projects, join array of sites into string
         result = (
           <td>{cell
             .map((projectId) => this.state.data.fieldOptions.projects[projectId])
             .join(', ')}
           </td>
         );
+        if (cell.length === 0) {
+          result = (
+            <td>This user has no project affiliations</td>
+          );
+        }
         break;
       case 'Username':
         url = loris.BaseURL + '/user_accounts/edit_user/' + row.Username;

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -43,9 +43,15 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        $cids = explode(',', $row['centerIds']);
-        $row['centerIds'] = $cids;
-        $pids = explode(',', $row['projectIds']);
+        $cids = [];
+        $pids = [];
+        if (isset($row['centerIds'])) {
+            $cids = explode(',', $row['centerIds']);
+        }
+        if (isset($row['projectIds'])) {
+            $pids = explode(',', $row['projectIds']);
+        }
+        $row['centerIds']  = $cids;
         $row['projectIds'] = $pids;
         return new UserAccountRow($row, $cids, $pids);
     }


### PR DESCRIPTION
## Brief summary of changes
Although this usecase should never happen as it is prevented by rules in the edit_user logic, a couple bugs have let it happen in the pass and the entire module becomes inaccessible. This makes the module load and displays a message in the user row informing the editor that the user does not currently have any sites and projects.

The only way to test this would be to manually delete all site associations directly in the DB `user_psc_rel` OR all project associations `user_project_rel`

Note that the module crashes even if the user not having any sites or projects is not the editor nor the editee... any user can cause this issue