### PR TITLE
Remove pattern from email validation

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1295,9 +1295,6 @@ class EmailElement extends Component {
         <div className={inputClass}>
           <input
             type="email"
-            pattern={'/^[a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[' +
-              'a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-' +
-              ']{0,61}[a-zA-Z0-9])?)*$/'}
             title="Please provide a valid email address!"
             className="form-control"
             name={this.props.name}


### PR DESCRIPTION
This removes the regex pattern from the "email" type. It currently
breaks on addresses that have a "+" in them and is difficult to debug.
(The regex looks like it should work, but it doesn't and is very complicated.)

This only potentially impacts browsers that *do* support "pattern" but
*don't* support the "email" data type. Otherwise, the browser's built in
validation will check the validity of the email address. In the case where
neither is supported, the browser will submit and fall back to server side
validation.

The [internet](https://www.html5pattern.com/Emails) suggests using "pattern" to validate email addresses is a bad idea because it's difficult to get right.

I've tested this on the request accounts page, and frontend validation still works
in Firefox, while if I change the element type to "text" backend validation still works
and pops up a swal error.


#### Testing instructions (if applicable)

1. Find somewhere that uses "email" such as request_account.
2. Enter an invalid address and ensure it's still
    an error. 
3. Enter a valid address and ensure it submits
4. Use dev console to change the type to "text" so that browser
    validation doesn't reject. Enter an invalid email and ensure the
    backend still validates.