### PR TITLE
[tools/CouchDB_Confirm_Integrity] Add case where VL doesn't exist in SQLDB

### DIFF
--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -94,7 +94,12 @@ class CouchDBIntegrityChecker
                 ]
             );
 
-            if (!empty($sqlDB) && $sqlDB['cActive'] == 'N') {
+            if (empty($sqlDB)) {
+                print "PSCID $pscid VL $vl does not exist but $row[id] still exists.
+                Deleting Doc. \n";
+
+                $this->CouchDB->deleteDoc($row['id']);
+            } else if (!empty($sqlDB) && $sqlDB['cActive'] == 'N') {
                 print "PSCID $pscid is inactive but $row[id] still exists. 
                 Deleting Doc.\n";
 


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Delete a session in SQL DB that has data associated with it i.e. instrument data
2. On main branch, run `php tools/CouchDB_Confirm_Integrity.php`. Go to the DQT, run a query with instrument data fields and notice that your deleted session data is still there.
3. On this PR branch, run `php tools/CouchDB_Confirm_Integrity.php` again. In the script output, you should see a print out that flags the deleted session. Go to the DQT, using the same query as you used above, notice that your deleted session data is no longer there.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
