### PR TITLE
2022 08 22 bug fix imaging uploader 24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ changes in the following format: PR #1234***
 - Addition of `image_type`, `PhaseEncodingDirection` and `EchoNumber` fields to the tables
   present in the "Could not identify scan" page of the MRI violation module (PR #8156)
 - Modification of the list of headers displayed in the image panel headers table (PR #8157)
+#### Bug Fixes
+- Bug fix to the imaging uploader so that when clicking on an upload row, the row is 
+  highlighted and the proper log is being displayed in the log viewer (PR #8154)
+  
 
 ## LORIS 24.0 (Release Date: 2022-03-24)
 ### Core

--- a/modules/imaging_uploader/jsx/LogPanel.js
+++ b/modules/imaging_uploader/jsx/LogPanel.js
@@ -59,7 +59,7 @@ class LogPanel extends Component {
 
           // If user clicked on the same row, it is interpreted as a de-selection:
           // deselect row and set log text to 'nothing selected'
-          if (event.currentTarget === uploadProgress.getUploadRow()) {
+          if (tr === uploadProgress.getUploadRow()) {
             uploadProgress.setUploadRow(null);
             uploadProgress.setProgressFromServer(null);
             this.setState({
@@ -69,8 +69,8 @@ class LogPanel extends Component {
             return;
           }
 
-          uploadProgress.setUploadRow(event.currentTarget);
-          event.currentTarget.style.backgroundColor = '#EFEFFB';
+          uploadProgress.setUploadRow(tr);
+          tr.style.backgroundColor = '#EFEFFB';
           this.monitorProgress(this.state.logType);
         }
       });


### PR DESCRIPTION
## Brief summary of changes

This fixes the imaging uploader so that when clicking on an upload row, the row is highlighted and the proper log is being displayed in the log viewer. 

Currently on demo that is on 24.0-release:
![185499956-5e49e9a3-cb9e-4cfd-a96c-f4e636c4e22f](https://user-images.githubusercontent.com/1402456/186004781-1dac207f-13aa-4af1-8f88-d7e2f50cf322.png)

On sandbox after the fix:
![Screen Shot 2022-08-22 at 3 40 43 PM](https://user-images.githubusercontent.com/1402456/186005137-66742b19-4e09-4caf-8ef9-84012b824163.png)

#### Testing instructions (if applicable)

1. On raisin bread, branch 24.0-release or latest bug fix release for 24.0, click on any row in the Upload table and notice that it is always the UploadID of the first row that is being shown in the log viewer
2. Check out this branch, run make dev and notice that clicking on different rows will bring up the information in the log viewer with the correct UploadID (the one showed in the selected row)

#### Link(s) to related issue(s)

* Resolves #8153