### PR TITLE
Remove dangling SNR from the image panel in the imaging browser when SNR is not available for the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ changes in the following format: PR #1234***
 #### Bug Fixes
 - Bug fix to the imaging uploader so that when clicking on an upload row, the row is 
   highlighted and the proper log is being displayed in the log viewer (PR #8154)
-  
+- Remove SNR label from the image panel of the imaging browser when no SNR values can
+be found for the image (PR #8155)
+
 
 ## LORIS 24.0 (Release Date: 2022-03-24)
 ### Core

--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -549,9 +549,13 @@ class ImagePanelQCSNRValue extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
+    let label = null;
+    if (this.props.SNR) {
+      label = 'SNR';
+    }
     return (
       <ImageQCStatic
-        Label="SNR"
+        Label={label}
         FormName="snr"
         FileID={this.props.FileID}
         defaultValue={this.props.SNR}


### PR DESCRIPTION
## Brief summary of changes

This modifies the image panel of the imaging browser to get rid of the weird dangling SNR label when no SNR value is associated to the file.

![image](https://user-images.githubusercontent.com/1402456/186019040-8dc47f3e-496a-4e01-a878-f03f051bc965.png)

#### Testing instructions (if applicable)

1. On branch 24.0-release or latest bug fix release for 24.0, check that the SNR label is always there whether there is actually an SNR value to be displayed or not
2. On this branch, check that the SNR label shows only for images that have SNR values associated to them

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/HBCD/issues/228
