### PR TITLE
[mri_violations] Add new mri_protocol fields to "Could not identify scan type" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ changes in the following format: PR #1234***
 - Addition of `PhaseEncodingDirection` and `EchoNumber` columns to the `files`, `files_qcstatus`
   and `feedback_mri_comments` tables to ensure uniqueness keys for specific GE sequences for
   which the `SeriesUID/EchoTime` combination is not enough (PR #8152).
+- Addition of `image_type`, `PhaseEncodingDirection` and `EchoNumber` fields to the tables
+  present in the "Could not identify scan" page of the MRI violation module (PR #8156)
 
 ## LORIS 24.0 (Release Date: 2022-03-24)
 ### Core

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -73,6 +73,9 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
             'mpv.zstep_range',
             'mpv.time_range',
             'mpv.SeriesUID',
+            'mpv.image_type',
+            'mpv.PhaseEncodingDirection',
+            'mpv.EchoNumber',
             'tarchive.TarchiveID',
         ];
         $this->validFilters = [
@@ -103,6 +106,9 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
             'Zstep',
             'Time',
             'SeriesUID',
+            'Image_Type',
+            'Phase_Encoding_Direction',
+            'Echo_Number',
             'TarchiveID',
         ];
         $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
@@ -175,7 +181,8 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
                     TI_max, slice_thickness_min, slice_thickness_max,
                     xspace_min, xspace_max, yspace_min, yspace_max, zspace_min,
                     zspace_max, xstep_min, xstep_max, ystep_min, ystep_max,
-                    zstep_min, zstep_max, time_min, time_max,series_description_regex
+                    zstep_min, zstep_max, time_min, time_max,series_description_regex,
+                    image_type, PhaseEncodingDirection, EchoNumber
              FROM mri_protocol as p
              LEFT JOIN mri_protocol_group mpg
              ON (mpg.MriProtocolGroupID=p.MriProtocolGroupID)

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -181,8 +181,9 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
                     TI_max, slice_thickness_min, slice_thickness_max,
                     xspace_min, xspace_max, yspace_min, yspace_max, zspace_min,
                     zspace_max, xstep_min, xstep_max, ystep_min, ystep_max,
-                    zstep_min, zstep_max, time_min, time_max,series_description_regex,
-                    image_type, PhaseEncodingDirection, EchoNumber
+                    zstep_min, zstep_max, time_min, time_max,
+                    series_description_regex, image_type, PhaseEncodingDirection,
+                    EchoNumber
              FROM mri_protocol as p
              LEFT JOIN mri_protocol_group mpg
              ON (mpg.MriProtocolGroupID=p.MriProtocolGroupID)


### PR DESCRIPTION
## Brief summary of changes

This adds the `image_type`, `PhaseEncodingDirection` and `EchoNumber` to the tables displayed under the page displayed after clicking on "Could not identify scan type" link in the main page.


#### Testing instructions (if applicable)

1. check out this branch
2. go to the MRI violation module and click on one of the "Could not identify scan type" link present in the violation table. That will redirect you to the page with the list of MRI protocol and list of fields for the violated scans. Ensure that there are `image_type`, `PhaseEncodingDirection` and `EchoNumber` (note: sometimes those fields will be empty if there is not restriction on the `mri_protocol` table for those fields or if the violated scan does not contain a `PhaseEncodingDirection` or multiple `EchoNumber`

Note: make sure to run the SQL patches that affect the MRI tables in the new patch directory

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/HBCD/issues/231
