### PR TITLE
[Instruments] Fix display and loading of time elements

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -3,8 +3,8 @@
 	.table-instrument>tbody>tr>th{
 		color: black;
 	}
-	.table-instrument>tbody>tr>th, .table-instrument>tbody>tr>td  { 
-	     border-top: none; 
+	.table-instrument>tbody>tr>th, .table-instrument>tbody>tr>td  {
+	     border-top: none;
 	 }
 </style>
 
@@ -260,7 +260,7 @@
                                 {else}
                                     {assign var="itemError" value=""}
                                 {/if}
-                                {if $gitem.type == 'date'}
+                                {if $gitem.type == 'date' || $gitem.type == 'time' }
                                     <td class="element form-inline{$itemError}">{$gitem.html}</td>
                                 {elseif $gitem.type == 'checkbox'}
                                     <td class="form-inline{$itemError}">{$gitem.html}</td>
@@ -417,7 +417,7 @@
 							{if $element.required}
 								<span style="color: #ff0000">*</span>
 							{/if}
-							{$element.label}  
+							{$element.label}
 						</label>
 						<div class="col-sm-8">
 							<div class="col-xs-12 element">

--- a/smarty/templates/time_element.tpl
+++ b/smarty/templates/time_element.tpl
@@ -4,9 +4,9 @@
 		{if $index < 10}
 			{assign var="displayValue" value="0$index"}
 			{if $displayValue eq $value['H']}
-				<option value="{$index}" selected="selected">{$displayValue}</option>
+				<option value="{$displayValue}" selected="selected">{$displayValue}</option>
 			{else}
-				<option value="{$index}">{$displayValue}</option>
+				<option value="{$displayValue}">{$displayValue}</option>
 			{/if}
 		{else}
 			{if $index eq $value['H']}
@@ -23,9 +23,9 @@
 		{if $index < 10}
 			{assign var="displayValue" value="0$index"}
 			{if $displayValue eq $value['i']}
-				<option value="{$index}" selected="selected">{$displayValue}</option>
+				<option value="{$displayValue}" selected="selected">{$displayValue}</option>
 			{else}
-				<option value="{$index}">{$displayValue}</option>
+				<option value="{$displayValue}">{$displayValue}</option>
 			{/if}
 		{else}
 			{if $index eq $value['i']}


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the display of time fields in instrument tables to be inline (hours at the left of minutes) instead of vertical (hours on top of minutes) AND fixes the loading of stored time values in the database when the time entry contains leading zeros i.e. `05:05:00`

More info on time data loading: When we were using SQL data saving, SQL seems to have been fixing our time fields by adding a leading 0 to the hours or minutes that were <10 so even when the code was sending `5:5:00`, SQL was converting it to `05:05:00`. Since we started using JSONdata instruments, this correction has not been happening and any time value saved without correction CAN NOT be reloaded when the instrument is reloaded thus magically erasing data.
