### PR TITLE
Add script which converts a REDCap data dictionary to LINST format

### DIFF
--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -96,6 +96,11 @@ function toLINST(
     case 'sql':
         // The "SQL" data type seems to just be for presentation? I hope?
         return "";
+    case'slider':
+        return "numeric{@}$redcapfieldname{@}$label{@}0{@}100";
+    case 'file':
+        // File upload - NOT SUPPORTED BY LINST
+        return "";
     case 'notes':
         // REDCap calls textareas notes
         return "textarea{@}$redcapfieldname{@}$label";

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -1,0 +1,124 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "generic_includes.php";
+
+$options = getopt("f:", 
+    [
+        "output-dir:",
+        "file:",
+    ]
+);
+
+$inputFile = $options['f'] ?? $options['file'] ?? '';
+$outputDir = $options['output-dir'] ?? '';
+
+if (empty($inputFile) || empty($outputDir)) {
+    showHelp();
+    exit(1);
+}
+if (!is_dir($outputDir)) {
+    fprintf(STDERR, "Output directory $outputDir doesn't exist.\n");
+    exit(1);
+}
+if (!is_writeable($outputDir)) {
+    fprintf(STDERR, "Output directory $outputDir is not writeable.\n");
+    exit(1);
+}
+
+$fp = fopen($inputFile, "r");
+if ($fp === false) {
+    fprintf(STDERR, "Could not open file $inputFile\n");
+    exit(1);
+}
+
+$headers = fgetcsv($fp);
+$instruments = [];
+while($row = fgetcsv($fp)) {
+    $inst = $row[1];
+    if (!isset($instruments[$inst])) {
+        $instruments[$inst] = [];
+    }
+    $linstFormat = toLINST($row[3], $row[0], $row[4], $row[5]);
+    if (!empty($linstFormat)) {
+        $instruments[$inst][] = $linstFormat;
+    }
+}
+fclose($fp);
+
+outputFiles($outputDir, $instruments);
+
+function toLINST(
+    string $redcaptype,
+    string $redcapfieldname,
+    string $redcaplabel,
+    string $redcapChoices,
+) : string {
+    $label = str_replace($redcaplabel, "\n", "<br /><br />");
+    switch ($redcaptype) {
+        case 'text':
+            // text maps directly to LORIS
+            return "text{@}$redcapfieldname{@}$label";
+        case 'descriptive':
+            // descriptive maps to label with no field.
+            return "static{@}{@}$label";
+        case 'radio':
+        case 'dropdown':
+            // Radio or dropdown maps to a select and the options are in the
+            // same format in the dictionary.
+            // select{@}fieldname{@}fieldlabel{@}NULL=>''{-}'a'=>'a'{-}'b'=>'b'{-}'c'=>'c'{-}'not_answered'=>'Not Answered'
+            return "select{@}$redcapfieldname{@}$label{@}" . optionsToLINST($redcapChoices);
+        case 'checkbox':
+            // checkboxes are the same format as radios but allow multiple options, so map to a
+            // selectmultiple instead of a select
+            return "selectmultiple{@}$redcapfieldname{@}$label{@}" . optionsToLINST($redcapChoices);
+        case 'yesno':
+            // Map yes/no fields to dropdowns with yes and no options.
+            return "select{@}$redcapfieldname{@}$label{@}NULL=>''{-}'yes'=>'Yes'{-}'no'=>'No'";
+        case 'calc':
+            // Calc maps to a score field. We create the DB field but don't do the score.
+            return "static{@}$redcapfieldname{@}$label";
+        case 'sql':
+            // The "SQL" data type seems to just be for presentation? I hope?
+            return "";
+        case 'notes':
+            // REDCap calls textareas notes
+            return "textarea{@}$redcapfieldname{@}$label";
+        default:
+            throw new \LorisException("Unhandled REDCap type $redcaptype");
+    }
+}
+
+function optionsToLINST(string $dictionary) {
+    $choices = explode(' | ', $dictionary);
+    $linstChoices = [];
+    foreach ($choices as $choice) {
+        $matches = [];
+        if (preg_match("/^(\s)*(\d+)(\s)*,(.*)$/", $choice, $matches) !== 1) {
+            throw new \DomainException("Could not parse radio option: $choice");
+
+        }
+        $backend = $matches[2] . '_' . preg_replace("/\s+/", "_", trim($matches[4]));
+        $linstFormat = "'$backend'=>'" . trim(strtolower($matches[4])) . '\'';
+        $linstChoices[] = $linstFormat;
+
+    }
+    return join('{-}', $linstChoices);
+}
+
+function showHelp() {
+    global $argv;
+    fprintf(STDERR, "Usage: $argv[0] --file=filename --output-dir=instrumentdirectory\n");
+}
+
+function outputFiles(string $outputDir, array $instruments) {
+    foreach ($instruments as $instname => $instrument) {
+        $fp = fopen("$outputDir/$instname.linst", "w");
+        foreach ($instrument as $field) {
+            fwrite($fp, "$field\n");
+        }
+        fclose($fp);
+
+    }
+}

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -146,8 +146,11 @@ Zipcode
     case 'dropdown':
         // Radio or dropdown maps to a select and the options are in the
         // same format in the dictionary.
-        return "select{@}$redcapfieldname{@}$label{@}"
-            . optionsToLINST($redcapChoices);
+        $selectoptions = optionsToLINST($redcapChoices);
+        if (!empty($selectoptions)) {
+            $selectoptions = "NULL=>''{-}" . $selectoptions;
+        }
+        return "select{@}$redcapfieldname{@}$label{@}$selectoptions";
     case 'checkbox':
         // checkboxes are the same format as radios but allow multiple options,
         // so map to a selectmultiple instead of a select

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -164,8 +164,10 @@ Zipcode
         // Calc maps to a score field. We create the DB field but don't do the score.
         return "static{@}$redcapfieldname{@}$label";
     case 'sql':
-        // The "SQL" data type seems to just be for presentation? I hope?
-        return "";
+        // The "SQL" data type is used for a dynamic display of enum options. Since
+        // we don't have access to the redcap database that the sql is selecting from,
+        // we treat it the same way as a score/calc field so that data can be imported.
+        return "static{@}$redcapfieldname{@}$label";
     case'slider':
         return "numeric{@}$redcapfieldname{@}$label{@}0{@}100";
     case 'file':

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -210,14 +210,14 @@ function optionsToLINST(string $dictionary) : string
     $linstChoices = [];
     foreach ($choices as $choice) {
         $matches = [];
-        if (preg_match("/^(\s)*(\d+)(\s)*,(.*)$/", $choice, $matches) !== 1) {
+            if (preg_match("/^(\s)*([[:alnum:]]+)(\s)*,(.*)$/", $choice, $matches) !== 1) {
             throw new \DomainException("Could not parse radio option: '$choice'");
 
         }
         // $backend        = $matches[2] . '_'
         //        . preg_replace("/\s+/", "_", trim($matches[4]));
         $backend = $matches[2];
-        $linstFormat    = "'$backend'=>'" . trim(strtolower($matches[4])) . '\'';
+        $linstFormat    = "'$backend'=>'" . trim($matches[4]) . '\'';
         $linstChoices[] = $linstFormat;
 
     }

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -167,6 +167,10 @@ function outputFiles(string $outputDir, array $instruments)
 {
     foreach ($instruments as $instname => $instrument) {
         $fp = fopen("$outputDir/$instname.linst", "w");
+        fwrite($fp, "table{@}$instname\n");
+        // FIXME: There should be a title{@} tag for it to be a valid linst
+        // that the instrument manager can recognize, but there doesn't seem
+        // to be any way to derive that from the redcap data dictionary csv?
         foreach ($instrument as $field) {
             fwrite($fp, "$field\n");
         }

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -92,6 +92,51 @@ function toLINST(
     $label = str_replace("\n", "<br /><br />", $redcaplabel);
     switch ($redcaptype) {
     case 'text':
+        /* switch ($redcapOptions) {
+            case '
+            date_dmy 31-12-2008
+            date_mdy 12-31-2008
+            date_ymd 2008-12-31
+
+            datetime_dmy 16-02-2011 17:45
+            datetime_mdy 02-16-2011 17:45
+            datetime_ymd 2011-02-16 17:45
+            datetime_seconds_dmy 16-02-2011 17:45:23
+            datetime_seconds_mdy 02-16-2011 17:45:23
+            datetime_seconds_ymd
+
+email john.doe@vanderbilt.edu
+integer 1, 4, -10 whole number with no decimal
+alpha_only name letters only, no numbers, spaces or special characters
+number 1.3, 22, -6.28, 3.14e-2 a general number or scientific notation (no spaces)
+number_1dp_comma_decimal number to 1 decimal place - comma as decimal
+number_1dp number to 1 decimal place
+number_2dp_comma_decimal number to 2 decimal place - comma as decimal
+number_2dp number to 2 decimal place
+number_3dp_comma_decimal number to 3 decimal place - comma as decimal
+number_3dp number to 3 decimal place
+number_4dp_comma_decimal number to 4 decimal place - comma as decimal
+number_4dp number to 4 decimal place
+number_comma_decimal number comma as decimal
+phone_australia
+phone 615-322-2222
+Area codes start with a number from 2-9, followed by 0-8 and
+then any third digit.
+The second group of three digits, known as the central office or
+schange code, starts with a number from 2-9, followed by any
+two digits.
+The final four digits, known as the station code, have no
+restrictions.
+postalcode_australia 2150 4-digit number
+postalcode_canada K1A 0B1 Format: A0A 0A0 where A is a letter and 0 is a digit
+ssn 123-12-1234 Format: xxx-xx-xxxx
+time 19:30 military time
+time_mm_ss 31:22 time in minutes and seconds
+vmrn 0123456789 10 digits
+Zipcode
+
+        }
+        */
         // text maps directly to LORIS
         return "text{@}$redcapfieldname{@}$label";
     case 'descriptive':

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -67,7 +67,7 @@ function toLINST(
     string $redcaplabel,
     string $redcapChoices,
 ) : string {
-    $label = str_replace($redcaplabel, "\n", "<br /><br />");
+    $label = str_replace("\n", "<br /><br />", $redcaplabel);
     switch ($redcaptype) {
     case 'text':
         // text maps directly to LORIS

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -244,6 +244,13 @@ function outputFiles(string $outputDir, array $instruments)
         // FIXME: There should be a title{@} tag for it to be a valid linst
         // that the instrument manager can recognize, but there doesn't seem
         // to be any way to derive that from the redcap data dictionary csv?
+
+        // Standard LORIS metadata fields that the instrument builder adds
+        // and LINST class automatically adds to instruments.
+        fwrite($fp, "date{@}Date_taken{@}Date of Administration{@}{@}\n");
+        fwrite($fp, "static{@}Candidate_Age{@}Candidate Age (Years)\n");
+        fwrite($fp, "static{@}Window_Difference{@}Window Difference (+/- Days)\n");
+        fwrite($fp, "select{@}Examiner{@}Examiner{@}NULL=>''\n");
         foreach ($instrument as $field) {
             fwrite($fp, "$field\n");
         }

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -191,7 +191,7 @@ function optionsToLINST(string $dictionary) : string
         $dictionary = substr($dictionary, 2);
     }
 
-    $choices      = explode(' | ', $dictionary);
+    $choices      = explode('|', $dictionary);
     $linstChoices = [];
     foreach ($choices as $choice) {
         $matches = [];

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -154,8 +154,9 @@ function optionsToLINST(string $dictionary) : string
             throw new \DomainException("Could not parse radio option: '$choice'");
 
         }
-        $backend        = $matches[2] . '_'
-                . preg_replace("/\s+/", "_", trim($matches[4]));
+        // $backend        = $matches[2] . '_'
+        //        . preg_replace("/\s+/", "_", trim($matches[4]));
+        $backend = $matches[2];
         $linstFormat    = "'$backend'=>'" . trim(strtolower($matches[4])) . '\'';
         $linstChoices[] = $linstFormat;
 

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -119,12 +119,17 @@ function toLINST(
  */
 function optionsToLINST(string $dictionary) : string
 {
+    $dictionary = str_replace(' | | ', ' | ', $dictionary);
+    if (str_starts_with($dictionary, '| ')) {
+        $dictionary = substr($dictionary, 2);
+    }
+
     $choices      = explode(' | ', $dictionary);
     $linstChoices = [];
     foreach ($choices as $choice) {
         $matches = [];
         if (preg_match("/^(\s)*(\d+)(\s)*,(.*)$/", $choice, $matches) !== 1) {
-            throw new \DomainException("Could not parse radio option: $choice");
+            throw new \DomainException("Could not parse radio option: '$choice'");
 
         }
         $backend        = $matches[2] . '_'


### PR DESCRIPTION
This adds a new `tools/` script, redcap2linst, which takes a REDCap data dictionary CSV and outputs a LINST file for each instrument in it. It does not (currently) deal with rules or scoring, only builds the LINST files. It also doesn't deal with inserting into the Test_names or creating the `.meta` files, as that's currently done by the instrument_manager when the LINST file is uploaded to LORIS.

I was only able to implement the types in the data dictionary that I was given for HBCD, so it's possible there are some data types that are missing which need to be implemented (in which case the script will currently throw an exception.)