### PR TITLE
[webpack] Update dependencies for latest nodejs (openssl unsupported)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "eslint-webpack-plugin": "2.1.0",
     "null-loader": "^4.0.1",
     "style-loader": "^1.1.3",
-    "terser-webpack-plugin": "^1.3.0",
+    "terser-webpack-plugin": "^5.3.6",
     "ts-loader": "^8.3.0",
     "typescript": "^3.0.1",
-    "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.0"
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
   },
   "scripts": {
     "lint:javascript": "./test/run-js-linter.sh",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,7 +153,7 @@ function lorisModule(mname, entries, override=false) {
     resolve: resolve,
     module: mod,
     mode: 'none',
-    stats: 'errors-warnings',
+    stats: 'errors-only',
   };
 }
 


### PR DESCRIPTION
## Brief summary of changes

Update dependencies for webpack, webpack-cli, and terser-webpack-plugin. Latest nodejs removed openssl causing error when trying to build Loris. Solution to upgrade dependencies. Changes are backwards compatible with current Loris supported version of nodejs.

Solves error:
````
webpack

node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);

Error: error:0308010C:digital envelope routines::unsupported

...
````

#### Testing instructions (if applicable)

1. git checkout pr
2. make clean
3. make dev
4. upgrade to latest nodejs example 18.10.0 nodejs.org/en/
5. make clean
6. make dev

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
