### PR TITLE
[eslintignore] cleanup of redundancy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ babel.config.js
 
 # compiled js ignored since it is run on the jsx directory
 modules/*/js/*
-modules/*/js/*/*
 modules/electrophysiology_browser/jsx/react-series-data-viewer/src/protocol-buffers/chunk_pb.js
 htdocs/js/components/*
 


### PR DESCRIPTION
## Brief summary of changes

Removal of `modules/*/js/*/*` because it's redundant since `modules/*/js/*` prevents git adding additional directories that may contain files as well.


