### PR TITLE
[Makefile] improve the "make clean" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ clean:
 	rm -f VERSION
 	rm -rf vendor
 	rm -rf node_modules
-	rm package-lock.json
+	rm -f package-lock.json
+	rm -rf modules/electrophysiology_browser/jsx/react-series-data-viewer/node_modules
+	rm -f modules/electrophysiology_browser/jsx/react-series-data-viewer/package-lock.json
 
 # Perform static analysis checks
 checkstatic: phpdev


### PR DESCRIPTION
## Brief summary of changes

The `make clean` command should remove the `node_modules` and `package-lock.json` files from the electrophysiology_browser module. I modified Makefile to include the cleanup task of those files.

#### Testing instructions (if applicable)

1. checkout pr
2. run `make clean`

