### PR TITLE
fix generic_includes for 24.1

### DIFF
--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -23,7 +23,7 @@ $configFile = __DIR__."/../project/config.xml";
 $client     = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize($configFile);
-$DB            = Database::singleton();
+$DB            = NDB_Factory::singleton()->database();
 $config        = NDB_Config::singleton();
 $lorisInstance = new \LORIS\LorisInstance(
     $DB,


### PR DESCRIPTION
`tools/generic_includes.php` missed the https://github.com/aces/Loris/pull/8074 refactoring boat in 24.1 where all `Database::singleton` have been replaced by `NDB_Factory::singleton()->database()`

This fixes the `generic_includes.php` file to use the new way of loading the DB object for branch 24.1-release.