### PR TITLE
[package.json] remove unnecessary plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,6 @@ module.exports = function(api) {
     "@babel/preset-env"
   ];
   const plugins = [
-    "@babel/plugin-proposal-object-rest-spread",
     ["@babel/plugin-transform-runtime",
       {
         "regenerator": true

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@babel/cli": "^7.6.4",
     "@babel/core": "^7.11.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.6.3",
     "@types/react": "^16.12.0",


### PR DESCRIPTION
## Brief summary of changes

The plugin @babel/plugin-proposal-object-rest-spread is unnecessary to install/include inside babel.config.js because the plugin is included in @babel/preset-env, in [ES2018]. See https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread

#### Testing instructions (if applicable)

1. checkout PR
2. make clean
3. make dev


