### PR TITLE
[dqt] Feature - clickable fields for Define Fields and Define Filters

### DIFF
--- a/modules/dqt/jsx/components/searchabledropdown.js
+++ b/modules/dqt/jsx/components/searchabledropdown.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -9,6 +9,14 @@ import PropTypes from 'prop-types';
  */
 const SearchableDropdown = (props) => {
   const [currentInput, setCurrentInput] = useState();
+
+  useEffect(() => {
+     props.setFieldFilter(setSearch);
+   }, []);
+
+   const setSearch = (value) => {
+     setCurrentInput(value);
+   };
 
   const getKeyFromValue = (value) => {
     const options = props.options;
@@ -59,15 +67,10 @@ const SearchableDropdown = (props) => {
     errorMessage = <span>{strictMessage}</span>;
   }
 
-  // determine value to place into text input
-  let value = '';
   // use value in options if valid
   if (props.value !== undefined &&
     Object.keys(options).indexOf(props.value) > -1) {
-    value = options[props.value];
-    // else, use input text value
-  } else if (currentInput) {
-    value = currentInput;
+    setCurrentInput(options[props.value]);
   }
 
   let newOptions = {};
@@ -109,7 +112,7 @@ const SearchableDropdown = (props) => {
             </span>
             <input type='text'
                    name={props.name + '_input'}
-                   value={value}
+                   value={currentInput || ''}
                    id={props.id}
                    list={props.name + '_list'}
                    className='form-control'

--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -95,6 +95,7 @@ class DataQueryApp extends Component {
     this.overrideQuery = this.overrideQuery.bind(this);
     this.loadFilterRule = this.loadFilterRule.bind(this);
     this.loadFilterGroup = this.loadFilterGroup.bind(this);
+    this.fieldClickedFromSidebar = this.fieldClickedFromSidebar.bind(this);
     this.loadSavedQuery = this.loadSavedQuery.bind(this);
     this.fieldVisitSelect = this.fieldVisitSelect.bind(this);
     this.fieldChange = this.fieldChange.bind(this);
@@ -946,6 +947,23 @@ class DataQueryApp extends Component {
   }
 
   /**
+    * field clicked from sidebar
+    * @param {object} field
+    */
+   fieldClickedFromSidebar(field) {
+     console.log('fieldClickedFromSidebar has ran!');
+     let state = JSON.parse(JSON.stringify(this.state));
+     console.log(state);
+     if (this.state.ActiveTab === 'DefineFields') {
+       // Set Query Fields Search.
+       this.setFieldSearch(field);
+     } else if (this.state.ActiveTab === 'DefineFilters') {
+       // Set Filter Rule.
+       this.setFilterRule(field);
+     }
+   }
+
+  /**
    * Build the queried data to be displayed in the data table
    * @param {number} displayID
    * @return {object}
@@ -1359,6 +1377,7 @@ class DataQueryApp extends Component {
             Visits={this.state.Visits}
             fieldVisitSelect={this.fieldVisitSelect}
             Loading={this.state.loading}
+            setFieldSearch={(field) => this.setFieldSearch = field}
             Active={this.state.ActiveTab === 'DefineFields'}
           />
         )}
@@ -1374,6 +1393,7 @@ class DataQueryApp extends Component {
           <FilterSelectTabPane
             key='DefineFilters'
             TabId='DefineFilters'
+            setFilterRule={(field) => this.setFilterRule = field}
             categories={this.state.categories}
             filter={this.state.filter}
             updateFilter={this.updateFilter}
@@ -1440,6 +1460,7 @@ class DataQueryApp extends Component {
             Fields={this.state.fields}
             Criteria={this.state.criteria}
             resetQuery={this.resetQuery}
+            fieldClickedFromSidebar={this.fieldClickedFromSidebar}
           />
         </div>
       )

--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -366,7 +366,16 @@ class FieldSelector extends Component {
     this.modifyCategoryFieldVists = this.modifyCategoryFieldVists.bind(this);
     this.changePage = this.changePage.bind(this);
     this.resetFilter = this.resetFilter.bind(this);
+    this.setSearchableDropdown = this.setSearchableDropdown.bind(this);
   }
+
+  /**
+   * Called by React when the component has been rendered on the page.
+   */
+  componentDidMount() {
+     console.log('componentDidMount in FieldSelector has ran');
+     this.props.setFieldSearch(this.setSearchableDropdown);
+   }
 
   /**
    * Wrapper function for field changes
@@ -384,6 +393,15 @@ class FieldSelector extends Component {
    * @param {string} category
    */
   onCategorySelect(elementName, category) {
+    console.log('onCategorySelect has ran');
+     if (category === undefined || category === '') {
+       // Prevent unnecessary GET request.
+       this.setState({
+         selectedCategory: null,
+         PageNumber: 1,
+       });
+       return;
+     }
     if (this.state.categoryFields[category]) {
     } else {
       // Retrieve the data dictionary
@@ -565,6 +583,22 @@ class FieldSelector extends Component {
   }
 
   /**
+   * Set searchable dropdown filter
+   * @param {string} field
+   */
+  setSearchableDropdown(field) {
+     console.log('setSearchableDropdown has ran!');
+     this.onCategorySelect('fieldsDropdown', field[0]);
+     console.log('field is ');
+     console.log(field);
+     this.setFieldFilter(field[0]);
+     this.setState({
+       selectedCategory: field[0],
+       filter: field[1],
+     });
+   }
+
+  /**
    * Renders the React component.
    *
    * @return {JSX} - React markup for the component
@@ -614,6 +648,7 @@ class FieldSelector extends Component {
           <SearchableDropdown
             id={'fieldsDropdown'}
             name="fieldsDropdown"
+            setFieldFilter={(field) => this.setFieldFilter = field}
             resetFilter={this.resetFilter}
             options={instruments}
             onUserInput={this.onCategorySelect}
@@ -641,7 +676,7 @@ class FieldSelector extends Component {
               <input type="text"
                      className="form-control"
                      onChange={this.filterChange}
-                     value={this.state.filter}
+                     value={this.state.filter || ''}
                      ref={(ref) => this.searchFieldsInputField = ref}
                      onFocus={(event) => {
                        setTimeout(() => this.onFocus(event), 0);

--- a/modules/dqt/jsx/react.sidebar.js
+++ b/modules/dqt/jsx/react.sidebar.js
@@ -98,6 +98,7 @@ class FieldsSidebar extends Component {
                  color: '#fff',
                  backgroundColor: '#4c8ad5',
                }}
+               onClick={() => this.props.fieldClickedFromSidebar(fieldInfo)}
                key={this.props.Fields[i]}>
             <h4 className='list-group-item-heading col-xs-12'
                 style={{color: '#fff'}}

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -125,6 +125,7 @@ let FieldSelectTabPane = (props) => {
         onFieldChange={props.onFieldChange}
         selectedFields={props.selectedFields}
         Visits={props.Visits}
+        setFieldSearch={props.setFieldSearch}
         fieldVisitSelect={props.fieldVisitSelect}
       />
     </TabPane>
@@ -146,6 +147,7 @@ let FilterSelectTabPane = (props) => {
                      filter={props.filter}
                      Visits={props.Visits}
                      Active={props.Active}
+                     setFilterRule={props.setFilterRule}
                      loadImportedCSV={props.loadImportedCSV}
                      getAllSessions={props.getAllSessions}
       />


### PR DESCRIPTION
## Brief summary of changes

The sidebar fields are now clickable with functionality:

Define Fields: when clicking a "field" on the sidebar, the filter of Define Fields will filter to the field clicked and make the user have a better experience when toggling visits for fields previously selected.

Define Filters (Optional): when clicking a "field" on the sidebar, the selected rule of the filter will be set to the details of the field clicked. Note: The user first has to click on the rule for the fields to set the rule. I'm making it so when a user clicks on a rule it turns blue.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. checkout pr
2. make clean
3. make dev
4. visit dqt
5. read feature and try for yourself.

