### PR TITLE
[Form.js] No required min/max for numeric elements

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1839,8 +1839,8 @@ class NumericElement extends Component {
 
 NumericElement.propTypes = {
   name: PropTypes.string.isRequired,
-  min: PropTypes.number.isRequired,
-  max: PropTypes.number.isRequired,
+  min: PropTypes.number,
+  max: PropTypes.number,
   label: PropTypes.string,
   value: PropTypes.string,
   id: PropTypes.string,


### PR DESCRIPTION
Input elements should not require a min and a max. They may not be required (or known) and aren't necessary for the underlying <input type="number"> element.