### PR TITLE
[Breadcrumbs] Added onClick handler to breadcrumbs

### DIFF
--- a/jsx/Breadcrumbs.js
+++ b/jsx/Breadcrumbs.js
@@ -92,17 +92,24 @@ class Breadcrumbs extends Component {
     for (let i = 0; i < this.props.breadcrumbs.length; i++) {
       const element = this.props.breadcrumbs[i];
       const url = baseURL + element.query;
+      const onClick=this.props.breadcrumbs[i].onClick
+        ? this.props.breadcrumbs[i].onClick
+        : () => {};
+
       if (i < this.props.breadcrumbs.length - this.state.displayCount) {
         dropdown.push(
           <li key={'drop_' + i}>
-            <a href={url}>
+            <a href={url} onClick={onClick}>
               {element.text}
             </a>
           </li>
         );
       } else {
         breadcrumbs.push(
-          <a key={'crumb_' + i} href={url} className='btn btn-primary'>
+          <a key={'crumb_' + i}
+             href={url}
+             className='btn btn-primary'
+             onClick={onClick}>
             <div>
               {element.text}
             </div>
@@ -140,6 +147,7 @@ class Breadcrumbs extends Component {
     );
   }
 }
+
 Breadcrumbs.propTypes = {
   baseURL: PropTypes.string,
   breadcrumbs: PropTypes.array,


### PR DESCRIPTION
This makes it possible for javascript modules to update the breadcrumbs dynamically and add an onClick handler to individual crumbs by doing something like:

```
const breadcrumbs = [
{
    text: 'Item1',
    onClick: (e) => {
        e.preventDefault();
        console.log('Clicked breadcrumb 1');
    },
},
{
    text: 'Item2',
    onClick: (e) => {
        e.preventDefault();
        console.log('Clicked breadcrumb 2');
    },
}
];

ReactDOM.render(
        <Breadcrumbs
            breadcrumbs={breadcrumbs}
            baseURL={loris.BaseURL}
        />,
        document.getElementById('breadcrumbs')
);
```