### PR TITLE
[dashboard] Use proper getActiveModules in dashboard

### DIFF
--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -78,12 +78,9 @@ class Dashboard extends \NDB_Form
         // otherwise setup() only gets called by handle() of NDB_Page while
         // calculating the body.
         $factory = \NDB_Factory::singleton();
-        $DB      = $factory->database();
         $user    = $factory->user();
 
-        // FIXME: This should use \LORIS\LorisInstance->getActiveModules(), but there
-        // is no access to a LORISInstance object at this point in the code.
-        $modules = \Module::getActiveModules($DB);
+        $modules = $loris->getActiveModules();
 
         $this->_smallwidgets = [];
         $this->_mainwidgets  = [];


### PR DESCRIPTION
The FIXME comment in the dashboard class is no longer accurate.

There is a LorisInstance passed as a function argument, so use it instead of the static call from the modules class.