### PR TITLE
[Performance] Do not load module logger from constructor

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -169,10 +169,6 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      */
     public function __construct(string $name, string $moduledir)
     {
-        $config   = \NDB_Factory::singleton()->config();
-        $loglevel = $config->getLogSettings()->getRequestLogLevel();
-
-        $this->logger = new \LORIS\Log\ErrorLogLogger($loglevel);
         parent::__construct(
             new \ArrayIterator(
                 [

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -144,7 +144,17 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
                 $module  = \Module::factory("timepoint_list");
-                $mr      = new ModuleRouter($module);
+
+                $requestloglevel = $logSettings->getRequestLogLevel();
+                if ($requestloglevel != "none") {
+                    $module->setLogger(
+                        new \LORIS\Log\ErrorLogLogger($requestloglevel)
+                    );
+                } else {
+                    $module->setLogger(new \PSR\Log\NullLogger);
+                }
+
+                $mr = new ModuleRouter($module);
                 return $ehandler->process($request, $mr);
             }
         }


### PR DESCRIPTION
This is an attempt to solve the speed issues with demo-24.loris.ca.

In LORIS 23, there was no LORISInstance object that was used for getting active modules, nor was there a logger instantiated from the constructor. The added overhead of retrieving the log settings for every module instantiation and LorisInstance->getActiveModules instantiating every module is adding up to a lot of overhead in the critical path on demo-24.loris.ca.

This moves the logger instantiation to be done after the Module::factory call in the router instead of in the constructor. The result is that it's only done once, instead of done n times (where n is the number of modules.)

This doesn't get demo-24.loris.ca up to the speed of demo.loris.ca, but it's significantly closer.

It's not clear why this performance regression is only happening on demo and not in other environments.