### PR TITLE
Fix for tools/lorisform_parser

### DIFF
--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -55,7 +55,7 @@ foreach ($files as $file) {
     echo "Requiring file...\n";
     include_once $file;
     echo "Instantiating new object...\n";
-    $obj =new $className($lorisInstance, new NullModule(), "", "", "", "");
+    $obj =new $className($lorisInstance, new NullModule($lorisInstance), "", "", "", "");
     echo "Initializing instrument object...\n";
     $obj->setup(null, null);
 


### PR DESCRIPTION
Following #7446, one of the changes involves `php/libraries/NullModule.class.inc` that now requires a `LorisInstance` type parameter.

This fix adds a missing parameter in the `lorisform_parser.php` script.