### PR TITLE
[JSX] Add InfoPanel component

### DIFF
--- a/jsx/InfoPanel.js
+++ b/jsx/InfoPanel.js
@@ -1,0 +1,33 @@
+/**
+ * Display a message in an information panel.
+ *
+ * @param {object} props - React props
+ *
+ * @return {JSX}
+ */
+function InfoPanel(props) {
+    return (
+        <div className="alert alert-info"
+           style={{
+             backgroundColor: '#BEDFFF',
+             color: 'black',
+             display: 'flex',
+             flexBasis: 'row',
+             flexWrap: 'nowrap',
+         }}>
+            <div style={{
+                alignSelf: 'center',
+                padding: '1em',
+            }}>
+                <i style={{fontSize: '2em', color: 'blue'}}
+                    className="fas fa-info-circle"></i>
+            </div>
+            <div style={{
+                paddingLeft: '1em',
+                alignSelf: 'center',
+            }}>{props.children}</div>
+         </div>
+   );
+}
+
+export default InfoPanel;


### PR DESCRIPTION
This adds an InfoPanel component to show a message to the user in a box that's styled to draw their attention. The "alert alert-info" bootstrap classes weren't working for me with our current stylesheet, so the InfoPanel wraps around what's needed to make it look reasonable and uses a FontAwesome icon to mark it as an information panel.

Usage:
```
<InfoPanel>
Message that should go in the panel, can include arbitrary other react or html if you want.
</InfoPanel>
```

It looks like this

![InfoPanel example](https://user-images.githubusercontent.com/498329/198337373-6aeff1bf-c29f-4423-a949-2c67b0c379b8.png)
