### PR TITLE
[Media] fix wrong file path -  user can't download file from custom directory.

### DIFF
--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -26,9 +26,10 @@ if (!$user->hasPermission('media_write')) {
 // by using a relative filename.
 $file     = html_entity_decode(basename($_GET['File']));
 $config   =& NDB_Config::singleton();
-$path     = $DB->pselectOne(
-            "SELECT data_dir FROM media WHERE file_name =:filename",['filename' => $file]
-            );
+
+$path = $DB->pselectOne(
+    "SELECT data_dir FROM media WHERE file_name =:filename",['filename' => $file]
+);
 
 $filePath = $path . $file;
 

--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -24,11 +24,12 @@ if (!$user->hasPermission('media_write')) {
 
 // Make sure that the user isn't trying to break out of the $path
 // by using a relative filename.
-$file     = html_entity_decode(basename($_GET['File']));
-$config   =& NDB_Config::singleton();
+$file   = html_entity_decode(basename($_GET['File']));
+$config =& NDB_Config::singleton();
 
 $path = $DB->pselectOne(
-    "SELECT data_dir FROM media WHERE file_name =:filename",['filename' => $file]
+    "SELECT data_dir FROM media WHERE file_name =:filename",
+    ['filename' => $file]
 );
 
 $filePath = $path . $file;

--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -26,9 +26,10 @@ if (!$user->hasPermission('media_write')) {
 // by using a relative filename.
 $file     = html_entity_decode(basename($_GET['File']));
 $config   =& NDB_Config::singleton();
-$path = $DB->pselectOne(
-      "SELECT data_dir FROM media WHERE file_name =:filename",
-      ['filename' => $file]);
+$path     = $DB->pselectOne(
+            "SELECT data_dir FROM media WHERE file_name =:filename",['filename' => $file]
+            );
+
 $filePath = $path . $file;
 
 $downloadNotifier = new NDB_Notifier(

--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -26,7 +26,9 @@ if (!$user->hasPermission('media_write')) {
 // by using a relative filename.
 $file     = html_entity_decode(basename($_GET['File']));
 $config   =& NDB_Config::singleton();
-$path     = $config->getSetting('mediaPath');
+$path = $DB->pselectOne(
+      "SELECT data_dir FROM media WHERE file_name =:filename",
+      ['filename' => $file]);
 $filePath = $path . $file;
 
 $downloadNotifier = new NDB_Notifier(


### PR DESCRIPTION
## Brief summary of changes
 fix wrong file path -  user can't download file from custom directory.
#### Testing instructions (if applicable)
1. upload a file to media module from any instrument with upload function. 
2. download the uploaded file form media module.
