### PR TITLE
[Imaging Uploader] Replace 'MINC' string by 'Files' in the imaging uploader column since imaging files created and inserted are not necessarily MINC files anymore

### DIFF
--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -135,8 +135,8 @@ class ImagingUploader extends Component {
       }
 
       if (cell === 'Success') {
-        const created = row['Number Of MINC Created'];
-        const inserted = row['Number Of MINC Inserted'];
+        const created = row['Number Of Files Created'];
+        const inserted = row['Number Of Files Inserted'];
         return (
           <td style={cellStyle}>
           {cell} ({inserted} out of {created})
@@ -164,7 +164,7 @@ class ImagingUploader extends Component {
       );
     }
 
-    if (column === 'Number Of MINC Inserted') {
+    if (column === 'Number Of Files Inserted') {
       if (cell > 0) {
         const url = loris.BaseURL
                     + '/imaging_browser/viewSession/?sessionID='
@@ -177,11 +177,12 @@ class ImagingUploader extends Component {
       }
     }
 
-    if (column === 'Number Of MINC Created') {
+    if (column === 'Number Of Files Created') {
       let violatedScans;
-      if (row['Number Of MINC Created'] - row['Number Of MINC Inserted'] > 0) {
+      // eslint-disable-next-line max-len
+      if (row['Number Of Files Created'] - row['Number Of Files Inserted'] > 0) {
         let numViolatedScans =
-             row['Number Of MINC Created'] - row['Number Of MINC Inserted'];
+             row['Number Of Files Created'] - row['Number Of Files Inserted'];
 
         let patientName = row.PatientName;
         violatedScans = <a

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -72,8 +72,8 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             'UploadDate AS Upload_Date',
             'UploadedBy AS Uploaded_By',
             'mu.TarchiveID AS Tarchive_Info',
-            'number_of_mincCreated AS Number_of_MINC_Created',
-            'number_of_mincInserted AS Number_of_MINC_Inserted',
+            'number_of_mincCreated AS Number_of_Files_Created',
+            'number_of_mincInserted AS Number_of_Files_Inserted',
             'ta.PatientName',
             's.ID AS SessionID',
         ];
@@ -408,9 +408,9 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $updateFile = isset($args['values']['overwrite'])
             ? (boolean) $args['values']['overwrite'] : false;
         $id         = $db->pselectOne(
-            "SELECT 
-                IF (InsertionComplete=0 AND 
-                (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
+            "SELECT
+                IF (InsertionComplete=0 AND
+                (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID
                 FROM mri_upload WHERE UploadLocation LIKE :ul",
             ['ul' => "%$file_name"]
         );
@@ -557,9 +557,9 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             // wildcard for files that were uploaded to a random temp path.
             $fileName = $file->fileInfo['name'];
             $id       = $db->pselectOne(
-                "SELECT 
-                IF (InsertionComplete=0 AND 
-                (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
+                "SELECT
+                IF (InsertionComplete=0 AND
+                (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID
                 FROM mri_upload WHERE UploadLocation LIKE :ul",
                 ['ul' => "%$fileName"]
             );


### PR DESCRIPTION
## Brief summary of changes

MINC is hardcoded in the column labels specifying the number of files created by the pipeline and the number of files inserted into the imaging browser. Since LORIS supports insertion of MINC files and NIfTI files only, it does not make sense to show 'Number of MINC created' and 'Number of MINC inserted' in the imaging uploader columns header when the files created are NIfTI files...

Replaced `MINC` string by `Files` in those columns to make it more generic to all project workflows.

#### Testing instructions 

1. Checkout this branch and run `make`
2. Check that the last two columns of the imaging uploader table are called 'Number of Files Created' and 'Number of Files Inserted'
3. Make sure that the column 'Number of Files Created' shows the number of violated scans if 'Number of Files Created' > 'Number of Files Inserted' 
