### PR TITLE
Download NIfTI file from imaging browser when a NIfTI file is available in addition to a MINC file

### DIFF
--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -826,6 +826,10 @@ class ImageDownloadButtons extends Component {
                         BaseURL={this.props.BaseURL}
                         Label="Download NRRD"
         />
+        <DownloadButton FileName={this.props.NiiFile}
+                        BaseURL={this.props.BaseURL}
+                        Label="Download NIfTI"
+        />
         <DownloadButton FileName={this.props.BvalFile}
                         BaseURL={this.props.BaseURL}
                         Label="Download BVAL"
@@ -854,6 +858,7 @@ ImageDownloadButtons.propTypes = {
   XMLProtocol: PropTypes.string,
   XMLReport: PropTypes.string,
   NrrdFile: PropTypes.string,
+  NiiFile: PropTypes.string,
   BvalFile: PropTypes.string,
   BvecFile: PropTypes.string,
   JsonFile: PropTypes.string,
@@ -921,6 +926,7 @@ class ImagePanelBody extends Component {
           XMLProtocol={this.props.XMLProtocol}
           XMLReport={this.props.XMLReport}
           NrrdFile={this.props.NrrdFile}
+          NiiFile={this.props.NiiFile}
           BvalFile={this.props.BvalFile}
           BvecFile={this.props.BvecFile}
           JsonFile={this.props.JsonFile}
@@ -947,6 +953,7 @@ ImagePanelBody.propTypes = {
   XMLProtocol: PropTypes.string,
   XMLReport: PropTypes.string,
   NrrdFile: PropTypes.string,
+  NiiFile: PropTypes.string,
   BvalFile: PropTypes.string,
   BvecFile: PropTypes.string,
   JsonFile: PropTypes.string,
@@ -1035,6 +1042,7 @@ class ImagePanel extends Component {
               XMLProtocol={this.props.XMLProtocol}
               XMLReport={this.props.XMLReport}
               NrrdFile={this.props.NrrdFile}
+              NiiFile={this.props.NiiFile}
               BvalFile={this.props.BvalFile}
               BvecFile={this.props.BvecFile}
               JsonFile={this.props.JsonFile}
@@ -1060,6 +1068,7 @@ ImagePanel.propTypes = {
   XMLProtocol: PropTypes.string,
   XMLReport: PropTypes.string,
   NrrdFile: PropTypes.string,
+  NiiFile: PropTypes.string,
   BvalFile: PropTypes.string,
   BvecFile: PropTypes.string,
   JsonFile: PropTypes.string,

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -308,6 +308,7 @@ class ViewSession extends \NDB_Form
             $XMLreport   = $FileObj->getParameter('processing:DTIPrepXmlReport');
             $XMLprotocol = $FileObj->getParameter('ProtocolFile');
             $NrrdFile    = $FileObj->getParameter('processing:nrrd_file');
+            $NiiFile     = $FileObj->getParameter('check_nii_filename');
             $BvalFile    = $FileObj->getParameter('check_bval_filename');
             $BvecFile    = $FileObj->getParameter('check_bvec_filename');
             $JsonFile    = $FileObj->getParameter('bids_json_file');
@@ -361,6 +362,7 @@ class ViewSession extends \NDB_Form
                 'XMLreport'                  => $XMLreport,
                 'XMLprotocol'                => $XMLprotocol,
                 'NrrdFile'                   => $NrrdFile,
+                'NiiFile'                    => $NiiFile,
                 'BvalFile'                   => $BvalFile,
                 'BvecFile'                   => $BvecFile,
                 'JsonFile'                   => $JsonFile,

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -66,6 +66,7 @@
                       "XMLProtocol" : "{$files[file].XMLprotocol}",
                       "XMLReport" : "{$files[file].XMLreport}",
                       "NrrdFile" : "{$files[file].NrrdFile}",
+                      "NiiFile" : "{$files[file].NiiFile}",
                       "BvalFile" : "{$files[file].BvalFile}",
                       "BvecFile" : "{$files[file].BvecFile}",
                       "JsonFile" : "{$files[file].JsonFile}",


### PR DESCRIPTION
## Brief summary of changes

This modifies the imaging browser so that NIfTI files associated to a MINC file can be downloaded through the imaging browser view session page. Currently, we can download BVAL and BVEC files when they are present for DWI but could not download the NIfTI file that comes with it.

This is a bug fix for projects using MINC files and producing NIfTI files at the time of insertion so that they can download.


#### Testing instructions (if applicable)

1. Check out 24.1-release and note that for DWI files on raisinbread, there are the following download buttons:
    - `Download Image` => will download a MINC file (extension `.mnc`)
    - `Download BVAL` => will download a .bval text file
    - `Download BVEC` => will download a .bvec text file
2. check out this branch and note that there is an additional button called `Download NIfTI` for raisinbread DWI MINC files with NIfTI files
