### PR TITLE
[Candidate DTO] Add CandidateData DTO object

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -13,7 +13,7 @@ jobs:
             - static
             - unit
             - integration
-            php: ['7.4','8.0','8.1']
+            php: ['8.0','8.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -35,8 +35,20 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
     \LORIS\StudyEntities\SiteHaver
 {
     var $candidateInfo;
-    var $listOfTimePoints;
 
+    protected $data;
+
+    /**
+     * Construct a new Candidate object optionally populated by
+     * the given DTO.
+     *
+     * @param ?CandidateData $data a Candidate DTO object to bypass
+     *                             the singleton constructor.
+     */
+    public function __construct(?CandidateData $data=null)
+    {
+        $this->data = $data;
+    }
     /**
      * This returns a single Candidate object for the given
      * candID, and will only ever instantiate one object in
@@ -99,9 +111,18 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             );
         }
 
+        // We need to refer to these when instantiating the CandidateData
+        // object after Timepoints have been selected, but by then $row
+        // will have been overwritten, so put them in other variables..
+        $registrationProjectID = new \ProjectID($row['RegistrationProjectID']);
+        $registrationCenterID  = $row['RegistrationCenterID'];
+
         // store user data in object property
         foreach ($row as $key=>$value) {
             switch ($key) {
+            case 'RegistrationProjectID':
+            case 'RegistrationCenterID':
+                break;
             case 'Sex':
                 $this->candidateInfo[$key] = empty($value) ? null : new Sex($value);
                 break;
@@ -118,8 +139,6 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $this->candidateInfo[$key] = $value;
             }
         }
-
-        $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
 
         $headerSetting = $config->getSetting('HeaderTable');
         if (!empty($headerSetting)) {
@@ -176,16 +195,29 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         }
 
         // get Time Point SessionIDs for the $candID
-        // select ALL of them - later you can filter out cancelled and inactive ones
-        $query = "SELECT s.ID FROM session as s
+        $query = "SELECT s.ID, s.ProjectID, s.CenterID FROM session as s
             WHERE s.CandID=:Candidate AND s.Active='Y'
             ORDER BY ID";
         $row   = $db->pselect($query, $CandArray);
 
         // store user data in object property
+        $timepoints = [];
         foreach ($row as $value) {
-            $this->listOfTimePoints[] = intval($value["ID"]);
+            $timepoints[] = new TimePoint(
+                new TimePointData(
+                    new SessionID($value["ID"]),
+                    new ProjectID($value["ProjectID"]),
+                    new CenterID($value["CenterID"]),
+                )
+            );
         }
+
+        $this->data = new CandidateData(
+            $registrationProjectID,
+            new \CenterID($registrationCenterID),
+            $timepoints,
+        );
+        $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
     }
 
     /**
@@ -374,7 +406,12 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getListOfTimePoints(): array
     {
-        return $this->listOfTimePoints ?? [];
+        return array_map(
+            function ($timepoint) {
+                return intval($timepoint->getSessionID());
+            },
+            $this->data->getTimePoints(),
+        );
     }
 
     /**
@@ -387,8 +424,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getSessionID(int $visitNo): ?int
     {
-        if (isset($this->listOfTimePoints[$visitNo-1]) ) {
-            return intval($this->listOfTimePoints[$visitNo-1]);
+        $timepoints = $this->data->getTimePoints();
+        if (isset($timepoints[$visitNo-1]) ) {
+            return intval($timepoints[$visitNo-1]);
         }
 
         return null;
@@ -453,7 +491,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getProjectID(): \ProjectID
     {
-        return $this->candidateInfo["RegistrationProjectID"];
+        return $this->data->getRegistrationProjectID();
     }
 
     /**
@@ -507,7 +545,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getCenterID(): CenterID
     {
-        return $this->candidateInfo["RegistrationCenterID"];
+        return $this->data->getRegistrationCenterID();
     }
 
     /**
@@ -905,20 +943,15 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         }
 
         // If we can't access due the registration, check if we
-        // have access to any sites. If we have access to a site,
-        // we need to be able to access the candidate to get to it.
-        $timepoints = $this->getListOfTimePoints();
-        foreach ($timepoints as $sessionID) {
-            $timepoint = \TimePoint::singleton(
-                new \SessionID(strval($sessionID))
-            );
-
+        // have access to any timepoints.
+        foreach ($this->data->getTimePoints() as $timepoint) {
             if ($timepoint->isAccessibleBy($user)) {
-                // There's at least one, we don't need to check
-                // any more.
                 return true;
             }
         }
+
+        // No Registration Project/Center match and no accessible
+        // timepoints, so no access.
         return false;
     }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -411,7 +411,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             function ($timepoint) {
                 return intval($timepoint->getSessionID());
             },
-            $this->data->getTimePoints(),
+            $this->data->timepoints,
         );
     }
 
@@ -425,7 +425,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getSessionID(int $visitNo): ?int
     {
-        $timepoints = $this->data->getTimePoints();
+        $timepoints = $this->data->timepoints;
         if (isset($timepoints[$visitNo-1]) ) {
             return intval($timepoints[$visitNo-1]);
         }
@@ -945,7 +945,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         // If we can't access due the registration, check if we
         // have access to any timepoints.
-        foreach ($this->data->getTimePoints() as $timepoint) {
+        foreach ($this->data->timepoints as $timepoint) {
             if ($timepoint->isAccessibleBy($user)) {
                 return true;
             }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -491,7 +491,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getProjectID(): \ProjectID
     {
-        return $this->data->getRegistrationProjectID();
+        return $this->data->registrationProjectID;
     }
 
     /**
@@ -545,7 +545,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getCenterID(): CenterID
     {
-        return $this->data->getRegistrationCenterID();
+        return $this->data->registrationCenterID;
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -213,6 +213,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         }
 
         $this->data = new CandidateData(
+            $candID,
             $registrationProjectID,
             new \CenterID($registrationCenterID),
             $timepoints,

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -205,9 +205,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         foreach ($row as $value) {
             $timepoints[] = new TimePoint(
                 new TimePointData(
-                    new SessionID($value["ID"]),
-                    new ProjectID($value["ProjectID"]),
-                    new CenterID($value["CenterID"]),
+                    new SessionID(strval($value["ID"])),
+                    new ProjectID(strval($value["ProjectID"])),
+                    new CenterID(strval($value["CenterID"])),
                 )
             );
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -113,16 +113,14 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         // We need to refer to these when instantiating the CandidateData
         // object after Timepoints have been selected, but by then $row
-        // will have been overwritten, so put them in other variables..
-        $registrationProjectID = new \ProjectID($row['RegistrationProjectID']);
-        $registrationCenterID  = $row['RegistrationCenterID'];
+        // will have been overwritten, so put them in other variables.
+        // Initialize them to null, they should get set in the foreach loop.
+        $registrationProjectID = null;
+        $registrationCenterID  = null;
 
         // store user data in object property
         foreach ($row as $key=>$value) {
             switch ($key) {
-            case 'RegistrationProjectID':
-            case 'RegistrationCenterID':
-                break;
             case 'Sex':
                 $this->candidateInfo[$key] = empty($value) ? null : new Sex($value);
                 break;
@@ -130,10 +128,12 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
             case 'RegistrationProjectID':
-                $this->candidateInfo[$key] = new \ProjectID($value);
+                $registrationProjectID     = new \ProjectID($value);
+                $this->candidateInfo[$key] = $registrationProjectID;
                 break;
             case 'RegistrationCenterID':
-                $this->candidateInfo[$key] = new \CenterID($value);
+                $registrationCenterID      = new \CenterID($value);
+                $this->candidateInfo[$key] = $registrationCenterID;
                 break;
             default:
                 $this->candidateInfo[$key] = $value;
@@ -215,7 +215,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $this->data = new CandidateData(
             $candID,
             $registrationProjectID,
-            new \CenterID($registrationCenterID),
+            $registrationCenterID,
             $timepoints,
         );
         $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
@@ -409,7 +409,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
     {
         return array_map(
             function ($timepoint) {
-                return intval($timepoint->getSessionID());
+                return intval(
+                    strval($timepoint->getSessionID())
+                );
             },
             $this->data->timepoints,
         );
@@ -427,7 +429,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
     {
         $timepoints = $this->data->timepoints;
         if (isset($timepoints[$visitNo-1]) ) {
-            return intval($timepoints[$visitNo-1]);
+            return intval(
+                strval($timepoints[$visitNo-1]->getSessionID())
+            );
         }
 
         return null;

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+use LORIS\StudyEntities\Candidate\CandID;
 /**
  * A CandidateData object is a DTO (data transfer object) to
  * store a representation of data associated with a Candidate
@@ -24,6 +25,7 @@
  */
 class CandidateData
 {
+    public CandID $CandID;
     public \ProjectID $registrationProjectID;
     public \CenterID $registrationCenterID;
 
@@ -32,26 +34,35 @@ class CandidateData
     /**
      * Construct a CandidateData object
      *
-     * @param ?\ProjectID  $projectID  The RegistrationProjectID
-     * @param ?\CenterID   $centerID   The RegistrationCenterID
-     * @param ?TimePoint[] $timepoints TimePoint objects for each visit of the
-     *                                 candidate
+     * @param ?CandID      $candID                The CandID for this candidate
+     * @param ?\ProjectID  $registrationProjectID The RegistrationProjectID
+     * @param ?\CenterID   $registrationCenterID  The RegistrationCenterID
+     * @param ?TimePoint[] $timepoints            TimePoint objects for each
+     *                                            visit of the candidate
      */
     public function __construct(
-        ?\ProjectID $registrationProjectID,
-        ?\CenterID $registrationCenterID,
-        ?array $timepoints,
+        ?CandID $candID=null,
+        ?\ProjectID $registrationProjectID=null,
+        ?\CenterID $registrationCenterID=null,
+        ?array $timepoints=null,
     ) {
+        if ($candID !== null) {
+            $this->CandID = $candID;
+        }
+
         if ($projectID !== null) {
             $this->registrationProjectID = $projectID;
         }
         if ($registrationCenterID !== null) {
-            $this->registrationCenterID  = $registrationCenterID;
+            $this->registrationCenterID = $registrationCenterID;
         }
         if ($this->timepoints !== null) {
             foreach ($timepoints as $timepoint) {
                 if (!($timepoint instanceof \TimePoint)) {
-                    throw new \DomainException("CandidateData timepoints must contain TimePoint classes");
+                    throw new \DomainException(
+                        "CandidateData timepoints must contain TimePoint "
+                        . "classes"
+                    );
                 }
             }
             $this->timepoints = $timepoints;

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -51,7 +51,7 @@ class CandidateData
         if ($this->timepoints !== null) {
             foreach ($timepoints as $timepoint) {
                 if (!($timepoint instanceof \TimePoint)) {
-                    throw new \DomainException("\Timepoints must contain TimePoint classes");
+                    throw new \DomainException("CandidateData timepoints must contain TimePoint classes");
                 }
             }
             $this->timepoints = $timepoints;

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -49,6 +49,11 @@ class CandidateData
             $this->registrationCenterID  = $registrationCenterID;
         }
         if ($this->timepoints !== null) {
+            foreach ($timepoints as $timepoint) {
+                if (!($timepoint instanceof \TimePoint)) {
+                    throw new \DomainException("\Timepoints must contain TimePoint classes");
+                }
+            }
             $this->timepoints = $timepoints;
         }
 

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -50,13 +50,13 @@ class CandidateData
             $this->CandID = $candID;
         }
 
-        if ($projectID !== null) {
-            $this->registrationProjectID = $projectID;
+        if ($registrationProjectID !== null) {
+            $this->registrationProjectID = $registrationProjectID;
         }
         if ($registrationCenterID !== null) {
             $this->registrationCenterID = $registrationCenterID;
         }
-        if ($this->timepoints !== null) {
+        if ($timepoints !== null) {
             foreach ($timepoints as $timepoint) {
                 if (!($timepoint instanceof \TimePoint)) {
                     throw new \DomainException(

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -24,9 +24,10 @@
  */
 class CandidateData
 {
-    protected $registrationProjectID;
-    protected $registrationCenterID;
-    protected $timepoints;
+    public \ProjectID $registrationProjectID;
+    public \CenterID $registrationCenterID;
+
+    public array $timepoints;
 
     /**
      * Construct a CandidateData object
@@ -37,52 +38,20 @@ class CandidateData
      *                                 candidate
      */
     public function __construct(
-        ?\ProjectID $projectID,
-        ?\CenterID $centerID,
+        ?\ProjectID $registrationProjectID,
+        ?\CenterID $registrationCenterID,
         ?array $timepoints,
     ) {
-        $this->registrationProjectID = $projectID;
-        $this->registrationCenterID  = $centerID;
-
-        $this->timepoints = $timepoints;
-    }
-
-    /**
-     * Get the RegistrationCenterID for this candidate.
-     *
-     * @return \CenterID
-     */
-    public function getRegistrationCenterID() : \CenterID
-    {
-        if ($this->registrationCenterID === null) {
-            throw new LogicException("CenterID not loaded in data");
+        if ($projectID !== null) {
+            $this->registrationProjectID = $projectID;
         }
-        return $this->registrationCenterID;
+        if ($registrationCenterID !== null) {
+            $this->registrationCenterID  = $registrationCenterID;
+        }
+        if ($this->timepoints !== null) {
+            $this->timepoints = $timepoints;
+        }
+
     }
 
-    /**
-     * Get the RegistrationProjectID for this candidate.
-     *
-     * @return \ProjectID
-     */
-    public function getRegistrationProjectID() : \ProjectID
-    {
-        if ($this->registrationProjectID === null) {
-            throw new LogicException("ProjectID not loaded in data");
-        }
-        return $this->registrationProjectID;
-    }
-
-    /**
-     * Get the timepoint objects for this candidate's visits
-     *
-     * @return TimePoint[]
-     */
-    public function getTimepoints() : array
-    {
-        if ($this->timepoints === null) {
-            throw new LogicException("Timepoints not instantiated");
-        }
-        return $this->timepoints;
-    }
 }

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -31,17 +31,17 @@ class CandidateData
     /**
      * Construct a CandidateData object
      *
-     * @param ?\ProjectID  $project    The RegistrationProjectID
+     * @param ?\ProjectID  $projectID  The RegistrationProjectID
      * @param ?\CenterID   $centerID   The RegistrationCenterID
      * @param ?TimePoint[] $timepoints TimePoint objects for each visit of the
      *                                 candidate
      */
     public function __construct(
-        ?\ProjectID $project,
+        ?\ProjectID $projectID,
         ?\CenterID $centerID,
         ?array $timepoints,
     ) {
-        $this->registrationProjectID = $project;
+        $this->registrationProjectID = $projectID;
         $this->registrationCenterID  = $centerID;
 
         $this->timepoints = $timepoints;

--- a/php/libraries/CandidateData.class.inc
+++ b/php/libraries/CandidateData.class.inc
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+/**
+ * A CandidateData object is a DTO (data transfer object) to
+ * store a representation of data associated with a Candidate
+ * object in LORIS.
+ *
+ * The CandidateData may be partially loaded, in which case any
+ * getter trying to access an unknown will throw an exception.
+ * This allows modules to only load relevant data in a query,
+ * and avoid the overhead of the Candidate::singleton() constructor.
+ *
+ * For instance, a query that selected CenterID and ProjectID and
+ * timepoint related information:
+ * the database could instantiate a Candidate as:
+ *    $visit = new Candidate(new CandidateData($projectid, $centerid, $timepoints));
+ *
+ * with data loaded from the query, and then call
+ * `$candidate->isAccessibleBy($user)` without having to load all the
+ * other data that Candidate::singleton() does. If an attempt is
+ * made to access a property not in the DTO, an exception is thrown,
+ * rather than silently returning the incorrect value.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class CandidateData
+{
+    protected $registrationProjectID;
+    protected $registrationCenterID;
+    protected $timepoints;
+
+    /**
+     * Construct a CandidateData object
+     *
+     * @param ?\ProjectID  $project    The RegistrationProjectID
+     * @param ?\CenterID   $centerID   The RegistrationCenterID
+     * @param ?TimePoint[] $timepoints TimePoint objects for each visit of the
+     *                                 candidate
+     */
+    public function __construct(
+        ?\ProjectID $project,
+        ?\CenterID $centerID,
+        ?array $timepoints,
+    ) {
+        $this->registrationProjectID = $project;
+        $this->registrationCenterID  = $centerID;
+
+        $this->timepoints = $timepoints;
+    }
+
+    /**
+     * Get the RegistrationCenterID for this candidate.
+     *
+     * @return \CenterID
+     */
+    public function getRegistrationCenterID() : \CenterID
+    {
+        if ($this->registrationCenterID === null) {
+            throw new LogicException("CenterID not loaded in data");
+        }
+        return $this->registrationCenterID;
+    }
+
+    /**
+     * Get the RegistrationProjectID for this candidate.
+     *
+     * @return \ProjectID
+     */
+    public function getRegistrationProjectID() : \ProjectID
+    {
+        if ($this->registrationProjectID === null) {
+            throw new LogicException("ProjectID not loaded in data");
+        }
+        return $this->registrationProjectID;
+    }
+
+    /**
+     * Get the timepoint objects for this candidate's visits
+     *
+     * @return TimePoint[]
+     */
+    public function getTimepoints() : array
+    {
+        if ($this->timepoints === null) {
+            throw new LogicException("Timepoints not instantiated");
+        }
+        return $this->timepoints;
+    }
+}

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -189,7 +189,20 @@ class CandidateTest extends TestCase
         //$this->_setUpTestDoublesForSelectCandidate();
         $this->_dbMock
             ->method('pselect')
-            ->willReturn([["ID" => 97],["ID"=>98]]);
+            ->willReturn(
+                [
+                    [
+                        "ID"        => 97,
+                        "ProjectID" => 1,
+                        "CenterID"  => 2,
+                    ],
+                    [
+                        "ID"        => 98,
+                        "ProjectID" => 1,
+                        "CenterID"  => 2,
+                    ]
+                ]
+            );
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
@@ -831,9 +844,42 @@ class CandidateTest extends TestCase
             ->method('pselect')
             ->will(
                 $this->onConsecutiveCalls(
-                    $this->_listOfTimePoints,
-                    [["ID" => 97],["ID"=>98]],
-                    $this->_listOfTimePoints
+                    [
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        =>98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
+                    ],
+                    [
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        =>98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
+                    ],
+                    [
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        =>98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
+                    ],
                 )
             );
 
@@ -1303,7 +1349,18 @@ class CandidateTest extends TestCase
             ->method('pselect')
             ->will(
                 $this->onConsecutiveCalls(
-                    [["ID" => 97],["ID"=>98]],
+                    [
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        =>98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
+                    ],
                     $this->_listOfTimePoints
                 )
             );


### PR DESCRIPTION
This adds a CandidateData DTO object which mirrors the TimepointData which already exists. It is the Candidate equivalent of PR#7432.

A CandidateData object is a DTO (data transfer object) to
store a representation of data associated with a Candidate
object in LORIS.

The CandidateData may be partially loaded, in which case any
getter trying to access an unknown will throw an exception.
This allows modules to only load relevant data in a query,
and avoid the overhead of the Candidate::singleton() constructor.