### PR TITLE
QueryEngine interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ changes in the following format: PR #1234***
 ## LORIS 25.0 (Release Date: ????-??-??)
 ### Core
 #### Features
-- placeholder 
+- Added new interface intended to be used for querying module data from PHP (PR #8215) 
 
 #### Updates and Improvements
 - Rename subproject to Cohort (PR #7817)
@@ -70,7 +70,6 @@ changes in the following format: PR #1234***
 ### Modules
 #### API
 - Ability to use PSCID instead of the CandID in the candidates API (PR #8138)
-
 
 ## LORIS 24.0 (Release Date: 2022-03-24)
 ### Core

--- a/src/Data/Query/Criteria.php
+++ b/src/Data/Query/Criteria.php
@@ -1,0 +1,16 @@
+<?php
+namespace LORIS\Data\Query;
+
+/**
+ * A Criteria represents a comparison to compare a data dictionary
+ * against for the purposes of querying.
+ *
+ * Generally, the operator is defined by the class type and the
+ * the value by getValue().
+ */
+interface Criteria {
+    /**
+     * Get the value of the comparison.
+     */
+    public function getValue();
+}

--- a/src/Data/Query/Criteria.php
+++ b/src/Data/Query/Criteria.php
@@ -8,7 +8,8 @@ namespace LORIS\Data\Query;
  * Generally, the operator is defined by the class type and the
  * the value by getValue().
  */
-interface Criteria {
+interface Criteria
+{
     /**
      * Get the value of the comparison.
      */

--- a/src/Data/Query/Criteria/EndsWith.php
+++ b/src/Data/Query/Criteria/EndsWith.php
@@ -6,16 +6,19 @@ namespace LORIS\Data\Query\Criteria;
  * An EndsWith criteria represents a search for values that
  * the string representation of ends with a certain value.
  */
-class EndsWith implements \LORIS\Data\Query\Criteria {
+class EndsWith implements \LORIS\Data\Query\Criteria
+{
     /**
      * Construct an EndsWith criteria
      *
      * @param mixed $suffix The suffix that values must end with
      */
-    public function __construct(private $suffix) {
+    public function __construct(private $suffix)
+    {
     }
 
-    public function getValue() {
+    public function getValue()
+    {
         return $this->suffix;
     }
 }

--- a/src/Data/Query/Criteria/EndsWith.php
+++ b/src/Data/Query/Criteria/EndsWith.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * An EndsWith criteria represents a search for values that
+ * the string representation of ends with a certain value.
+ */
+class EndsWith implements \LORIS\Data\Query\Criteria {
+    /**
+     * Construct an EndsWith criteria
+     *
+     * @param mixed $suffix The suffix that values must end with
+     */
+    public function __construct(private $suffix) {
+    }
+
+    public function getValue() {
+        return $this->suffix;
+    }
+}

--- a/src/Data/Query/Criteria/Equal.php
+++ b/src/Data/Query/Criteria/Equal.php
@@ -1,0 +1,23 @@
+<?php
+namespace LORIS\Data\Query\Criteria;
+use LORIS\Data\Query\Criteria;
+
+/**
+ * An Equal criteria matches data which equals a given
+ * value.
+ */
+class Equal implements Criteria {
+    /**
+     * Construct an Equal criteria.
+     *
+     * @param mixed $value The value that must be equal
+     */
+    public function __construct(private $value) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue() {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/Equal.php
+++ b/src/Data/Query/Criteria/Equal.php
@@ -1,23 +1,28 @@
 <?php
 namespace LORIS\Data\Query\Criteria;
+
 use LORIS\Data\Query\Criteria;
 
 /**
  * An Equal criteria matches data which equals a given
  * value.
  */
-class Equal implements Criteria {
+class Equal implements Criteria
+{
     /**
      * Construct an Equal criteria.
      *
      * @param mixed $value The value that must be equal
      */
-    public function __construct(private $value) {}
+    public function __construct(private $value)
+    {
+    }
 
     /**
      * {@inheritDoc}
      */
-    public function getValue() {
+    public function getValue()
+    {
         return $this->value;
     }
 }

--- a/src/Data/Query/Criteria/GreaterThan.php
+++ b/src/Data/Query/Criteria/GreaterThan.php
@@ -1,0 +1,26 @@
+<?php
+namespace LORIS\Data\Query\Criteria;
+
+use LORIS\Data\Query\Criteria;
+
+/**
+ * A GreaterThan Criteria specifies that an item must be strictly
+ * > a given value.
+ */
+class GreaterThan implements Criteria
+{
+    /**
+     * Construct a GreaterThan comparison
+     */
+    public function __construct(protected $value)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/GreaterThanOrEqual.php
+++ b/src/Data/Query/Criteria/GreaterThanOrEqual.php
@@ -1,0 +1,26 @@
+<?php
+namespace LORIS\Data\Query\Criteria;
+
+use LORIS\Data\Query\Criteria;
+
+/**
+ * A GreaterThanOrEqual criteria denotes a criteria that must
+ * be >= a given value.
+ */
+class GreaterThanOrEqual implements Criteria
+{
+    /**
+     * Constructor
+     */
+    public function __construct(protected $value)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/In.php
+++ b/src/Data/Query/Criteria/In.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * In represents a criteria specifying that the value must be
+ * in a given set of choices.
+ */
+class In implements \LORIS\Data\Query\Criteria
+{
+    protected array $val;
+
+    /**
+     * Construct an In criteria.
+     *
+     * @param $val The set that the value must be in.
+     */
+    public function __construct(...$val)
+    {
+        $this->val = $val;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->val;
+    }
+}

--- a/src/Data/Query/Criteria/IsNull.php
+++ b/src/Data/Query/Criteria/IsNull.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * Criteria to compare if a value is null
+ */
+class IsNull implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Stub to implement Criteria interface
+     */
+    public function getValue()
+    {
+        return null;
+    }
+}

--- a/src/Data/Query/Criteria/LessThan.php
+++ b/src/Data/Query/Criteria/LessThan.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * Criteria to specify that a given item must be strictly <
+ * a comparison value.
+ */
+class LessThan implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Constructor
+     */
+    public function __construct(protected $value)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/LessThanOrEqual.php
+++ b/src/Data/Query/Criteria/LessThanOrEqual.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * A Criteria to determine that a DictionaryItem must be <= a
+ * given value
+ */
+class LessThanOrEqual implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Constructor
+     *
+     * @param mixed $value The comparison value
+     */
+    public function __construct(protected $value)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/NotEqual.php
+++ b/src/Data/Query/Criteria/NotEqual.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+use LORIS\Data\Query\Criteria;
+
+/**
+ * A NotEqual Criteria specifies that the value should be compared
+ * against not being a given value.
+ */
+class NotEqual implements Criteria
+{
+    /**
+     * Construct a NotEqual criteria
+     */
+    public function __construct(protected $value)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/Query/Criteria/NotNull.php
+++ b/src/Data/Query/Criteria/NotNull.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * A Criteria to specify querying for items that must not be
+ * null
+ */
+class NotNull implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Stub to implement Criteria interface
+     */
+    public function getValue()
+    {
+        return null;
+    }
+}

--- a/src/Data/Query/Criteria/StartsWith.php
+++ b/src/Data/Query/Criteria/StartsWith.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * A Criteria to specify that the string serialization must
+ * start with a given prefix.
+ */
+class StartsWith implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Construct a StartsWith
+     */
+    public function __construct(protected $prefix)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->prefix;
+    }
+}

--- a/src/Data/Query/Criteria/Substring.php
+++ b/src/Data/Query/Criteria/Substring.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LORIS\Data\Query\Criteria;
+
+/**
+ * Criteria to specify that the string serialization of a
+ * value must contain a substring.
+ */
+class Substring implements \LORIS\Data\Query\Criteria
+{
+    /**
+     * Construct a Substring criteria
+     *
+     * @param string $substr The substring that must be contained in
+     *                       the value
+     */
+    public function __construct(protected $substr)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue()
+    {
+        return $this->substr;
+    }
+}

--- a/src/Data/Query/QueryEngine.php
+++ b/src/Data/Query/QueryEngine.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+namespace LORIS\Data\Query;
+/**
+ * A QueryEngine is an entity which represents a set of data and
+ * the ability to query against them.
+ *
+ * Queries are divided into 2 phases, filtering the data down to
+ * a set of CandIDs, and retrieving the data for a known set of
+ * CandID/SessionIDs.
+ *
+ * There is usually one query engine per module that deals with
+ * candidate data.
+ */
+interface QueryEngine {
+    /**
+     * Return a data dictionary of data types managed by this QueryEngine.
+     * DictionaryItems are grouped into categories and an engine may know
+     * about 0 or more categories of DictionaryItems.
+     *
+     * @return \LORIS\Data\Dictionary\Category[]
+     */
+    public function getDataDictionary() : iterable;
+
+    /**
+     * Return an iterable of CandIDs matching the given criteria.
+     *
+     * If visitlist is provided, session scoped variables will match
+     * if the criteria is met for at least one of those visit labels.
+     */
+    public function getCandidateMatches(QueryTerm $criteria, ?array $visitlist=null) : iterable;
+
+    /**
+     * Retrieve the data for a given list of DictionaryItems from this
+     * engine's data dictionary and a given list of CandIDs.
+     *
+     * If visits is declared, only include data for those visits labels.
+     *
+     * @param DictionaryItem[] $items Data points to retrieve
+     * @param CandID[] $candidates    Candidates to retrieve data for
+     * @param ?string[] $visits       Visit labels to restrict data to
+     *
+     * @return DataInstance[]
+     */
+    public function getCandidateData(array $items, iterable $candidates, ?array $visitlist) : iterable;
+
+    /**
+     * Get the list of visits at which a DictionaryItem is valid
+     *
+     * @return string[]
+     */
+    public function getVisitList(\LORIS\Data\Dictionary\Category $inst, \LORIS\Data\Dictionary\DictionaryItem $item) : iterable;
+}

--- a/src/Data/Query/QueryEngine.php
+++ b/src/Data/Query/QueryEngine.php
@@ -1,5 +1,10 @@
 <?php declare(strict_types=1);
 namespace LORIS\Data\Query;
+
+use \LORIS\StudyEntities\Candidate\CandID;
+use \LORIS\Data\Dictionary\DictionaryItem;
+use \LORIS\Data\DataInstance;
+
 /**
  * A QueryEngine is an entity which represents a set of data and
  * the ability to query against them.
@@ -11,7 +16,8 @@ namespace LORIS\Data\Query;
  * There is usually one query engine per module that deals with
  * candidate data.
  */
-interface QueryEngine {
+interface QueryEngine
+{
     /**
      * Return a data dictionary of data types managed by this QueryEngine.
      * DictionaryItems are grouped into categories and an engine may know
@@ -27,7 +33,10 @@ interface QueryEngine {
      * If visitlist is provided, session scoped variables will match
      * if the criteria is met for at least one of those visit labels.
      */
-    public function getCandidateMatches(QueryTerm $criteria, ?array $visitlist=null) : iterable;
+    public function getCandidateMatches(
+        QueryTerm $criteria,
+        ?array $visitlist = null
+    ) : iterable;
 
     /**
      * Retrieve the data for a given list of DictionaryItems from this
@@ -48,5 +57,8 @@ interface QueryEngine {
      *
      * @return string[]
      */
-    public function getVisitList(\LORIS\Data\Dictionary\Category $inst, \LORIS\Data\Dictionary\DictionaryItem $item) : iterable;
+    public function getVisitList(
+        \LORIS\Data\Dictionary\Category $inst,
+        \LORIS\Data\Dictionary\DictionaryItem $item
+    ) : iterable;
 }

--- a/src/Data/Query/QueryTerm.php
+++ b/src/Data/Query/QueryTerm.php
@@ -1,0 +1,21 @@
+<?php
+namespace LORIS\Data\Query;
+use LORIS\Data\Dictionary\DictionaryItem;
+
+/**
+ * A QueryTerm represents a single criteria used as part of a query
+ * For instance "age < 5"
+ */
+class QueryTerm {
+    /**
+     * Construct a query term.
+     *
+     * @param DictionaryItem $dictionary The term being compared.
+     * @param Criteria       $criteria   The criteria to compare the
+     *                                   term against.
+     */
+    function __construct(
+        public \LORIS\Data\Dictionary\DictionaryItem $dictionary,
+        public Criteria $criteria) {
+    }
+}

--- a/src/Data/Query/QueryTerm.php
+++ b/src/Data/Query/QueryTerm.php
@@ -1,12 +1,14 @@
 <?php
 namespace LORIS\Data\Query;
+
 use LORIS\Data\Dictionary\DictionaryItem;
 
 /**
  * A QueryTerm represents a single criteria used as part of a query
  * For instance "age < 5"
  */
-class QueryTerm {
+class QueryTerm
+{
     /**
      * Construct a query term.
      *
@@ -14,8 +16,9 @@ class QueryTerm {
      * @param Criteria       $criteria   The criteria to compare the
      *                                   term against.
      */
-    function __construct(
+    public function __construct(
         public \LORIS\Data\Dictionary\DictionaryItem $dictionary,
-        public Criteria $criteria) {
+        public Criteria $criteria
+    ) {
     }
 }


### PR DESCRIPTION
This defines the QueryEngine interface that I've been using to build a new, CouchDB-free DQT as well as used to create a new candidates module. It's stable enough that I'm confident it will require little modification now.

```

/**
 * A QueryEngine is an entity which represents a set of data and
 * the ability to query against them.
 *
 * Queries are divided into 2 phases, filtering the data down to
 * a set of CandIDs, and retrieving the data for a known set of
 * CandID/SessionIDs.
 *
 * There is usually one query engine per module that deals with
 * candidate data.
 */
```

After this is merged, the QueryEngine()->getDataDictionary() for a module will replace the getDataDictionary() method that currently exists and I'll begin sending individual engines as they're completed and well tested. (I currently have instruments, candidate parameters, imaging, and bvl feedback that I've been using for the DQT but the latter two still need significant testing and refactoring.)

Other than the `QueryEngine` interface, the rest of the classes in this PR are classes that the interface depends on (ie are used by the interface.)