### PR TITLE
[LorisInstance] add getModule function

### DIFF
--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -106,7 +106,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         $module = new \NullModule($this->lorisinstance);
         if (!empty($mname)) {
             if (!isset($modules[$mname])) {
-                $modules[$mname] = \Module::factory($this->lorisinstance, $mname);
+                $modules[$mname] = $this->lorisinstance->getModule($mname);
             }
             $module = &$modules[$mname];
         }

--- a/modules/module_manager/php/modulerow.class.inc
+++ b/modules/module_manager/php/modulerow.class.inc
@@ -46,7 +46,7 @@ class ModuleRow implements \LORIS\Data\DataInstance
     public function __construct(\LORIS\LorisInstance $loris, array $row)
     {
         $this->lorisinstance = $loris;
-        $this->Module        = \Module::factory($loris, $row['name']);
+        $this->Module        = $loris->getModule($row['name']);
         $this->Active        = $row['active'];
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -253,7 +253,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 // since it isn't a real module, but it's required for the page
                 // constructor.
                 $loris,
-                Module::factory($loris, "instruments"),
+                $loris->getModule("instruments"),
                 $page,
                 $commentID,
                 $commentID,
@@ -272,7 +272,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             // Now go ahead and instantiate it
             $obj = new $class(
                 $loris,
-                Module::factory($loris, "instruments"),
+                $loris->getModule("instruments"),
                 $page,
                 $commentID,
                 $commentID,

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -76,7 +76,7 @@ class LorisInstance
         $modules = [];
         foreach ($mnames as $name) {
             try {
-                $mod       = \Module::factory($this, $name);
+                $mod       = $this->getModule($name);
                 $modules[] = $mod;
             } catch (\LorisModuleMissingException $e) {
                 error_log($e->getMessage() . " " . $e->getTraceAsString());

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -76,7 +76,8 @@ class LorisInstance
         $modules = [];
         foreach ($mnames as $name) {
             try {
-                $modules[] = \Module::factory($this, $name);
+                $mod       = \Module::factory($this, $name);
+                $modules[] = $mod;
             } catch (\LorisModuleMissingException $e) {
                 error_log($e->getMessage() . " " . $e->getTraceAsString());
             }
@@ -114,6 +115,18 @@ class LorisInstance
             }
         }
         return false;
+    }
+
+    /**
+     * Get the \Module class for the module named $name,
+     * if enabled on this LORIS instance or throw an exception
+     * if it doesn't exist.
+     *
+     * @return \Module
+     */
+    public function getModule(string $name) : \Module
+    {
+        return \Module::factory($this, $name);
     }
 
     /**

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -120,7 +120,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $factory->setBaseURL($baseurl);
 
-            $module  = \Module::factory($this->lorisinstance, $modulename);
+            $module  = $this->lorisinstance->getModule($modulename);
             $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
             return $ehandler->process($request, $mr);
@@ -136,7 +136,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 $request = $request
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
-                $module  = \Module::factory($this->lorisinstance, "timepoint_list");
+                $module  = $this->lorisinstance->getModule("timepoint_list");
                 $mr      = new ModuleRouter($module);
                 return $ehandler->process($request, $mr);
             }


### PR DESCRIPTION
LorisInstance already has functions to check if a module exists, get the module directories, etc.

This adds a getModule to replace \Module::factory() so that the code dealing with modules can be centralized in one place.