### PR TITLE
[Docs - LORIS installation] Updated installation instructions to reflect the requirement of PHP 8.0+

### DIFF
--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -12,7 +12,7 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
 * MariaDB 10.3 is supported for LORIS 24.
 
-* PHP 7.4 (or higher) is supported for LORIS 24.
+* PHP 8.0 (or higher) is supported for LORIS 24.
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher  
@@ -31,17 +31,17 @@ sudo yum install httpd
 sudo systemctl enable httpd
 sudo systemctl start httpd
 ```
-## PHP 7.4
+## PHP 8.0
 ```bash
 sudo yum install epel-release
-sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+sudo yum install http://rpms.remirepo.net/enterprise/remi-release-8.rpm
 sudo yum install yum-utils
 sudo yum update
 
 # By default, the repository for PHP 5.4 is enabled
 # Make sure to have only one repository for PHP enabled
 sudo yum-config-manager --disable remi-php54
-sudo yum-config-manager --enable remi-php74
+sudo yum-config-manager --enable remi-php80
 sudo yum install php php-pdo php-pdo_mysql php-fpm php-gd php-json php-mbstring php-mysqlnd php-xml php-xmlrpc php-opcache
 ```
 ## MariaDB

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -18,7 +18,7 @@ LORIS requires a LAMP stack in order to run, specifically:
 
 * MySQL 5.7 (or MariaDB 10.3) (or higher)  
 
-* PHP 7.4 (or higher)
+* PHP 8.0 (or higher)
 
 Additionally, the following package manager are required to build LORIS:  
 
@@ -46,19 +46,19 @@ The following Ubuntu packages are required and should be installed using
 
 * software-properties-common  
 
-* php7.4-mysql  
+* php8.0-mysql  
 
-* php7.4-xml  
+* php8.0-xml  
 
-* php7.4-mbstring  
+* php8.0-mbstring  
 
-* php7.4-gd  
+* php8.0-gd  
 
-* php7.4-zip  
+* php8.0-zip  
 
-* php7.4-curl (for development instances only)  
+* php8.0-curl (for development instances only)  
 
-* libapache2-mod-php7.4  
+* libapache2-mod-php8.0  
 
 
 ## Creating the lorisadmin user
@@ -80,8 +80,9 @@ sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
+projectname='loris'
 sudo mkdir -m 755 -p /var/www/$projectname
-sudo chown lorisadmin.lorisadmin /var/www/$projectname
+sudo chown lorisadmin:lorisadmin /var/www/$projectname
 su - lorisadmin
 ```
 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -80,7 +80,6 @@ sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
-projectname='loris'
 sudo mkdir -m 755 -p /var/www/$projectname
 sudo chown lorisadmin:lorisadmin /var/www/$projectname
 su - lorisadmin

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -80,7 +80,7 @@ sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
-sudo mkdir -m 755 -p /var/www/$projectname
+sudo mkdir -m 755 -p /var/www/loris
 sudo chown lorisadmin:lorisadmin /var/www/$projectname
 su - lorisadmin
 ```

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -81,7 +81,7 @@ sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
 sudo mkdir -m 755 -p /var/www/loris
-sudo chown lorisadmin:lorisadmin /var/www/$projectname
+sudo chown lorisadmin:lorisadmin /var/www/loris
 su - lorisadmin
 ```
 


### PR DESCRIPTION
## Brief summary of changes

- Modified the instructions to include the correct PHP library versions required for both Ubuntu and CentOS.
- Added the missing variable assignment to the section titled: 'Creating the lorisadmin user'.
- Changed an argument of the chown command in 'Creating the lorisadmin user' to prevent unwanted side-effects of creating a user with a period in its name.

#### Link(s) to related issue(s)

Resolves #8220 
