### PR TITLE
[SQL] Make release patch compatible with mariadb 10.3

### DIFF
--- a/SQL/Archive/24.1/2022-08-10-add_PhaseEncodingDirection_and_EchoNumber_to_files_and_mri_qc_tables.sql
+++ b/SQL/Archive/24.1/2022-08-10-add_PhaseEncodingDirection_and_EchoNumber_to_files_and_mri_qc_tables.sql
@@ -27,4 +27,5 @@ ALTER TABLE mri_violations_log ADD COLUMN `EchoNumber`             VARCHAR(20) D
 -- ---------------------------------------------------------------------------------------------
 INSERT INTO parameter_type (Name, Type, Description, SourceFrom)
 SELECT 'PhaseEncodingDirection', 'text', 'BIDS PhaseEncodingDirection (a.k.a. i, i-, j, j-, k, k-)', 'parameter_file'
+FROM DUAL
 WHERE NOT EXISTS (SELECT * FROM parameter_type where Name='PhaseEncodingDirection');

--- a/SQL/Release_patches/24.0_To_24.1_upgrade.sql
+++ b/SQL/Release_patches/24.0_To_24.1_upgrade.sql
@@ -44,6 +44,7 @@ ALTER TABLE mri_violations_log ADD COLUMN `EchoNumber`             VARCHAR(20) D
 -- ---------------------------------------------------------------------------------------------
 INSERT INTO parameter_type (Name, Type, Description, SourceFrom)
 SELECT 'PhaseEncodingDirection', 'text', 'BIDS PhaseEncodingDirection (a.k.a. i, i-, j, j-, k, k-)', 'parameter_file'
+FROM DUAL
 WHERE NOT EXISTS (SELECT * FROM parameter_type where Name='PhaseEncodingDirection');
 
 -- ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
An error was reported where the query being modified returns an SQL error because of the missing `FROM` clause on mariaDB 10.3

This fix was taken from the MAriaDB official documentation to fix the issue https://mariadb.com/kb/en/dual/