### PR TITLE
[ESLint] Disable on prod instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: clean dev all check checkstatic unittests test phpdev javascript testdata
+.PHONY: clean dev all check checkstatic unittests phpdev jslatest testdata
 
-all: VERSION jsdev
+all: VERSION
+	npm ci
+	npm run build
 	composer install --no-dev
 
 # If anything changes, re-generate the VERSION file
@@ -10,7 +12,7 @@ VERSION: .
 phpdev:
 	composer install
 
-jsdev:
+dev: VERSION phpdev
 	npm ci
 	npm run compile
 
@@ -19,8 +21,6 @@ jslatest: clean
 	rm -rf modules/electrophysiology_browser/jsx/react-series-data-viewer/package-lock.json
 	npm install
 	npm run compile
-
-dev: VERSION phpdev jsdev
 
 clean:
 	rm -f smarty/templates_c/*

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: clean dev all check checkstatic unittests phpdev jslatest testdata
 
 all: VERSION
+	composer install --no-dev
 	npm ci
 	npm run build
-	composer install --no-dev
 
 # If anything changes, re-generate the VERSION file
 VERSION: .

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "tests:unit:debug": "DEBUG=true ./test/dockerized-unit-tests.sh",
     "tests:integration": "./test/dockerized-integration-tests.sh",
     "tests:integration:debug": "DEBUG=true ./test/dockerized-integration-tests.sh",
-    "compile": "webpack",
+    "compile": "webpack --node-env=development",
+    "build": "webpack --node-env=production",
     "watch": "webpack --watch",
     "postinstall": "node npm-postinstall.js"
   },


### PR DESCRIPTION
Prevent ESLint to be run when make is run (prod instances) vs make dev (dev instance).

#### Note
make steps order were switched to solve a bug with `make clean && make` (thanks to @maltheism amazing testing skills). The post-install node script runs a tool that requires autoload.php to be generated so composer needs to be run first.