### PR TITLE
[Webpack] Viz status check fix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,7 @@ if (!fs.existsSync(
 ) {
   mod.rules.push({
     test: /react-series-data-viewer\/src\/chunks/,
+    exclude: /project/,
     use: 'null-loader',
   });
 }


### PR DESCRIPTION
To prevent a compilation error when protobuf is not installed, we check if the compiled protobuf file exists to turn 'ON' the visualization. Fix a bug that turns 'OFF' the viz when the EEG Browser is overridden in project/