### PR TITLE
[Tools] delete physiological files

### DIFF
--- a/tools/data_integrity/data_deletion/delete_candidate.php
+++ b/tools/data_integrity/data_deletion/delete_candidate.php
@@ -14,19 +14,13 @@
  *
  * @category Main
  * @package  Loris
- * @author   Various <example@example.com>
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
  * @license  Loris license
  * @link     https://www.github.com/aces/Loris/
  */
 
-set_include_path(
-    get_include_path().":".
-    __DIR__."/../project/tools:".
-    __DIR__."/../php/tools:"
-);
-
-require_once __DIR__ . "/../vendor/autoload.php";
-require_once "generic_includes.php";
+require_once __DIR__ . "/../../../vendor/autoload.php";
+require_once __DIR__ . "/../../generic_includes.php";
 use \LORIS\StudyEntities\Candidate\CandID;
 
 /**
@@ -82,7 +76,7 @@ default:
     break;
 }
 
-$DB =& Database::singleton();
+$DB = \NDB_Factory::singleton()->database();
 
 /*
  * Perform validations on arguments
@@ -135,7 +129,7 @@ function showHelp()
     echo <<<USAGE
 *** Delete Candidate Info ***
 
-Usage: php delete_candidate.php delete_candidate CandID PSCID [confirm]
+Usage: php delete_candidate.php delete_candidate CandID PSCID [confirm] [tosql]
 Example: php delete_candidate.php delete_candidate 965327 dcc0007
 Example: php delete_candidate.php delete_candidate 965327 dcc0007 confirm
 Example: php delete_candidate.php delete_candidate 965327 dcc0007 tosql
@@ -315,25 +309,25 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         $DB->delete("parameter_candidate", ["CandID" => $CandID]);
 
         //delete from SNP_candidate_rel
-        $result = $DB->delete("SNP_candidate_rel", ["CandID" => $CandID]);
+        $DB->delete("SNP_candidate_rel", ["CandID" => $CandID]);
 
         //delete from CNV
-        $result = $DB->delete("CNV", ["CandID" => $CandID]);
+        $DB->delete("CNV", ["CandID" => $CandID]);
 
         //delete from genomic_candidate_files_rel
-        $result = $DB->delete(
+        $DB->delete(
             "genomic_candidate_files_rel",
             ["CandID" => $CandID]
         );
 
         //delete from genomic_sample_candidate_rel
-        $result = $DB->delete(
+        $DB->delete(
             "genomic_sample_candidate_rel",
             ["CandID" => $CandID]
         );
 
         //delete from issues
-        $result = $DB->delete("issues", ["candID" => $CandID]);
+        $DB->delete("issues", ["candID" => $CandID]);
 
         //delete from candidate
         $DB->delete("candidate", ["CandID" => $CandID]);

--- a/tools/data_integrity/data_deletion/delete_ignored_conflicts.php
+++ b/tools/data_integrity/data_deletion/delete_ignored_conflicts.php
@@ -28,12 +28,16 @@
  * @package  Loris
  * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
  * @license  Loris license
- * @link     https://www.github.com/aces/Loris-Trunk/
+ * @link     https://www.github.com/aces/Loris/
  */
 
-set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+set_include_path(
+    get_include_path().":".
+    __DIR__."../../../project/libraries:" .
+    __DIR__."../../../php/libraries:"
+);
 
-require_once __DIR__ . "/../vendor/autoload.php";
+require_once __DIR__ . "/../../../vendor/autoload.php";
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
 $client->makeCommandLine();
@@ -131,18 +135,18 @@ function detectIgnoreColumns($instruments)
  */
 function defaultIgnoreColumns()
 {
-    $db =& Database::singleton();
+    $db = \NDB_Factory::singleton()->database();
 
     if ($this->confirm) {
         foreach ($this->defaultFields as $field) {
-            $defaultQuery = "DELETE FROM conflicts_unresolved 
+            $defaultQuery = "DELETE FROM conflicts_unresolved
                 WHERE FieldName = '$field'";
             $changes      = $db->run($defaultQuery);
             echo $changes . "\n";
         }
     } else {
         foreach ($this->defaultFields as $field) {
-            $defaultQuery  = "SELECT TableName, FieldName, Value1, Value2 
+            $defaultQuery  = "SELECT TableName, FieldName, Value1, Value2
           FROM conflicts_unresolved WHERE FieldName = '$field'";
             $defaultColumn = $db->pselectOne($defaultQuery, []);
             echo "TableName, FieldName, Value1, Value2: ";

--- a/tools/data_integrity/data_deletion/delete_physiological_file.php
+++ b/tools/data_integrity/data_deletion/delete_physiological_file.php
@@ -259,13 +259,13 @@ function deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, &$ou
             $files[] = $data_path . $annotations_archive['FilePath'];
         }
 
-        foreach ($chunks as $chunk) {
-            $files[] = $data_path . $chunk['FilePath'];
-        }
-
         foreach ($files as $file) {
             echo "Deleting $file\n";
-            //unlink($file);
+            unlink($file);
+        }
+
+        foreach ($chunks as $chunk) {
+            deleteDirectory(dirname($data_path . $chunk['FilePath']));
         }
 
         echo "\Deleting DB entries\n";
@@ -460,4 +460,35 @@ function _exportSQL($output, $physioFileID)
 if ($confirm === false && $printToSQL === false) {
     echo "\n\nRun this tool again with the argument 'confirm' or 'tosql' to ".
         "perform the changes or export them as an SQL patch\n\n";
+}
+
+/**
+ * Delete directory
+ *
+ * @param string $dir The directory to delete.
+ *
+ * @return void
+ */
+function deleteDirectory($dir)
+{
+    if (!file_exists($dir)) {
+        return true;
+    }
+
+    if (!is_dir($dir)) {
+        return unlink($dir);
+    }
+
+    foreach (scandir($dir) as $item) {
+        if ($item == '.' || $item == '..') {
+            continue;
+        }
+
+        if (!deleteDirectory($dir . DIRECTORY_SEPARATOR . $item)) {
+            return false;
+        }
+
+    }
+
+    return rmdir($dir);
 }

--- a/tools/data_integrity/data_deletion/delete_physiological_file.php
+++ b/tools/data_integrity/data_deletion/delete_physiological_file.php
@@ -189,15 +189,25 @@ function deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, &$ou
     );
     print_r($events);
 
-    echo "\nAnnotations\n";
+    echo "\nAnnotations Files\n";
     echo "----------------------------\n";
-    $annotations = $DB->pselect(
+    $annotations_files = $DB->pselect(
         'SELECT DISTINCT FilePath
         FROM physiological_annotation_file
         WHERE PhysiologicalFileID=:pfid',
         ['pfid' => $physioFileID]
     );
-    print_r($annotations);
+    print_r($annotations_files);
+
+    echo "\nAnnotations Archives";
+    echo "----------------------------\n";
+    $annotations_archives = $DB->pselect(
+        'SELECT DISTINCT FilePath
+        FROM physiological_annotation_archive
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($annotations_archives);
 
     echo "\nChunks\n";
     echo "----------------------------\n";
@@ -241,8 +251,12 @@ function deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, &$ou
             $files[] = $data_path . $event['FilePath'];
         }
 
-        foreach ($annotations as $annotation) {
-            $files[] = $data_path . $annotation['FilePath'];
+        foreach ($annotations_files as $annotation_file) {
+            $files[] = $data_path . $annotation_file['FilePath'];
+        }
+
+        foreach ($annotations_archives as $annotations_archive) {
+            $files[] = $data_path . $annotations_archive['FilePath'];
         }
 
         foreach ($chunks as $chunk) {
@@ -295,6 +309,12 @@ function deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, &$ou
         // delete from the physiological_annotation_file table
         $DB->delete(
             "physiological_annotation_file",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_annotation_archive table
+        $DB->delete(
+            "physiological_annotation_archive",
             ["PhysiologicalFileID" => $physioFileID]
         );
 

--- a/tools/data_integrity/data_deletion/delete_physiological_file.php
+++ b/tools/data_integrity/data_deletion/delete_physiological_file.php
@@ -1,0 +1,443 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This script deletes all the data associated with an EEG file
+ *
+ * Delete all table rows for a given EEG file
+ * "Usage: php delete_physiological_file.php PhysiologicalFileID";
+ * "Example: php delete_physiological_file.php 25";
+ *
+ * PHP Version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Various <example@example.com>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+require_once __DIR__ . "/../../../vendor/autoload.php";
+require_once __DIR__ . "/../../generic_includes.php";
+
+/**
+ * This script deletes the specified physiological file information.
+ *
+ * Delete all table rows for a given physiological file
+ * "Usage: php delete_physiological_file.php PhysiologicalFileID [confirm] [tosql]";
+ * "Example: php delete_physiological_file.php 25";
+ * "Example: php delete_physiological_file.php 25 confirm";
+ * "Example: php delete_physiological_file.php 25 tosql";
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+const MIN_NUMBER_OF_ARGS = 2;
+
+//define the command line parameters
+if (count($argv) < MIN_NUMBER_OF_ARGS
+    || $argv[1] == 'help'
+) {
+    showHelp();
+}
+
+// set default arguments
+$physioFileID = $argv[1];
+$confirm      = false;
+
+// SQL output
+$printToSQL = false;
+$output     = "";
+
+// get the rest of the arguments
+if (!empty($argv[2]) && $argv[2] == 'confirm') {
+    $confirm = true;
+} else if (!empty($argv[2]) && $argv[2] == 'tosql') {
+    $printToSQL = true;
+} else if (empty($argv[1])) {
+    showHelp();
+}
+
+$DB = \NDB_Factory::singleton()->database();
+
+/*
+ * Perform validations on arguments
+ */
+
+$fileExists = $DB->pselectOneInt(
+    "SELECT COUNT(*)
+      FROM `physiological_file`
+      WHERE PhysiologicalFileID = :pfid",
+    ['pfid' => $physioFileID]
+);
+if ($fileExists == 0) {
+    echo "\nThe physiological file with PhysiologicalFileID : $physioFileID does ".
+        "not exist in the database.\n\n";
+    die();
+}
+
+deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, $output);
+
+/**
+ * Prints the usage and example help text and stop program
+ *
+ * @return void
+ */
+function showHelp()
+{
+    echo <<<USAGE
+*** Delete Physiological File Info ***
+
+Usage: php delete_physiological_file.php PhysiologicalFileID [confirm] [tosql]
+Example: php delete_physiological_file.php 25
+Example: php delete_physiological_file.php 25 confirm
+Example: php delete_physiological_file.php 25 tosql
+
+When the 'tosql' function is used, the SQL file exported will be located
+under the following path:
+    loris_root/project/tables_sql/DELETE_PhysiologicalFile_physioFileID.sql
+USAGE;
+    die;
+}
+
+/**
+ * All tables with entries to be deleted with relations to `physiological_file`.
+ *
+ * @param int      $physioFileID Identifying the physiological file
+ * @param string   $confirm      Whether to execute the script
+ * @param string   $printToSQL   Whether to print the results
+ * @param Database $DB           The database to connect to
+ * @param string   $output       The string containing the statements to execute
+ *
+ * @return void
+ */
+function deletePhysiologicalFile($physioFileID, $confirm, $printToSQL, $DB, &$output)
+{
+
+    // Passing argument to delete session script
+    $outputType = "";
+    if ($printToSQL) {
+        $outputType ="tosql";
+    } elseif ($confirm) {
+        $outputType ="confirm";
+    }
+
+    echo "\nArchives\n";
+    echo "----------------------------\n";
+    $archives = $DB->pselect(
+        'SELECT FilePath, InsertTime
+        FROM physiological_archive
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($archives);
+
+    echo "\nPhysiological File\n";
+    echo "----------------------------\n";
+    $file = $DB->pselectRow(
+        'SELECT FilePath, OutputTypeName, SessionID
+        FROM physiological_file
+        JOIN `physiological_output_type` USING(PhysiologicalOutputTypeID)
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($file);
+
+    echo "\nPhysiological Metadata File\n";
+    echo "----------------------------\n";
+    $metadata_file = $DB->pselectRow(
+        'SELECT ppf.Value AS FilePath
+        FROM physiological_parameter_file as ppf
+        LEFT JOIN parameter_type as pt USING (ParameterTypeID)
+        WHERE PhysiologicalFileID=:pfid
+        AND pt.Name = "eegjson_file"',
+        ['pfid' => $physioFileID]
+    );
+    print_r($metadata_file);
+
+    echo "\nChannels\n";
+    echo "----------------------------\n";
+    $channels = $DB->pselect(
+        'SELECT DISTINCT FilePath
+        FROM physiological_channel
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($channels);
+
+    echo "\nElectrodes\n";
+    echo "----------------------------\n";
+    $electrodes = $DB->pselect(
+        'SELECT DISTINCT FilePath
+        FROM physiological_electrode
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($electrodes);
+
+    echo "\nEvents\n";
+    echo "----------------------------\n";
+    $events = $DB->pselect(
+        'SELECT DISTINCT FilePath
+        FROM physiological_task_event
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($events);
+
+    echo "\nAnnotations\n";
+    echo "----------------------------\n";
+    $annotations = $DB->pselect(
+        'SELECT DISTINCT FilePath
+        FROM physiological_annotation_file
+        WHERE PhysiologicalFileID=:pfid',
+        ['pfid' => $physioFileID]
+    );
+    print_r($annotations);
+
+    echo "\nChunks\n";
+    echo "----------------------------\n";
+    $chunks = $DB->pselect(
+        'SELECT ppf.Value AS FilePath
+        FROM physiological_parameter_file as ppf
+        LEFT JOIN parameter_type as pt USING (ParameterTypeID)
+        WHERE PhysiologicalFileID=:pfid
+        AND pt.Name = "electrophyiology_chunked_dataset_path"',
+        ['pfid' => $physioFileID]
+    );
+    print_r($chunks);
+
+    // IF CONFIRMED, DELETE ENTRIES AND FILES
+    if ($confirm) {
+        echo "\nDropping all DB entries and files on disk for physiological file: " .
+        $physioFileID . "\n";
+
+        echo "\nDeleting files\n";
+        echo "----------------------------\n";
+
+        $data_path = \NDB_Config::singleton()->getSetting("dataDirBasepath");
+
+        $files = [];
+        foreach ($archives as $archive) {
+            $files[] = $data_path . $archive['FilePath'];
+        }
+
+        $files[] = $data_path . $file['FilePath'];
+        $files[] = $data_path . $metadata_file['FilePath'];
+
+        foreach ($channels as $channel) {
+            $files[] = $data_path . $channel['FilePath'];
+        }
+
+        foreach ($electrodes as $electrode) {
+            $files[] = $data_path . $electrode['FilePath'];
+        }
+
+        foreach ($events as $event) {
+            $files[] = $data_path . $event['FilePath'];
+        }
+
+        foreach ($annotations as $annotation) {
+            $files[] = $data_path . $annotation['FilePath'];
+        }
+
+        foreach ($chunks as $chunk) {
+            $files[] = $data_path . $chunk['FilePath'];
+        }
+
+        foreach ($files as $file) {
+            echo "Deleting $file\n";
+            //unlink($file);
+        }
+
+        echo "\Deleting DB entries\n";
+        echo "----------------------------\n";
+
+        // delete from the physiological_archive table
+        $DB->delete(
+            "physiological_archive",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_file table
+        $DB->delete(
+            "physiological_file",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_task_event table
+        $DB->delete(
+            "physiological_task_event",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_annotation_instance table
+        $AnnotationFileIDs = $DB->pselect(
+            'SELECT AnnotationFileID
+            FROM physiological_annotation_file
+            WHERE PhysiologicalFileID=:pfid',
+            ['pfid' => $physioFileID]
+        );
+
+        if (!empty($AnnotationFileIDs)) {
+            foreach ($AnnotationFileIDs as $AnnotationFileID) {
+                $DB->delete(
+                    "physiological_annotation_instance",
+                    ["AnnotationFileID" => $AnnotationFileID]
+                );
+            }
+        }
+
+        // delete from the physiological_annotation_file table
+        $DB->delete(
+            "physiological_annotation_file",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_channel table
+        $DB->delete(
+            "physiological_channel",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_electrode table
+        $DB->delete(
+            "physiological_electrode",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+
+        // delete from the physiological_parameter_file table
+        $DB->delete(
+            "physiological_parameter_file",
+            ["PhysiologicalFileID" => $physioFileID]
+        );
+    } elseif ($printToSQL) {
+        echo "Generating all DELETE statements for physiological file: " .
+             $physioFileID . "\n";
+
+        //delete from the physiological_archive table
+        _printResultsSQL(
+            "physiological_archive",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        //delete from the physiological_file table
+        _printResultsSQL(
+            "physiological_file",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        //delete from the physiological_task_event table
+        _printResultsSQL(
+            "physiological_task_event",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        // delete from the physiological_annotation_instance table
+        $AnnotationFileIDs = $DB->pselect(
+            'SELECT AnnotationFileID
+            FROM physiological_annotation_file
+            WHERE PhysiologicalFileID=:pfid',
+            ['pfid' => $physioFileID]
+        );
+
+        if (!empty($AnnotationFileIDs)) {
+            foreach ($AnnotationFileIDs as $AnnotationFileID) {
+                _printResultsSQL(
+                    "physiological_annotation_instance",
+                    ["AnnotationFileID" => $AnnotationFileID],
+                    $output,
+                    $DB
+                );
+            }
+        }
+
+        // delete from the physiological_annotation_file table
+        _printResultsSQL(
+            "physiological_annotation_file",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        //delete from the physiological_channel table
+        _printResultsSQL(
+            "physiological_channel",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        //delete from the physiological_electrode table
+        _printResultsSQL(
+            "physiological_electrode",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        //delete from the physiological_parameter_file table
+        _printResultsSQL(
+            "physiological_parameter_file",
+            ["PhysiologicalFileID" => $physioFileID],
+            $output,
+            $DB
+        );
+
+        _exportSQL($output, $physioFileID);
+    }
+}
+
+/**
+ * Format delete statements.
+ *
+ * @param string    $table  The name of a LORIS table.
+ * @param string    $where  The where clause of the SQl statement
+ * @param string    $output A reference to the string to append to.
+ * @param \Database $DB     The database to connect to.
+ *
+ * @return void
+ */
+function _printResultsSQL($table, $where, &$output, $DB)
+{
+    $query  = "DELETE FROM $table WHERE ";
+    $where  = $DB->_implodeWithKeys(' AND ', $where);
+    $query .= $where;
+    $query .= ";\n";
+
+    $output .=$query;
+}
+
+/**
+ * Write SQL commands to file.
+ *
+ * @param string $output       SQL statements to write to file.
+ * @param string $physioFileID The physiological file to be deleted.
+ *
+ * @return void
+ */
+function _exportSQL($output, $physioFileID)
+{
+    //export file
+    $filename = __DIR__ .
+                "/../../../project/tables_sql/" .
+                "DELETE_PhysiologicalFile_$physioFileID.sql";
+    $fp       = fopen($filename, "w");
+    fwrite($fp, $output);
+    fclose($fp);
+}
+
+if ($confirm === false && $printToSQL === false) {
+    echo "\n\nRun this tool again with the argument 'confirm' or 'tosql' to ".
+        "perform the changes or export them as an SQL patch\n\n";
+}

--- a/tools/data_integrity/data_deletion/delete_timepoint.php
+++ b/tools/data_integrity/data_deletion/delete_timepoint.php
@@ -10,11 +10,11 @@
  * @package  Loris
  * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
+ * @link     https://www.github.com/aces/Loris/
  */
 
-require_once __DIR__ . "/../vendor/autoload.php";
-require_once __DIR__ . "/generic_includes.php";
+require_once __DIR__ . "/../../../vendor/autoload.php";
+require_once __DIR__ . "/../../generic_includes.php";
 
 /*
  * The minimum number of arguments required to run this script.
@@ -63,15 +63,15 @@ default:
     break;
 }
 
-$DB =& Database::singleton();
+$DB = \NDB_Factory::singleton()->database();
 
 /*
  * Perform validations on arguments
  */
 
 $candExists = $DB->pselectOne(
-    "SELECT COUNT(*) 
-      FROM candidate 
+    "SELECT COUNT(*)
+      FROM candidate
       WHERE CandID = :cid AND PSCID = :pid AND Active ='Y'",
     ['cid' => $CandID, 'pid' => $PSCID]
 );


### PR DESCRIPTION
- Script to delete all the files/db entries created by an eeg file ingestion.
  Usage: php delete_physiological_file.php [PID] confirm|tosql
  Split files not supported at the moment.

- Move deletion tools into data_integrity/data_deletion