### PR TITLE
[Tests] php install failure (Docker)

### DIFF
--- a/Dockerfile.test.php7.debug
+++ b/Dockerfile.test.php7.debug
@@ -9,4 +9,5 @@ RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install extensions through the scripts the container provides
-RUN docker-php-ext-install pdo_mysql zip
+RUN apt-get install -y libzip-dev zip && \
+    docker-php-ext-install pdo_mysql zip

--- a/Dockerfile.test.php8
+++ b/Dockerfile.test.php8
@@ -3,5 +3,6 @@ FROM php:8.0
 RUN apt-get update && \
     apt-get install -y mariadb-client libzip-dev
 
-RUN docker-php-ext-install pdo_mysql && \
+RUN apt-get install -y libzip-dev zip && \
+    docker-php-ext-install pdo_mysql && \
     docker-php-ext-install zip

--- a/Dockerfile.test.php8
+++ b/Dockerfile.test.php8
@@ -1,8 +1,7 @@
-FROM php:8.0
+FROM php:8.1
 
 RUN apt-get update && \
     apt-get install -y mariadb-client libzip-dev
 
-RUN apt-get install -y libzip-dev zip && \
-    docker-php-ext-install pdo_mysql && \
+RUN docker-php-ext-install pdo_mysql && \
     docker-php-ext-install zip

--- a/Dockerfile.test.php8.debug
+++ b/Dockerfile.test.php8.debug
@@ -1,12 +1,12 @@
-FROM php:7.4
+FROM php:8.1
 
 RUN apt-get update && \
-    apt-get install -y mariadb-client zlib1g-dev
+    apt-get install -y mariadb-client libzip-dev
 
-RUN yes | pecl install xdebug-2.8.0
+RUN yes | pecl install xdebug-3.1.0
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini
-RUN echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install extensions through the scripts the container provides
 RUN apt-get install -y libzip-dev zip && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
   web-debug:
     build:
       context: .
-      dockerfile: Dockerfile.test.php7.debug
+      dockerfile: Dockerfile.test.php8.debug
     volumes:
       - ./:/app
       - ./test/test_instrument:/app/project/instruments
@@ -88,7 +88,7 @@ services:
   unit-tests-debug:
     build:
       context: .
-      dockerfile: Dockerfile.test.php7.debug
+      dockerfile: Dockerfile.test.php8.debug
     volumes:
       - ./:/app
     working_dir: /app
@@ -103,7 +103,7 @@ services:
   integration-tests-debug:
     build:
       context: .
-      dockerfile: Dockerfile.test.php7.debug
+      dockerfile: Dockerfile.test.php8.debug
     volumes:
       - ./:/app
     working_dir: /app


### PR DESCRIPTION
PHP does not install libzip anymore, resulting in a error when running `npm run tests:integration`

```
configure: error: Package requirements (libzip >= 0.11 libzip != 1.3.1 libzip != 1.7.0) were not met:
No package 'libzip' found
```

Upgrade Dockerfile php image to 8.1 to fix

```
Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.0". You are running 8.0.25. in /app/vendor/composer/platform_check.php on line 24
```