### PR TITLE
npm postinstall script

### DIFF
--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -32,7 +32,7 @@ submodules.forEach((submodule) => {
 
   cp.spawnSync(
     'npm',
-    ['i', '--package-lock-only'],
+    ['ci'],
     {
       env: process.env,
       cwd: submodule,

--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const submodules = [
+  'project',
+  'modules/electrophysiology_browser/jsx/react-series-data-viewer',
+];
+
+submodules.forEach((submodule) => {
+  // Check if the submodule is in modules/, and has an override
+  submodulePath = submodule.split(path.sep);
+
+  if (
+    submodulePath[0] === 'modules' &&
+    fs.existsSync(path.join(__dirname, 'project', 'modules', submodulePath[1]))
+  ) {
+    submodule = path.join('project', submodule);
+  }
+
+  submodule = path.join(__dirname, submodule);
+
+  // ensure submodule has package.json
+  if (!fs.existsSync(path.join(submodule, 'package.json'))) return;
+
+  // install folder
+  console.info(
+    '\n ----- \n >> Installing packages in '
+    + submodule
+    + '\n -----'
+  );
+
+  cp.spawnSync(
+    'npm',
+    ['i', '--package-lock-only'],
+    {
+      env: process.env,
+      cwd: submodule,
+      stdio: 'inherit',
+    }
+  );
+});
+

--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -30,9 +30,15 @@ submodules.forEach((submodule) => {
     + '\n -----'
   );
 
+  let installMode = 'ci';
+  // ensure submodule has package-lock.json
+  if (!fs.existsSync(path.join(submodule, 'package-lock.json'))) {
+    installMode = 'i';
+  }
+
   cp.spawnSync(
     'npm',
-    ['ci'],
+    [installMode],
     {
       env: process.env,
       cwd: submodule,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "tests:integration:debug": "DEBUG=true ./test/dockerized-integration-tests.sh",
     "compile": "webpack",
     "watch": "webpack --watch",
-    "postinstall": "cd modules/electrophysiology_browser/jsx/react-series-data-viewer && npm install"
+    "postinstall": "node npm-postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -190,6 +190,7 @@ let config = [
           'jslib/',
           'htdocs/js/',
           'webpack.config.js',
+          'npm-postinstall.js',
         ],
         cache: true,
       }),


### PR DESCRIPTION
Following a discussion with @regisoc,
this script defines a set of paths where a package.json with additional dependencies can potentially exists.
This script is executed with npm install (postinstall step).

This fixes several issues:
- allow automated installation of /project additional npm dependencies;
- allow to automatically detect if a path is inside modules and overridden in project, and amend the path with project/

Potential improvements: Migrating the [EEG Browser install step](https://github.com/aces/Loris/tree/main/modules/electrophysiology_browser#-installation-requirements-to-use-the-visualization-features) in this script with a config Enable_EEGBrowser_visualization set to yes/no.