### PR TITLE
[behavioural_qc] Fix critical error

### DIFF
--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -126,7 +126,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
      */
     public function getCenterID(): \CenterID
     {
-        return new \CenterID($this->_site);
+        return new \CenterID(strval($this->_site));
     }
 
     /**
@@ -137,7 +137,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID($this->_project);
+        return new \ProjectID(strval($this->_project));
     }
 
     /**

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -112,7 +112,7 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
      */
     public function getCenterID(): \CenterID
     {
-        return new \CenterID($this->_site);
+        return new \CenterID(strval($this->_site));
     }
 
     /**
@@ -123,7 +123,7 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID($this->_project);
+        return new \ProjectID(strval($this->_project));
     }
 
     /**

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -112,7 +112,7 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
      */
     public function getCenterID(): \CenterID
     {
-        return new \CenterID($this->_site);
+        return new \CenterID(strval($this->_site));
     }
 
     /**
@@ -123,7 +123,7 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID($this->_project);
+        return new \ProjectID(strval($this->_project));
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

fixes 
```
<b>Fatal error</b>:  Uncaught TypeError: ValidatableIdentifier::__construct(): Argument #1 ($value) must be of type string, int given, called in /var/www/loris/modules/behavioural_qc/php/models/incompletedto.class.inc on line 126
```

Testing: Module currently doesnt load, it should load