### PR TITLE
Replace all `Smarty_neurodb` occurrences in the code with correct name of the class `Smarty_NeuroDB`

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -235,7 +235,7 @@ class DirectDataEntryMainPage
 
         $this->tpl_data['workspace'] = $e->getMessage();
         $this->tpl_data['complete']  = false;
-        $smarty = new Smarty_neurodb;
+        $smarty = new Smarty_NeuroDB;
         $smarty->assign($this->tpl_data);
         $smarty->display('directentry.tpl');
 
@@ -371,7 +371,7 @@ class DirectDataEntryMainPage
             $this->updateStatus('In Progress');
             $this->tpl_data['workspace'] = $workspace;
         }
-        $smarty = new Smarty_neurodb;
+        $smarty = new Smarty_NeuroDB;
         $smarty->assign($this->tpl_data);
         $smarty->display('directentry.tpl');
     }

--- a/modules/imaging_browser/php/feedback_mri_popup.class.inc
+++ b/modules/imaging_browser/php/feedback_mri_popup.class.inc
@@ -321,7 +321,7 @@ class Feedback_MRI_Popup extends \NDB_Page
     {
         $this->tpl_data = $this->getData();
 
-        $smarty = new \Smarty_neurodb("imaging_browser");
+        $smarty = new \Smarty_NeuroDB("imaging_browser");
 
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("form_feedback_mri_popup.tpl");

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -195,7 +195,7 @@ class Imaging_Session_ControlPanel
     {
         $this->tpl_data['subject'] = $this->getData();
 
-        $smarty = new \Smarty_neurodb("imaging_browser");
+        $smarty = new \Smarty_NeuroDB("imaging_browser");
 
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("imaging_session_controlpanel.tpl");

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -879,7 +879,7 @@ class ViewSession extends \NDB_Form
             $tpl_data['useEDC'] = true;
         }
 
-        $smarty = new \Smarty_neurodb('imaging_browser');
+        $smarty = new \Smarty_NeuroDB('imaging_browser');
 
         $smarty->assign($tpl_data);
         $html = $smarty->fetch("table_session_header.tpl");

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -94,7 +94,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         // BVLQCStatus
         $this->_displayBVLQCStatus();
 
-        $smarty = new \Smarty_neurodb("instrument_list");
+        $smarty = new \Smarty_NeuroDB("instrument_list");
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("instrument_list_controlpanel.tpl");
         return $html;

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -103,7 +103,7 @@ class Stats_Demographic extends \NDB_Form
             htmlspecialchars($_REQUEST['test_name']) : '';
         $tpl_data['Subsection'] = $subsection;
         $tpl_data['Visits']     = $visits;
-        $smarty = new \Smarty_neurodb('statistics');
+        $smarty = new \Smarty_NeuroDB('statistics');
         $tpl_data['SectionHeader'] = $sectionHeader;
         $tpl_data['TableHeader']   = $tableHeader;
         $tpl_data['Disclamer']     = $disclamer;
@@ -356,7 +356,7 @@ class Stats_Demographic extends \NDB_Form
                           count(DISTINCT(c.PSCID)) as val
                       FROM candidate as c
                           LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
-                          LEFT JOIN participant_status_options pso 
+                          LEFT JOIN participant_status_options pso
                                     ON (pso.ID=ps.participant_status)
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
@@ -389,7 +389,7 @@ class Stats_Demographic extends \NDB_Form
                           count(DISTINCT(c.PSCID)) as val
                       FROM candidate as c
                           LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
-                          LEFT JOIN participant_status_options pso 
+                          LEFT JOIN participant_status_options pso
                                       ON (pso.ID=ps.participant_status)
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -99,7 +99,7 @@ class Stats_MRI extends \NDB_Form
             : '';
         $tpl_data['Subsection'] = $Subsection;
         $tpl_data['Visits']     = $visits;
-        $smarty = new \Smarty_neurodb("statistics");
+        $smarty = new \Smarty_NeuroDB("statistics");
         $tpl_data['SectionHeader'] = $sectionHeader;
         $tpl_data['TableHeader']   = $tableHeader;
         $tpl_data['Disclamer']     = $disclamer;

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -80,7 +80,7 @@ Class TimePoint_List_ControlPanel extends \Candidate
         $settings = $factory->settings();
         $this->tpl_data['baseurl'] = $settings->getBaseURL();
 
-        $smarty = new \Smarty_neurodb('timepoint_list');
+        $smarty = new \Smarty_NeuroDB('timepoint_list');
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("timepoint_list_controlpanel.tpl");
         return $html;

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -81,7 +81,7 @@ class Error extends HtmlResponse
 
         $template_file = (string) $status . '.tpl';
 
-        $body = (new \Smarty_neurodb())
+        $body = (new \Smarty_NeuroDB())
             ->assign($tpl_data)
             ->fetch($template_file);
 

--- a/src/Middleware/AnonymousPageDecorationMiddleware.php
+++ b/src/Middleware/AnonymousPageDecorationMiddleware.php
@@ -75,7 +75,7 @@ class AnonymousPageDecorationMiddleware implements MiddlewareInterface
                       'workspace' => $undecorated->getBody(),
                      );
 
-        $smarty = new \Smarty_neurodb;
+        $smarty = new \Smarty_NeuroDB;
         $smarty->assign($tpl_data);
 
         return $undecorated->withBody(new \LORIS\Http\StringStream($smarty->fetch("public_layout.tpl")));

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -277,7 +277,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
                       'workspace' => $undecorated->getBody(),
                      );
 
-        $smarty = new \Smarty_neurodb;
+        $smarty = new \Smarty_NeuroDB;
         $smarty->assign($tpl_data);
         return $undecorated->withBody(new \LORIS\Http\StringStream($smarty->fetch("main.tpl")));
     }


### PR DESCRIPTION
## Brief summary of changes

For some reason, the class `Smarty_NeuroDB` in `Smarty_hook.class.inc` is being called in other scripts as `Smarty_neurodb`. The non-matching case returned the following error:
```
Fatal error: Uncaught Error: Class "Smarty_neurodb" not found in /Users/cmadjar/Development/Github/Loris/src/Http/Error.php:84 Stack trace: #0 /Users/cmadjar/Development/Github/Loris/src/Router/PrefixRouter.php(102): LORIS\Http\Error->__construct(Object(Laminas\Diactoros\ServerRequest), 404) #1 /Users/cmadjar/Development/Github/Loris/php/libraries/Module.class.inc(336): LORIS\Router\PrefixRouter->handle(Object(Laminas\Diactoros\ServerRequest)) #2 /Users/cmadjar/Development/Github/Loris/src/Middleware/ResponseGenerator.php(50): Module->handle(Object(Laminas\Diactoros\ServerRequest)) #3 /Users/cmadjar/Development/Github/Loris/src/Middleware/AuthMiddleware.php(63): LORIS\Middleware\ResponseGenerator->process(Object(Laminas\Diactoros\ServerRequest), Object(LORIS\dashboard\Module)) #4 /Users/cmadjar/Development/Github/Loris/src/Router/ModuleRouter.php(74): LORIS\Middleware\AuthMiddleware->process(Object(Laminas\Diactoros\ServerRequest), Object(LORIS\dashboard\Module)) #5 /Users/cmadjar/Development/Github/Loris/src/Middleware/ExceptionHandlingMiddleware.php(54): LORIS\Router\ModuleRouter->handle(Object(Laminas\Diactoros\ServerRequest)) #6 /Users/cmadjar/Development/Github/Loris/src/Router/BaseRouter.php(133): LORIS\Middleware\ExceptionHandlingMiddleware->process(Object(Laminas\Diactoros\ServerRequest), Object(LORIS\Router\ModuleRouter)) #7 /Users/cmadjar/Development/Github/Loris/src/Middleware/ResponseGenerator.php(50): LORIS\Router\BaseRouter->handle(Object(Laminas\Diactoros\ServerRequest)) #8 /Users/cmadjar/Development/Github/Loris/src/Middleware/ContentLength.php(52): LORIS\Middleware\ResponseGenerator->process(Object(Laminas\Diactoros\ServerRequest), Object(LORIS\Router\BaseRouter)) #9 /Users/cmadjar/Development/Github/Loris/htdocs/index.php(55): LORIS\Middleware\ContentLength->process(Object(Laminas\Diactoros\ServerRequest), Object(LORIS\Router\BaseRouter)) #10 {main} thrown in /Users/cmadjar/Development/Github/Loris/src/Http/Error.php on line 84
```
