### PR TITLE
[login] Make it possible to set default page and values via query params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,7 @@ check: checkstatic unittests
 
 testdata:
 	php tools/raisinbread_refresh.php
+
+login:
+	target=login npm run compile
+

--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -41,7 +41,7 @@ class Login extends Component {
           message: '',
         },
       },
-      mode: 'login',
+      mode: props.defaultmode || 'login',
       component: {
         requestAccount: null,
         expiredPassword: null,
@@ -282,6 +282,9 @@ class Login extends Component {
           module={'reset'}
           setMode={this.setMode}
           data={this.state.component.requestAccount}
+          defaultFirstName={this.props.defaultRequestFirstName}
+          defaultLastName={this.props.defaultRequestLastName}
+          defaultEmail={this.props.defaultRequestEmail}
         />
       );
     }
@@ -302,8 +305,16 @@ Login.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  const params = new URLSearchParams(window.location.search);
+  const getParam = (name, deflt) => {
+      return params.has(name) ? params.get(name) : deflt;
+  };
   ReactDOM.render(
     <Login
+      defaultmode={getParam('page', null)}
+      defaultRequestFirstName={getParam('firstname', '')}
+      defaultRequestLastName={getParam('lastname', '')}
+      defaultRequestEmail={getParam('email', '')}
       module={'login'}
     />,
     document.getElementsByClassName('main-content')[0]

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -22,9 +22,9 @@ class RequestAccount extends Component {
     this.state = {
       form: {
         value: {
-          firstname: '',
-          lastname: '',
-          email: '',
+          firstname: this.props.defaultFirstName || '',
+          lastname: this.props.defaultLastName || '',
+          email: this.props.defaultEmail || '',
           site: this.props.data.site
             ? Object.keys(this.props.data.site)['']
             : '',


### PR DESCRIPTION
This makes it possible to link to the Request Account page by making it possible to set a default mode in the login module via the page=?? query param. It also makes it possible to set the firstname, lastname, or email address by passing them as query params.

This is useful for authentication workflows (such as OpenID Connect) that might want to direct the user to sign up for an account and pre-populate it with known values