### PR TITLE
[new_timepoint] only show null language option when multiple exist

### DIFF
--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -152,7 +152,7 @@ class CreateTimepoint extends React.Component {
           // Populate the select options for languages.
           if (Object.keys(data.languages).length > 1) {
             state.form.options.languages = data.languages;
-            state.form.display.languages = true;
+            state.form.display.languages = Object.keys(data.languages).length > 1;
           }
           this.setState(state);
         });

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -150,7 +150,7 @@ class CreateTimepoint extends React.Component {
             this.handleVisitLabel();
           }
           // Populate the select options for languages.
-          if (data.languages) {
+          if (Object.keys(data.languages).length > 1) {
             state.form.options.languages = data.languages;
             state.form.display.languages = true;
           }

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -152,7 +152,8 @@ class CreateTimepoint extends React.Component {
           // Populate the select options for languages.
           if (Object.keys(data.languages).length > 1) {
             state.form.options.languages = data.languages;
-            state.form.display.languages = Object.keys(data.languages).length > 1;
+            state.form.display.languages =
+              Object.keys(data.languages).length > 1;
           }
           this.setState(state);
         });

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -150,10 +150,9 @@ class CreateTimepoint extends React.Component {
             this.handleVisitLabel();
           }
           // Populate the select options for languages.
-          if (Object.keys(data.languages).length > 1) {
+          if (data.languages) {
             state.form.options.languages = data.languages;
-            state.form.display.languages =
-              Object.keys(data.languages).length > 1;
+            state.form.display.languages = true;
           }
           this.setState(state);
         });
@@ -402,6 +401,7 @@ class CreateTimepoint extends React.Component {
       />
     ) : null;
     // Include languages select.
+    const emptyLangOption = Object.keys(data.languages).length > 1;
     const languages = this.state.form.display.languages ? (
       <SelectElement
         id={'languageID'}
@@ -410,7 +410,7 @@ class CreateTimepoint extends React.Component {
         value={this.state.form.value.languages}
         options={this.state.form.options.languages}
         onUserInput={this.setForm}
-        emptyOption={true}
+        emptyOption={emptyLangOption}
         disabled={false}
         autoSelect={true}
         required={this.state.form.options.required.languages}

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -401,7 +401,8 @@ class CreateTimepoint extends React.Component {
       />
     ) : null;
     // Include languages select.
-    const emptyLangOption = Object.keys(data.languages).length > 1;
+    const emptyLangOption =
+      Object.keys(this.state.form.options.languages).length > 1;
     const languages = this.state.form.display.languages ? (
       <SelectElement
         id={'languageID'}

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -181,16 +181,13 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             $this->lorisinstance->getDatabaseConnection()
         ))->getVisitFromVisitLabel($visitLabel)->getName();
 
-        $language = !is_null($values['languages'])
-                ? intval($values['languages'])
-                : null;
         \TimePoint::createNew(
             \Candidate::singleton(new CandID($values['candID'])),
             intval($values['cohort']),
             $visitName,
             $site,
             $project,
-            $language
+            intval($values['languages']) ?? null
         );
         return new \LORIS\Http\Response\JSON\Created(['success']);
     }

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -100,11 +100,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $values['visitGroups'] = $visitGroups;
 
         // List languages
-        $languages = \Utility::getLanguageList();
-        if (count($languages) > 1) {
-            $languages = [null] + $languages;
-        }
-        $values['languages'] = $languages;
+        $values['languages'] = \Utility::getLanguageList();
 
         if (!empty($conflict)) {
             return new \LORIS\Http\Response\JSON\Conflict(
@@ -185,13 +181,16 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             $this->lorisinstance->getDatabaseConnection()
         ))->getVisitFromVisitLabel($visitLabel)->getName();
 
+        $language = !is_null($values['languages'])
+                ? intval($values['languages'])
+                : null;
         \TimePoint::createNew(
             \Candidate::singleton(new CandID($values['candID'])),
             intval($values['cohort']),
             $visitName,
             $site,
             $project,
-            intval($values['languages']) ?? null
+            $language
         );
         return new \LORIS\Http\Response\JSON\Created(['success']);
     }

--- a/modules/create_timepoint/test/TestPlan.md
+++ b/modules/create_timepoint/test/TestPlan.md
@@ -40,9 +40,9 @@ visit label already exists for the candidate.
 successful form submission. Click on "Ok" button and ensure that it brings you back
 to timepoint list page for that candidate and confirm that the new timepoint appears in the list.
   [Manual Testing]
-14. Ensure that there is no null value and a language is automatically selected when only one 
+14. Ensure that there is no empty option in the language select element and a language is automatically selected when only one 
 language exists in the `language` table.
-15. Ensure that there is a null value and the language field is required when more than one 
+15. Ensure that there is an empty option in the language select element and the field is required when more than one 
 lagnuage exists in the `language` table
 16. Check that page is inaccessible if either the user does not have data_entry
 permission or the user and candidate are not the same site.

--- a/modules/create_timepoint/test/TestPlan.md
+++ b/modules/create_timepoint/test/TestPlan.md
@@ -40,6 +40,10 @@ visit label already exists for the candidate.
 successful form submission. Click on "Ok" button and ensure that it brings you back
 to timepoint list page for that candidate and confirm that the new timepoint appears in the list.
   [Manual Testing]
-14. Check that page is inaccessible if either the user does not have data_entry
+14. Ensure that there is no null value and a language is automatically selected when only one 
+language exists in the `language` table.
+15. Ensure that there is a null value and the language field is required when more than one 
+lagnuage exists in the `language` table
+16. Check that page is inaccessible if either the user does not have data_entry
 permission or the user and candidate are not the same site.
   [Manual Testing]


### PR DESCRIPTION
## Brief summary of changes
In this PR, the language drop down for timepoints is only contains a null option when creating a new timepoint if there are more than one languages to choose from in the language table. Otherwise the field automatically selected. 

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Check that exactly one language exists in the language table
2. Create a new timepoint
3. Make sure that the language drop down does not contain a null option & that you are successfully able to create the timepoint with the one option automatically selected
4. Add a language to the language table to have 2 or more
5. Create another timepoint and make sure that the language drop down is displayed with a null option
6. Check that the language field is required in this case, and that you can not save without it
7. If the language selection is made, make sure that you are able to save the timepoint properly

#### Link(s) to related issue(s)

* Resolves #7997
