### PR TITLE
[user_accounts] Fix alignment of checkboxes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,9 @@ check: checkstatic unittests
 
 testdata:
 	php tools/raisinbread_refresh.php
+
+login:
+	target=login npm run compile
+
+user_accounts:
+	target=user_accounts npm run compile

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -972,11 +972,21 @@ class Edit_User extends \NDB_Form
             }
             $group[] = $this->createCheckbox(
                 'permID['.$row['permID'].']',
-                htmlspecialchars($row['label']) . "<br>",
+                '<span>' . htmlspecialchars($row['label']) . '</span>',
                 $attribs
             );
         }
-        $this->addGroup($group, 'PermID_Group', 'Permissions', "");
+        $this->addGroup(
+            $group,
+            'PermID_Group',
+            'Permissions',
+            "",
+            [
+                'prefix_wrapper'  => '<div style="'
+                        . 'display: flex; gap: 5px; align-items: center;">',
+                'postfix_wrapper' => '</div>',
+            ]
+        );
         unset($group);
 
         //getting users name and emails to create checkboxes

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1607,9 +1607,11 @@ class LorisForm
         //  CSS to wrap the tag which avoids the label from being separated from the
         //  checkbox. We don't wrap the whole label in it because if it's a long
         //  label it's still allowed to have linebreaks.
-        return "<span style=\"white-space: nowrap\"><input name=\"$el[name]\""
-            . " type=\"checkbox\" $checked $value "
-            . "$disabled/>"
+        return "<span style=\"white-space: nowrap; display: flex; "
+                    . " flex-direction: column; align-content: center;\">"
+                    . " <input name=\"$el[name]\""
+                        . " type=\"checkbox\" $checked $value "
+                        . "$disabled/>"
             . " </span>$el[label]";
     }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1607,9 +1607,9 @@ class LorisForm
         //  CSS to wrap the tag which avoids the label from being separated from the
         //  checkbox. We don't wrap the whole label in it because if it's a long
         //  label it's still allowed to have linebreaks.
-        return "<span style=\"white-space: nowrap; display: flex; "
+        return "<span style=\"white-space: nowrap; display: flex;"
                     . " flex-direction: column; align-content: center;\">"
-                    . " <input name=\"$el[name]\""
+                    . "<input name=\"$el[name]\""
                         . " type=\"checkbox\" $checked $value "
                         . "$disabled/>"
             . " </span>$el[label]";

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1335,7 +1335,9 @@ class LorisForms_Test extends TestCase
     {
         $this->form->addCheckbox("abc", "Hello", []);
         $this->assertEquals(
-            "<span style=\"white-space: nowrap\"><input name=\"abc\" " .
+            "<span style=\"white-space: nowrap; display: flex; "
+                . "flex-direction: column; align-content: center;\">"
+                . "<input name=\"abc\" " .
             "type=\"checkbox\"   /> </span>Hello",
             $this->form->checkboxHTML($this->form->form['abc'])
         );
@@ -1356,7 +1358,9 @@ class LorisForms_Test extends TestCase
         $this->form->addCheckbox("abc", "Hello", $testAttributes);
         $this->form->setDefaults(['abc' => 'abc_default']);
         $this->assertEquals(
-            "<span style=\"white-space: nowrap\"><input name=\"abc\" " .
+            "<span style=\"white-space: nowrap; display: flex; "
+                . "flex-direction: column; align-content: center;\">"
+                . "<input name=\"abc\" " .
             "type=\"checkbox\" checked=\"checked\"" .
             " value=\"value1\" disabled/> </span>Hello",
             $this->form->checkboxHTML($this->form->form['abc'])


### PR DESCRIPTION
This fixes the alignment of checkboxes on the user_accounts page by using flexbox to align the row.

Resolves #7934
