### PR TITLE
[core] return error message on invalid dob

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -241,7 +241,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 $pscid,
                 $project->getId()
             );
-        } catch (\LorisException $e) {
+        } catch (\LorisException | \InvalidArgumentException $e) {
             return new \LORIS\Http\Response\JSON\BadRequest($e->getMessage());
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -281,8 +281,8 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             );
         }
         $dob = DateTime::createFromFormat('Y-m-d', $dateOfBirth);
-        if (!empty(\DateTime::getLastErrors())) {
-            error_log(print_r(\DateTime::getLastErrors(), true));
+        if (!empty($dob->getLastErrors())) {
+            error_log(print_r($dob->getLastErrors(), true));
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -281,20 +281,13 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             );
         }
         $dob = DateTime::createFromFormat('Y-m-d', $dateOfBirth);
-        if (is_bool($dob) && $dob === false) {
+        if (!empty(\DateTime::getLastErrors())) {
+            error_log(print_r(\DateTime::getLastErrors(), true));
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
             );
-        } elseif (is_object($dob)
-            && ($dob->getLastErrors()['error_count'] > 0
-            || $dob->getLastErrors()['warning_count'] > 0)
-        ) {
-            throw new InvalidArgumentException(
-                "Date of Birth is invalid (expected format: YYYY-MM-DD)",
-                DOB_INVALID
-            );
-        }
+        } 
 
         if ($PSCIDSettings['generation'] == 'user') {
             // check pscid is specified

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -287,7 +287,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
             );
-        } 
+        }
 
         if ($PSCIDSettings['generation'] == 'user') {
             // check pscid is specified

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -281,7 +281,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             );
         }
         $dob = DateTime::createFromFormat('!Y-m-d', $dateOfBirth);
-        if (!empty(\DateTime::getLastErrors())) {
+        if ($dob === false) {
             error_log(print_r(\DateTime::getLastErrors(), true));
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
@@ -323,7 +323,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $setArray = [
             'RegistrationCenterID'  => $centerID,
             'PSCID'                 => $PSCID,
-            'DoB'                   => $dob->format('Y-m-d'),
+            'DoB'                   => $dateOfBirth,
             'EDC'                   => $edc,
             'Sex'                   => $sex,
             'RegistrationProjectID' => $registrationProjectID,

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -282,7 +282,6 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         }
         $dob = DateTime::createFromFormat('!Y-m-d', $dateOfBirth);
         if ($dob === false) {
-            error_log(print_r(\DateTime::getLastErrors(), true));
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -18,6 +18,7 @@ define('PSCID_NOT_UNIQUE', 3);
 define('PSCID_INVALID_STRUCTURE', 4);
 define('EDC_NOT_SPECIFIED', 5);
 define('DOB_NOT_SPECIFIED', 6);
+define('DOB_INVALID', 7);
 
 /**
  * Wrapper around a candidate in Loris. Mostly, it gets information
@@ -273,13 +274,25 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 EDC_NOT_SPECIFIED
             );
         }
-        if ($dateOfBirth !== null
-            && (DateTime::createFromFormat('Y-m-d', $dateOfBirth) === false
-            || empty($dateOfBirth))
-        ) {
+        if (empty($dateOfBirth)) {
             throw new InvalidArgumentException(
                 "Date of Birth must be specified",
                 DOB_NOT_SPECIFIED
+            );
+        }
+        $dob = DateTime::createFromFormat('Y-m-d', $dateOfBirth);
+        if (is_bool($dob) && $dob === false) {
+            throw new InvalidArgumentException(
+                "Date of Birth is invalid",
+                DOB_INVALID
+            );
+        } elseif (is_object($dob)
+            && ($dob->getLastErrors()['error_count'] > 0
+            || $dob->getLastErrors()['warning_count'] > 0)
+        ) {
+            throw new InvalidArgumentException(
+                "Date of Birth is invalid",
+                DOB_INVALID
             );
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -280,9 +280,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 DOB_NOT_SPECIFIED
             );
         }
-        $dob = DateTime::createFromFormat('Y-m-d', $dateOfBirth);
-        if (!empty($dob->getLastErrors())) {
-            error_log(print_r($dob->getLastErrors(), true));
+        $dob = DateTime::createFromFormat('!Y-m-d', $dateOfBirth);
+        if (!empty(\DateTime::getLastErrors())) {
+            error_log(print_r(\DateTime::getLastErrors(), true));
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
@@ -323,7 +323,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $setArray = [
             'RegistrationCenterID'  => $centerID,
             'PSCID'                 => $PSCID,
-            'DoB'                   => $dateOfBirth,
+            'DoB'                   => $dob->format('Y-m-d'),
             'EDC'                   => $edc,
             'Sex'                   => $sex,
             'RegistrationProjectID' => $registrationProjectID,

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -283,7 +283,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $dob = DateTime::createFromFormat('Y-m-d', $dateOfBirth);
         if (is_bool($dob) && $dob === false) {
             throw new InvalidArgumentException(
-                "Date of Birth is invalid",
+                "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
             );
         } elseif (is_object($dob)
@@ -291,7 +291,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             || $dob->getLastErrors()['warning_count'] > 0)
         ) {
             throw new InvalidArgumentException(
-                "Date of Birth is invalid",
+                "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
             );
         }


### PR DESCRIPTION
## Brief summary of changes

When using `/api/v0.0.3/candidates` with an invalid date format, returns 400 Bad Requests/JSON errors.
This PR checks the date of birth and returns the correct format in the message ('yyyy-mm-dd').

#### Testing instructions (if applicable)

1. Log into to get a token:

```bash
curl -v -k -X 'POST' \
  'https://<hostname>/api/v0.0.3/login' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "username": "<username>",
  "password": "<password>"
}'
```

2. Test for `/api/v0.0.3/candidates` endpoint:

```bash
curl -v -k -X POST 'https://<hostname>/api/v0.0.3/candidates' \
    -H "Authorization: Bearer <token>" \
    -d '{
        "Candidate": {
            "Project": "Rye",
            "Site": "Montreal",
            "DoB": "<a_date>",
            "Sex": "Female"
        }
    }'
```

#### Link(s) to related issue(s)

* #8127
