### PR TITLE
[Instrument template] Remove each() as is deprecated since php 7.2 and removed in php 8.0

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -150,8 +150,8 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         }
         //echo error messages
         if(!empty($file->errorLog)){
-        foreach($file->errorLog as $fileType => $fileErrors){
-            foreach($fileErrors as $error){
+        foreach($file->errorLog AS $fileType => $fileErrors){
+            foreach($fileErrors AS $error){
                  echo "<span style='color:red'><b>Upload Error</b> $fileType: $error</span><br>";
             }
          }

--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -150,8 +150,8 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         }
         //echo error messages
         if(!empty($file->errorLog)){
-        while(list($fileType,$fileErrors)=each($file->errorLog)){
-            foreach($fileErrors AS $error){
+        foreach($file->errorLog as $fileType => $fileErrors){
+            foreach($fileErrors as $error){
                  echo "<span style='color:red'><b>Upload Error</b> $fileType: $error</span><br>";
             }
          }


### PR DESCRIPTION
fixes #8241