### PR TITLE
[core] Fix incorrect message/error for instrument access

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -362,24 +362,18 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         } else { //check if user has instrument's permissions
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;
-            $instrumentList   = $instrumentPermissions["instrument"];
-            if (array_key_exists("Test_name", $instrumentList)) {
-                // if only one instrument is listed in config.xml file
-                if ($instrumentList["Test_name"] == $this->testName) {
+            // get an array of instruments
+            // if one instrument, get it into an array
+            $instrumentList   = Utility::asArray(
+                $instrumentPermissions["instrument"]
+            );
+            // iterate through instruments
+            foreach ($instrumentList as $instrument) {
+                if ($instrument["Test_name"] == $this->testName) {
                     $instrumentListed = true;
                     $instrumentPerms  = Utility::asArray(
-                        $instrumentList["permission"]
+                        $instrument["permission"]
                     );
-                }
-            } else {
-                // multiple instruments listed
-                foreach ($instrumentList as $instrument) {
-                    if ($instrument["Test_name"] == $this->testName) {
-                        $instrumentListed = true;
-                        $instrumentPerms  = Utility::asArray(
-                            $instrument["permission"]
-                        );
-                    }
                 }
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -364,7 +364,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $instrumentListed = false;
             // get an array of instruments
             // if one instrument, get it into an array
-            $instrumentList   = Utility::asArray(
+            $instrumentList = Utility::asArray(
                 $instrumentPermissions["instrument"]
             );
             // iterate through instruments

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -362,10 +362,20 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         } else { //check if user has instrument's permissions
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;
-            foreach ($instrumentPermissions["instrument"] as $instrument) {
-                if ($instrument["Test_name"] == $this->testName) {
+            $instrumentList = $instrumentPermissions["instrument"];
+            if (array_key_exists("Test_name", $instrumentList)) {
+                // if only one instrument is listed in config.xml file
+                if ($instrumentList["Test_name"] == $this->testName) {
                     $instrumentListed = true;
-                    $instrumentPerms  = Utility::asArray($instrument["permission"]);
+                    $instrumentPerms  = Utility::asArray($instrumentList["permission"]);
+                }
+            } else {
+                // multiple instruments listed
+                foreach ($instrumentList as $instrument) {
+                    if ($instrument["Test_name"] == $this->testName) {
+                        $instrumentListed = true;
+                        $instrumentPerms  = Utility::asArray($instrument["permission"]);
+                    }
                 }
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -362,19 +362,23 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         } else { //check if user has instrument's permissions
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;
-            $instrumentList = $instrumentPermissions["instrument"];
+            $instrumentList   = $instrumentPermissions["instrument"];
             if (array_key_exists("Test_name", $instrumentList)) {
                 // if only one instrument is listed in config.xml file
                 if ($instrumentList["Test_name"] == $this->testName) {
                     $instrumentListed = true;
-                    $instrumentPerms  = Utility::asArray($instrumentList["permission"]);
+                    $instrumentPerms  = Utility::asArray(
+                        $instrumentList["permission"]
+                    );
                 }
             } else {
                 // multiple instruments listed
                 foreach ($instrumentList as $instrument) {
                     if ($instrument["Test_name"] == $this->testName) {
                         $instrumentListed = true;
-                        $instrumentPerms  = Utility::asArray($instrument["permission"]);
+                        $instrumentPerms  = Utility::asArray(
+                            $instrument["permission"]
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Brief summary of changes

An incorrect error message was displayed on the frontend when a user did not have the permission to access an instrument.
The code was test looping on ALL permissions, but it failed when trying to do so on only ONE permission (the loop went through the instrument name and permission instead of the actual instruments objects). 
This PR fix the error message linked to permission listing. 

#### Testing instructions (if applicable)

1. Add a new user
2. Give the user permissions through the `db` and `config.xml` file except one permission on one instrument (e.g. instrument "bmi", permission "data_entry")
3. Enter the permission selected in 2. in the config.xml file (`instrumentPermissions` section)
4. Go to Loris > Menu > Candidate > Access Profile
5. Choose one PSCID (candidate) then one associated visit (visit label)
6. In the "Behavioural Battery of Instruments", choose one instrument the user should not have access to according to the access rules
7. This should print the 403 page, with "You do not have access to this page." message 

#### Link(s) to related issue(s)

* #8171 
