### PR TITLE
[core] Remove \Module::factory, update remaining instances to $loris->getModule()

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -89,14 +89,14 @@ if (is_dir($basePath . "project/modules/$Module")
 
 $public = false;
 try {
-    // Anything that's still in an ajax directory isn't using the lorisinstance
-    // object, so for now just make a fake one to pass to the factory.
+    // GetModule doesn't use the database or ndb_config, so for now
+    // just pass a fake one to the constructor
     $loris = new \LORIS\LorisInstance(
         new \Database(),
         new \NDB_Config(),
-        []
+        [__DIR__ . "/../modules", __DIR__ . "/../project/modules"]
     );
-    $m     = Module::factory($loris, $Module);
+    $m     = $loris->getModule($Module);
 
     $public = $m->isPublicModule();
 } catch (LorisModuleMissingException $e) {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -69,9 +69,7 @@ class Candidate_List extends \DataFrameworkMenu
      */
     function getFieldOptions() : array
     {
-        // Relying on a side-effect of the the server process module to autoload
-        // its namespace.
-        \Module::factory($this->loris, 'candidate_parameters');
+        $this->loris->getModule('candidate_parameters')->registerAutoloader();
 
         // create user object
         $factory = \NDB_Factory::singleton();

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -302,17 +302,9 @@ function getFamilyInfoFields()
  */
 function getParticipantStatusFields()
 {
-    // All we care about is the namespace loading, so we just need to ensure
-    // that the directory path has this module in it
-    $loris = new \LORIS\LorisInstance(
-        new Database(),
-        new NDB_Config(),
-        [
-            __DIR__ . '../'
-        ]
-    );
+    global $loris;
 
-    \Module::factory($loris, 'candidate_parameters');
+    $loris->getModule('candidate_parameters')->registerAutoloader();
     $candID = new CandID($_GET['candID']);
 
     $db = \NDB_Factory::singleton()->database();

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -25,7 +25,7 @@ try {
 
     $moduleName  = $_REQUEST['testName'] ?? null;
     $subpageName = $_REQUEST['subtest'] ?? null;
-    $m           = Module::factory($loris, $moduleName);
+    $m           = $loris->getModule($moduleName);
     // Load help data. Try to load subpage first as its more specific and
     // will only be present some of the time. Fallback to the module name if
     // no subpage present.

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -58,68 +58,31 @@ abstract class Module extends \LORIS\Router\PrefixRouter
 
         $rv = [];
         foreach ($mnames as $row) {
-            $rv[$row['ID']] = self::factory($loris, $row['Name']);
+            $rv[$row['ID']] = $loris->getModule($row['Name']);
         }
         return $rv;
     }
 
-
     /**
-     * Returns a Module instance for the module named $name. The returned
-     * value may be a subtype of the base LORIS module class and override
-     * it's method.
+     * Register an autoloader for this module's namespace.
      *
-     * This also sets up PHP class autoloading for the module that is loaded,
-     * such that files in the module/php directory can be autoloaded.
-     *
-     * @param \Loris\LorisInstance $loris The LORIS instance containing the module
-     * @param string               $name  The module name we'd like information about
-     *
-     * @throws \LorisNoSuchModuleException
-     * @throws \LorisModuleMissingException
-     * @throws \NotFound
-     *
-     * @return \Module object
+     * @return void
      */
-    static public function factory(
-        \Loris\LorisInstance $loris,
-        string $name
-    ) : \Module {
-        $factory = NDB_Factory::singleton();
-        $config  = $factory->config();
-        $base    = $config->getSetting("base");
-
-        // TODO: Module search path should be a config option.
-        if (is_dir($base . "project/modules/$name")) {
-            $mpath = $base . "project/modules/$name";
-        } else if (is_dir($base . "modules/$name")) {
-            $mpath = $base . "modules/$name";
-        } else {
-            throw new LorisNoSuchModuleException("No such module: $name");
-        }
-
-        if (!file_exists($mpath . "/php/module.class.inc")) {
-            // Check if there's a module class to see if the module has been
-            // updated. This can be removed once support for old Modules has
-            // been removed. If it hasn't been updated, fall back on the old
-            // style.
-            throw new LorisModuleMissingException("$name is missing Module class");
-        }
+    public function registerAutoloader() : void
+    {
         // Manually do dependency injection for the module's php/ directory,
         // since composer doesn't know anything about our modules and we only
         // want *this* module's classes autoloaded anyways.
         spl_autoload_register(
-            function ($class) use ($name,
-                $mpath
-            ) {
-                if (strpos($class, "LORIS\\$name\\") === 0) {
-                    $fpath = $mpath . "/php/"
-                    . strtolower(substr($class, strlen("LORIS\\$name\\")))
+            function ($class) {
+                if (strpos($class, "LORIS\\{$this->name}\\") === 0) {
+                    $fpath = $this->dir. "/php/"
+                    . strtolower(substr($class, strlen("LORIS\\{$this->name}\\")))
                     . ".class.inc";
                     $fpath = str_replace('\\', '/', $fpath);
                     if (!file_exists($fpath)) {
                         throw new \NotFound(
-                            "Could not load module `$name`: file `$fpath` " .
+                            "Could not load module `{$this->name}`: file `$fpath` " .
                             "does not exist"
                         );
                     }
@@ -127,15 +90,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
                 }
             }
         );
-
-        // Manually do the require for the module descriptor because of
-        // namespacing
-        //require_once $mpath . "/php/Module.class.inc";
-        $className = "\LORIS\\$name\Module";
-        $cls       = new $className($loris, $name, $mpath);
-        return $cls;
     }
-
     /**
      * Creates a new module instance
      *

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -126,7 +126,19 @@ class LorisInstance
      */
     public function getModule(string $name) : \Module
     {
-        return \Module::factory($this, $name);
+        foreach ($this->modulesDirs as $modulesDir) {
+            $mpath = "$modulesDir/$name";
+
+            $moduleclasspath = "$mpath/php/module.class.inc";
+
+            if (file_exists($moduleclasspath)) {
+                include_once $moduleclasspath;
+                $className = "\LORIS\\$name\Module";
+                $cls       = new $className($this, $name, $mpath);
+                return $cls;
+            }
+        }
+        throw new \LorisNoSuchModuleException("No such module: $name");
     }
 
     /**

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -120,7 +120,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $factory->setBaseURL($baseurl);
 
-            $module = $this->lorisinstance->getModule($modulename);
+            $module = $this->loris->getModule($modulename);
             $module->registerAutoloader();
 
             $mr      = new ModuleRouter($module);
@@ -138,7 +138,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 $request = $request
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
-                $module  = $this->lorisinstance->getModule("timepoint_list");
+                $module  = $this->loris->getModule("timepoint_list");
                 $module->registerAutoloader();
 
                 $mr = new ModuleRouter($module);

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -120,7 +120,9 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $factory->setBaseURL($baseurl);
 
-            $module  = $this->loris->getModule($modulename);
+            $module = $this->lorisinstance->getModule($modulename);
+            $module->registerAutoloader();
+
             $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
             return $ehandler->process($request, $mr);

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -138,8 +138,10 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 $request = $request
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
-                $module  = $this->loris->getModule("timepoint_list");
-                $mr      = new ModuleRouter($module);
+                $module  = $this->lorisinstance->getModule("timepoint_list");
+                $module->registerAutoloader();
+
+                $mr = new ModuleRouter($module);
                 return $ehandler->process($request, $mr);
             }
         }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -1132,7 +1132,7 @@ class UserTest extends TestCase
         $loris = new \LORIS\LorisInstance(
             $this->_dbMock,
             new \NDB_Config(),
-            [],
+            [__DIR__ . "/../../modules"],
         );
         $this->assertEquals(
             $this->_user->getPermissionsVerbose($loris),

--- a/tools/manage_modules.php
+++ b/tools/manage_modules.php
@@ -9,8 +9,7 @@
  * have a valid \Module descriptor to the modules table.
  *
  * If the --remove parameter is provided, it will remove anything in the
- * modules table that can not be instantiated with Module::factory from
- * the modules table.
+ * modules table that can not be instantiated with from the modules table.
  *
  * If the -n flag is provided, it will not actually add/delete from the
  * table, but only tell you what it would otherwise do.
@@ -52,7 +51,7 @@ $currentModules = $DB->pselectCol(
 if (isset($flags['remove'])) {
     foreach ($currentModules as $module) {
         try {
-            Module::factory($module);
+            $lorisInstance->getModule($module);
         } catch (\LorisNoSuchModuleException | \LorisModuleMissingException $e) {
             print "Removing $module\n";
             if ($dryrun) {
@@ -80,6 +79,7 @@ if (isset($flags['add'])) {
 function addDir(string $moduledir): void
 {
     global $DB;
+    global $lorisInstance;
     global $dryrun;
     global $currentModules;
 
@@ -91,7 +91,7 @@ function addDir(string $moduledir): void
         if (!in_array($module, $currentModules, true)) {
             if (is_dir("$moduledir/$module")) {
                 try {
-                    Module::factory($module);
+                    $lorisInstance->getModule($module);
                 } catch (\LorisNoSuchModuleException
                     | \LorisModuleMissingException $e
                 ) {


### PR DESCRIPTION
This finishes what was started in PR#8221 and eliminates the \Module::factory method. All remaining instances are updated to use $loris->getModule instead, which takes the LorisInstance module paths into consideration.