### PR TITLE
[Document Repository] Upload multiple files at once

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1928,10 +1928,12 @@ class FileElement extends Component {
           break;
 
         case 'object':
-          if (this.props.value instanceof FileList)
-            fileName = Array.from(this.props.value).map((file) => file.name).join(', ');
-          else
+          if (this.props.value instanceof FileList) {
+            const files = this.props.value;
+            fileName = Array.from(files).map((file) => file.name).join(', ');
+          } else {
             fileName = this.props.value.name;
+          }
           break;
 
         default:

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1886,7 +1886,7 @@ NumericElement.defaultProps = {
 
 /**
  * File Component
- * React wrapper for a simple or 'multiple' <select> element.
+ * React wrapper for a simple or 'multiple' <input type="file"> element.
  */
 class FileElement extends Component {
   /**
@@ -1905,8 +1905,10 @@ class FileElement extends Component {
    */
   handleChange(e) {
     // Send current file to parent component
-    const file = e.target.files[0] ? e.target.files[0] : '';
-    this.props.onUserInput(this.props.name, file);
+    const files = e.target.files
+      ? (this.props.allowMultiple ? e.target.files : e.target.files[0])
+      : '';
+    this.props.onUserInput(this.props.name, files);
   }
 
   /**
@@ -1918,6 +1920,7 @@ class FileElement extends Component {
     const required = this.props.required ? 'required' : null;
 
     let fileName = undefined;
+
     if (this.props.value) {
       switch (typeof this.props.value) {
         case 'string':
@@ -1925,7 +1928,10 @@ class FileElement extends Component {
           break;
 
         case 'object':
-          fileName = this.props.value.name;
+          if (this.props.value instanceof FileList)
+            fileName = Array.from(this.props.value).map((file) => file.name).join(', ');
+          else
+            fileName = this.props.value.name;
           break;
 
         default:
@@ -1997,6 +2003,7 @@ class FileElement extends Component {
     } else {
         classSz = 'col-sm-12';
     }
+
     return (
       <div className={elementClass}>
         {labelHTML}
@@ -2018,6 +2025,7 @@ class FileElement extends Component {
                   name={this.props.name}
                   onChange={this.handleChange}
                   required={required}
+                  multiple={this.props.allowMultiple}
                 />
               </div>
             </div>
@@ -2039,6 +2047,7 @@ FileElement.propTypes = {
   id: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  allowMultiple: PropTypes.bool,
   hasError: PropTypes.bool,
   errorMessage: PropTypes.string,
   onUserInput: PropTypes.func,
@@ -2051,6 +2060,7 @@ FileElement.defaultProps = {
   id: null,
   disabled: false,
   required: false,
+  allowMultiple: false,
   hasError: false,
   errorMessage: 'The field is required!',
   onUserInput: function() {

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2370,7 +2370,7 @@ class ButtonElement extends Component {
             onClick={this.handleClick}
             disabled={this.props.disabled}
           >
-            {this.props.label}
+            {this.props.disabled ? 'Uploading...' : this.props.label}
           </button>
         </div>
       </div>

--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -5,3 +5,9 @@
 .tool:hover + .tip {
    visibility: visible;
 }
+
+.upload-response {
+  max-height: 400px;
+  overflow-y: scroll;
+  text-align: left;
+}

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -197,7 +197,6 @@ class DocUploadForm extends Component {
         body: formObject,
       })
         .then((resp) => {
-          console.error(resp);
           if (resp.ok) {
             resp.json().then((data) => {
               if (data.error_count === 0) {
@@ -209,6 +208,7 @@ class DocUploadForm extends Component {
                     }
                 });
               } else {
+                console.error(resp);
                 swal.fire('Upload Incomplete', data.message, 'warning');
               }
             }).catch((error) => {
@@ -221,6 +221,7 @@ class DocUploadForm extends Component {
             });
           } else {
             resp.json().then((data) => {
+              console.error(resp);
               swal.fire('Could not upload files', data.error, 'error');
             }).catch((error) => {
               console.error(error);

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -8,7 +8,7 @@ import Loader from 'Loader';
  * Media Upload Form
  *
  * Fetches data from Loris backend and displays a form allowing
- * to upload a document file
+ * to upload document files
  *
  * @author Shen Wang
  * @version 1.0.0
@@ -32,7 +32,7 @@ class DocUploadForm extends Component {
     };
 
     this.setFormData = this.setFormData.bind(this);
-    this.uploadFile = this.uploadFile.bind(this);
+    this.uploadFiles = this.uploadFiles.bind(this);
     this.fetchData = this.fetchData.bind(this);
   }
 
@@ -90,10 +90,10 @@ class DocUploadForm extends Component {
           <FormElement
             name="docUpload"
             fileUpload={true}
-            onSubmit={this.uploadFile}
+            onSubmit={this.uploadFiles}
             method="POST"
           >
-            <h3>Upload a file</h3><br/>
+            <h3>Upload files</h3><br/>
             <SelectElement
               name="category"
               label="Category"
@@ -145,14 +145,15 @@ class DocUploadForm extends Component {
               value={this.state.formData.comments}
             />
             <FileElement
-              name="file"
+              name="files"
               id="docUploadEl"
               onUserInput={this.setFormData}
-              label="File to upload"
+              label="File(s) to upload"
               required={true}
-              value={this.state.formData.file}
+              value={this.state.formData.files}
+              allowMultiple={true}
             />
-            <ButtonElement label="Upload File"/>
+            <ButtonElement label="Upload File(s)"/>
           </FormElement>
         </div>
       </div>
@@ -164,15 +165,21 @@ class DocUploadForm extends Component {
    *********************************************************************************/
 
   /**
-   * Upload file
+   * Upload file(s)
    */
-  uploadFile() {
+  uploadFiles() {
     // Set form data and upload the media file
     let formData = this.state.formData;
     let formObject = new FormData();
     for (let key in formData) {
       if (formData[key] !== '') {
-        formObject.append(key, formData[key]);
+        if (key === 'files' && document.querySelector('.fileUpload').multiple) {
+          Array.from(formData[key]).forEach((file) => {
+            formObject.append('files[]', file);
+          });
+        } else {
+          formObject.append(key, formData[key]);
+        }
       }
     }
 
@@ -185,15 +192,21 @@ class DocUploadForm extends Component {
     .then((resp) => {
       console.error(resp);
       if (resp.ok) {
-        swal.fire('Upload Successful!', '', 'success').then((result) => {
-          if (result.value) {
-            this.setState({formData: {}});
-            this.props.refreshPage();
+        resp.json().then((data) => {
+          if (data.error_count === 0) {
+            swal.fire('Upload Successful!', '', 'success').then((result) => {
+              if (result.value) {
+                this.setState({formData: {}});
+                this.props.refreshPage();
+              }
+            });
+          } else {
+            swal.fire('Upload Incomplete', data.message, 'warning');
           }
         });
       } else {
         resp.json().then((data) => {
-          swal.fire('Could not upload file', data.error, 'error');
+          swal.fire('Could not upload files', data.error, 'error');
         }).catch((error) => {
           console.error(error);
           swal.fire(

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -204,7 +204,7 @@ class DocUploadForm extends Component {
                 swal.fire('Upload Successful!', '', 'success')
                   .then((result) => {
                     if (result.value) {
-                      this.setState({formData: {}, uploadInProgress: false});
+                      this.setState({formData: {}});
                       this.props.refreshPage();
                     }
                 });
@@ -221,7 +221,6 @@ class DocUploadForm extends Component {
             });
           } else {
             resp.json().then((data) => {
-              this.setState({uploadInProgress: false});
               swal.fire('Could not upload files', data.error, 'error');
             }).catch((error) => {
               console.error(error);

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -179,10 +179,11 @@ class DocUploadForm extends Component {
       let formObject = new FormData();
       for (let key in formData) {
         if (formData[key] !== '') {
-          if (key === 'files' && document.querySelector('.fileUpload').multiple) {
-            Array.from(formData[key]).forEach((file) => {
-              formObject.append('files[]', file);
-            });
+          if (key === 'files' &&
+            document.querySelector('.fileUpload').multiple) {
+              Array.from(formData[key]).forEach((file) => {
+                formObject.append('files[]', file);
+              });
           } else {
             formObject.append(key, formData[key]);
           }
@@ -200,11 +201,12 @@ class DocUploadForm extends Component {
           if (resp.ok) {
             resp.json().then((data) => {
               if (data.error_count === 0) {
-                swal.fire('Upload Successful!', '', 'success').then((result) => {
-                  if (result.value) {
-                    this.setState({formData: {}, uploadInProgress: false});
-                    this.props.refreshPage();
-                  }
+                swal.fire('Upload Successful!', '', 'success')
+                  .then((result) => {
+                    if (result.value) {
+                      this.setState({formData: {}, uploadInProgress: false});
+                      this.props.refreshPage();
+                    }
                 });
               } else {
                 swal.fire('Upload Incomplete', data.message, 'warning');

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -332,6 +332,7 @@ class Files extends \NDB_Page
 
         $responseMessages = [];
         $errorCounter     = 0;
+        $addedFiles       = [];
 
         foreach ($uploadedFiles as $uploadedFile) {
             $filename = urldecode($uploadedFile->getClientFilename());
@@ -420,17 +421,22 @@ class Files extends \NDB_Page
                 ]
             );
 
+            $addedFiles[]       = $filename;
+            $responseMessages[] = "$filename: Success";
+        }
+
+        if (count($addedFiles) > 0) {
             $uploadNotifier     = new \NDB_Notifier(
                 "document_repository",
                 "upload"
             );
             $msg_data           = [
                 'newDocument' => 'Document Repository',
-                'document'    => $filename,
+                'documents'   => $addedFiles,
             ];
-            $responseMessages[] = "$filename: Success";
             $uploadNotifier->notify($msg_data);
         }
+
 
         $uploadResponse  = '<div class="upload-response">';
         $uploadResponse .= join("<br/><br/>", $responseMessages);

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -426,17 +426,16 @@ class Files extends \NDB_Page
         }
 
         if (count($addedFiles) > 0) {
-            $uploadNotifier     = new \NDB_Notifier(
+            $uploadNotifier = new \NDB_Notifier(
                 "document_repository",
                 "upload"
             );
-            $msg_data           = [
+            $msg_data       = [
                 'newDocument' => 'Document Repository',
                 'documents'   => $addedFiles,
             ];
             $uploadNotifier->notify($msg_data);
         }
-
 
         $uploadResponse  = '<div class="upload-response">';
         $uploadResponse .= join("<br/><br/>", $responseMessages);

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -371,7 +371,10 @@ class Files extends \NDB_Page
                 continue;
             }
 
-            $response = $uploader->handle($request->withUploadedFiles([$uploadedFile]));
+            $response = $uploader->handle(
+                $request->withUploadedFiles([$uploadedFile])
+            );
+
             if (!in_array($response->getStatusCode(), [200, 201], true)) {
                 $errorResponse      = json_decode(
                     $response->getBody()->getContents()

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -327,10 +327,11 @@ class Files extends \NDB_Page
             );
         }
 
-        $uploadedFiles = is_array($uploadedFiles) ? $uploadedFiles : [$uploadedFiles];
+        $uploadedFiles = is_array($uploadedFiles)
+            ? $uploadedFiles : [$uploadedFiles];
 
         $responseMessages = [];
-        $errorCounter = 0;
+        $errorCounter     = 0;
 
         foreach ($uploadedFiles as $uploadedFile) {
             $filename = urldecode($uploadedFile->getClientFilename());
@@ -339,7 +340,7 @@ class Files extends \NDB_Page
                 // If a record of this a file with the same name already exists
                 // in the database, don't proceed with upload.
                 $responseMessages[] = "$filename: " . self::FILE_EXISTS_IN_DB;
-                $errorCounter += 1;
+                $errorCounter      += 1;
                 continue;
             }
 
@@ -366,15 +367,17 @@ class Files extends \NDB_Page
                     );
             } catch (\ConfigurationException $e) {
                 $responseMessages[] = "$filename: {$e->getMessage()}";
-                $errorCounter += 1;
+                $errorCounter      += 1;
                 continue;
             }
 
             $response = $uploader->handle($request->withUploadedFiles([$uploadedFile]));
             if (!in_array($response->getStatusCode(), [200, 201], true)) {
-                $errorResponse = json_decode($response->getBody()->getContents());
+                $errorResponse      = json_decode(
+                    $response->getBody()->getContents()
+                );
                 $responseMessages[] = "$filename: $errorResponse->error";
-                $errorCounter += 1;
+                $errorCounter      += 1;
                 continue;
             }
 
@@ -414,16 +417,16 @@ class Files extends \NDB_Page
                 ]
             );
 
-            $uploadNotifier = new \NDB_Notifier(
+            $uploadNotifier     = new \NDB_Notifier(
                 "document_repository",
                 "upload"
             );
-            $msg_data       = [
+            $msg_data           = [
                 'newDocument' => 'Document Repository',
                 'document'    => $filename,
             ];
-            $uploadNotifier->notify($msg_data);
             $responseMessages[] = "$filename: Success";
+            $uploadNotifier->notify($msg_data);
         }
 
         $uploadResponse  = '<div class="upload-response">';
@@ -432,7 +435,7 @@ class Files extends \NDB_Page
 
         return (new \LORIS\Http\Response\JSON\OK(
             [
-                'message' => $uploadResponse,
+                'message'     => $uploadResponse,
                 'error_count' => $errorCounter
             ]
         ));

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -312,14 +312,6 @@ class Files extends \NDB_Page
             throw new \LorisException("Expected parsed body to be an array");
         }
 
-        $uploadedFile = $request->getUploadedFiles()['file'] ?? null;
-        if (is_null($uploadedFile)) {
-            return new \LORIS\Http\Response\JSON\BadRequest(
-                'No file uploaded'
-            );
-        }
-        $filename = urldecode($uploadedFile->getClientFilename());
-
         $category = $body['category']; // required
         if (!\Utility::valueIsPositiveInteger($category)) {
             // $category is a string representation of an ID, and so should be
@@ -327,94 +319,123 @@ class Files extends \NDB_Page
             return new \LORIS\Http\Response\JSON\BadRequest(self::BAD_CATEGORY);
         }
 
-        if ($this->existFilename($filename)) {
-            // If a record of this a file with the same name already exists
-            // in the database, don't proceed with upload.
-            return new \LORIS\Http\Response\JSON\Conflict(
-                self::FILE_EXISTS_IN_DB
+        $uploadedFiles = $request->getUploadedFiles()['files'] ?? null;
+
+        if (is_null($uploadedFiles)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'No files uploaded'
             );
         }
 
-        // Initialize FilesUploadHandler
-        $path = \Utility::pathJoin(
-            $config->getSetting("documentRepositoryPath"),
-            $name
-        );
-        if (!is_dir($path)) {
-            mkdir($path, 0770);
-        }
+        $uploadedFiles = is_array($uploadedFiles) ? $uploadedFiles : [$uploadedFiles];
 
-        $targetdir = new \SplFileInfo($path);
+        $responseMessages = [];
+        $errorCounter = 0;
 
-        try {
-            $uploader = (new \LORIS\FilesUploadHandler($targetdir))
-                ->withPermittedMIMETypes(
-                    'application/pdf',
-                    'image/jpeg',
-                    'image/png',
-                    'image/gif',
-                    'image/svg+xml',
-                    'text/plain'
-                );
-        } catch (\ConfigurationException $e) {
-            return new \LORIS\Http\Response\JSON\InternalServerError(
-                $e->getMessage()
+        foreach ($uploadedFiles as $uploadedFile) {
+            $filename = urldecode($uploadedFile->getClientFilename());
+
+            if ($this->existFilename($filename)) {
+                // If a record of this a file with the same name already exists
+                // in the database, don't proceed with upload.
+                $responseMessages[] = "$filename: " . self::FILE_EXISTS_IN_DB;
+                $errorCounter += 1;
+                continue;
+            }
+
+            // Initialize FilesUploadHandler
+            $path = \Utility::pathJoin(
+                $config->getSetting("documentRepositoryPath"),
+                $name
             );
+            if (!is_dir($path)) {
+                mkdir($path, 0770);
+            }
+
+            $targetdir = new \SplFileInfo($path);
+
+            try {
+                $uploader = (new \LORIS\FilesUploadHandler($targetdir))
+                    ->withPermittedMIMETypes(
+                        'application/pdf',
+                        'image/jpeg',
+                        'image/png',
+                        'image/gif',
+                        'image/svg+xml',
+                        'text/plain'
+                    );
+            } catch (\ConfigurationException $e) {
+                $responseMessages[] = "$filename: {$e->getMessage()}";
+                $errorCounter += 1;
+                continue;
+            }
+
+            $response = $uploader->handle($request->withUploadedFiles([$uploadedFile]));
+            if (!in_array($response->getStatusCode(), [200, 201], true)) {
+                $errorResponse = json_decode($response->getBody()->getContents());
+                $responseMessages[] = "$filename: $errorResponse->error";
+                $errorCounter += 1;
+                continue;
+            }
+
+            // Prepare fields for database entry once upload has completed.
+            $site = $body['forSite']       !== '' ? $body['forSite'] : null;
+            $site = $DB->pselectOne(
+                "SELECT CenterID FROM psc WHERE Name=:name",
+                ['name' => $site]
+            );
+
+            // Set empty values equal to NULL for insertion into the database.
+            $instrument = !empty($body['instrument']) ? $body['instrument'] : null;
+            $pscid      = !empty($body['pscid'])      ? $body['pscid']      : null;
+            $visit      = !empty($body['visitLabel']) ? $body['visitLabel'] : null;
+            $comments   = !empty($body['comments'])   ? $body['comments']   : null;
+            $version    = !empty($body['version'])    ? $body['version']    : null;
+
+            $fileSize = $uploadedFile->getSize();
+            $fileType = pathinfo($filename, PATHINFO_EXTENSION);
+
+            // Insert record of this file into the `document_repository` table.
+            $DB->unsafeInsertOnDuplicateUpdate(
+                'document_repository',
+                [
+                    'File_category' => $category,
+                    'For_site'      => $site,
+                    'comments'      => $comments,
+                    'version'       => $version,
+                    'File_name'     => $filename,
+                    'File_size'     => $fileSize,
+                    'Data_dir'      => "$name/$filename",
+                    'uploaded_by'   => $name,
+                    'Instrument'    => $instrument,
+                    'PSCID'         => $pscid,
+                    'visitLabel'    => $visit,
+                    'File_type'     => $fileType,
+                ]
+            );
+
+            $uploadNotifier = new \NDB_Notifier(
+                "document_repository",
+                "upload"
+            );
+            $msg_data       = [
+                'newDocument' => 'Document Repository',
+                'document'    => $filename,
+            ];
+            $uploadNotifier->notify($msg_data);
+            $responseMessages[] = "$filename: Success";
         }
 
-        $response = $uploader->handle($request);
-        if (!in_array($response->getStatusCode(), [200, 201], true)) {
-            // Something went wrong. Return early to skip further processing.
-            return $response;
-        }
+        $uploadResponse  = '<div class="upload-response">';
+        $uploadResponse .= join("<br/><br/>", $responseMessages);
+        $uploadResponse .= '</div>';
 
-        // Prepare fields for database entry once upload has completed.
-        $site = $body['forSite']       !== '' ? $body['forSite'] : null;
-        $site = $DB->pselectOne(
-            "SELECT CenterID FROM psc WHERE Name=:name",
-            ['name' => $site]
-        );
-
-        // Set empty values equal to NULL for insertion into the database.
-        $instrument = !empty($body['instrument']) ? $body['instrument'] : null;
-        $pscid      = !empty($body['pscid'])      ? $body['pscid']      : null;
-        $visit      = !empty($body['visitLabel']) ? $body['visitLabel'] : null;
-        $comments   = !empty($body['comments'])   ? $body['comments']   : null;
-        $version    = !empty($body['version'])    ? $body['version']    : null;
-
-        $fileSize = $uploadedFile->getSize();
-        $fileType = pathinfo($filename, PATHINFO_EXTENSION);
-
-        // Insert record of this file into the `document_repository` table.
-        $DB->unsafeInsertOnDuplicateUpdate(
-            'document_repository',
+        return (new \LORIS\Http\Response\JSON\OK(
             [
-                'File_category' => $category,
-                'For_site'      => $site,
-                'comments'      => $comments,
-                'version'       => $version,
-                'File_name'     => $filename,
-                'File_size'     => $fileSize,
-                'Data_dir'      => "$name/$filename",
-                'uploaded_by'   => $name,
-                'Instrument'    => $instrument,
-                'PSCID'         => $pscid,
-                'visitLabel'    => $visit,
-                'File_type'     => $fileType,
+                'message' => $uploadResponse,
+                'error_count' => $errorCounter
             ]
-        );
-
-        $uploadNotifier = new \NDB_Notifier(
-            "document_repository",
-            "upload"
-        );
-        $msg_data       = [
-            'newDocument' => 'Document Repository',
-            'document'    => $filename,
-        ];
-        $uploadNotifier->notify($msg_data);
-
-        return $response;
+        ));
     }
     /**
      * Check the find name in the database, if exists return false

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -103,7 +103,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
                 "form > div > div:nth-child(1) > h3"
             )
         )->getText();
-        $this->assertStringContainsString("Upload a file", $text);
+        $this->assertStringContainsString("Upload files", $text);
 
     }
     /**

--- a/smarty/templates/email/notifier_document_repository_upload.tpl
+++ b/smarty/templates/email/notifier_document_repository_upload.tpl
@@ -2,7 +2,9 @@ Subject: [LORIS Notification] Document Repository: new document uploaded
 
 Hello {$notified_user},
 
-New document named "{$document}" was added!
+{foreach from=$documents item=document}
+    New document named "{$document}" was added!
+{/foreach}
 Visit {$newDocument} to view the updates.
 
 Thank you,


### PR DESCRIPTION
### Brief summary of changes

- \<FileElement\> now supports the 'multiple' attribute.
- The document_repository module has been modified to support multiple uploaded files.
- Some visual feedback has been added (error reporting + uploading status).

### Testing instructions

- Ensure that another module using \<FileElement\> still works as intended.
- Try with different files, file types and folder permissions to ensure proper error reporting.

### Related issue: #8218