### PR TITLE
[Instrument] Remove exception from NDB_BVL_Instrument::factory

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -103,10 +103,16 @@ class DirectDataEntryMainPage
             throw new Exception("Data has already been submitted.", 403);
         }
 
-        $instrumentObj  = \NDB_BVL_Instrument::factory(
+        $instrumentObj = \NDB_BVL_Instrument::factory(
             $this->loris,
             $this->TestName,
         );
+
+        $user = \User::singleton();
+        if ($instrumentObj->_hasAccess($user) !== true) {
+            throw new \Exception("Permission denied", 403);
+        }
+
         $subtests       = $instrumentObj->getSubtestList();
         $this->NumPages = count($subtests) + 1;
 

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -131,6 +131,11 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 '',
                 true
             );
+
+            $user = $request->getAttribute('user');
+            if ($instrument->_hasAccess($user) == false) {
+                return new \LORIS\Http\Response\JSON\Forbidden();
+            };
         } catch (\Exception $e) {
             return new \LORIS\Http\Response\JSON\NotFound();
         }

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -108,6 +108,11 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 '',
                 true
             );
+
+            $user = $request->getAttribute("user");
+            if ($instrument->_hasAccess($user) == false) {
+                return new \LORIS\Http\Response\JSON\Forbidden();
+            }
         } catch (\Exception $e) {
             return new \LORIS\Http\Response\JSON\NotFound();
         }

--- a/modules/conflict_resolver/php/endpoints/unresolved.class.inc
+++ b/modules/conflict_resolver/php/endpoints/unresolved.class.inc
@@ -253,7 +253,7 @@ class Unresolved extends Endpoint implements ETagCalculator
             true
         );
         if ($instrument->_hasAccess($user) == false) {
-            return new \LORIS\Http\Response\JSON\NotFound(
+            return new \LORIS\Http\Response\JSON\Forbidden(
                 'Permission denied for ' . $conflict['TableName']
             );
         }

--- a/modules/conflict_resolver/php/endpoints/unresolved.class.inc
+++ b/modules/conflict_resolver/php/endpoints/unresolved.class.inc
@@ -252,6 +252,11 @@ class Unresolved extends Endpoint implements ETagCalculator
             '',
             true
         );
+        if ($instrument->_hasAccess($user) == false) {
+            return new \LORIS\Http\Response\JSON\NotFound(
+                'Permission denied for ' . $conflict['TableName']
+            );
+        }
         $instrument->_saveValues(
             [$conflict['FieldName'] => $conflict['CorrectAnswer']]
         );

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -60,6 +60,7 @@ class Datadict extends \DataFrameworkMenu
     {
         $instruments     = \Utility::getAllInstruments();
         $dictInstruments = [];
+
         foreach ($instruments as $instrument => $name) {
             // Since the testname does not always match the table name in the
             // database we need to instantiate the object to get the table name
@@ -70,6 +71,13 @@ class Datadict extends \DataFrameworkMenu
                     '',
                     ''
                 );
+                if ($iObj->_hasAccess($user)) {
+                    $this->logger->debug(
+                        "Skipping $instrument in field options"
+                        . " because user does not have permission"
+                    );
+                    continue;
+                }
             } catch (\Exception $e) {
                 error_log(
                     "There was a problem instantiating the instrument ".

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -84,6 +84,13 @@ class Module extends \Module
             $page
         );
 
+        $user = $request->getAttribute("user");
+        if ($instrument->_hasAccess($user) == false) {
+            return (new \Laminas\Diactoros\Response())
+                ->withStatus(403)
+                ->withBody(new \LORIS\Http\StringStream("Permission denied"));
+        }
+
         $request = $request->withAttribute('pageclass', $instrument);
 
         return $instrument->process($request, $instrument);
@@ -151,4 +158,3 @@ class Module extends \Module
         return [];
     }
 }
-

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -114,6 +114,10 @@ class VisitSummary extends \NDB_Page
                 false
             );
             if ($instrument->_hasAccess($user) == false) {
+                $this->logger->debug(
+                    "Skipping $testName"
+                    . " because user does not have permission"
+                );
                 continue;
             }
             if ($instrument === null) {

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -52,6 +52,7 @@ class VisitSummary extends \NDB_Page
             return $this->_handleGET(
                 new CandID($params['CandID']),
                 $params['VisitLabel'],
+                $user,
             );
         default:
             return new \LORIS\Http\Response\JSON\MethodNotAllowed(
@@ -61,15 +62,16 @@ class VisitSummary extends \NDB_Page
     }
 
     /**
-     * Helper to specifically handle PATCH HTTP methods to the endpoint.
+     * Helper to specifically handle GET HTTP methods to the endpoint.
      *
      * @param CandID $candid     The CandID for the visit.
      * @param string $visitLabel The visit label string.
+     * @param \User  $user       The user accessing the endpoint
      *
      * @return ResponseInterface
      */
     private function _handleGET(
-        CandID $candid, string $visitLabel
+        CandID $candid, string $visitLabel, \User $user
     ) : ResponseInterface {
         $DB = \NDB_Factory::singleton()->database();
 
@@ -111,6 +113,9 @@ class VisitSummary extends \NDB_Page
                 '',
                 false
             );
+            if ($instrument->_hasAccess($user) == false) {
+                continue;
+            }
             if ($instrument === null) {
                 $bvl_result[$key]['Completion'] = 0;
             } else {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -308,17 +308,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $base . "project/instruments/$instrument.rules"
         );
 
-        $user   = \User::singleton();
-        $access = $obj->_hasAccess($user);
-
-        // check that user has access
-        if ($access == false) {
-            throw new Exception(
-                "You do not have access to this page.",
-                403
-            );
-        }
-
         return $obj;
     }
 
@@ -380,9 +369,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     return true;
                 }
             }
-
-            //no user permissions match required instrument permissions
-            throw new Exception("You do not have access to this page.", 403);
+            return false;
         }
     }
 


### PR DESCRIPTION
This removes the exception from NDB_BVL_Instrument::factory(), so that it's possible to call hasAccess on an instrument. Currently the hasAccess or Factory call mix concerns, making it difficult for a module to check if a user has access to an instrument.