### PR TITLE
[tools] Fix path in recreate_conflict

### DIFF
--- a/tools/recreate_conflicts.php
+++ b/tools/recreate_conflicts.php
@@ -12,10 +12,10 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-require_once __DIR__ . 'generic_includes.php';
+require_once __DIR__ . '/generic_includes.php';
 
 $config = NDB_Config::singleton();
-$db     = Database::singleton();
+$db     = $lorisInstance->getDatabaseConnection();
 
 /**
  * HELP SCREEN
@@ -94,6 +94,7 @@ foreach ($ddeInstruments as $test) {
             print "Recreating conflicts for " . $instrument['Test_name'] .
                 ':'. $instrument['CommentID'] . "\n";
             $diff = ConflictDetector::detectConflictsForCommentIds(
+                $lorisInstance,
                 $instrument['Test_name'],
                 $instrument['CommentID'],
                 $instrument['DDECommentID']


### PR DESCRIPTION
This fixes the wrong path in the require_once for recreate_conflict. It also passes a missing LorisInstance object to the ConflictDetector function.

I still wasn't able to run the script to completion because I don't have instruments that are properly configured on my sandbox for this version of LORIS, but this resolves #8063.

Someone with up to date instruments should test the rest of the script.
