### PR TITLE
[Webpack] Compilation error fix

### DIFF
--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -75,8 +75,19 @@ const getConfig = cp.spawn('php', [
   'useEEGBrowserVisualizationComponents',
 ], {});
 
+let EEGVisEnabled = false;
 getConfig.stdout.on('data', (data) => {
-  const EEGVisEnabled = JSON.parse(data);
+  try {
+    EEGVisEnabled = JSON.parse(data);
+  } catch (e) {
+    console.warn(
+      '\x1b[33m',
+      'WARNING: Unable to fetch DB config',
+      'useEEGBrowserVisualizationComponents',
+      '\x1b[0m',
+    );
+  }
+
   if (EEGVisEnabled === 'true') {
     console.info('\n ----- \n >> '
       + 'EEG Browser visualization components enabled '
@@ -99,10 +110,12 @@ getConfig.stdout.on('data', (data) => {
     );
 
     protoc.on('error', (error) => {
-      console.error('ERROR: '
-        + 'Make sure that protoc '
-        + '(https://github.com/protocolbuffers/protobuf/releases/) '
-        + 'is installed on your system '
+      console.error(
+        '\x1b[31m',
+        'ERROR: Make sure that protoc',
+        '(https://github.com/protocolbuffers/protobuf/releases/)',
+        'is installed on your system',
+        '\x1b[0m',
       );
       console.error(error);
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,16 @@ if ('EEG_VIS_ENABLED' in process.env) {
     'useEEGBrowserVisualizationComponents',
   ], {});
 
-  EEGVisEnabled = JSON.parse(getConfig.stdout);
+  try {
+    EEGVisEnabled = JSON.parse(getConfig.stdout);
+  } catch (e) {
+    console.warn(
+      '\x1b[33m',
+      'WARNING: Unable to fetch DB config',
+      'useEEGBrowserVisualizationComponents',
+      '\x1b[0m',
+    );
+  }
 }
 
 modulePlugins.push(


### PR DESCRIPTION
Address an issue that prevents webpack and the post-install script to run when patch SQL/New_patches/2022-12-05-AddVizConfig.sql is not applied.

Now the errors are caught and a warning is printed on the screen. 

<img width="529" alt="Screen Shot 2022-12-20 at 1 22 45 PM" src="https://user-images.githubusercontent.com/32041423/208742800-86e066ca-b3fd-4fc8-977d-a33be5f0e2ec.png">
