### PR TITLE
[Core] Replace all $this->lorisinstance with $this->loris

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -71,7 +71,7 @@ class Candidate_List extends \DataFrameworkMenu
     {
         // Relying on a side-effect of the the server process module to autoload
         // its namespace.
-        \Module::factory($this->lorisinstance, 'candidate_parameters');
+        \Module::factory($this->loris, 'candidate_parameters');
 
         // create user object
         $factory = \NDB_Factory::singleton();

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -74,7 +74,7 @@ class Candidate_Profile extends \NDB_Page
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
 
-        $modules = $this->lorisinstance->getActiveModules();
+        $modules = $this->loris->getActiveModules();
 
         $widgets = [];
         foreach ($modules as $module) {

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -70,7 +70,7 @@ class Module extends \Module
         case 'candidate':
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();
-            $modules = $this->lorisinstance->getActiveModules();
+            $modules = $this->loris->getActiveModules();
 
             $params = [];
             foreach ($modules as $module) {

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -182,7 +182,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         );
         $visitLabel = $visits[$values['visit']];
         $visitName  = (new VisitController(
-            $this->lorisinstance->getDatabaseConnection()
+            $this->loris->getDatabaseConnection()
         ))->getVisitFromVisitLabel($visitLabel)->getName();
 
         \TimePoint::createNew(
@@ -274,7 +274,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         );
         $visitLabel = $visits[$values['visit']];
         $visitName  = (new VisitController(
-            $this->lorisinstance->getDatabaseConnection()
+            $this->loris->getDatabaseConnection()
         ))->getVisitFromVisitLabel($visitLabel)->getName();
 
         try {

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -136,7 +136,7 @@ class Module extends \Module
     private function _getTasksWidget()
     {
         $factory = \NDB_Factory::singleton();
-        $modules = $this->lorisinstance->getActiveModules();
+        $modules = $this->loris->getActiveModules();
         $user    = $factory->user();
 
         $widgets = [];

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -60,13 +60,12 @@ class Datadict extends \DataFrameworkMenu
     {
         $instruments     = \Utility::getAllInstruments();
         $dictInstruments = [];
-        $lorisinstance   = $this->lorisinstance;
         foreach ($instruments as $instrument => $name) {
             // Since the testname does not always match the table name in the
             // database we need to instantiate the object to get the table name
             try {
                 $iObj = \NDB_BVL_Instrument::factory(
-                    $lorisinstance,
+                    $this->loris,
                     $instrument,
                     '',
                     ''

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -67,7 +67,7 @@ class Dictionary extends \DataFrameworkMenu
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
         return new DataDictRowProvisioner(
-            $this->lorisinstance,
+            $this->loris,
             $this->categoryitems
         );
     }
@@ -135,12 +135,10 @@ class Dictionary extends \DataFrameworkMenu
     public function loadResources(
         \User $user, ServerRequestInterface $request
     ) : void {
-        $this->lorisinstance = $request->getAttribute("loris");
-
         assert($this->Module instanceof Module);
         $modulesandcats = $this->Module->getUserModuleCategories(
             $user,
-            $this->lorisinstance,
+            $this->loris,
         );
 
         $this->categoryitems = $modulesandcats['CategoryItems'];

--- a/modules/dictionary/php/fields.class.inc
+++ b/modules/dictionary/php/fields.class.inc
@@ -80,12 +80,12 @@ class Fields extends \NDB_Page
      */
     private function _getOriginalDescription(string $name) : string
     {
-        $modules = $this->lorisinstance->getActiveModules();
+        $modules = $this->loris->getActiveModules();
 
         // Brute force finding the name since we don't know what module
         // the dictionary item came from.
         foreach ($modules as $module) {
-            $mdict = $module->getDataDictionary($this->lorisinstance);
+            $mdict = $module->getDataDictionary($this->loris);
             foreach ($mdict as $cat) {
                 foreach ($cat->getItems() as $item) {
                     $iname = $cat->getName() . '_' . $item->getName();
@@ -109,7 +109,7 @@ class Fields extends \NDB_Page
      */
     private function _replaceDescription(string $name, string $description) : string
     {
-        $DB       = $this->lorisinstance->getDatabaseConnection();
+        $DB       = $this->loris->getDatabaseConnection();
         $origdesc = $this->_getOriginalDescription($name);
 
         if ($description == $origdesc) {

--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -95,7 +95,7 @@ class Module extends \Module
                 continue;
             }
 
-            $mdict = $module->getDataDictionary($this->lorisinstance);
+            $mdict = $module->getDataDictionary($this->loris);
             $mname = $module->getName();
 
             if (count($mdict) > 0) {

--- a/modules/dictionary/php/moduledict.class.inc
+++ b/modules/dictionary/php/moduledict.class.inc
@@ -62,7 +62,7 @@ class ModuleDict extends \NDB_Page
         \User $user,
         string $modulename
     ) : ResponseInterface {
-        $loris  = $this->lorisinstance;
+        $loris  = $this->loris;
         $module = null;
 
         foreach ($loris->getActiveModules() as $m) {

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -54,7 +54,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
      */
     function getDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new IssueRowProvisioner($this->lorisinstance);
+        $provisioner = new IssueRowProvisioner($this->loris);
 
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
@@ -141,7 +141,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         }
 
         $modules = array_reduce(
-            $this->lorisinstance->getActiveModules(),
+            $this->loris->getActiveModules(),
             function (
                 $result,
                 $module

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -31,14 +31,13 @@ namespace LORIS\issue_tracker;
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     private array $allCenterIDs;
-    private \LORIS\LorisInstance $lorisinstance;
 
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
      *
      * @param \LORIS\LorisInstance $loris the LORIS instance with the issues
      */
-    function __construct(\LORIS\LorisInstance $loris)
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
@@ -49,8 +48,6 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             $loris->getAllSites()
         );
         $userID = $user->getUsername();
-
-        $this->lorisinstance = $loris;
 
         //note that this needs to be in the same order as the headers array
         parent::__construct(
@@ -103,10 +100,10 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         static $modules = [];
 
         $mname  = $row['module'];
-        $module = new \NullModule($this->lorisinstance);
+        $module = new \NullModule($this->loris);
         if (!empty($mname)) {
             if (!isset($modules[$mname])) {
-                $modules[$mname] = $this->lorisinstance->getModule($mname);
+                $modules[$mname] = $this->loris->getModule($mname);
             }
             $module = &$modules[$mname];
         }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -103,7 +103,7 @@ class Media extends \DataFrameworkMenu
         foreach ($instrumentsQuery as $instrument) {
             try {
                 $instrumentName = \NDB_BVL_Instrument::factory(
-                    $this->lorisinstance,
+                    $this->loris,
                     $instrument["Test_name"],
                 )->getFullname();
             } catch (\Exception $e) {
@@ -153,7 +153,7 @@ class Media extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new MediaFileProvisioner($this->lorisinstance);
+        return new MediaFileProvisioner($this->loris);
     }
 
     /**

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -30,8 +30,6 @@ namespace LORIS\media;
  */
 class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-    protected $lorisinstance;
-
     /**
      * Cache of instrument->getFullname returned value.
      * Initializing empty keys to prevent instanciation of empty testnames.
@@ -42,13 +40,11 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      * Create a MediaFileProvisioner, which gets files for the meida
      * menu table.
      *
-     * @param \LORIS\LorisInstance $lorisinstance The LORIS instance that the module
-     *                                            is serving.
+     * @param \LORIS\LorisInstance $loris The LORIS instance that the module
+     *                                    is serving.
      */
-    function __construct(\LORIS\LorisInstance $lorisinstance)
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
-        $this->lorisinstance = $lorisinstance;
-
         parent::__construct(
             "SELECT m.file_name as fileName,
                     m.instrument as testName,
@@ -92,7 +88,7 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         // make sure not to call the factory when $testname is null or ''
         if (!empty($testname) && !isset($this->_instrumentnames[$testname])) {
             $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
-                $this->lorisinstance,
+                $this->loris,
                 $testname,
             )->getFullname();
         }

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -64,7 +64,7 @@ class Module_Manager extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new ModuleManagerProvisioner($this->lorisinstance);
+        return new ModuleManagerProvisioner($this->loris);
     }
 
     /**

--- a/modules/module_manager/php/modulemanagerprovisioner.class.inc
+++ b/modules/module_manager/php/modulemanagerprovisioner.class.inc
@@ -30,17 +30,14 @@ namespace LORIS\module_manager;
  */
 class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-    protected \LORIS\LorisInstance $lorisinstance;
-
     /**
      * Create a ModuleManagerProvisioner, which gets modules for the
      * module manager menu table.
      *
      * @param \LORIS\LorisInstance $loris The LORIS instance
      */
-    function __construct(\LORIS\LorisInstance $loris)
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
-        $this->lorisinstance = $loris;
         parent::__construct(
             "SELECT name, active FROM modules",
             []
@@ -56,6 +53,6 @@ class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-            return new ModuleRow($this->lorisinstance, $row);
+            return new ModuleRow($this->loris, $row);
     }
 }

--- a/modules/module_manager/php/modulerow.class.inc
+++ b/modules/module_manager/php/modulerow.class.inc
@@ -35,7 +35,6 @@ class ModuleRow implements \LORIS\Data\DataInstance
     protected $Module;
     protected $DBRow;
     protected $Active;
-    protected $lorisinstance;
 
     /**
      * Create a new ModuleRow Instance.
@@ -43,11 +42,10 @@ class ModuleRow implements \LORIS\Data\DataInstance
      * @param \LORIS\LorisInstance $loris The LORIS instance with the module
      * @param array                $row   The ModuleRow Instance
      */
-    public function __construct(\LORIS\LorisInstance $loris, array $row)
+    public function __construct(protected \LORIS\LorisInstance $loris, array $row)
     {
-        $this->lorisinstance = $loris;
-        $this->Module        = $loris->getModule($row['name']);
-        $this->Active        = $row['active'];
+        $this->Module = $loris->getModule($row['name']);
+        $this->Active = $row['active'];
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -945,7 +945,7 @@ class Edit_User extends \NDB_Form
                 = self::canRejectAccount(\User::factory($this->identifier));
         }
 
-        $perms = $editor->getPermissionsVerbose($this->lorisinstance);
+        $perms = $editor->getPermissionsVerbose($this->loris);
 
         $lastRole = '';
         $group    = [];

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -33,7 +33,7 @@ trait LegacyInstrumentTrait
      *
      * @var \LORIS\LorisInstance
      */
-    protected $loris;
+    protected \LORIS\LorisInstance $loris;
 
     /**
      * The testName being accessed. Not that this is set in

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -35,7 +35,7 @@ trait LorisFormDictionaryImpl
      * Variable from NDB_Page. Must be included in trait
      * to avoid PhanUndeclaredProperty errors.
      */
-    protected $loris;
+    protected \LORIS\LorisInstance $loris;
 
     /**
      * Recursively extract non-group elements from $elements, and

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -38,10 +38,6 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     const CONFIGURATION_ERROR = "LORIS configuration settings are invalid or "
         . "missing and as a result execution cannot proceed. Please contact "
         . "your project administrator and/or verify your LORIS configuration.";
-    protected $name;
-    protected $dir;
-
-    protected \LORIS\LorisInstance $lorisinstance;
 
     /**
      * Retrieve all active module descriptors from the given database, indexed
@@ -143,15 +139,15 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     /**
      * Creates a new module instance
      *
-     * @param \LORIS\LorisInstance $loris     The LORIS instance for the module
-     * @param string               $name      The name of the module
-     * @param string               $moduledir The directory on the filesystem
-     *                                        containing the module
+     * @param \LORIS\LorisInstance $loris The LORIS instance for the module
+     * @param string               $name  The name of the module
+     * @param string               $dir   The directory on the filesystem
+     *                                    containing the module
      */
     public function __construct(
-        \LORIS\LorisInstance $loris,
-        string $name,
-        string $moduledir
+        protected \LORIS\LorisInstance $loris,
+        protected string $name,
+        protected string $dir,
     ) {
         $loglevel = $loris->getConfiguration()
             ->getLogSettings()
@@ -164,30 +160,25 @@ abstract class Module extends \LORIS\Router\PrefixRouter
                 [
                     "/css/"    => new \LORIS\Router\ModuleFileRouter(
                         $this,
-                        $moduledir,
+                        $dir,
                         "css",
                         "text/css"
                     ),
                     "/js/"     => new \LORIS\Router\ModuleFileRouter(
                         $this,
-                        $moduledir,
+                        $dir,
                         "js",
                         "application/javascript"
                     ),
                     "/static/" => new \LORIS\Router\ModuleFileRouter(
                         $this,
-                        $moduledir,
+                        $dir,
                         "static",
                         ""
                     ),
                 ]
             )
         );
-
-        $this->lorisinstance = $loris;
-
-        $this->name = $name;
-        $this->dir  = $moduledir;
     }
 
     /**
@@ -346,9 +337,8 @@ abstract class Module extends \LORIS\Router\PrefixRouter
             return $resp;
         }
 
-        $this->lorisinstance = $request->getAttribute("loris");
-        $pagename            = $this->getName();
-        $path = trim($request->getURI()->getPath(), "/");
+        $pagename = $this->getName();
+        $path     = trim($request->getURI()->getPath(), "/");
         if (!empty($path)) {
             // There is a subpage
             $pagename = explode("/", $path)[0];

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -30,7 +30,6 @@ class NDB_Page implements RequestHandlerInterface
 {
     use Psr\Log\LoggerAwareTrait;
 
-    protected $lorisinstance;
     /**
      * The name of the test_name being accessed
      */
@@ -77,13 +76,6 @@ class NDB_Page implements RequestHandlerInterface
     public $template;
 
     /**
-     * The LorisInstance that this page was created to serve.
-     *
-     * @var \LORIS\LorisInstance
-     */
-    protected $loris;
-
-    /**
      * The format that the page content should be returned in. This is generally
      * the value of the `?format=` GET parameter from the request, and is usually
      * either 'json' or empty (for the default return value of HTML format).
@@ -126,13 +118,12 @@ class NDB_Page implements RequestHandlerInterface
      * @param string               $commentID  The CommentID to load the data for
      */
     function __construct(
-        \LORIS\LorisInstance $loris,
+        protected \LORIS\LorisInstance $loris,
         \Module $module,
         string $page,
         string $identifier,
         string $commentID
     ) {
-        $this->loris  = $loris;
         $this->Module = $module;
         $this->name   = $module->getName(); // for legacy purposes.
 
@@ -707,9 +698,6 @@ class NDB_Page implements RequestHandlerInterface
                     new \LORIS\Http\StringStream("Permission Denied")
                 )->withStatus(403);
         }
-
-        $loris = $request->getAttribute("loris");
-        $this->lorisinstance = $loris;
 
         // The NDB_Page object itself is sometimes required by middleware,
         // but since the PSR15 Middleware interface is fixed, it needs to be

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -30,7 +30,7 @@ use \Psr\Http\Server\RequestHandlerInterface;
  */
 class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 {
-    protected $lorisinstance;
+    protected $loris;
     protected $user;
 
     /**
@@ -43,8 +43,8 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
      */
     public function __construct(\User $user, string $projectdir, string $moduledir)
     {
-        $this->user          = $user;
-        $this->lorisinstance = new \LORIS\LorisInstance(
+        $this->user  = $user;
+        $this->loris = new \LORIS\LorisInstance(
             \NDB_Factory::singleton()->database(),
             \NDB_Factory::singleton()->config(),
             [
@@ -72,7 +72,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         // route
         $path    = preg_replace("/\/$/", "", $path);
         $request = $request->withAttribute("user", $this->user)
-            ->withAttribute("loris", $this->lorisinstance);
+            ->withAttribute("loris", $this->loris);
 
         if ($path == "") {
             if ($this->user instanceof \LORIS\AnonymousUser) {
@@ -94,7 +94,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
         $factory           = \NDB_Factory::singleton();
         $ehandler          = new \LORIS\Middleware\ExceptionHandlingMiddleware();
-        $exceptionloglevel = $this->lorisinstance->getConfiguration()
+        $exceptionloglevel = $this->loris->getConfiguration()
             ->getLogSettings()
             ->getExceptionLogLevel();
 
@@ -108,7 +108,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $ehandler->setLogger(new \PSR\Log\NullLogger);
         }
 
-        if ($this->lorisinstance->hasModule($modulename)) {
+        if ($this->loris->hasModule($modulename)) {
             $uri    = $request->getURI();
             $suburi = $this->stripPrefix($modulename, $uri);
 
@@ -120,7 +120,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $factory->setBaseURL($baseurl);
 
-            $module  = $this->lorisinstance->getModule($modulename);
+            $module  = $this->loris->getModule($modulename);
             $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
             return $ehandler->process($request, $mr);
@@ -136,7 +136,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 $request = $request
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
-                $module  = $this->lorisinstance->getModule("timepoint_list");
+                $module  = $this->loris->getModule("timepoint_list");
                 $mr      = new ModuleRouter($module);
                 return $ehandler->process($request, $mr);
             }


### PR DESCRIPTION
This removes the duplicate references to the LorisInstance object in NDB_Page and harmonizes them to all use $this->loris, which is set from the constructor.

Resolves #8049