### PR TITLE
Fix TimePoint getScreeningStatus return type

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -500,9 +500,9 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets this timepoint's screening status.
      *
-     * @return string 'Pass', 'Failure', 'Withdrawal', or 'In Progress'
+     * @return ?string 'Pass', 'Failure', 'Withdrawal', or 'In Progress'
      */
-    function getScreeningStatus(): string
+    function getScreeningStatus(): ?string
     {
         return $this->_timePointInfo["Screening"];
     }


### PR DESCRIPTION
Updates the return type of getScreeningStatus() to allow null values.

See:
https://github.com/aces/Loris/blob/9860f7f4bba8d70f29936594b8372f45c71b6050/php/libraries/TimePoint.class.inc#L774

https://github.com/aces/Loris/blob/main/SQL/0000-00-00-schema.sql#L194

Fixes #7282