### PR TITLE
[issue tracker] Fix emailing bug found in HBCD

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -557,7 +557,7 @@ class Edit extends \NDB_Page implements ETagCalculator
      */
     function emailUser(int $issueID, string $changed_assignee,
         string $changed_watcher, \User $user
-    ){
+    ) {
         $db      = $this->loris->getDatabaseConnection();
         $baseurl = \NDB_Factory::singleton()->settings()->getBaseURL();
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -490,7 +490,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             $db->replace('issues_watching', $nowWatching);
 
             // sending email
-            $this->emailUser($issueID, $issueValues['assignee'], $user);
+            $this->emailUser($issueID, $issueValues['assignee'], '', $user);
         }
 
         // Adding others from multiselect to watching table.
@@ -519,7 +519,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                     ) {
                         continue;
                     }
-                    $this->emailUser($issueID, $usersWatching, $user);
+                    $this->emailUser($issueID, '', $usersWatching, $user);
                 }
             }
         }
@@ -550,11 +550,12 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @param int    $issueID          the issueID
      * @param string $changed_assignee changed assignee
+     * @param string $changed_watcher  changed watcher
      * @param \User  $user             the user requesting the change
      *
      * @return void
      */
-    function emailUser(int $issueID, string $changed_assignee, \User $user)
+    function emailUser(int $issueID, string $changed_assignee, string $changed_watcher, \User $user)
     {
         $db      = $this->loris->getDatabaseConnection();
         $baseurl = \NDB_Factory::singleton()->settings()->getBaseURL();
@@ -611,12 +612,12 @@ class Edit extends \NDB_Page implements ETagCalculator
                         INNER JOIN issues_watching w ON (w.userID = u.UserID)
                     WHERE
                         w.issueID = :issueID
-                        AND w.userID = :uid
-                        AND u.UserID = :assignee",
+                        AND u.UserID = :watcher
+                        AND u.UserID != :currentUser",
             [
                 'issueID'  => $issueID,
-                'uid'      => $user->getUsername(),
-                'assignee' => $changed_assignee,
+                'watcher' => $changed_watcher,
+                'currentUser' => $user->getUserName(),
             ]
         );
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -556,8 +556,8 @@ class Edit extends \NDB_Page implements ETagCalculator
      * @return void
      */
     function emailUser(int $issueID, string $changed_assignee,
-                       string $changed_watcher, \User $user)
-    {
+        string $changed_watcher, \User $user
+    ){
         $db      = $this->loris->getDatabaseConnection();
         $baseurl = \NDB_Factory::singleton()->settings()->getBaseURL();
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -599,9 +599,6 @@ class Edit extends \NDB_Page implements ETagCalculator
                     $msg_data
                 );
             }
-        } else {
-            // so query below doesn't break..
-            $changed_assignee = $user->getUsername();
         }
 
         $issue_change_emails = $db->pselect(

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -555,7 +555,8 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @return void
      */
-    function emailUser(int $issueID, string $changed_assignee, string $changed_watcher, \User $user)
+    function emailUser(int $issueID, string $changed_assignee,
+                       string $changed_watcher, \User $user)
     {
         $db      = $this->loris->getDatabaseConnection();
         $baseurl = \NDB_Factory::singleton()->settings()->getBaseURL();
@@ -615,8 +616,8 @@ class Edit extends \NDB_Page implements ETagCalculator
                         AND u.UserID = :watcher
                         AND u.UserID != :currentUser",
             [
-                'issueID'  => $issueID,
-                'watcher' => $changed_watcher,
+                'issueID'     => $issueID,
+                'watcher'     => $changed_watcher,
                 'currentUser' => $user->getUserName(),
             ]
         );


### PR DESCRIPTION
## Brief summary of changes

The logic to send emails to watchers and assignee was off. Watchers ended up receiving emails that an issue was assigned to them even though it was not. With this bug fix:
- an "issue assigned" email is sent to new assignees
- a 'issue changed' email is sent to watchers