### PR TITLE
[issue_tracker] make assignee drop down not required

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -246,7 +246,7 @@ class IssueForm extends Component {
             onUserInput={this.setFormData}
             disabled={!hasEditPermission}
             value={this.state.formData.assignee}
-            required={true}
+            required={false}
           />
           <SelectElement
             name='centerID'


### PR DESCRIPTION
## Brief summary of changes

This makes the assignee drop down not required when creating an issue.

#### Link(s) to related issue(s)

* Resolves #4818
