### PR TITLE
JS/ESLint warning cleanup

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -103,7 +103,7 @@ function Filter(props) {
             key: filter.name,
             name: filter.name,
             label: field.label,
-            value: (props.filters[filter.name] || {}).value || false,
+            value: (props.filters[filter.name] || {}).value || null,
             onUserInput: onFieldUpdate,
           }
         ));

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -75,7 +75,6 @@ class DataDictIndex extends Component {
    * @param {string} cell - cell content
    * @param {array} rowData - array of cell contents for a specific row
    * @param {array} rowHeaders - array of table headers (column names)
-   *
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -178,8 +178,9 @@ class ImagingUploader extends Component {
 
     if (column === 'Number Of Files Created') {
       let violatedScans;
-      // eslint-disable-next-line max-len
-      if (row['Number Of Files Created'] - row['Number Of Files Inserted'] > 0) {
+      if (
+        row['Number Of Files Created'] - row['Number Of Files Inserted'] > 0
+      ) {
         let numViolatedScans =
              row['Number Of Files Created'] - row['Number Of Files Inserted'];
 


### PR DESCRIPTION
- clean 2 eslint warnings
- fix a js warning in modules index pages (ex: /help_editor)
```
Warning: Failed prop type: Invalid prop `value` of type `boolean` supplied to `TextboxElement`, expected `string`.
```