### PR TITLE
Parallelize integration tests

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -11,13 +11,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+        fail-fast: false
         matrix:
-            testsuite:
-            - static
-            - unit
-            - integration
+            testsuite: ['integration']
             php: ['8.1','8.2']
+            ci_node_index: [0,1,2,3]
 
+            include:
+            # add a variable but do not display it in the job's name 
+            - ci_node_total: 4
+
+            - testsuite: 'static'
+              php: '8.1'
+            - testsuite: 'static'
+              php: '8.2'
+            - testsuite: 'unit'
+              php: '8.1'
+            - testsuite: 'unit'
+              php: '8.2'
+            
     steps:
     - uses: actions/checkout@v2
 
@@ -57,3 +69,8 @@ jobs:
 
     - name: Run Test Suite
       run: npm run tests:${{ matrix.testsuite }}
+      env:
+          # Specifies how many jobs you would like to run in parallel,
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          # Use the index from matrix as an environment variable
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -80,6 +80,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         )->getText();
         $this->assertStringContainsString('Cannot continue', $bodyText);
         $this->resetPermissions();
+        $this->restoreConfigSetting("mriCodePath");
     }
 
     /**
@@ -90,7 +91,6 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testLoadsWithoutPermissionRead()
     {
-        // This function sets mriCodePath for all future functions
         $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
         $this->setupPermissions([""]);
         $this->safeGet($this->url . "/server_processes_manager/");
@@ -102,6 +102,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             $bodyText
         );
         $this->resetPermissions();
+        $this->restoreConfigSetting("mriCodePath");
     }
     /**
      * Tests that the page does not load if the user does not have correct
@@ -111,6 +112,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testDoesNotLoadWithPermission()
     {
+        $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
         $this->setupPermissions(["server_processes_manager"]);
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->safeFindElement(
@@ -125,6 +127,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             $bodyText
         );
         $this->resetPermissions();
+        $this->restoreConfigSetting("mriCodePath");
     }
 
     /**
@@ -134,6 +137,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testPageUIs()
     {
+        $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
         $this->safeGet($this->url . "/server_processes_manager/");
         foreach ($this->_loadingUI as $key => $value) {
             $text = $this->safeFindElement(
@@ -141,6 +145,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             )->getText();
             $this->assertStringContainsString($key, $text);
         }
+        $this->restoreConfigSetting("mriCodePath");
     }
     /**
      * Testing React filter in this page.
@@ -149,6 +154,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testFilters()
     {
+        $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
         $this->safeGet($this->url . "/server_processes_manager/");
         $this->_filterTest(
             self::$pid,
@@ -171,6 +177,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             'admin',
             '51'
         );
+        $this->restoreConfigSetting("mriCodePath");
     }
 }
 

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -8,6 +8,17 @@ else
     CONTAINER=integration-tests
 fi
 
+if [[ -z "${CI_NODE_TOTAL-}" || -z "${CI_NODE_INDEX-}" ]]; then
+  FILTER=""
+else
+  SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+  classes=($(cd ${SCRIPTPATH} && ../vendor/bin/phpunit --list-tests  --testsuite LorisCoreIntegrationTests,LorisModuleIntegrationTests | awk -F'[: ]' '!seen[$5]++ && /^ \-/ { print "::"$5"$"}'))
+  
+  n=$((${#classes[@]} / CI_NODE_TOTAL + 1))
+  slice=(${classes[@]:CI_NODE_INDEX * $n:$n})
+  slicestr=$(IFS="|" ; echo "${slice[*]}")
+  FILTER="--filter '/|${slicestr}|/'"
+fi
+
 # Core integration tests
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*
+docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests,LorisModuleIntegrationTests ${FILTER} $*


### PR DESCRIPTION
Split the integration tests methods in roughly 4 equal datasets.
Execution time decreased from 45min to 20min.