### PR TITLE
[candidate_list] Fix Typo 'VisitCount' to 'Visit Count' 

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -281,7 +281,7 @@ class CandidateListIndex extends Component {
         },
       },
       {
-        'label': 'VisitCount',
+        'label': 'Visit Count',
         'show': true,
         'filter': {
           name: 'visitCount',


### PR DESCRIPTION
## Brief summary of changes

Fix Typo 'VisitCount' to 'Visit Count', VisitCount should have a space in the middle
#7609 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
