### PR TITLE
[EEG Browser] Fix Download broken links

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -132,10 +132,7 @@ case 'xml':
     $DownloadFilename = basename($File);
     break;
 case 'edf':
-    $FullPath         = $imagePath . '/' . $File;
-    $MimeType         = 'application/octet-stream';
-    $DownloadFilename = basename($File);
-    break;
+case 'fdt':
 case 'set':
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = 'application/octet-stream';

--- a/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
+++ b/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
@@ -55,14 +55,8 @@ class DownloadPanel extends Component {
                   margin: '0 auto',
                 }
               }>
-                {panel.links.map((download, j) => {
+                {Object.entries(panel.links).map(([type, download], j) => {
                   const disabled = (download.file === '');
-
-                  // Hide the download in this particular case
-                  // It does not make sense to display Not Available for FDT files
-                  if (disabled && download.type === 'physiological_fdt_file') {
-                    return null;
-                  }
 
                   return (
                     <div
@@ -92,16 +86,16 @@ class DownloadPanel extends Component {
                         : <a
                             className='btn btn-primary download col-xs-6'
                             href={
-                              (download.type ==
+                              (type ==
                               'physiological_annotation_files' ||
-                              download.type == 'all_files') ?
+                              type == 'all_files') ?
                                 this.state.annotationsAction
                                 + '?physioFileID=' + this.state.physioFileID
                                 + '&filePath=' + download.file
                                 : '/mri/jiv/get_file.php?file=' + download.file
                             }
                             target='_blank'
-                            download={this.state.downloads[0].file}
+                            download
                             style={{
                               margin: 0,
                             }}

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -123,7 +123,7 @@ class ElectrophysiologySessionView extends Component {
             },
             downloads: [
               {
-                type: 'physiological_file',
+                type: 'physiological_files',
                 file: '',
               },
               {
@@ -144,10 +144,6 @@ class ElectrophysiologySessionView extends Component {
               },
               {
                 type: 'all_files',
-                file: '',
-              },
-              {
-                type: 'physiological_fdt_file',
                 file: '',
               },
             ],
@@ -226,10 +222,10 @@ class ElectrophysiologySessionView extends Component {
                 dbEntry
                 && dbEntry.file.downloads.map(
                   (group) =>
-                    group.links[1]?.file
+                    group.links['physiological_electrode_file']?.file
                     && loris.BaseURL
                       + '/electrophysiology_browser/file_reader/?file='
-                      + group.links[1].file
+                      + group.links['physiological_electrode_file'].file
               ),
             events:
               dbEntry

--- a/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
@@ -119,7 +119,7 @@ class ElectrophysioAnnotations
             }
 
             //If no derivative files exist, must create new files
-            $annotationFID = $db->pselect(
+            $annotationFIDs = $db->pselect(
                 "SELECT AnnotationFileID
                     FROM physiological_annotation_file
                     WHERE PhysiologicalFileID=:PFID",
@@ -144,10 +144,7 @@ class ElectrophysioAnnotations
             ];
 
             //Insert new files and data into DB
-            if (empty($annotationFID)) {
-
-                //Create new annotation files
-                $this->_createFiles();
+            if (empty($annotationFIDs)) {
 
                 //Get new annotation file ID
                 $annotation_tsv_ID = $db->pselectOne(
@@ -277,7 +274,7 @@ class ElectrophysioAnnotations
     }
 
     /**
-     * Updates the derivative files associated with the given
+     * Updates the derivative files associated with the
      * physiological file ID
      *
      * @return void
@@ -286,6 +283,19 @@ class ElectrophysioAnnotations
     function updateFiles(): void
     {
         $db = \NDB_Factory::singleton()->database();
+
+        //If no derivative files exist, must create new files
+        $annotationFIDs = $db->pselect(
+            "SELECT AnnotationFileID
+                FROM physiological_annotation_file
+                WHERE PhysiologicalFileID=:PFID",
+            ['PFID' => $this->_physioFileID]
+        );
+        //Insert new files and data into DB
+        if (empty($annotationFIDs)) {
+            //Create new annotation files
+            $this->_createFiles();
+        }
 
         //Get data directory base path from Config
         $dataDir = $db->pselectOne(
@@ -334,9 +344,7 @@ class ElectrophysioAnnotations
             //Update the three files with the given paths
             $labels   = []; // Label Name => Label Description
             $tsv_file = fopen($tsv_path, 'w'); //Will override all file content
-            //Add columns
-            $columns = implode("\t", $tsv_entries);
-            fwrite($tsv_file, $columns."\n");
+
             //Get all annotation instances
             //Then go thru each and get the label name + description
             //add label name to file and also to an array for json file
@@ -356,6 +364,14 @@ class ElectrophysioAnnotations
                 WHERE p.AnnotationFileID=:AFID",
                 ['AFID' => $tsv[0]['id']]
             );
+
+            if (count($instances) < 1) {
+                return;
+            }
+
+            //Add columns
+            $columns = implode("\t", $tsv_entries);
+            fwrite($tsv_file, $columns."\n");
 
             foreach ($instances as $instance) {
                 //Add labels to list for parameter file

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -559,8 +559,28 @@ class Sessions extends \NDB_Page
         $downloadLinks[] = [
             'type'  => 'physiological_file',
             'file'  => $physioFile,
-            'label' => 'EEG File',
+            'label' => 'EEG File(s)',
         ];
+
+        $queryFDT = "SELECT
+            Value AS FilePath,
+            'physiological_fdt_file' AS FileType
+            FROM
+            physiological_parameter_file
+            JOIN parameter_type AS pt USING (ParameterTypeID)
+            WHERE
+            pt.Name='fdt_file'
+            AND PhysiologicalFileID=:PFID";
+        $queryFDT = $db->pselectRow($queryFDT, ['PFID' => $physioFileID]);
+        if (isset($queryFDT['FileType'])) {
+            $downloadLinks[] = [
+                'type'  => $queryFDT['FileType'],
+                'file'  => $queryFDT['FilePath'],
+                'label' => '',
+            ];
+        }
+
+        // Metadata
 
         $queries = [
             'physiological_electrode'          => 'physiological_electrode_file',
@@ -580,7 +600,7 @@ class Sessions extends \NDB_Page
 
         foreach ($queries as $query_key => $query_value) {
             $query_statement = "SELECT
-                            DISTINCT(FilePath), '$query_value' AS FileType
+                            DISTINCT(FilePath)
                             FROM
                             $query_key
                             WHERE
@@ -589,44 +609,19 @@ class Sessions extends \NDB_Page
                 $query_statement,
                 ['PFID' => $physioFileID]
             );
-            if (isset($query_statement['FileType'])) {
-                $downloadLinks[] = [
-                    'type'  => $query_statement['FileType'],
+            if ($query_statement) {
+                $downloadLinks[$query_value] = [
                     'file'  => $query_statement['FilePath'],
-                    'label' => $labels[$query_statement['FileType']]
+                    'label' => $labels[$query_value],
                 ];
             } else {
-                $downloadLinks[] = [
-                    'type'  => $query_value,
+                $downloadLinks[$query_value] = [
                     'file'  => '',
                     'label' => $labels[$query_value],
                 ];
             }
         }
 
-        $queryFDT = "SELECT
-                Value AS FilePath,
-                'physiological_fdt_file' AS FileType
-                FROM
-                physiological_parameter_file
-                JOIN parameter_type AS pt USING (ParameterTypeID)
-                WHERE
-                pt.Name='fdt_file'
-                AND PhysiologicalFileID=:PFID";
-        $queryFDT = $db->pselectRow($queryFDT, ['PFID' => $physioFileID]);
-        if (isset($queryFDT['FileType'])) {
-            $downloadLinks[] = [
-                'type'  => $queryFDT['FileType'],
-                'file'  => $queryFDT['FilePath'],
-                'label' => '',
-            ];
-        } else {
-            $downloadLinks[] = [
-                'type'  => 'physiological_fdt_file',
-                'file'  => '',
-                'label' => '',
-            ];
-        }
         return $downloadLinks;
     }
 


### PR DESCRIPTION
Fix a few issues with EEGLAB set/fdt files:
- Download link broken
- incorrect placement, it should be logically after the .set file

Download `All files` fails when no annotations exists. 
Migrate the annotation files creation logic from `update` to `updateFiles`, since `update` handles DB updates only.