### PR TITLE
Issue tracker - assignees option is empty

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -372,7 +372,7 @@ class IssueForm extends Component {
           if (newIssue) {
             formData.centerID = null;
             Object.keys(data.inactiveUsers).map((user) => {
-              delete data.assignees[user];
+              delete data.inactiveUsers[user];
             });
             data.inactiveUsers = {};
           } else {


### PR DESCRIPTION
## Brief summary of changes
create a new user without access_all_profiles, then can't create a new issue (assignee option is empty)

#### Testing instructions (if applicable)
create a new user without access_all_profiles, then can't create a new issue (assignee option is empty)
1.

#### Link(s) to related issue(s)
* 24.1-release[ issue track] - when a new user without accross all sites can't create a new issue. #8329

