### PR TITLE
[EEG] new table to track EEG additional events (24.1)

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -144,7 +144,7 @@ CREATE TABLE `physiological_channel` (
 CREATE TABLE `physiological_electrode_type` (
   `PhysiologicalElectrodeTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `ElectrodeType`                VARCHAR(50)     NOT NULL UNIQUE,
-  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)
+  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)=
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create physiological_electrode_material table
@@ -204,6 +204,19 @@ CREATE TABLE `physiological_task_event` (
     ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+
+-- Create `physiological_task_event_opt` table
+-- tracks additional events from bids archives
+CREATE TABLE `physiological_task_event_opt` (
+    `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `PhysiologicalTaskEventID` int(10) unsigned NOT NULL,
+    `TaskName` varchar(50) NOT NULL,
+    `TaskValue` varchar(255) NULL,
+    PRIMARY KEY (`ID`),
+    CONSTRAINT `FK_event_task_opt`
+        FOREIGN KEY (`PhysiologicalTaskEventID`)
+        REFERENCES `physiological_task_event` (`PhysiologicalTaskEventID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Create physiological_archive which will store archives of all the files for

--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -144,7 +144,7 @@ CREATE TABLE `physiological_channel` (
 CREATE TABLE `physiological_electrode_type` (
   `PhysiologicalElectrodeTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `ElectrodeType`                VARCHAR(50)     NOT NULL UNIQUE,
-  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)=
+  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create physiological_electrode_material table

--- a/SQL/New_patches/2022-11-22-eeg-additional-events-table.sql
+++ b/SQL/New_patches/2022-11-22-eeg-additional-events-table.sql
@@ -1,0 +1,12 @@
+-- Create `physiological_task_event_opt` table
+-- tracks additional events from bids archives
+CREATE TABLE `physiological_task_event_opt` (
+    `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `PhysiologicalTaskEventID` int(10) unsigned NOT NULL,
+    `TaskName` varchar(50) NOT NULL,
+    `TaskValue` varchar(255) NULL,
+    PRIMARY KEY (`ID`),
+    CONSTRAINT `FK_event_task_opt`
+        FOREIGN KEY (`PhysiologicalTaskEventID`)
+        REFERENCES `physiological_task_event` (`PhysiologicalTaskEventID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Brief summary of changes

Rebase of #8237 (main -> 24.1-release).
This PR adds a new table to keep additional data from BIDS event files (Loris-MRI).
Currently, additional data are ignored.

Linked to:
- [Loris-MRI issue 835](https://github.com/aces/Loris-MRI/issues/835)
- [Loris-MRI PR 873](https://github.com/aces/Loris-MRI/pull/873)
