### PR TITLE
[Issue tracker] - fix can't Delete attachment #8006

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -153,6 +153,7 @@ class IssueForm extends Component {
                        baseURL={this.props.baseURL}
                        attachments={this.state.issueData['attachments']}
                        userHasPermission={this.props.userHasPermission}
+                       whoami={this.state.issueData.whoami}
       />
     );
 

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -570,7 +570,6 @@ IssueForm.propTypes = {
   baseURL: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
   issue: PropTypes.string.isRequired,
-  whoami: PropTypes.string.isRequired,
 };
 
 export default IssueForm;

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -100,7 +100,7 @@ class AttachmentsList extends Component {
    */
   displayAttachmentOptions(deleteData, item) {
     if (this.props.userHasPermission
-      || this.state.attachments.whoami === item.user) {
+      || this.state.issueData.whoami === item.user) {
       return (
         <div className='row'>
           <div className='col-md-12'>

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -100,7 +100,7 @@ class AttachmentsList extends Component {
    */
   displayAttachmentOptions(deleteData, item) {
     if (this.props.userHasPermission
-      || this.state.issueData.whoami === item.user) {
+      || this.props.whoami === item.user) {
       return (
         <div className='row'>
           <div className='col-md-12'>
@@ -244,6 +244,7 @@ AttachmentsList.propTypes = {
   issue: PropTypes.string.isRequired,
   baseURL: PropTypes.string.isRequired,
   attachments: PropTypes.array,
+  whoami: PropTypes.string.isRequired,
 };
 AttachmentsList.defaultProps = {
   attachments: [],

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -852,7 +852,8 @@ class Edit extends \NDB_Page implements ETagCalculator
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('data_entry');
+        return $user->hasPermission('issue_tracker_reporter')
+            || $user->hasPermission('issue_tracker_developer');
     }
 
     /**


### PR DESCRIPTION
[Issue tracker] - Delete attachment #8006
A clear and concise description of what the bug is
If a user does not have Issue Tracker: Close/Edit/Re-assign/Comment on All Issues, they cannot delete their own attachment.
#### Testing instructions 
If a user does not have Issue Tracker: Close/Edit/Re-assign/Comment on All Issues, they can delete their own attachment.
