### PR TITLE
[Core] Change SameSite cookie policy from strict to Lax

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -136,7 +136,7 @@ class NDB_Client
         );
         // start php session
         $sessionOptions = ['cookie_httponly' => true];
-        $sessionOptions['cookie_samesite'] = "Strict";
+        $sessionOptions['cookie_samesite'] = "Lax";
 
         // API Detect
         if (strpos(


### PR DESCRIPTION
Strict is too strict, while "Lax" still provides SameSite protection.

The differences are well summarized in the graphic in this Stack Overflow post https://stackoverflow.com/questions/59990864/what-is-the-difference-between-samesite-lax-and-samesite-strict

There are some situations blocked by "Strict" that we want to support for our session cookies. Currently, opening a link from an email sent by LORIS logs you out, or opening a tab from the browser dev tools. Strict would also prevent us from using OAuth or other third party authentication providers in the future (such as in PR#8255)