### PR TITLE
[index.php] Allow post response processing

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -36,7 +36,9 @@ $client->initialize();
 // Middleware that happens on every request. This doesn't include
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.
-$middlewarechain = (new \LORIS\Middleware\ContentLength())
+$middlewarechain = (new \LORIS\Middleware\PostResponseProcessQueuer())
+    ->withMiddleware(new \LORIS\Middleware\ResponsePrinter())
+    ->withMiddleware(new \LORIS\Middleware\ContentLength())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 
 $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();
@@ -53,32 +55,3 @@ $entrypoint = new \LORIS\Router\BaseRouter(
 
 // Now handle the request.
 $response = $middlewarechain->process($serverrequest, $entrypoint);
-
-// Add the HTTP header line.
-header(
-    "HTTP/" . $response->getProtocolVersion()
-    . " " . $response->getStatusCode()
-    . " " . $response->getReasonPhrase()
-);
-
-// Add the headers from the response.
-$headers = $response->getHeaders();
-foreach ($headers as $name => $values) {
-    header($name . ': ' . implode(', ', $values));
-}
-
-// Include the body.
-$bodystream = $response->getBody();
-
-// First we need to disable any output buffering so that
-// it streams to the output instead of into the buffer
-// and uses up all the memory for large chunks of data.
-for ($i = ob_get_level(); $i != 0; $i = ob_get_level()) {
-    ob_end_clean();
-}
-ob_implicit_flush();
-
-while ($bodystream->eof() == false) {
-    // 64k oughta be enough for anybody.
-    print $bodystream->read(1024*64);
-}

--- a/src/Middleware/PostResponseProcessQueuer.php
+++ b/src/Middleware/PostResponseProcessQueuer.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Implements the PostResponseQueuer middleware class
+ *
+ * PHP Version 7
+ *
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+namespace LORIS\Middleware;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\MiddlewareInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ *
+ */
+class PostResponseProcessQueuer implements MiddlewareInterface, MiddlewareChainer
+{
+    use MiddlewareChainerMixin;
+
+    private array $callableQueue;
+
+    /**
+     * @param ServerRequestInterface  $request The incoming PSR7 request.
+     * @param RequestHandlerInterface $handler The PSR15 handler to delegate
+     *                                         content generation to.
+     *
+     * @return ResponseInterface the PSR15 response
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+
+        $this->callableQueue = [];
+
+        $request = $request->withAttribute('PostResponseProcessQueuer', $this);
+
+        $response = $this->next->process($request, $handler);
+
+        if (function_exists('\fastcgi_finish_request')) {
+            \fastcgi_finish_request();
+        }
+
+        foreach ($this->callableQueue as $callback) {
+            $callback();
+        }
+
+        return $response;
+    }
+
+    public function addCallback(callable $obj): void
+    {
+        $this->callableQueue[] = $obj;
+    }
+}

--- a/src/Middleware/ResponsePrinter.php
+++ b/src/Middleware/ResponsePrinter.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Implements the PostResponseQueuer middleware class
+ *
+ * PHP Version 7
+ *
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+namespace LORIS\Middleware;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\MiddlewareInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ *
+ */
+class ResponsePrinter implements MiddlewareInterface, MiddlewareChainer
+{
+    use MiddlewareChainerMixin;
+
+    /**
+     * @param ServerRequestInterface  $request The incoming PSR7 request.
+     * @param RequestHandlerInterface $handler The PSR15 handler to delegate
+     *                                         content generation to.
+     *
+     * @return ResponseInterface the PSR15 response
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+error_log(__METHOD__);
+        $response = $this->next->process($request, $handler);
+
+        // Add the HTTP header line.
+        header(
+            "HTTP/" . $response->getProtocolVersion()
+            . " " . $response->getStatusCode()
+            . " " . $response->getReasonPhrase()
+        );
+        
+        // Add the headers from the response.
+        $headers = $response->getHeaders();
+        foreach ($headers as $name => $values) {
+            header($name . ': ' . implode(', ', $values));
+        }
+        
+        // Include the body.
+        $bodystream = $response->getBody();
+        
+        // First we need to disable any output buffering so that
+        // it streams to the output instead of into the buffer
+        // and uses up all the memory for large chunks of data.
+        for ($i = ob_get_level(); $i != 0; $i = ob_get_level()) {
+            ob_end_clean();
+        }
+        ob_implicit_flush();
+        
+        while ($bodystream->eof() == false) {
+            // 64k oughta be enough for anybody.
+            print $bodystream->read(1024*64);
+        }
+error_log('response printed');
+        return $response;
+    }
+}


### PR DESCRIPTION
# DRAFT

This allows to continue processing after having the response printed to the client.

Adding the following to a request handler would print `yeah!` in error_log. (printing to stdout won't do anaything since the client is not listening anymore.)
```
$queuer = $request->getAttribute('PostResponseProcessQueuer');

$callback = function() {
            error_log('yeah!');
};

$queuer->addCallback($callback);
```

@driusan yay? nay?