### PR TITLE
[configuration] Fix error messages & saving with null Alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ be found for the image (PR #8155)
 - Add psr/log to composer (PR #8109)
 - Fixed broken DB calls in `assign_missing_instruments` and `instruments` (PR #8162)
 - Add support for PHP 8.1 (PR #7989)
+- Fix Project tab of Configuration module to give correct errors, and prevent saving without Alias (PR #8349)
 ### Modules
 #### API
 - Ability to use PSCID instead of the CandID in the candidates API (PR #8138)

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -44,10 +44,9 @@ if ($projectID == 'new') {
         exit;
     }
 
-    if (
-        empty($_POST['Name']) ||
-        empty($_POST['Alias']) ||
-        strlen($_POST['Alias']) > 4
+    if (empty($_POST['Name'])
+        || empty($_POST['Alias'])
+        || strlen($_POST['Alias']) > 4
     ) {
         http_response_code(400);
         echo json_encode(['error' => 'Bad Request']);
@@ -60,10 +59,9 @@ if ($projectID == 'new') {
         ["UserID"=>$user->getId(),"ProjectID"=>$project->getId()]
     );
 } else {
-    if (
-        empty($_POST['Name']) ||
-        empty($_POST['Alias']) ||
-        strlen($_POST['Alias']) > 4
+    if (empty($_POST['Name'])
+        || empty($_POST['Alias'])
+        || strlen($_POST['Alias']) > 4
     ) {
         http_response_code(400);
         echo json_encode(['error' => 'Bad Request']);

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -44,18 +44,37 @@ if ($projectID == 'new') {
         exit;
     }
 
+    if (
+        empty($_POST['Name']) ||
+        empty($_POST['Alias']) ||
+        strlen($_POST['Alias']) > 4
+    ) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Bad Request']);
+        exit;
+    }
+
     $project = \Project::createNew($projectName, $projectAlias, $recTarget);
     $db->insert(
         'user_project_rel',
         ["UserID"=>$user->getId(),"ProjectID"=>$project->getId()]
     );
 } else {
+    if (
+        empty($_POST['Name']) ||
+        empty($_POST['Alias']) ||
+        strlen($_POST['Alias']) > 4
+    ) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Bad Request']);
+        exit;
+    }
+
     // Update Project fields
     $project = \Project::getProjectFromID(new \ProjectID($projectID));
     $project->updateName($projectName);
     $project->updateAlias($projectAlias);
     $project->updateRecruitmentTarget($recTarget);
-
 }
 
 // Subproject information isn't mandatory. If the array is empty, give an

--- a/modules/configuration/js/project.js
+++ b/modules/configuration/js/project.js
@@ -31,7 +31,15 @@ $(document).ready(function() {
         }
 
         var errorClosure = function(i, form) {
-          if (isNaN(recruitmentTarget)) {
+          if (!Name) {
+            return function () {
+              $(form.find(".saveStatus")).text("Failed to save, must enter a Project Name!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+            }
+          } else if (!Alias) {
+            return function () {
+              $(form.find(".saveStatus")).text("Failed to save, must enter an Alias!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+            }
+          } else if (isNaN(recruitmentTarget)) {
             return function () {
               $(form.find(".saveStatus")).text("Failed to save, recruitment target must be an integer!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
@@ -39,7 +47,7 @@ $(document).ready(function() {
             return function () {
               $(form.find(".saveStatus")).text("Failed to save, Alias should be at most 4 characters long!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
-          }else {
+          } else {
             return function () {
               $(form.find(".saveStatus")).text("Failed to save, same name already exist!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }


### PR DESCRIPTION
## Brief summary of changes
This PR prevents the user from saving a Project configuration with a null Alias in a new project as well as existing projects. 

While testing, I also noticed that several of the error messages were broken, so those were fixed as well

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Try testing a new project with the following mistakes and make sure that the form does not save, and a relevant error message is given in each case.
- No project name
- No Alias
- An Alias longer than 4 characters
2. Repeat above steps but in an existing Project

#### Link(s) to related issue(s)

* Resolves #7948
