### PR TITLE
[issue tracker] Fix issue description

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -200,12 +200,13 @@ class IssueForm extends Component {
         </div>
       );
 
+      const descr = <Markdown content={this.state.issueData.desc} />;
       description = (
         <StaticElement
           name='description'
           label='Description'
           ref='description'
-          text={this.state.issueData.desc}
+          text={descr}
         />
       );
     }


### PR DESCRIPTION
The issue description is currently rendered in a static text field, while comments (or the description in the comments) are rendered as markdown. This updates the description to be wrapped in a `<Markdown>` tag so that it gets consistently rendered.