### PR TITLE
[imaging browser] Fix Human dangling out of nowhere

### DIFF
--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -167,6 +167,11 @@ class ImagingBrowserIndex extends Component {
         type: 'multiselect',
         options: options.pendingNew,
       }},
+      {label: 'Entity Type', show: false, filter: {
+       name: 'entityType',
+       type: 'multiselect',
+       option: options.entityType,
+      }},
     ];
     /**
      * Adding columns based on the Imaging Browser Tabulated Scan Types

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -137,6 +137,12 @@ class Imaging_Browser extends \DataFrameworkMenu
         $config = \NDB_Config::singleton();
         $toTable_scan_types = $config->getSetting('tblScanTypes');
 
+        // get entity type options
+        $entityType = [
+            'Human'   => 'Human',
+            'Scanner' => 'Scanner',
+        ];
+
         return [
             'sites'         => $siteList,
             'projects'      => $list_of_projects,
@@ -144,6 +150,7 @@ class Imaging_Browser extends \DataFrameworkMenu
             'sequenceTypes' => $sequenceTypes,
             'pendingNew'    => $pending,
             'configLabels'  => $toTable_scan_types,
+            'entityType'    => $entityType,
         ];
 
     }

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -189,9 +189,9 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               s.ID as sessionID,
               GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,
               $PendingNewquery as pending,
-              $modalities_subquery
               s.CenterID as CenterID,
               c.Entity_type as entityType,
+              $modalities_subquery
               s.ProjectID
             FROM psc AS p
               JOIN session s ON (s.CenterID=p.CenterID)


### PR DESCRIPTION
## Brief summary of changes

This resolves https://github.com/aces/Loris/issues/7876.

When downloading the imaging browser list data as CSV, there are dangling "Human"s with no header associated to it as can be seen below:
![image](https://user-images.githubusercontent.com/1402456/217100365-c97aaceb-3267-4518-a55e-878984dc76f2.png)

This PR corrects the issue so that the Human's have a proper header. It also resolves the Human being placed under T1 QC status for example when no scan types are selected to be displayed in the Config module under the Imaging Module tab. See screenshot below for the bug that was introduced in 24:
![Screen Shot 2023-02-06 at 5 24 52 PM](https://user-images.githubusercontent.com/1402456/217101426-b36c0010-bf35-424b-85dd-133bd1f75ea4.png)

As for the content of the CSV showing more columns than what is being displayed, this is a LORIS wide behaviour, not an actual bug.