### PR TITLE
Fix CouchDB_MRI_Importer.php for php8

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -438,7 +438,7 @@ class CouchDBMRIImporter
                 $row['PSCID'],
                 $row['Visit_label'],
             ];
-            $docid      = 'MRI_Files:' . join($identifier, '_');
+            $docid      = 'MRI_Files:' . join('_', $identifier);
             unset($doc['PSCID']);
             unset($doc['Visit_label']);
             unset($doc['SessionID']);


### PR DESCRIPTION
Fixes
```
php CouchDB_Import_MRI.php
PHP Fatal error:  Uncaught TypeError: join(): Argument #2 ($array) must be of type ?array, string given in /var/www/loris/tools/CouchDB_MRI_Importer.php:446
Stack trace:
#0 /var/www/loris/tools/CouchDB_MRI_Importer.php(446): join()
#1 /var/www/loris/tools/CouchDB_MRI_Importer.php(78): CouchDBMRIImporter->updateCandidateDocs()
#2 /var/www/loris/tools/CouchDB_MRI_Importer.php(781): CouchDBMRIImporter->run()
#3 /var/www/loris/tools/CouchDB_Import_MRI.php(19): require_once('/var/www/loris/...')
#4 {main}
  thrown in /var/www/loris/tools/CouchDB_MRI_Importer.php on line 446
```