### PR TITLE
[issue_tracker] Make Comments and History easier to read 

### DIFF
--- a/modules/issue_tracker/css/issue_tracker.css
+++ b/modules/issue_tracker/css/issue_tracker.css
@@ -81,9 +81,15 @@ h3 {
 
 .history-item-changes {
   margin-left: 2em;
+  margin-top: 1em;
 }
 
 .history-item-user {
   font-weight: bold;
   margin: 0 4px;
+}
+
+.history-comment {
+  margin-top: 1em;
+  margin-left: 4em;
 }

--- a/modules/issue_tracker/jsx/CommentList.js
+++ b/modules/issue_tracker/jsx/CommentList.js
@@ -49,7 +49,7 @@ class CommentList extends Component {
       const item = changes[key];
       const textItems = Object.keys(item.data).map(function(index, j) {
         if (index == 'comment') {
-            comment = <div style={{marginTop: '1em'}}>
+            comment = <div className='history-comment'>
               <Markdown content={item.data[index]} />
             </div>;
             return;


### PR DESCRIPTION
## Brief summary of changes

This PR modifies the margins of the history and comments so that it's easier on the eyes to read

Before:
<img width="1360" alt="Screenshot 2023-02-14 at 1 28 52 PM" src="https://user-images.githubusercontent.com/17415878/218828141-e6dedbcd-2244-43b6-b839-e1902115ee54.png">

After:
<img width="1362" alt="Screenshot 2023-02-14 at 1 31 46 PM" src="https://user-images.githubusercontent.com/17415878/218828182-2965c4e9-8702-4bd0-8bc9-9a0a30085fcb.png">

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
