### PR TITLE
[document_repository] Fix download path to correct user

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -164,6 +164,8 @@ class DocIndex extends React.Component {
       case 'File Name':
         let downloadURL = loris.BaseURL
                           + '/document_repository/Files/'
+                          + encodeURIComponent(row['Uploaded By'])
+                          + '/'
                           + encodeURIComponent(row['File Name']);
         result = <td>
           <a

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -71,25 +71,26 @@ class Files extends \NDB_Page
                 ['message' => 'File deleted.']
             ));
         case "GET":
-            $filename = urldecode(basename($request->getUri()->getPath()));
             $route    = explode('/', $request->getUri()->getPath());
             if ($route[2] == 'meta') {
+                $id = urldecode(basename($request->getUri()->getPath()));
                 return (new \LORIS\Http\Response())
                     ->withHeader("Content-Type", "text/plain")
                     ->withBody(
                         new \LORIS\Http\StringStream(
-                            json_encode($this->getUploadDocFields($filename))
+                            json_encode($this->getUploadDocFields($id))
                         )
                     );
             }
 
-            // the file's user directory is the username of the file uploader,
-            // not the user currently requesting the download
-            $uploader = urldecode(basename(dirname($request->getUri()->getPath())));
+            $filename = explode(
+                'Files',
+                urldecode($request->getUri()->getPath())
+            )[1];
 
             $downloader = new \LORIS\FilesDownloadHandler(
                 new \SPLFileInfo(
-                    $downloadpath . $uploader
+                    $downloadpath
                 )
             );
             return $downloader->handle(

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -82,9 +82,14 @@ class Files extends \NDB_Page
                         )
                     );
             }
+
+            // the file's user directory is the username of the file uploader,
+            // not the user currently requesting the download
+            $uploader = urldecode(basename(dirname($request->getUri()->getPath())));
+
             $downloader = new \LORIS\FilesDownloadHandler(
                 new \SPLFileInfo(
-                    $downloadpath . $request->getAttribute('user')->getUsername()
+                    $downloadpath . $uploader
                 )
             );
             return $downloader->handle(

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -71,7 +71,7 @@ class Files extends \NDB_Page
                 ['message' => 'File deleted.']
             ));
         case "GET":
-            $route    = explode('/', $request->getUri()->getPath());
+            $route = explode('/', $request->getUri()->getPath());
             if ($route[2] == 'meta') {
                 $id = urldecode(basename($request->getUri()->getPath()));
                 return (new \LORIS\Http\Response())

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -86,7 +86,10 @@ class Module extends \Module
             $last_login = $user->getLastLogin($DB);
 
             $docs         = $DB->pselect(
-                "SELECT File_name, Date_uploaded, CONCAT(uploaded_by, '/', File_name) AS Data_dir FROM document_repository
+                "SELECT File_name,
+                        Date_uploaded,
+                        CONCAT(uploaded_by, '/', File_name) AS Data_dir
+                 FROM document_repository
                  ORDER BY Date_uploaded DESC LIMIT 4",
                 []
             );

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -86,7 +86,7 @@ class Module extends \Module
             $last_login = $user->getLastLogin($DB);
 
             $docs         = $DB->pselect(
-                "SELECT File_name, Date_uploaded, Data_dir FROM document_repository
+                "SELECT File_name, Date_uploaded, CONCAT(uploaded_by, '/', File_name) AS Data_dir FROM document_repository
                  ORDER BY Date_uploaded DESC LIMIT 4",
                 []
             );


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Checkout branch 24.1-release and run make dev or npm run compile
2. Upload a file as User 1 (i.e. your own). Download that file once uploaded and confirm that the download worked.
3. Login as User 2 (i.e. admin). Try to download the same file and confirm that the download fails.
4. Go to the dashboard and click on one of the items in the 'Document Repository Notifications' widget. Confirm that the download fails.
5. Checkout this PR branch. Download the same file as User 2 and confirm that the download worked
6. Go to the dashboard and click on one of the items in the 'Document Repository Notifications' widget. Confirm that the download worked.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
