### PR TITLE
[examiner] Column for 'Instrument' in certification menu appears narrow

### DIFF
--- a/modules/examiner/templates/form_editExaminer.tpl
+++ b/modules/examiner/templates/form_editExaminer.tpl
@@ -12,7 +12,7 @@
                     </div>
                     {/foreach}
                     <div class="row hidden-xs hidden-sm">
-                        <div class="col-md-1">
+                        <div class="col-md-3">
                             <label>Instrument</label>
                         </div>
                         <div class="col-md-2">


### PR DESCRIPTION
## Brief summary of changes

This PR is changing the CSS class used in the examiner page. The former class had a small percentage of the width causing the first field become narrow, by changing it to another class, the problem is solved.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to the examiner module
2. Select an examiner to access the 'Certification' page
3. Text in the 'Instrument' column should not be narrow anymore.

#### Link(s) to related issue(s)

* Resolves #  #8026
