### PR TITLE
Add unique keys and new MRICandidateErrors columns to default schema

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -967,7 +967,6 @@ CREATE TABLE `mri_violations_log` (
   `PhaseEncodingDirection` VARCHAR(3) DEFAULT NULL,
   `EchoNumber` VARCHAR(20) DEFAULT NULL,  `MriProtocolChecksGroupID` INT(4) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`LogID`),
-  UNIQUE KEY `unique_mvl_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `Scan_type`, `Severity`, `Header`, `Value`, `ValidRange`, `ValidRegex`),
   CONSTRAINT `FK_tarchive_mriViolationsLog_1`
     FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`),
   CONSTRAINT `FK_mri_checks_group_1`

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -973,6 +973,9 @@ CREATE TABLE `mri_violations_log` (
   CONSTRAINT `FK_mri_checks_group_1`
     FOREIGN KEY (`MriProtocolChecksGroupID`) REFERENCES `mri_protocol_checks_group` (`MriProtocolChecksGroupID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+ALTER TABLE mri_violations_log
+    ADD COLUMN `all_columns_hash` binary(32) GENERATED ALWAYS AS (UNHEX(SHA2(CONCAT(SeriesUID, '-', EchoTime, '-', PhaseEncodingDirection, '-', EchoNumber, '-', Scan_type, '-', Severity, '-', Header, '-', Value, '-', ValidRange, '-', ValidRegex), 256))),
+    ADD UNIQUE INDEX `unique_mvl_entry` (`all_columns_hash`);
 
 CREATE TABLE `violations_resolved` (
   `ID` bigint(20) NOT NULL AUTO_INCREMENT,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -939,7 +939,10 @@ CREATE TABLE `MRICandidateErrors` (
   `PatientName` varchar(255) DEFAULT NULL,
   `Reason` varchar(255) DEFAULT NULL,
   `EchoTime` double DEFAULT NULL,
+  `PhaseEncodingDirection` VARCHAR(3)  DEFAULT NULL,
+  `EchoNumber`             VARCHAR(20) DEFAULT NULL,
   PRIMARY KEY (`ID`),
+  UNIQUE KEY `unique_MCE_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `PatientName`, `Reason`),
   CONSTRAINT `FK_tarchive_MRICandidateError_1`
     FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -964,6 +967,7 @@ CREATE TABLE `mri_violations_log` (
   `PhaseEncodingDirection` VARCHAR(3) DEFAULT NULL,
   `EchoNumber` VARCHAR(20) DEFAULT NULL,  `MriProtocolChecksGroupID` INT(4) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`LogID`),
+  UNIQUE KEY `unique_mvl_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `Scan_type`, `Severity`, `Header`, `Value`, `ValidRange`, `ValidRegex`),
   CONSTRAINT `FK_tarchive_mriViolationsLog_1`
     FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`),
   CONSTRAINT `FK_mri_checks_group_1`
@@ -1008,6 +1012,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
   `EchoNumber` VARCHAR(20) DEFAULT NULL,
   `MriProtocolGroupID` INT(4) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`ID`),
+  UNIQUE KEY `unique_mpvs_entry` (`SeriesUID`, `TE_range`, `PhaseEncodingDirection`, `EchoNumber`),
   KEY `TarchiveID` (`TarchiveID`),
   CONSTRAINT `FK_mri_violated_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`),
   CONSTRAINT `FK_mri_violated_2` FOREIGN KEY (`MriProtocolGroupID`) REFERENCES `mri_protocol_group` (`MriProtocolGroupID`)

--- a/SQL/New_patches/2023-02-17_add_unique_indices_to_mri_violation_tables.sql
+++ b/SQL/New_patches/2023-02-17_add_unique_indices_to_mri_violation_tables.sql
@@ -7,6 +7,8 @@ ALTER TABLE MRICandidateErrors ADD COLUMN `EchoNumber`             VARCHAR(20) D
 
 ALTER TABLE MRICandidateErrors ADD UNIQUE KEY `unique_MCE_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `PatientName`, `Reason`);
 
-ALTER TABLE mri_violations_log ADD UNIQUE KEY `unique_mvl_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `Scan_type`, `Severity`, `Header`, `Value`, `ValidRange`, `ValidRegex`);
+ALTER TABLE mri_violations_log
+    ADD COLUMN `all_columns_hash` binary(32) GENERATED ALWAYS AS (UNHEX(SHA2(CONCAT(SeriesUID, '-', EchoTime, '-', PhaseEncodingDirection, '-', EchoNumber, '-', Scan_type, '-', Severity, '-', Header, '-', Value, '-', ValidRange, '-', ValidRegex), 256))),
+    ADD UNIQUE INDEX `unique_mvl_entry` (`all_columns_hash`);
 
 ALTER TABLE mri_protocol_violated_scans ADD UNIQUE KEY `unique_mpvs_entry` (`SeriesUID`, `TE_range`, `PhaseEncodingDirection`, `EchoNumber`);

--- a/SQL/New_patches/2023-02-17_add_unique_indices_to_mri_violation_tables.sql
+++ b/SQL/New_patches/2023-02-17_add_unique_indices_to_mri_violation_tables.sql
@@ -1,0 +1,12 @@
+-- ---------------------------------------------------------------------------------------------
+-- alter MRICandidateErrors table to add PhaseEncodingDirection and EchoNumber
+-- ---------------------------------------------------------------------------------------------
+ALTER TABLE MRICandidateErrors ADD COLUMN `PhaseEncodingDirection` VARCHAR(3)  DEFAULT NULL;
+ALTER TABLE MRICandidateErrors ADD COLUMN `EchoNumber`             VARCHAR(20) DEFAULT NULL;
+
+
+ALTER TABLE MRICandidateErrors ADD UNIQUE KEY `unique_MCE_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `PatientName`, `Reason`);
+
+ALTER TABLE mri_violations_log ADD UNIQUE KEY `unique_mvl_entry` (`SeriesUID`, `EchoTime`, `PhaseEncodingDirection`, `EchoNumber`, `Scan_type`, `Severity`, `Header`, `Value`, `ValidRange`, `ValidRegex`);
+
+ALTER TABLE mri_protocol_violated_scans ADD UNIQUE KEY `unique_mpvs_entry` (`SeriesUID`, `TE_range`, `PhaseEncodingDirection`, `EchoNumber`);


### PR DESCRIPTION
## Brief summary of changes

This adds some unique key constraint to the MRI violation tables to avoid having the same violation reported multiple times in the table.

It also adds the two new fields added to all other MRI tables that determine a unique file (aka: SeriesUID, EchoTime, EchoNumber and PhaseEncodingDirection, see https://github.com/aces/Loris/pull/8152).


#### Link(s) to related issue(s)

* Related to https://github.com/aces/Loris-MRI/issues/890
