### PR TITLE
Cleanup endpoint hierarchy

### DIFF
--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -101,13 +101,13 @@ class Module extends \Module
 
         switch ($handlername) {
         case 'candidates':
-            $handler = new \LORIS\api\Endpoints\Candidates();
+            $handler = new \LORIS\api\Endpoints\Candidates($this->loris);
             break;
         case 'login':
-            $handler = new \LORIS\api\Endpoints\Login();
+            $handler = new \LORIS\api\Endpoints\Login($this->loris);
             break;
         case 'projects':
-            $handler = new \LORIS\api\Endpoints\Projects();
+            $handler = new \LORIS\api\Endpoints\Projects($this->loris);
             break;
         default:
             return new \LORIS\Http\Response\JSON\NotFound();

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -60,10 +60,10 @@ class Module extends \Module
         $path = trim($request->getURI()->getPath(), "/");
         switch ($path) {
         case 'unresolved':
-            $handler = new Endpoints\Unresolved();
+            $handler = new Endpoints\Unresolved($this->loris);
             break;
         case 'resolved':
-            $handler = new Endpoints\Resolved();
+            $handler = new Endpoints\Resolved($this->loris);
             break;
         default:
             return parent::handle($request);

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -26,7 +26,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class NDB_Page implements RequestHandlerInterface
+class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
 {
     use Psr\Log\LoggerAwareTrait;
 
@@ -124,6 +124,8 @@ class NDB_Page implements RequestHandlerInterface
         string $identifier,
         string $commentID
     ) {
+        parent::__construct($loris);
+
         $this->Module = $module;
         $this->name   = $module->getName(); // for legacy purposes.
 

--- a/src/Http/Endpoint.php
+++ b/src/Http/Endpoint.php
@@ -1,36 +1,34 @@
 <?php declare(strict_types=1);
-/**
- * An endpoint is a HTTP request handler which abstracts away common element
- * of different LORIS API endpoints.
- *
- * PHP Version 7
- *
- * @category Main
- * @package  Loris
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
 namespace LORIS\Http;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Server\RequestHandlerInterface;
 use \Psr\Http\Message\ResponseInterface;
 
+use \Psr\Log\LoggerAwareTrait;
+
 /**
- * An abstract class for common concerns of different API endpoints.
+ * An endpoint is a HTTP request handler which abstracts away common element
+ * of different LORIS API endpoints.
  *
- * @category Main
- * @package  Loris
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 abstract class Endpoint implements RequestHandlerInterface
 {
+    use LoggerAwareTrait;
+
     /**
-     * An Endpoint overrides the default LORIS middleware to remove the
-     * PageDecorationMiddleware.
+     * Construct an endpoint
+     *
+     * @param \LORIS\LorisInstance $loris
+     */
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+    ) {
+    }
+
+    /**
+     * An Endpoint acts as middleware which will calculate ETag if applicable.
      *
      * @param ServerRequestInterface  $request The incoming PSR7 request
      * @param RequestHandlerInterface $handler The PSR15 request handler
@@ -50,7 +48,7 @@ abstract class Endpoint implements RequestHandlerInterface
     }
 
     /**
-     * Make sur the user is allowed to access the endpoint.
+     * Make sure the user is allowed to access the endpoint.
      *
      * @param \User $user The requesting user
      *


### PR DESCRIPTION
This makes sure that endpoints always have access to things that are always necessary (such as the LorisInstance object and PSR logger). NDB_Page is updated to extend Endpoint, since pages are types of endpoints.