### PR TITLE
[SQL] Reorder release patches for 24.0 release

### DIFF
--- a/SQL/Release_patches/23.0_To_24.0_upgrade_A.sql
+++ b/SQL/Release_patches/23.0_To_24.0_upgrade_A.sql
@@ -1,0 +1,9 @@
+SELECT 'Running: SQL/Archive/24.0/2021-07-19-log_level.sql';
+
+ALTER TABLE `ConfigSettings` MODIFY COLUMN `DataType` ENUM('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path', 'log_level');
+
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('logs', 'Settings related to logging', 1, 0, 'Log Settings', 12);
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'database_log_level', 'Verbosity of database logging', 1, 0, 'log_level', ID, 'Database Log Level', 3 FROM ConfigSettings WHERE Name='logs';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'request_log_level', 'Verbosity of HTTP request logs', 1, 0, 'log_level', ID, 'HTTP Request Log Level', 3 FROM ConfigSettings WHERE Name='logs';
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'exception_log_level', 'Verbosity of PHP exception logging', 1, 0, 'log_level', ID, 'Exception Log Level', 3 FROM ConfigSettings WHERE Name='logs';
+

--- a/SQL/Release_patches/23.0_To_24.0_upgrade_B.sql
+++ b/SQL/Release_patches/23.0_To_24.0_upgrade_B.sql
@@ -999,16 +999,6 @@ INSERT INTO `parameter_type` (Name, Alias, Type, Description, SourceFrom) VALUES
     ('pixel_padding_value','PixelPaddingValue','text','Value of pixels added to non-rectangular image to pad to rectangular format. DICOM:0028_0120','parameter_file')
     ON DUPLICATE KEY UPDATE Alias='PixelPaddingValue', Description='Value of pixels added to non-rectangular image to pad to rectangular format. DICOM:0028_0120';
 
-SELECT 'Running: SQL/Archive/24.0/2021-07-19-log_level.sql';
-
-ALTER TABLE `ConfigSettings` MODIFY COLUMN `DataType` ENUM('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path', 'log_level');
-
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('logs', 'Settings related to logging', 1, 0, 'Log Settings', 12);
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'database_log_level', 'Verbosity of database logging', 1, 0, 'log_level', ID, 'Database Log Level', 3 FROM ConfigSettings WHERE Name='logs';
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'request_log_level', 'Verbosity of HTTP request logs', 1, 0, 'log_level', ID, 'HTTP Request Log Level', 3 FROM ConfigSettings WHERE Name='logs';
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'exception_log_level', 'Verbosity of PHP exception logging', 1, 0, 'log_level', ID, 'Exception Log Level', 3 FROM ConfigSettings WHERE Name='logs';
-
-
 SELECT 'Running: SQL/Archive/24.0/2021-07-28_add_EchoTime_field_to_violation_tables.sql';
 
 ALTER TABLE MRICandidateErrors ADD `EchoTime` double DEFAULT NULL AFTER `Reason`;


### PR DESCRIPTION
## Brief summary of changes
Extracts one patch from the main release patch file for the 24.0 LORIS release and adds it to a new file to be run ahead of any PHP scripts. this is required as all PHP scripts (even the ones that have to be run before the release patch) depend on these SQL statements causing a circular dependency.

Once this is merged and release, Existing major and minor releases should be updated to reflect the changes