### PR TITLE
Fixes the revert section of the subproject/cohort patch

### DIFF
--- a/SQL/New_patches/2022-12-01-subprojects_no_more.sql
+++ b/SQL/New_patches/2022-12-01-subprojects_no_more.sql
@@ -20,13 +20,13 @@ ALTER TABLE cohort RENAME TO subproject;
 ALTER TABLE project_cohort_rel RENAME TO project_subproject_rel;
 ALTER TABLE visit_project_cohort_rel RENAME TO visit_project_subproject_rel;
 
-ALTER TABLE cohort CHANGE `CohortID` `SubprojectID` int(10) unsigned NOT NULL auto_increment;
-ALTER TABLE project_cohort_rel CHANGE `ProjectCohortRelID` `ProjectSubprojectRelID` int(10) unsigned NOT NULL AUTO_INCREMENT;
-ALTER TABLE project_cohort_rel CHANGE `CohortID` `SubprojectID` int(10) unsigned NOT NULL;
+ALTER TABLE subproject CHANGE `CohortID` `SubprojectID` int(10) unsigned NOT NULL auto_increment;
+ALTER TABLE project_subproject_rel CHANGE `ProjectCohortRelID` `ProjectSubprojectRelID` int(10) unsigned NOT NULL AUTO_INCREMENT;
+ALTER TABLE project_subproject_rel CHANGE `CohortID` `SubprojectID` int(10) unsigned NOT NULL;
 ALTER TABLE session CHANGE `CohortID` `SubprojectID` int(10) unsigned DEFAULT NULL;
 ALTER TABLE test_battery CHANGE `CohortID` `SubprojectID` int(10) unsigned DEFAULT NULL;
 ALTER TABLE mri_protocol_checks_group_target CHANGE `CohortID` `SubprojectID` int(10) unsigned DEFAULT NULL;
 ALTER TABLE mri_protocol_group_target CHANGE `CohortID` `SubprojectID` int(10) unsigned DEFAULT NULL;
-ALTER TABLE visit_project_cohort_rel CHANGE `VisitProjectCohortRelID` `VisitProjectSubprojectRelID` int(10) unsigned NOT NULL AUTO_INCREMENT;
-ALTER TABLE visit_project_cohort_rel CHANGE `ProjectCohortRelID` `ProjectSubprojectRelID` int(10) unsigned NOT NULL;
+ALTER TABLE visit_project_subproject_rel CHANGE `VisitProjectCohortRelID` `VisitProjectSubprojectRelID` int(10) unsigned NOT NULL AUTO_INCREMENT;
+ALTER TABLE visit_project_subproject_rel CHANGE `ProjectCohortRelID` `ProjectSubprojectRelID` int(10) unsigned NOT NULL;
  */


### PR DESCRIPTION
## Brief summary of changes

This fixes the revert section of the `SQL/New_patches/2022-12-01-subprojects_no_more.sql` patch so can easily switch between main and 24.1-release branches when developing.

#### Testing instructions (if applicable)

1. Run the alter statements on your DB if your DB has subproject instead of cohort
2. Run the revert alter statements to revert cohort to subproject.

#### Link(s) to related issue(s)

* Related to https://github.com/aces/Loris/pull/7817
