### PR TITLE
Code customization doc

### DIFF
--- a/docs/wiki/99_Developers/Code_Customization.md
+++ b/docs/wiki/99_Developers/Code_Customization.md
@@ -2,15 +2,14 @@
 ## The project/ directory
 
 The `project/` directory is designed to house project-specific code and some data such as documents.  This includes instrument forms, instrument table schemas, and any customizations to other pages or modules in the Loris codebase.  
-The `project/` folder and its subdirectories are created by the install script, which also installs the `config.xml` file there.
+The `project/` folder and its subdirectories are created by the install script, which also installs the `_config.xml_` file there.
 
-Instrument forms (.linst or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/`
+[[Instrument forms|Behavioural-Database]] (_.linst_ or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/` 
 
-## Backing up project/
+## Backing up `project/`
 
-**IMPORTANT:** Commit your project/ directory and its contents to a separate private repo - e.g. on GitHub
-
-**EQUALLY IMPORTANT:** Exclude all data and the config.xml file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub). Back up this data and the config file elsewhere on another server, using a cronjob. 
+* Important: Commit your project/ directory and its contents to a separate private repo - e.g. on GitHub
+* Equally Important: Exclude all data and the _config.xml_ file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub).  Back up this data and the config file elsewhere on another server, using a cronjob. 
 
 ## Tracking changes
 
@@ -18,31 +17,13 @@ It is highly recommended to keep a Readme file under the project/ directory trac
 
 ## Modifying and overriding code under the project/ directory
 
-Code stored under `project/libraries/` will override the file of the same name found in the same path under `php/libraries/` i.e. `project/libraries/_filename.class.inc_` will override `php/libraries/_filename.class.inc_`.
+Code stored under `project/modules/` and `project/libraries/` and `project/templates/` **will override** the file of the same name found in the same path under Loris root `php/libraries/`.
 
-**NOTE:** It is strongly not recommended to override LORIS library classes unless absolutely necessary. Overrides on libraries can cause upgrade issues and long term bugs and come at a great maintenance and overhead costs.*
+i.e. `/var/www/loris/project/libraries/_filename.class.inc` will override `/var/www/loris/php/libraries/_filename.class.inc_`
 
-Template stored under `project/templates/` will override the file of the same name found in the same path under `smarty/templates/`.
+***NOTE:** It is strongly not recommended to override LORIS library classes unless absolutely necessary. Overrides on libraries can cause upgrade issues and long term bugs and come at a great maintenance and overhead costs.*
 
 ## Module override
 
-For projects wishing to customize existing modules, the recommended best practice is to copy *all* module code from `modules/_module_name_/*` to `project/modules/_module_name_/*` and modify code there.  
+For projects wishing to customize existing modules, the recommended best practice is to copy _all_ module code from `$lorisroot/modules/_module_name_/*` to a new `project/modules/` subdirectory (project/modules/_module_name_/* ) and modify code there.  
 This will use the `project/` override functionality of Loris.  These changes should be added and committed to your project-specific private repo. 
-
-## Manage additional npm dependencies
-
-To add new npm packages to your project, you can create a package.json file in `project/` by running `npm init`. Any dependencies in this file will be automatically installed under `project/` when make or npm ci/npm install is run from loris root.
-
-## Webpack compilation
-
-Modules overriden js files will automatically compile and replace the file they intend to modify. On the other hand, new js files will need to be registered in order to be compiled with `npm run compile`. To register, for example, a new React components located in `project/modules/_new_module_name_/jsx/_react_component_.js` you can create `project/webpack-project.config.js` with the following template:
-
-```
-const entry = {
-  '_new_module_name_': [
-    '_react_component_',
-  ],
-};
-
-module.exports = entry;
-```

--- a/docs/wiki/99_Developers/Code_Customization.md
+++ b/docs/wiki/99_Developers/Code_Customization.md
@@ -29,10 +29,6 @@ Template stored under `project/templates/` will override the file of the same na
 For projects wishing to customize existing modules, the recommended best practice is to copy *all* module code from `modules/_module_name_/*` to `project/modules/_module_name_/*` and modify code there.  
 This will use the `project/` override functionality of Loris.  These changes should be added and committed to your project-specific private repo. 
 
-## Manage additional composer dependencies
-
-In case your project requires additional composer dependencies or different dependency version requirements, you can create a composer.json file in `project/` by running `composer init`. Any existing or new dependencies in this file will be merged with the main composer dependencies in `vendor/` after `composer update` has been run.
-
 ## Manage additional npm dependencies
 
 To add new npm packages to your project, you can create a package.json file in `project/` by running `npm init`. Any dependencies in this file will be automatically installed under `project/` when make or npm ci/npm install is run from loris root.

--- a/docs/wiki/99_Developers/Code_Customization.md
+++ b/docs/wiki/99_Developers/Code_Customization.md
@@ -2,14 +2,15 @@
 ## The project/ directory
 
 The `project/` directory is designed to house project-specific code and some data such as documents.  This includes instrument forms, instrument table schemas, and any customizations to other pages or modules in the Loris codebase.  
-The `project/` folder and its subdirectories are created by the install script, which also installs the `_config.xml_` file there.
+The `project/` folder and its subdirectories are created by the install script, which also installs the `config.xml` file there.
 
-[[Instrument forms|Behavioural-Database]] (_.linst_ or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/` 
+Instrument forms (.linst or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/`
 
-## Backing up `project/`
+## Backing up project/
 
-* Important: Commit your project/ directory and its contents to a separate private repo - e.g. on GitHub
-* Equally Important: Exclude all data and the _config.xml_ file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub).  Back up this data and the config file elsewhere on another server, using a cronjob. 
+**IMPORTANT:** Commit your project/ directory and its contents to a separate private repo - e.g. on GitHub
+
+**EQUALLY IMPORTANT:** Exclude all data and the config.xml file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub). Back up this data and the config file elsewhere on another server, using a cronjob. 
 
 ## Tracking changes
 
@@ -17,13 +18,35 @@ It is highly recommended to keep a Readme file under the project/ directory trac
 
 ## Modifying and overriding code under the project/ directory
 
-Code stored under `project/modules/` and `project/libraries/` and `project/templates/` **will override** the file of the same name found in the same path under Loris root `php/libraries/`.
+Code stored under `project/libraries/` will override the file of the same name found in the same path under `php/libraries/` i.e. `project/libraries/_filename.class.inc_` will override `php/libraries/_filename.class.inc_`.
 
-i.e. `/var/www/loris/project/libraries/_filename.class.inc` will override `/var/www/loris/php/libraries/_filename.class.inc_`
+**NOTE:** It is strongly not recommended to override LORIS library classes unless absolutely necessary. Overrides on libraries can cause upgrade issues and long term bugs and come at a great maintenance and overhead costs.*
 
-***NOTE:** It is strongly not recommended to override LORIS library classes unless absolutely necessary. Overrides on libraries can cause upgrade issues and long term bugs and come at a great maintenance and overhead costs.*
+Template stored under `project/templates/` will override the file of the same name found in the same path under `smarty/templates/`.
 
 ## Module override
 
-For projects wishing to customize existing modules, the recommended best practice is to copy _all_ module code from `$lorisroot/modules/_module_name_/*` to a new `project/modules/` subdirectory (project/modules/_module_name_/* ) and modify code there.  
+For projects wishing to customize existing modules, the recommended best practice is to copy *all* module code from `modules/_module_name_/*` to `project/modules/_module_name_/*` and modify code there.  
 This will use the `project/` override functionality of Loris.  These changes should be added and committed to your project-specific private repo. 
+
+## Manage additional composer dependencies
+
+In case your project requires additional composer dependencies or different dependency version requirements, you can create a composer.json file in `project/` by running `composer init`. Any existing or new dependencies in this file will be merged with the main composer dependencies in `vendor/` after `composer update` has been run.
+
+## Manage additional npm dependencies
+
+To add new npm packages to your project, you can create a package.json file in `project/` by running `npm init`. Any dependencies in this file will be automatically installed under `project/` when make or npm ci/npm install is run from loris root.
+
+## Webpack compilation
+
+Modules overriden js files will automatically compile and replace the file they intend to modify. On the other hand, new js files will need to be registered in order to be compiled with `npm run compile`. To register, for example, a new React components located in `project/modules/_new_module_name_/jsx/_react_component_.js` you can create `project/webpack-project.config.js` with the following template:
+
+```
+const entry = {
+  '_new_module_name_': [
+    '_react_component_',
+  ],
+};
+
+module.exports = entry;
+```

--- a/readthedocs/mkdocs.yml
+++ b/readthedocs/mkdocs.yml
@@ -45,14 +45,15 @@ nav:
         - Overview: 'docs/wiki/99_Developers/README.md'
         - 'Developers Guide': 'docs/wiki/99_Developers/Developers_Guide.md'
         - 'Coding Standards': 'docs/CodingStandards.md'
-        - 'SQL Modeling Standard': 'docs/SQLModelingStandard.md'
-        - 'SQL Dictionary': 'docs/wiki/99_Developers/SQL_Dictionary.md'
         - 'LORIS Glossary': 'docs/wiki/99_Developers/LORIS_Glossary.md'
-        - 'Automated Testing': 'docs/wiki/99_Developers/Automated_Testing.md'
-        - 'Style Guide (for help text)': 'docs/wiki/99_Developers/Help_Style_Guide.md'
         - 'Creating a Module': 'docs/wiki/99_Developers/Creating_Module.md'
         - 'ReactJS Guidelines': 'docs/wiki/99_Developers/ReactJS_Guidelines.md'
+        - 'SQL Modeling Standard': 'docs/SQLModelingStandard.md'
+        - 'SQL Dictionary': 'docs/wiki/99_Developers/SQL_Dictionary.md'
+        - 'Code Customization': 'docs/wiki/99_Developers/Code_Customization.md'
         - 'Code Review Guide': 'docs/wiki/99_Developers/Code_Review_Guide.md'
+        - 'Automated Testing': 'docs/wiki/99_Developers/Automated_Testing.md'
+        - 'Style Guide (for help text)': 'docs/wiki/99_Developers/Help_Style_Guide.md'
         - 'NixOS': 'docs/wiki/99_Developers/Alternative_Install/Nix.md'
 
 use_directory_urls: False
@@ -65,5 +66,5 @@ theme:
 plugins:
     - search
     - root:
-        ignore_folders: ['node_modules', 'vendor', 'deprecated_wiki', '_DELETED', '_ARCHIVE']
+        ignore_folders: ['node_modules', 'vendor', 'deprecated_wiki']
         ignore_hidden: True

--- a/readthedocs/mkdocs.yml
+++ b/readthedocs/mkdocs.yml
@@ -50,7 +50,6 @@ nav:
         - 'ReactJS Guidelines': 'docs/wiki/99_Developers/ReactJS_Guidelines.md'
         - 'SQL Modeling Standard': 'docs/SQLModelingStandard.md'
         - 'SQL Dictionary': 'docs/wiki/99_Developers/SQL_Dictionary.md'
-        - 'Code Customization': 'docs/wiki/99_Developers/Code_Customization.md'
         - 'Code Review Guide': 'docs/wiki/99_Developers/Code_Review_Guide.md'
         - 'Automated Testing': 'docs/wiki/99_Developers/Automated_Testing.md'
         - 'Style Guide (for help text)': 'docs/wiki/99_Developers/Help_Style_Guide.md'

--- a/readthedocs/themes/loris_theme/css/theme_extra.css
+++ b/readthedocs/themes/loris_theme/css/theme_extra.css
@@ -1,0 +1,190 @@
+/*
+ * Wrap inline code samples otherwise they shoot of the side and
+ * can't be read at all.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/313
+ * https://github.com/mkdocs/mkdocs/issues/233
+ * https://github.com/mkdocs/mkdocs/issues/834
+ */
+.rst-content code {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    padding: 2px 5px;
+}
+
+/**
+ * Make code blocks display as blocks and give them the appropriate
+ * font size and padding.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/855
+ * https://github.com/mkdocs/mkdocs/issues/834
+ * https://github.com/mkdocs/mkdocs/issues/233
+ */
+.rst-content pre code {
+    white-space: pre;
+    word-wrap: normal;
+    display: block;
+    padding: 12px;
+    font-size: 12px;
+}
+
+/**
+ * Fix code colors
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2027
+ */
+.rst-content code {
+    color: #E74C3C;
+}
+
+.rst-content pre code {
+    color: #000;
+    background: #f8f8f8;
+}
+
+/*
+ * Fix link colors when the link text is inline code.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/718
+ */
+a code {
+    color: #2980B9;
+}
+a:hover code {
+    color: #3091d1;
+}
+a:visited code {
+    color: #9B59B6;
+}
+
+/*
+ * The CSS classes from highlight.js seem to clash with the
+ * ReadTheDocs theme causing some code to be incorrectly made
+ * bold and italic.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/411
+ */
+pre .cs, pre .c {
+    font-weight: inherit;
+    font-style: inherit;
+}
+
+/*
+ * Fix some issues with the theme and non-highlighted code
+ * samples. Without and highlighting styles attached the
+ * formatting is broken.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/319
+ */
+.rst-content .no-highlight {
+    display: block;
+    padding: 0.5em;
+    color: #333;
+}
+
+
+/*
+ * Additions specific to the search functionality provided by MkDocs
+ */
+
+.search-results {
+    margin-top: 23px;
+}
+
+.search-results article {
+    border-top: 1px solid #E1E4E5;
+    padding-top: 24px;
+}
+
+.search-results article:first-child {
+    border-top: none;
+}
+
+form .search-query {
+    width: 100%;
+    border-radius: 50px;
+    padding: 6px 12px;  /* csslint allow: box-model */
+    border-color: #D1D4D5;
+}
+
+/*
+ * Improve inline code blocks within admonitions.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/656
+ */
+ .rst-content .admonition code {
+    color: #404040;
+    border: 1px solid #c7c9cb;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    background: #f8fbfd;
+    background: rgba(255, 255, 255, 0.7);
+}
+
+/*
+ * Account for wide tables which go off the side.
+ * Override borders to avoid weirdness on narrow tables.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/834
+ * https://github.com/mkdocs/mkdocs/pull/1034
+ */
+.rst-content .section .docutils {
+    width: 100%;
+    overflow: auto;
+    display: block;
+    border: none;
+}
+
+td, th {
+    border: 1px solid #e1e4e5 !important; /* csslint allow: important */
+    border-collapse: collapse;
+}
+
+/*
+ * Without the following amendments, the navigation in the theme will be
+ * slightly cut off. This is due to the fact that the .wy-nav-side has a
+ * padding-bottom of 2em, which must not necessarily align with the font-size of
+ * 90 % on the .rst-current-version container, combined with the padding of 12px
+ * above and below. These amendments fix this in two steps: First, make sure the
+ * .rst-current-version container has a fixed height of 40px, achieved using
+ * line-height, and then applying a padding-bottom of 40px to this container. In
+ * a second step, the items within that container are re-aligned using flexbox.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2012
+ */
+ .wy-nav-side {
+    padding-bottom: 40px;
+}
+
+/*
+ * The second step of above amendment: Here we make sure the items are aligned
+ * correctly within the .rst-current-version container. Using flexbox, we
+ * achieve it in such a way that it will look like the following:
+ *
+ * [No repo_name]
+ *         Next >>                    // On the first page
+ * << Previous     Next >>            // On all subsequent pages
+ *
+ * [With repo_name]
+ *    <repo_name>        Next >>      // On the first page
+ * <repo_name>  << Previous  Next >>  // On all subsequent pages
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2012
+ */
+.rst-versions .rst-current-version {
+    padding: 0 12px;
+    display: flex;
+    font-size: initial;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/*
+ * Please note that this amendment also involves removing certain inline-styles
+ * from the file ./mkdocs/themes/readthedocs/versions.html.
+ *
+ * https://github.com/mkdocs/mkdocs/issues/2012
+ */
+.rst-current-version span {
+    flex: 1;
+    text-align: center;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -368,7 +368,7 @@ if (fs.existsSync('./project/webpack-project.config.js')) {
   const projConfig = require('./project/webpack-project.config.js');
 
   for (const [module, files] of Object.entries(projConfig)) {
-    config.push(lorisModule(module, files, true));
+    config.push(lorisModule(module, files));
   }
 }
 


### PR DESCRIPTION
- Reordering of the RDT Developers sections by logical concepts
- Fix a typo in `webpack.config.js` found while working on this PR
- A few RTD templates fixes like:
<img width="336" alt="Screen Shot 2023-02-21 at 11 21 59 AM" src="https://user-images.githubusercontent.com/32041423/220401617-fd34c3af-8c59-4583-b898-384f24067c87.png">

To review: https://loris-dev.readthedocs.io/en/latest/docs/wiki/99_Developers/Code_Customization.html