### PR TITLE
[dqt] Replace jQuery ajax calls with fetch in DQT

### DIFF
--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -395,7 +395,7 @@ class FieldSelector extends Component {
       fetch(loris.BaseURL
         + '/AjaxHelper.php'
         + '?Module=dqt'
-        + '&script=datadictionary.php',
+        + '&script=datadictionary.php'
         + '&category=' + category)
       .then((resp) => resp.json())
       .then( (data) => {

--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -392,15 +392,19 @@ class FieldSelector extends Component {
     if (this.state.categoryFields[category]) {
     } else {
       // Retrieve the data dictionary
-      $.get(loris.BaseURL
-        + '/AjaxHelper.php?Module=dqt&script=datadictionary.php',
-        {category: category}, (data) => {
+      fetch(loris.BaseURL
+        + '/AjaxHelper.php'
+        + '?Module=dqt'
+        + '&script=datadictionary.php',
+        + '&category=' + category)
+      .then((resp) => resp.json())
+      .then( (data) => {
           let cf = this.state.categoryFields;
           cf[category] = data;
           this.setState({
             categoryFields: cf,
           });
-        }, 'json');
+      });
     }
     this.setState({
       selectedCategory: category,

--- a/modules/dqt/jsx/react.filterBuilder.js
+++ b/modules/dqt/jsx/react.filterBuilder.js
@@ -115,12 +115,16 @@ class FilterRule extends Component {
     let rule = this.props.rule;
     if (event.target.value) {
       rule.instrument = event.target.value;
-      $.get(loris.BaseURL
-        + '/dqt/ajax/datadictionary.php',
-        {category: rule.instrument}, (data) => {
+      fetch(
+        loris.BaseURL + + '/dqt/ajax/datadictionary.php?category='
+            + rule.instrument,
+        {credentials: 'same-origin'},
+      )
+      .then( (resp) => resp.json())
+      .then( (data) => {
         rule.fields = data;
         this.props.updateRule(this.props.index, rule);
-      }, 'json');
+      });
     }
   }
 
@@ -218,15 +222,16 @@ class FilterRule extends Component {
         this.props.updateSessions(this.props.index, rule);
       };
       let ajaxRetrieve = (script) => {
-        $.get(loris.BaseURL + '/dqt/ajax/' + script,
-          {
-            category: rule.instrument,
-            field: rule.field,
-            value: this.state.value,
-          },
-          responseHandler,
-          'json',
-        );
+          fetch(loris.BaseURL + '/dqt/ajax/' + script
+            + '?category=' + rule.instrument
+            + '&field=' + rule.field
+            + '&value=' + this.state.value,
+            {credentials: 'same-origin'},
+          )
+          .then( (resp) => resp.json())
+          .then( (data) => {
+                  responseHandler(data);
+          });
       };
       switch (rule.operator) {
         case 'equal':

--- a/modules/dqt/jsx/react.filterBuilder.js
+++ b/modules/dqt/jsx/react.filterBuilder.js
@@ -116,7 +116,7 @@ class FilterRule extends Component {
     if (event.target.value) {
       rule.instrument = event.target.value;
       fetch(
-        loris.BaseURL + + '/dqt/ajax/datadictionary.php?category='
+        loris.BaseURL + '/dqt/ajax/datadictionary.php?category='
             + rule.instrument,
         {credentials: 'same-origin'},
       )


### PR DESCRIPTION
This replaces all the jQuery ajax calls with fetch in the files modules/dqt/jsx/react.fieldselector.js and modules/dqt/jsx/react.filterBuilder.js.

N.B. this should be tested. I don't have CouchDB setup to test it but the behaviour should theoretically be the same.