### PR TITLE
[Meta] Remove css config setting and rowsPerPage

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -81,9 +81,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'rowsPerPage', 'Number of table rows to display per page', 1, 0, 'text', ID, 'Table rows per page', 2 FROM ConfigSettings WHERE Name="gui";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 3 FROM ConfigSettings WHERE Name="gui";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 2 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'useEEGBrowserVisualizationComponents', 'Whether to enable the visualization components on the EEG Browser module', 1, 0, 'boolean', ID, 'Enable the EEG Browser components', 4 FROM ConfigSettings WHERE Name="gui";
 
 

--- a/SQL/Cleanup_patches/2023-02-21-unusedconfigs.sql
+++ b/SQL/Cleanup_patches/2023-02-21-unusedconfigs.sql
@@ -1,0 +1,2 @@
+DELETE FROM ConfigSettings WHERE Name='css';
+DELETE FROM ConfigSettings WHERE Name='rowsPerPage';

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -457,7 +457,7 @@ class NDB_Menu_Filter extends NDB_Menu
         }
 
         $config         =& NDB_Config::singleton();
-        $resultsPerPage = $config->getSetting('rowsPerPage');
+        $resultsPerPage = 25;
         $limit          = " LIMIT $resultsPerPage"
                           ." OFFSET " . (($pageNum-1)*$resultsPerPage);
         $result         = $DB->pselect($query . $limit, $qparams);
@@ -554,7 +554,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // create instance of config object
         $config =& NDB_Config::singleton();
         // configure the page pagination
-        $rowsPerPage = $config->getSetting('rowsPerPage');
+        $rowsPerPage = 25;
 
         $pageID = isset($_GET['pageID']) ? $_GET['pageID'] : 1;
 

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -456,7 +456,6 @@ class NDB_Menu_Filter extends NDB_Menu
             $pageNum = $_REQUEST['pageID'];
         }
 
-        $config         =& NDB_Config::singleton();
         $resultsPerPage = 25;
         $limit          = " LIMIT $resultsPerPage"
                           ." OFFSET " . (($pageNum-1)*$resultsPerPage);
@@ -551,14 +550,11 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _setDataTable()
     {
-        // create instance of config object
-        $config =& NDB_Config::singleton();
-        // configure the page pagination
         $rowsPerPage = 25;
 
         $pageID = isset($_GET['pageID']) ? $_GET['pageID'] : 1;
 
-        $this->setTemplateVar('rowsPerPage', $rowsPerPage);
+        $this->setTemplateVar('rowsPerPage', strval($rowsPerPage));
         $this->setTemplateVar('pageID', $pageID);
 
         if (isset($_GET['filter'])

--- a/src/Middleware/AnonymousPageDecorationMiddleware.php
+++ b/src/Middleware/AnonymousPageDecorationMiddleware.php
@@ -39,8 +39,7 @@ class AnonymousPageDecorationMiddleware implements MiddlewareInterface
                      'sandbox'     => ($this->Config->getSetting("sandbox") === '1'),
                     );
 
-        // I don't think anyone uses this. It's not really supported
-        $tpl_data['css'] = $this->Config->getSetting('css');
+        $tpl_data['css'] = $this->BaseURL . '/main.css';
 
         //Display the footer links, as specified in the config file
         $links =$this->Config->getExternalLinks('FooterLink');

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -131,9 +131,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         // Stuff that probably shouldn't be here, but exists because it was in
         // main.php
-
-        // I don't think anyone uses this. It's not really supported
-        $tpl_data['css'] = $this->Config->getSetting('css');
+        $tpl_data['css'] = $this->BaseURL . '/main.css';
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 


### PR DESCRIPTION
This removes the `css` config setting (which has the ability to point to a different file than main.css but in practice is never edited because everything in LORIS would break without main.css loaded) and rowsPerPage (which is no longer supported because it's not honoured by our React menu filters.)