### PR TITLE
[Database] remove showDatabaseQueries config.xml option

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -74,10 +74,6 @@
     </study>
     <!-- end of study definition -->
 
-    <gui>
-        <showDatabaseQueries>0</showDatabaseQueries>
-    </gui>
-
     <!-- used by _hasAccess in NDB_BVL_Instrument to determine
          what permissions should be required for each instrument
          on a configurable basis. -->

--- a/docs/deprecated_wiki/Setup/Initial Setup/Imaging Database/Imaging-Database.md
+++ b/docs/deprecated_wiki/Setup/Initial Setup/Imaging Database/Imaging-Database.md
@@ -238,7 +238,6 @@ In cases where a subject was scanned in two scanner sessions within a single stu
 
 Troubleshooting notes: 
 * `/data/$PROJ` directory and subdirectories must be readable and executable by the Apache linux user.
-* If [`showDatabaseQueries`](Behavioural-Database#showdatabasequeries) is enabled, image volumes will not display properly in the Imaging Browser.
 * Verify the Configuration module (_Paths_) `MINC files` setting is `/data/$PROJ/data/`. 
 
 ### 8) Quality Control within the Imaging Browser

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -41,8 +41,6 @@ class Database implements LoggerAwareInterface
      */
     var $lastInsertID;
 
-    var $_showQueries = false;
-
     var $_trackChanges = true;
 
     var $_preparedStoreHistory;
@@ -158,7 +156,6 @@ class Database implements LoggerAwareInterface
 
         if (class_exists('NDB_Config')) {
             $config =& NDB_Config::singleton();
-            $this->_showQueries = $config->getSetting('showDatabaseQueries');
 
             // get history database from config
             $dbsettings = $config->getSetting("database");
@@ -566,7 +563,7 @@ class Database implements LoggerAwareInterface
             $set = $this->_HTMLEscapeArray($set);
         }
         /* This is still here to print the easily readable version on
-         * the top of the page when showDatabaseQueries is on. It isn't
+         * the top of the page when debug log level is on. It isn't
          * actually executed. */
         $query  = "UPDATE $table SET ";
         $query .= $this->_implodeWithKeys(', ', $set, 'set_');
@@ -1269,7 +1266,7 @@ class Database implements LoggerAwareInterface
     }
 
     /**
-     * Print a query if showDatabaseQueries defined in config file
+     * Logs a query if debug log level is on.
      *
      * @param string                $query  The query to replace
      * @param array<string, string> $params The prepared statement parameters
@@ -1288,12 +1285,6 @@ class Database implements LoggerAwareInterface
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
         $this->logger->debug($query, []);
-        if (!$this->_showQueries) {
-            return;
-        }
-        print "$this->_databaseName:"
-            . date("j-M-Y G:i:s", time())
-            .": $query<br>\n";
     }
 
     /**

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -269,7 +269,6 @@ class NDB_Config
         switch ($name) {
         case 'database':
         case 'sandbox':
-        case 'showDatabaseQueries':
             return null;
         }
 

--- a/raisinbread/config/config.xml
+++ b/raisinbread/config/config.xml
@@ -78,10 +78,6 @@
     </study>
     <!-- end of study definition -->
 
-    <gui>
-        <showDatabaseQueries>0</showDatabaseQueries>
-    </gui>
-
     <!-- used by _hasAccess in NDB_BVL_Instrument to determine
          what permissions should be required for each instrument
          on a configurable basis. -->

--- a/test/config.xml
+++ b/test/config.xml
@@ -71,10 +71,6 @@
     </study>
     <!-- end of study definition -->
 
-    <gui>
-        <showDatabaseQueries>0</showDatabaseQueries>
-    </gui>
-
     <!-- used by _hasAccess in NDB_BVL_Instrument to determine
          what permissions should be required for each instrument
          on a configurable basis. -->

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -173,8 +173,7 @@ class NDB_ConfigTest extends TestCase
     }
 
     /**
-     * Test getSettingFromDB() method. Given any of (database,sandbox,
-     * showDatabaseQueries), it will return null.
+     * Test getSettingFromDB() method. Given any of (database,sandbox), it will return null.
      * If database class exists and the dabase returns 'AllowMultiple' => '0',
      * 'ParentID' => 'test', this method should return a non-null value.
      *
@@ -185,7 +184,6 @@ class NDB_ConfigTest extends TestCase
     {
         $this->assertNull($this->_config->getSettingFromDB("database"));
         $this->assertNull($this->_config->getSettingFromDB("sandbox"));
-        $this->assertNull($this->_config->getSettingFromDB("showDatabaseQueries"));
         $this->_dbMock->expects($this->any())
             ->method('isConnected')
             ->willReturn(true);

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -173,7 +173,8 @@ class NDB_ConfigTest extends TestCase
     }
 
     /**
-     * Test getSettingFromDB() method. Given any of (database,sandbox), it will return null.
+     * Test getSettingFromDB() method. Given any of (database,sandbox),
+     * it will return null.
      * If database class exists and the dabase returns 'AllowMultiple' => '0',
      * 'ParentID' => 'test', this method should return a non-null value.
      *


### PR DESCRIPTION
With this PR the venerable debug option showDatabaseQueries is no more. It has been replaced with the Database debug log level, which now logs queries to the error log instead of printing them to the wild.

RIP showDatabaseQueries 1999(est.)-2023.

It is survived by its config.xml contemporaries sandbox, database connection information, and PSCID structure.