### PR TITLE
[mri_violations] Fix main branch

### DIFF
--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -79,6 +79,9 @@ class Module extends \Module
             $factory = \NDB_Factory::singleton();
             $link    = $factory->settings()->getBaseURL() . '/' . $this->getName();
 
+            if (!class_exists('Provisioner')) {
+                self::registerAutoloader();
+            }
             $provisioner = new Provisioner();
 
             if ($user->hasPermission('violated_scans_view_allsites')) {


### PR DESCRIPTION
The main branch is failing since #8287 because when dashboard calls getWidgets() on the mri_violations module the module autoloader hasn't been loaded. This registers the autoloader when it's called so that the "new" class can be found.