### PR TITLE
Fix Console Output on timepoint list

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -380,7 +380,7 @@ class NDB_BVL_Feedback
     function getMaxThreadStatus($select_inactive_threads): ?string
     {
         // new DB Object
-        $db =& \NDB_Factory::singleton()->database();
+        $db = \NDB_Factory::singleton()->database();
 
         $query   = "SELECT MAX(Status) FROM feedback_bvl_thread WHERE";
         $qparams = [];


### PR DESCRIPTION
Fix the warnings
```
<br />
<b>Notice</b>:  Only variables should be assigned by reference in <b>/home/driusan/Code/Loris/php/libraries/NDB_BVL_Feedback.class.inc</b> on line <b>383</b><br />
<br />
<b>Notice</b>:  Only variables should be assigned by reference in <b>/home/driusan/Code/Loris/php/libraries/NDB_BVL_Feedback.class.inc</b> on line <b>383</b><br />
<br />
<b>Notice</b>:  Only variables should be assigned by reference in <b>/home/driusan/Code/Loris/php/libraries/NDB_BVL_Feedback.class.inc</b> on line <b>383</b><br />
```

when accessing some candidates (depending on their feedback status) in LORIS such as CandID 587630 in Raisinbread.