### PR TITLE
[webpack] Added node-env specification to webpack command

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tests:integration:debug": "DEBUG=true ./test/dockerized-integration-tests.sh",
     "compile": "webpack --node-env=development",
     "build": "webpack --node-env=production",
-    "watch": "webpack --watch",
+    "watch": "webpack --watch --progress --node-env=development",
     "postinstall": "node npm-postinstall.js"
   },
   "repository": {


### PR DESCRIPTION
#8229 introduces a change which causes the `npm run watch` script to run in production mode.

I added a specifier so that it runs in development mode and I also added the `--progress` flag, which is very nice to have and useful to me.