### PR TITLE
[Form.js] Add placeholder option for TextareaElement

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1043,6 +1043,7 @@ class TextareaElement extends Component {
             name={this.props.name}
             id={this.props.id}
             value={this.props.value || ''}
+            placeholder={this.props.placeholder}
             required={required}
             disabled={disabled}
             onChange={this.handleChange}
@@ -1058,6 +1059,7 @@ TextareaElement.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   value: PropTypes.string,
+  placeholder: PropTypes.string,
   id: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -1070,6 +1072,7 @@ TextareaElement.defaultProps = {
   name: '',
   label: '',
   value: '',
+  placeholder: '',
   id: null,
   disabled: false,
   required: false,


### PR DESCRIPTION
This adds a placeholder option for the TextareaElement, similar to TextboxElements.