### PR TITLE
[Form.js] Add support for step to NumericElement

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1847,6 +1847,7 @@ class NumericElement extends Component {
             id={this.props.id}
             min={this.props.min}
             max={this.props.max}
+            step={this.props.step}
             value={this.props.value || ''}
             disabled={disabled}
             required={required}
@@ -1863,6 +1864,7 @@ NumericElement.propTypes = {
   name: PropTypes.string.isRequired,
   min: PropTypes.number,
   max: PropTypes.number,
+  step: PropTypes.string,
   label: PropTypes.string,
   value: PropTypes.string,
   id: PropTypes.string,
@@ -1875,6 +1877,7 @@ NumericElement.defaultProps = {
   name: '',
   min: null,
   max: null,
+  step: '1',
   label: '',
   value: '',
   id: null,


### PR DESCRIPTION
This adds support for the "step" attribute to the NumericElement wrapper. The step is a string type (rather than an integer) so that step="any" is supported for decimals (as per the <input type="number" /> spec.)