### PR TITLE
[Form.js] Add support for vertical Radio button groups

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2549,7 +2549,7 @@ class RadioElement extends React.Component {
 
     const styleRow = {
       display: 'flex',
-      flexDirection: 'row',
+      flexDirection: this.props.vertical == false ? 'row' : 'column',
       flexWrap: 'wrap',
       width: '100%',
     };
@@ -2657,6 +2657,7 @@ RadioElement.propTypes = {
   options: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  vertical: PropTypes.bool,
   checked: PropTypes.string.isRequired,
   errorMessage: PropTypes.string,
   elementClass: PropTypes.string,
@@ -2665,6 +2666,7 @@ RadioElement.propTypes = {
 RadioElement.defaultProps = {
   disabled: false,
   required: false,
+  vertical: false,
   errorMessage: '',
   elementClass: 'row form-group',
   onUserInput: function() {


### PR DESCRIPTION
This adds a vertical=true/false attribute to our <RadioElement> wrapper. The option toggles whether the radio options are displayed vertically or horizontally on the page.