### PR TITLE
[API] Fix Candidate endpoint error

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -148,7 +148,11 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $candID = new CandID($pscids[0]["CandID"]);
         }
 
-        $candidate = \NDB_Factory::singleton()->candidate($candID);
+        try {
+            $candidate = \NDB_Factory::singleton()->candidate($candID);
+        } catch (\DomainException $e) {
+            return new \LORIS\Http\Response\JSON\NotFound('Candidate not found');
+        }
 
         $endpoint = new Candidate\Candidate($candidate);
 


### PR DESCRIPTION
The candidates/{CanID} endpoint throws a fatal if a missing but valid (format pass validation) CanID is provided.
- a 404 NotFound is returned [here](https://github.com/aces/Loris/blob/main/modules/api/php/endpoints/candidates.class.inc#L137) if the missing  CanID is not valid (incorrect format) since `new CanID()` will throw an error
- a fatal is thrown by `\NDB_Factory::singleton()->candidate()` if the format is valid but the value does not exist in the DB.

This PR catches the Exception thrown by new Candidate() to return a 404 NotFound.