### PR TITLE
[Issue tracker] change userID to fullname

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -341,6 +341,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 $comment['fieldChanged'] = 'Visit Label';
             } else if ($comment['fieldChanged'] === 'assignee' || $comment['fieldChanged'] === 'lastUpdatedBy') {
                 $comment['newValue'] = $this->formatUserInformation($comment['newValue']);
+            }
         }
         return $unformattedComments; //now formatted I guess
     }

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -439,8 +439,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
 
         $issueID = intval($values['issueID']);
-
-        $issueValues['lastUpdatedBy'] = $this->formatUserInformation($user->getUserName());
+        $issueValues['lastUpdatedBy'] = $user->getUserName();
 
         $validatedInput = $this->validateInput($validateValues, $user);
         if (!is_array($validatedInput)) { // Error exists.
@@ -465,6 +464,10 @@ class Edit extends \NDB_Page implements ETagCalculator
             $db->insert('issues', $issueValues);
             $issueID = intval($db->getLastInsertId());
         }
+
+        // convert the aspect of 'lastUpdatedBy' to Fullname
+        // once the db has registered the username (userID)
+        $issueValues['lastUpdatedBy'] = $this->formatUserInformation($user->getUserName());
 
         $this->updateHistory($historyValues, $issueID, $user);
         $this->updateComments($values['comment'], $issueID, $user);

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -104,11 +104,11 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
 
         foreach ($assignee_expanded as $a_row) {
-            $assignees[$a_row['UserID']] = $a_row['Real_name'];
+            $assignees[$a_row['UserID']] = $this->formatUserInformation($a_row['UserID']);
         }
 
         foreach ($inactive_users_expanded as $u_row) {
-            $inactive_users[$u_row['UserID']] = $u_row['Real_name'];
+            $inactive_users[$u_row['UserID']] = $this->formatUserInformation($u_row['UserID']);
         }
 
         $otherWatchers = [];
@@ -118,7 +118,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         );
         foreach ($potential_watchers_expanded as $w_row) {
             if ($w_row['UserID'] != $user->getUsername()) {
-                $otherWatchers[$w_row['UserID']] = $w_row['Real_name'];
+                $otherWatchers[$w_row['UserID']] = $this->formatUserInformation($w_row['UserID']);
             }
         }
 
@@ -251,7 +251,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         $db = $this->loris->getDatabaseConnection();
 
         if (!empty($issueID)) {
-            return $db->pselectRow(
+            $issueData = $db->pselectRow(
                 "SELECT
                             i.*,
                             c.PSCID,
@@ -264,10 +264,16 @@ class Edit extends \NDB_Page implements ETagCalculator
                             issueID = :issueID",
                 ['issueID' => $issueID]
             ) ?? [];
+            // format users
+            $issueData['reporter'] = $this->formatUserInformation($issueData['reporter']);
+            $issueData['assignee'] = $this->formatUserInformation($issueData['assignee']);
+            $issueData['lastUpdatedBy'] = $this->formatUserInformation($issueData['lastUpdatedBy']);
+            // return
+            return $issueData;
         }
 
         return [
-            'reporter'      => $user->getUsername(),
+            'reporter'      => $this->formatUserInformation($user->getUsername()),
             'dateCreated'   => date('Y-m-d H:i:s'),
             'centerID'      => $user->getCenterIDs(),
             'status'        => 'new',
@@ -308,6 +314,9 @@ class Edit extends \NDB_Page implements ETagCalculator
         // looping by reference so can edit in place
         $modules = \Module::getActiveModulesIndexed($this->loris);
         foreach ($unformattedComments as &$comment) {
+            // for all users that added a comment, get their full name
+            $comment['addedBy'] = $this->formatUserInformation($comment['addedBy']);
+            // specific changes
             if ($comment['fieldChanged'] === 'module') {
                 $mid = $comment['newValue'];
                 $comment['newValue'] = $modules[$mid]->getLongName();
@@ -330,7 +339,8 @@ class Edit extends \NDB_Page implements ETagCalculator
                 );
                 $comment['newValue'] = $visitLabel;
                 $comment['fieldChanged'] = 'Visit Label';
-            }
+            } else if ($comment['fieldChanged'] === 'assignee' || $comment['fieldChanged'] === 'lastUpdatedBy') {
+                $comment['newValue'] = $this->formatUserInformation($comment['newValue']);
         }
         return $unformattedComments; //now formatted I guess
     }
@@ -429,7 +439,7 @@ class Edit extends \NDB_Page implements ETagCalculator
 
         $issueID = intval($values['issueID']);
 
-        $issueValues['lastUpdatedBy'] = $user->getUsername();
+        $issueValues['lastUpdatedBy'] = $this->formatUserInformation($user->getUserName());
 
         $validatedInput = $this->validateInput($validateValues, $user);
         if (!is_array($validatedInput)) { // Error exists.
@@ -786,6 +796,24 @@ class Edit extends \NDB_Page implements ETagCalculator
             }
         }
         return $changedValues;
+    }
+
+    /**
+     * Get a formatted string from user information.
+     *
+     * @param string $userid a username/userid
+     *
+     * @return string a formatted string "fullname (userid)"
+     */
+    function formatUserInformation(string $userid) {
+        $user = \User::factory($userid);
+        $un = $user->getUsername();
+        if (empty($un)) {
+            // e.g. in case of anonymous user
+            return $user->getFullname();
+        }  else {
+            return $user->getFullname() . " (" . $un . ")";
+        }
     }
 
     /**

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -123,7 +123,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             []
         );
         foreach ($reporter_expanded as $r_row) {
-            $reporters[$r_row['UserID']] = $r_row['Real_name'];
+            $reporters[$r_row['Real_name']] = $r_row['Real_name'];
         }
 
         //assignees
@@ -137,7 +137,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             []
         );
         foreach ($assignee_expanded as $a_row) {
-            $assignees[$a_row['UserID']] = $a_row['Real_name'];
+            $assignees[$a_row['Real_name']] = $a_row['Real_name'];
         }
 
         $modules = array_reduce(

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -55,8 +55,8 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     i.title,
                     m.name as module,
                     i.category,
-                    i.reporter,
-                    i.assignee,
+                    CONCAT(uReporter.First_name, ' ', uReporter.Last_name),
+                    CONCAT(uAssignee.First_name, ' ', uAssignee.Last_name),
                     i.status,
                     i.priority,
                     i.centerID as centerId,
@@ -78,6 +78,10 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
               ON (i.issueID = w.issueID AND w.userID=:username)
             LEFT JOIN issues_comments ic
               ON (i.issueID = ic.issueID)
+            JOIN users uReporter
+              ON (i.reporter = uReporter.UserID)
+            JOIN users uAssignee
+              ON (i.assignee = uAssignee.UserID)
             GROUP BY i.issueID, w.userID
             ORDER BY i.issueID DESC",
             ['username' => $userID]


### PR DESCRIPTION
## Brief summary of changes

Change user IDs to user full names throughout the main pages. 

#### Testing instructions (if applicable)

1. Go to the issue tracker.
2. Check the `assignee` and `reporter` columns in the main table (there should be user full names).
3. Click on one issue to print the details.
4. All information should contain the user full names (i.e top of the page, table, and history section).
