### PR TITLE
[dictionary] Add visits for session scoped variables to API

### DIFF
--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -18,6 +18,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
     protected DictionaryItem $item;
     protected string $desc;
     protected string $status;
+    protected ?array $visits;
 
     /**
      * Construct a DataDictRow
@@ -28,19 +29,22 @@ class DataDictRow implements \LORIS\Data\DataInstance,
      * @param DictionaryItem $item       The DictionaryItem for this row
      * @param string         $desc       The (possibly overridden) description
      * @param string         $descstatus The status of the description override
+     * @param ?string[]      $visits     List of visits for the item.
      */
     public function __construct(
         \Module $itemmodule,
         Category $cat,
         DictionaryItem $item,
         string $desc,
-        string $descstatus
+        string $descstatus,
+        ?array $visits,
     ) {
         $this->itemmodule   = $itemmodule;
         $this->itemcategory = $cat;
         $this->item         = $item;
         $this->desc         = $desc;
         $this->status       = $descstatus;
+        $this->visits       = $visits;
     }
 
     /**
@@ -50,20 +54,25 @@ class DataDictRow implements \LORIS\Data\DataInstance,
      */
     public function jsonSerialize() : array
     {
-        $val = [
+        $scope = $this->getScope();
+        $val   = [
             'module'             => $this->itemmodule->getName(),
             'category'           => $this->itemcategory->getName(),
             'field'              => $this->getFieldName(),
             'description'        => $this->desc,
             'description_status' => $this->status,
-            'datascope'          => $this->getScope(),
+            'datascope'          => $scope,
             'type'               => $this->getDataType(),
             'cardinality'        => $this->getCardinality(),
+            'visits'             => $this->visits,
         ];
 
         $itype = $this->item->getDataType();
         if ($itype instanceof \LORIS\Data\Types\Enumeration) {
             $val['options'] = $itype->getOptions();
+        }
+        if ($scope->__toString() == "session") {
+            $val['visits'] = $this->visits;
         }
 
         return $val;
@@ -141,5 +150,16 @@ class DataDictRow implements \LORIS\Data\DataInstance,
     public function getCardinality() : \LORIS\Data\Cardinality
     {
         return $this->item->getCardinality();
+    }
+
+    /**
+     * Return a list of visits for this item if the item
+     * is session scoped.
+     *
+     * @return ?string[]
+     */
+    public function getVisits() : ?array
+    {
+        return $this->visits;
     }
 }

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -52,6 +52,8 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
             $module = $row['Module'];
             $cat    = $row['Category'];
 
+            $qe = $module->getQueryEngine();
+
             foreach ($cat->getItems() as $item) {
                 $name   = $item->getName();
                 $status = 'Unchanged';
@@ -66,12 +68,14 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
                     $status = 'Empty';
                 }
 
+                $visits = $qe->getVisitList($cat, $item);
                 $dict[] = $this->getInstance(
                     $module,
                     $cat,
                     $item,
                     $desc,
                     $status,
+                    $visits,
                 );
             }
         }
@@ -90,6 +94,7 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
      *                                   table
      * @param string         $desc       The overridden description of the item
      * @param string         $descstatus The status of the description override
+     * @param ?[]string      $visits     The visits for session scoped variables
      *
      * @return \LORIS\Data\DataInstance An instance representing this row.
      */
@@ -98,8 +103,9 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
         Category $cat,
         DictionaryItem $item,
         string $desc,
-        string $descstatus
+        string $descstatus,
+        array $visits,
     ) : \LORIS\Data\DataInstance {
-        return new DataDictRow($module, $cat, $item, $desc, $descstatus);
+        return new DataDictRow($module, $cat, $item, $desc, $descstatus, $visits);
     }
 }

--- a/modules/dictionary/php/moduledict.class.inc
+++ b/modules/dictionary/php/moduledict.class.inc
@@ -90,6 +90,7 @@ class ModuleDict extends \NDB_Page
             }
             $fieldname = $row->getFieldName();
             $datatype  = $row->getDataType();
+            $scope     = $row->getScope();
             $organized[$cat][$fieldname] = [
                 'description' => $row->getDescription(),
                 'scope'       => $row->getScope(),
@@ -98,6 +99,9 @@ class ModuleDict extends \NDB_Page
             ];
             if ($datatype instanceof \LORIS\Data\Types\Enumeration) {
                 $organized[$cat][$fieldname]['options'] = $datatype->getOptions();
+            }
+            if ($scope->__toString() == "session") {
+                $organized[$cat][$fieldname]['visits'] = $row->getVisits();
             }
         }
         return new \LORIS\Http\Response\JSON\OK($organized);

--- a/modules/dictionary/php/moduledict.class.inc
+++ b/modules/dictionary/php/moduledict.class.inc
@@ -93,7 +93,7 @@ class ModuleDict extends \NDB_Page
             $scope     = $row->getScope();
             $organized[$cat][$fieldname] = [
                 'description' => $row->getDescription(),
-                'scope'       => $row->getScope(),
+                'scope'       => $scope,
                 'type'        => $row->getDataType(),
                 'cardinality' => $row->getCardinality(),
             ];


### PR DESCRIPTION
PR#6936 includes a /dictionary/module/(modulename) REST endpoint to act as an API which provides the dictionary for the QueryEngine of a module.

This updates it to include the valid visits for which the data point is valid for session scoped variables.

#### Testing instructions (if applicable)

1. This requires a module with session based variables in its QueryEngine such as #8216 (instruments) or #8288 (candidate parameters). Access `$LORISURL/dictionary/module/$modulename` and look at the JSON returned. Session scoped variables should include a visits key with an array of the correct visits for that variable.
