### PR TITLE
[Core] Remove Database::singleton function

### DIFF
--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -32,16 +32,16 @@ Prepared statements MUST be used for any database interactions that use user inp
 
 LORIS has many classes that use a Singleton design pattern. To facilitate with
 unit testing, it is best to use these singletons via the NDB_Factory class.
-For example, you should use the Database class like this:
+For example, you should use the Project class like this:
 
 ```php
-$database = \NDB_Factory::singleton()->database();
+$project = \NDB_Factory::singleton()->project("controlproject");
 ```
 
 instead of 
 
 ```php
-$database = \Database::singleton();
+$project = \Project::singleton("controlproject");
 ```
 
 # HTML

--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -189,7 +189,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
    function importFile(&$file, $args) {
         $fp=fopen($file->fileInfo['tmp_name'], "r");
 
-        $db=& $this->loris->getDatabaseConnection();
+        $db= $this->loris->getDatabaseConnection();
         ///Setting trackchanges to false because getting error messages
         $db->_trackChanges = false;
         ////////////////////////////////////////////////////////////////

--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -189,7 +189,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
    function importFile(&$file, $args) {
         $fp=fopen($file->fileInfo['tmp_name'], "r");
 
-        $db=& Database::singleton();
+        $db=& $this->loris->getDatabaseConnection();
         ///Setting trackchanges to false because getting error messages
         $db->_trackChanges = false;
         ////////////////////////////////////////////////////////////////

--- a/docs/wiki/99_Developers/UnitTestGuide.md
+++ b/docs/wiki/99_Developers/UnitTestGuide.md
@@ -395,7 +395,6 @@ This can be used for almost any class within LORIS. In the section right below, 
 
 
 ```
-    $DB      = \Database::singleton();
     $config  = \NDB_Config::singleton();
     $user    = \User::singleton();
 ```
@@ -406,7 +405,6 @@ Please update the code to use this LORIS standard declaration:
 
 ```
     $factory = NDB_Factory::singleton();
-    $DB      = $factory->database();
     $config  = $factory->config();
     $user    = $factory->user();
 ```
@@ -526,20 +524,11 @@ protected function setUp(): void \
     $this->_factory->setTesting(false);
     
     $this->_configMock = $this->_factory->Config(CONFIG_XML);
-    $database          = $this->_configMock->getSetting('database');
-	
-    $this->_dbMock     = \Database::singleton(
-        $database['database'],
-        $database['username'],
-        $database['password'],
-        $database['host'],
-        true
-    );
-
+    $this->_dbMock     = $this->_factory->database();
 } 
 
 ```
-As you can see, the `$this->_dbMock` object is now declared as a `\Database::singleton()` rather than as a mock object. This is why it is not a pure unit test and why we cannot use the same “expects” method as in the previous section. 
+As you can see, the `$this->_dbMock` object is now declared as a Database object rather than as a mock object. This is why it is not a pure unit test and why we cannot use the same “expects” method as in the previous section. 
 
 	
 The **tearDown** function is the same as before:

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -108,6 +108,11 @@ class Database implements LoggerAwareInterface
 
         }
 
+            $this->_PDO = new PDO(
+                "mysql:host=$host;dbname=$database;charset=UTF8",
+                $username,
+                $password
+            );
         try {
             $this->_PDO = new PDO(
                 "mysql:host=$host;dbname=$database;charset=UTF8",
@@ -117,6 +122,7 @@ class Database implements LoggerAwareInterface
         } catch (PDOException $e) {
             // This exception will not be included in the error log as it will
             // likely include credentials.
+            throw $e;
             throw new DatabaseException(
                 "Could not establish a PDO object using the following values: "
                 . "username: `$username`, dbname: `$database`, host: `$host` "

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -71,6 +71,41 @@ class Database implements LoggerAwareInterface
     }
 
     /**
+     * Singleton design pattern implementation - creates the object
+     * and also connects to the database if necessary.
+     *
+     * To avoid credentials being displayed in stack traces,
+     * credentials must be passed in environment variables.
+     *
+     * The caller must ensure there are variables named
+     * LORIS_$dbname_USERNAME, LORIS_$dbname_PASSWORD, and
+     * LORIS_$dbname_HOST with their respective values. This
+     * is usually done by NDB_Factory.
+     *
+     * @param string $database     the database to select
+     * @param bool   $trackChanges boolean determining if changes should be
+     *                             logged to the history table
+     *
+     * @return     \Database
+     * @throws     \DatabaseException
+     * @access     public
+     * @deprecated
+     */
+    static function singleton(
+        string $database,
+        bool $trackChanges = true
+    ): \Database {
+        // We don't have access to $this->logger since it's a static function,
+        // so we need to use error_log() instead of $this->logger->warning().
+        error_log(
+            "Database::singleton is deprecated. "
+            . "Use the getDatabaseConnection method from your LorisInstance"
+            . " object instead."
+        );
+        return \NDB_Factory::singleton()->database();
+    }
+
+    /**
      * Creates the connection to the database server and selects the
      * desired database.  the connection is stored in the Database
      * object, and should never be accessed directly by the user.

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1570,8 +1570,9 @@ class Database implements LoggerAwareInterface
      */
     public function closeConnection() : void
     {
+        $this->_preparedStoreHistory = null;
         $this->_PDO = null;
-        unset($this->_PDO);
+        $this->_HistoryPDO = null;
 
     }
 }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -56,7 +56,8 @@ class Database implements LoggerAwareInterface
 
     /**
      * Constructor must be public for unit tests to pass, but this should not
-     * be used directly. Should only be called by singleton method.
+     * be used directly. References should only be retrieved via the LorisInstance
+     * object.
      */
     public function __construct()
     {
@@ -64,70 +65,6 @@ class Database implements LoggerAwareInterface
         // level until after the database connection is established for NDB_Config,
         // NDB_Factory will set an appropriate ApacheLogger after the fact.
         $this->setLogger(new \Psr\Log\NullLogger);
-    }
-    /**
-     * Singleton design pattern implementation - creates the object
-     * and also connects to the database if necessary.
-     *
-     * To avoid credentials being displayed in stack traces,
-     * credentials must be passed in environment variables.
-     *
-     * The caller must ensure there are variables named
-     * LORIS_$dbname_USERNAME, LORIS_$dbname_PASSWORD, and
-     * LORIS_$dbname_HOST with their respective values. This
-     * is usually done by NDB_Factory.
-     *
-     * @param string $database     the database to select
-     * @param bool   $trackChanges boolean determining if changes should be
-     *                             logged to the history table
-     *
-     * @return \Database
-     * @throws \DatabaseException
-     * @access public
-     */
-    static function &singleton(
-        string $database,
-        bool $trackChanges = true
-    ): \Database {
-        $username = getenv("LORIS_{$database}_USERNAME");
-        $password = getenv("LORIS_{$database}_PASSWORD");
-        $host     = getenv("LORIS_{$database}_HOST");
-
-        static $connections = [];
-
-        // if no arguments, try to get the first connection or choke
-        if (empty($database)
-            && empty($username)
-            && empty($password)
-            && empty($host)
-        ) {
-            if (!empty($connections)) {
-                reset($connections);
-                $connection = current($connections);
-                return $connection;
-            } else {
-                throw new DatabaseException("No database connection exists");
-            }
-        } else {
-            // name the connection.
-            if ($trackChanges) {
-                $connection = md5($database.$host.$username.$password.'yep');
-            } else {
-                $connection = md5($database.$host.$username.$password.'nope');
-            }
-
-            // create the connection if none exists
-            if (empty($connections[$connection])) {
-                $connections[$connection] = new Database();
-                $connections[$connection]->connect(
-                    $database,
-                    $trackChanges
-                );
-            }
-
-            // return the connection
-            return $connections[$connection];
-        }
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -26,7 +26,7 @@ class Database implements LoggerAwareInterface
      * @var    PDO
      * @access private
      */
-    private $_PDO = null;
+    var $_PDO = null;
 
     /**
      * The database handle for storing history information.
@@ -1565,8 +1565,13 @@ class Database implements LoggerAwareInterface
 
     /**
      * Close the database connection.
+     *
+     * @return void
      */
-    public function closeConnection() : void {
+    public function closeConnection() : void
+    {
         $this->_PDO = null;
+        unset($this->_PDO);
+
     }
 }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -23,7 +23,7 @@ class Database implements LoggerAwareInterface
      * last (only) reference to it, which is how connections
      * are closed in PDO
      *
-     * @var    PDO
+     * @var    ?PDO
      * @access private
      */
     var $_PDO = null;
@@ -111,11 +111,6 @@ class Database implements LoggerAwareInterface
 
         }
 
-            $this->_PDO = new PDO(
-                "mysql:host=$host;dbname=$database;charset=UTF8",
-                $username,
-                $password
-            );
         try {
             $this->_PDO = new PDO(
                 "mysql:host=$host;dbname=$database;charset=UTF8",
@@ -125,7 +120,6 @@ class Database implements LoggerAwareInterface
         } catch (PDOException $e) {
             // This exception will not be included in the error log as it will
             // likely include credentials.
-            throw $e;
             throw new DatabaseException(
                 "Could not establish a PDO object using the following values: "
                 . "username: `$username`, dbname: `$database`, host: `$host` "
@@ -1568,10 +1562,11 @@ class Database implements LoggerAwareInterface
      *
      * @return void
      */
-    public function closeConnection() : void
+    public function closeConnection(): void
     {
         $this->_preparedStoreHistory = null;
-        $this->_PDO = null;
+
+        $this->_PDO        = null;
         $this->_HistoryPDO = null;
 
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -18,12 +18,15 @@ class Database implements LoggerAwareInterface
     use \Psr\Log\LoggerAwareTrait;
 
     /**
-     * The database handle, created by the connect() method
+     * The database handle, created by the connect() method.
+     * This *MUST* be private to ensure close deletes the
+     * last (only) reference to it, which is how connections
+     * are closed in PDO
      *
      * @var    PDO
      * @access private
      */
-    var $_PDO = null;
+    private $_PDO = null;
 
     /**
      * The database handle for storing history information.
@@ -1558,5 +1561,12 @@ class Database implements LoggerAwareInterface
     public function getArchitecture(): string
     {
         return $this->_getServerVariable('version_comment');
+    }
+
+    /**
+     * Close the database connection.
+     */
+    public function closeConnection() : void {
+        $this->_PDO = null;
     }
 }

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -53,9 +53,6 @@ class NDB_Client
 
         $config = $factory->config($configFile);
 
-        // The factory uses the Settings object to call Database::singleton().
-        // This is required so that further calls to Database::singleton()
-        // will work.
         $DB = $factory->database();
 
         // Register S3 stream wrapper if configured

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -173,9 +173,10 @@ class NDB_Factory
         putenv("LORIS_{$dbname}_PASSWORD=" . $settings->dbPassword());
         putenv("LORIS_{$dbname}_HOST=" . $settings->dbHost());
 
-        $db_ref = \Database::singleton(
+        $db_ref = new Database();
+        $db_ref->connect(
             $settings->dbName(),
-            true
+            true,
         );
 
         // Unset the variables now that they're no longer needed.

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -92,11 +92,7 @@ class Database_Test extends TestCase
         $this->factory = NDB_Factory::singleton();
         $this->factory->reset();
         $this->config = $this->factory->Config(CONFIG_XML);
-        $database     = $this->config->getSetting('database');
         $this->DB     = $this->factory->database();
-
-        $this->factory->setDatabase($this->DB);
-        $this->factory->setConfig($this->config);
     }
 
     /**

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -93,13 +93,7 @@ class Database_Test extends TestCase
         $this->factory->reset();
         $this->config = $this->factory->Config(CONFIG_XML);
         $database     = $this->config->getSetting('database');
-        $this->DB     = $this->factory->database(
-            $database['database'],
-            $database['username'],
-            $database['password'],
-            $database['host'],
-            true,
-        );
+        $this->DB     = $this->factory->database();
 
         $this->factory->setDatabase($this->DB);
         $this->factory->setConfig($this->config);

--- a/test/unittests/Loris_PHPUnit_Database_TestCase.php
+++ b/test/unittests/Loris_PHPUnit_Database_TestCase.php
@@ -82,22 +82,6 @@ abstract class Loris_PHPUnit_Database_TestCase extends TestCase
      */
     protected function createLorisDBConnection()
     {
-        $dbname = $this->factory->settings()->dbName();
-        putenv(
-            "LORIS_{$dbname}_USERNAME="
-            . $this->factory->settings()->dbUserName()
-        );
-        putenv(
-            "LORIS_{$dbname}_PASSWORD="
-            . $this->factory->settings()->dbPassword()
-        );
-        putenv(
-            "LORIS_{$dbname}_HOST="
-            . $this->factory->settings()->dbHost()
-        );
-        $this->database = Database::singleton(
-            $this->factory->settings()->dbName(),
-        );
+        $this->database = $this->factory->database();
     }
-
 }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -260,17 +260,7 @@ class UserTest extends TestCase
      * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_mockDB;
-    /**
-     * Test double for Database object for hasLoggedIn method
-     *
-     * @note This is needed for User::hasLoggedIn because it declares and uses
-     *       the database differently than other methods in the User class.
-     *       This can be changed when the rest of the User class updates how it
-     *       declares its database. - Alexandra Livadas
-     *
-     * @var NDB_Factory
-     */
-    private $_mockFactory;
+
     /**
      * Maps config names to values
      * Used to set behaviour of NDB_Config test double
@@ -300,8 +290,6 @@ class UserTest extends TestCase
 
         $this->_mockDB      = $mockdb;
         $this->_mockConfig  = $mockconfig;
-        $this->_mockFactory = \NDB_Factory::singleton();
-        $this->_mockFactory->setDatabase($this->_dbMock);
 
         $this->_factory->setConfig($this->_mockConfig);
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -354,6 +354,7 @@ class UserTest extends TestCase
      */
     public function testGetDataForLanguagePreferences()
     {
+        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['language_preference'],
@@ -369,6 +370,7 @@ class UserTest extends TestCase
      */
     public function testGetFullname()
     {
+        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['Real_name'],
@@ -384,6 +386,7 @@ class UserTest extends TestCase
      */
     public function testGetId()
     {
+        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['ID'],
@@ -399,6 +402,7 @@ class UserTest extends TestCase
      */
     public function testGetUsername()
     {
+        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['UserID'],

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -324,6 +324,7 @@ class UserTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+        $this->_factory->database()->closeConnection();
         $this->_factory->reset();
     }
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -621,6 +621,7 @@ class UserTest extends TestCase
         $newUserInfo           = $this->_userInfo;
         $newUserInfo['ID']     = 2;
         $newUserInfo['UserID'] = '968776';
+        $newUserInfo['Email']  = 'notjohn.doe@mcgill.ca';
         \User::insert($newUserInfo);
         $this->_otherUser = \User::factory('968776');
         $this->assertEquals('968776', $this->_otherUser->getUsername());

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -290,13 +290,7 @@ class UserTest extends TestCase
         $this->_factory->reset();
         $this->_configMock = $this->_factory->Config(CONFIG_XML);
         $database          = $this->_configMock->getSetting('database');
-        $this->_dbMock     = $this->_factory->database(
-            $database['database'],
-            $database['username'],
-            $database['password'],
-            $database['host'],
-            true
-        );
+        $this->_dbMock     = $this->_factory->database();
 
         $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
         $mockdb     = $this->getMockBuilder('Database')->getMock();

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -279,7 +279,6 @@ class UserTest extends TestCase
         $this->_factory = \NDB_Factory::singleton();
         $this->_factory->reset();
         $this->_configMock = $this->_factory->Config(CONFIG_XML);
-        $database          = $this->_configMock->getSetting('database');
         $this->_dbMock     = $this->_factory->database();
 
         $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
@@ -288,8 +287,8 @@ class UserTest extends TestCase
         '@phan-var \Database $mockdb';
         '@phan-var \NDB_Config $mockconfig';
 
-        $this->_mockDB      = $mockdb;
-        $this->_mockConfig  = $mockconfig;
+        $this->_mockDB     = $mockdb;
+        $this->_mockConfig = $mockconfig;
 
         $this->_userInfoComplete       = $this->_userInfo;
         $this->_userInfoComplete['ID'] = '1';
@@ -312,6 +311,7 @@ class UserTest extends TestCase
         $this->_userInfo['Password_hash']         = $passwordHash;
         $this->_userInfoComplete['Password_hash'] = $passwordHash;
 
+        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
     }
 
@@ -339,7 +339,6 @@ class UserTest extends TestCase
      */
     public function testFactoryRetrievesUserInfo()
     {
-        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         //validate _user Info
         $this->assertEquals($this->_userInfoComplete, $this->_user->getData());
@@ -354,7 +353,6 @@ class UserTest extends TestCase
      */
     public function testGetDataForLanguagePreferences()
     {
-        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['language_preference'],
@@ -370,7 +368,6 @@ class UserTest extends TestCase
      */
     public function testGetFullname()
     {
-        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['Real_name'],
@@ -386,7 +383,6 @@ class UserTest extends TestCase
      */
     public function testGetId()
     {
-        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['ID'],
@@ -402,7 +398,6 @@ class UserTest extends TestCase
      */
     public function testGetUsername()
     {
-        $this->_setUpTestDoublesForFactoryUser();
         $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['UserID'],
@@ -662,10 +657,10 @@ class UserTest extends TestCase
 
         // Cause usePwnedPasswordsAPI config option to return false.
         $mockConfig = &$this->_mockConfig;
-        '@phan-var \PHPUnit\Framework\MockObject\MockObject $mockConfig';
 
         $this->_factory->setConfig($mockConfig);
 
+        '@phan-var \PHPUnit\Framework\MockObject\MockObject $mockConfig';
         $mockConfig->expects($this->any())
             ->method('settingEnabled')
             ->willReturn(false);
@@ -701,6 +696,7 @@ class UserTest extends TestCase
             ->method('settingEnabled')
             ->willReturn(false);
 
+        $mockConfig = &$this->_mockConfig;
         $this->_factory->setConfig($mockConfig);
 
         $this->_user->updatePassword(

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -636,6 +636,14 @@ class UserTest extends TestCase
      */
     public function testUpdate()
     {
+        // Insert the user so that it can be updated.
+        $newUserInfo           = $this->_userInfo;
+        $newUserInfo['ID']     = 2;
+        $newUserInfo['UserID'] = '968776';
+        $newUserInfo['Email']  = 'notjohn.doe@mcgill.ca';
+        \User::insert($newUserInfo);
+
+        // Test the update.
         $this->_otherUser = \User::factory('968776');
         $newInfo          = ['ID' => '3'];
         $this->_otherUser->update($newInfo);

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -291,8 +291,6 @@ class UserTest extends TestCase
         $this->_mockDB      = $mockdb;
         $this->_mockConfig  = $mockconfig;
 
-        $this->_factory->setConfig($this->_mockConfig);
-
         $this->_userInfoComplete       = $this->_userInfo;
         $this->_userInfoComplete['ID'] = '1';
         $this->_userInfoComplete['Privilege']           = '1';
@@ -661,6 +659,9 @@ class UserTest extends TestCase
         // Cause usePwnedPasswordsAPI config option to return false.
         $mockConfig = &$this->_mockConfig;
         '@phan-var \PHPUnit\Framework\MockObject\MockObject $mockConfig';
+
+        $this->_factory->setConfig($mockConfig);
+
         $mockConfig->expects($this->any())
             ->method('settingEnabled')
             ->willReturn(false);
@@ -695,6 +696,8 @@ class UserTest extends TestCase
         $this->_mockConfig->expects($this->any())
             ->method('settingEnabled')
             ->willReturn(false);
+
+        $this->_factory->setConfig($mockConfig);
 
         $this->_user->updatePassword(
             new \Password(\Utility::randomString(16))

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -61,10 +61,8 @@ class VisitTest extends TestCase
         putenv("LORIS_{$database['database']}_PASSWORD={$database['password']}");
         putenv("LORIS_{$database['database']}_HOST={$database['host']}");
 
-        $this->DB = \Database::singleton(
-            $database['database'],
-            true,
-        );
+        $this->DB = $this->factory->database();
+
         $this->visitController = new \Loris\VisitController($this->DB);
 
         $v1 = new \Loris\Visit('V1');


### PR DESCRIPTION
There are currently 3 methods of getting a reference to a database in LORIS, in order of preference:

1. LorisInstance->getDatabaseConnection()
2. NDB_Factory::singleton()->database();
3. Database::singleton()

The only reference to 3 left is in the implementation of option 2. This removes the Database::singleton by inlineing the reference into the factory and removes all remaining references to Database::singleton (mostly from documentation and a couple unit tests.)