### PR TITLE
task to property prefix for additional events table

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -316,8 +316,8 @@ CREATE TABLE `physiological_task_event` (
 CREATE TABLE `physiological_task_event_opt` (
     `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `PhysiologicalTaskEventID` int(10) unsigned NOT NULL,
-    `TaskName` varchar(50) NOT NULL,
-    `TaskValue` varchar(255) NULL,
+    `PropertyName`             varchar(50) NOT NULL,
+    `PropertyValue`            varchar(255) NULL,
     PRIMARY KEY (`ID`),
     CONSTRAINT `FK_event_task_opt`
         FOREIGN KEY (`PhysiologicalTaskEventID`)

--- a/SQL/New_patches/2022-11-22-eeg-additional-events-table.sql
+++ b/SQL/New_patches/2022-11-22-eeg-additional-events-table.sql
@@ -3,8 +3,8 @@
 CREATE TABLE `physiological_task_event_opt` (
     `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `PhysiologicalTaskEventID` int(10) unsigned NOT NULL,
-    `TaskName` varchar(50) NOT NULL,
-    `TaskValue` varchar(255) NULL,
+    `PropertyName`             varchar(50) NOT NULL,
+    `PropertyValue`            varchar(255) NULL,
     PRIMARY KEY (`ID`),
     CONSTRAINT `FK_event_task_opt`
         FOREIGN KEY (`PhysiologicalTaskEventID`)


### PR DESCRIPTION
## Brief summary of changes

Rename the additional events' table attributes prefix from `Task` to `Property`. 