### PR TITLE
[dqt] Fix loading saved query

### DIFF
--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -682,23 +682,23 @@ class DataQueryApp extends Component {
       alertSaved: false,
       loading: false,
     });
-    for (let i = 0; i < fieldsList.length; i++) {
-      $.ajax({
-        url: loris.BaseURL + '/dqt/ajax/datadictionary.php',
-        success: (data) => {
-          if (data[0] && data[0].value.IsFile) {
-            let key = data[0].key[0] + ',' + data[0].key[1];
+    $.ajax({
+      url: loris.BaseURL + '/dqt/ajax/datadictionary.php',
+      success: (data) => {
+        for (let i = 0; i < fieldsList.length; i++) {
+          if (data[i] && data[i].value.IsFile) {
+            let key = data[i].key[0] + ',' + data[i].key[1];
             let downloadable = this.state.downloadableFields;
             downloadable[key] = true;
             this.setState({
               downloadableFields: downloadable,
             });
           }
-        },
-        data: {key: fieldsList[i]},
-        dataType: 'json',
-      });
-    }
+        }
+      },
+      data: {keys: JSON.stringify(fieldsList)},
+      dataType: 'json',
+    });
   }
 
   /**


### PR DESCRIPTION
## Brief summary of changes

This bit of code was introduced in this [PR](https://github.com/aces/Loris/commit/90e17c78ff5a15c8c24e00553647fdc700bef54d#diff-54b30034c9a58a43476f9a8142cc301d7df7d22d769efaa31529757b06f3125fR509) and then reverted back in this [PR](https://github.com/aces/Loris/commit/c59d5f8dbb17011191fe11fb06ac17d5fa09906c#diff-54b30034c9a58a43476f9a8142cc301d7df7d22d769efaa31529757b06f3125f).

I am reverting the code back to what it was when it was introduced as the ['keys' parameter in the query string](https://github.com/aces/Loris/blob/65e676a1604f50447af1331d0ae7f5a43608131a/modules/dqt/ajax/datadictionary.php#L46) wasn't changed back. I'm assuming reverting the code was a mistake when it got lumped in with the rest of the intended code changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
