### PR TITLE
Make getModule register autoloader for module

### DIFF
--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -117,6 +117,7 @@ class LorisInstance
         return false;
     }
 
+    private array $moduleInstances;
     /**
      * Get the \Module class for the module named $name,
      * if enabled on this LORIS instance or throw an exception
@@ -126,6 +127,9 @@ class LorisInstance
      */
     public function getModule(string $name) : \Module
     {
+        if (isset($this->moduleInstances[$name])) {
+            return $this->moduleInstances[$name];
+        }
         foreach ($this->modulesDirs as $modulesDir) {
             $mpath = "$modulesDir/$name";
 
@@ -135,6 +139,8 @@ class LorisInstance
                 include_once $moduleclasspath;
                 $className = "\LORIS\\$name\Module";
                 $cls       = new $className($this, $name, $mpath);
+                $this->moduleInstances[$name] = $cls;
+                $cls->registerAutoloader();
                 return $cls;
             }
         }


### PR DESCRIPTION
PR#8287 refactored the code in a way which removed the side-effect of registering an autoloader when calling Module::factory. This was probably not a good idea. Calls to methods on a Module instance retrieved now crash when attempting to call a method on the module if the module uses a class internal to the module.

Since the caller doesn't know if the module is going to use internal namespace classes, this re-adds the implicit autoloader registration when getting a module to the LorisInstance object.

It also caches the module descriptor in the LorisInstance after it's retrieved in order prevent registering the same autoloader multiple times.