### PR TITLE
[mri_violations] Provide feedback on resolution status change

### DIFF
--- a/modules/mri_violations/jsx/mriViolationsIndex.js
+++ b/modules/mri_violations/jsx/mriViolationsIndex.js
@@ -16,6 +16,7 @@ import ProtocolModal from './protocolModal.js';
 function MRIViolationsIndex(props) {
   const [fieldOptions, setFieldOptions] = useState({});
   const [violationModal, setViolationModal] = useState(false);
+  const [modifiedColumns, setModifiedColumns] = useState({});
 
   const mapper = columnMapper(fieldOptions);
 
@@ -34,7 +35,13 @@ function MRIViolationsIndex(props) {
         formatter={formatColumn(
           mapper,
           setViolationModal,
-          props.ModuleURL + '/resolve'
+          props.ModuleURL + '/resolve',
+          (hashname) => {
+              let newColumns = {...modifiedColumns};
+              newColumns[hashname] = true;
+              setModifiedColumns(newColumns);
+          },
+          modifiedColumns,
         )}
         fields={violationFilters(fieldOptions)}
         setFieldOptions={setFieldOptions}

--- a/modules/mri_violations/jsx/violations.js
+++ b/modules/mri_violations/jsx/violations.js
@@ -103,9 +103,19 @@ export function violationFilters(fieldoptions) {
  * @param {function} setPage - a callback to set the current page
  * @param {string} resolvePostURL - the URL to send a post request to when
  *                                  a resolution status is selected
+ * @param {function} onResolutionChanged - a callback to call when the
+                                           resolution status changes
+ * @param {object} modifiedColumns - list of columns which have been modified
+ *                                   since he page load
  * @return {function} a formatter callback which uses mapper for data mapping
  */
-export function formatColumn(mapper, setPage, resolvePostURL) {
+export function formatColumn(
+    mapper,
+    setPage,
+    resolvePostURL,
+    onResolutionChanged,
+    modifiedColumns,
+) {
     const Mapper = function(column, cell, rowData, rowHeaders) {
         cell = mapper(column, cell);
         // Create the mapping between rowHeaders and rowData in a row object.
@@ -195,8 +205,12 @@ export function formatColumn(mapper, setPage, resolvePostURL) {
         }
         if (column === 'Select Resolution') {
             const hashName = rowData.hash;
+            const color = modifiedColumns[hashName] ? {
+                backgroundColor: '#d1ffcf',
+                transition: 'background-color 1s',
+            } : {};
             return (
-                    <td>
+                    <td style={color}>
                     <select
                         name={hashName}
                         className="form-control input-sm"
@@ -214,6 +228,8 @@ export function formatColumn(mapper, setPage, resolvePostURL) {
                                     value: value,
                                     hash: hashName,
                                 }),
+                            }).then(() => {
+                                onResolutionChanged(hashName);
                             });
                           }
                         }


### PR DESCRIPTION
There is currently no feedback to the user when they change the resolution status of a violation that something has changed, which can be confusing.

This fades the table cell to green after the cell has been changed in the same way that the conflict resolver does, so that the user is aware that something happened.

Green is probably not the ideal colour, but is consistent with the conflict resolver.

Fixes #8441