### PR TITLE
[issue tracker] Popualte reporter dropdown

### DIFF
--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -119,7 +119,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
                     u.Real_name
              FROM issues i
              INNER JOIN users u
-               ON(i.assignee=u.UserID)",
+               ON(i.reporter=u.UserID)",
             []
         );
         foreach ($reporter_expanded as $r_row) {


### PR DESCRIPTION
## Brief summary of changes

In the issue tracker module, the reporter dropdown is populated with the assignee users instead of the reporter users.
This PR fills the reporter dropdown with the right reporter values.

#### Testing instructions (if applicable)

1. Go to the menu > tools > issue tracker.
2. See the values in the reporter dropdown field, they should be different from the assignee values (depending on the values in the table - reporter and assignee columns).

#### Link(s) to related issue(s)

* #8429 
