### PR TITLE
Fix aces/main branch

### DIFF
--- a/modules/instrument_manager/jsx/instrumentManagerIndex.js
+++ b/modules/instrument_manager/jsx/instrumentManagerIndex.js
@@ -293,6 +293,12 @@ class InstrumentManagerIndex extends Component {
   }
 }
 
+InstrumentManagerIndex.propTypes = {
+    BaseURL: PropTypes.string,
+    dataURL: PropTypes.string.isRequired,
+    hasPermission: PropTypes.func.isRequired,
+};
+
 /**
  * Create a componenet to select permissions from a list of available
  * permissions.
@@ -321,9 +327,10 @@ function PermissionSelect(props) {
            />;
 }
 
-InstrumentManagerIndex.propTypes = {
-  dataURL: PropTypes.string.isRequired,
-  hasPermission: PropTypes.func.isRequired,
+PermissionSelect.propTypes = {
+    codes: PropTypes.array,
+    selected: PropTypes.array,
+    modifySelected: PropTypes.func,
 };
 
 window.addEventListener('load', () => {


### PR DESCRIPTION
PR#7300 made proptypes required, but PR#8302 was merged between the time it was rebased and merged and was missing some proptypes.

This adds the missing proptypes to fix the build on aces/main.