### PR TITLE
Add required proptypes to react.savedqueries.js

### DIFF
--- a/modules/dqt/jsx/react.savedqueries.js
+++ b/modules/dqt/jsx/react.savedqueries.js
@@ -234,6 +234,7 @@ function publicquerydelete() {
 ManageSavedQueryRow.propTypes = {
   Name: PropTypes.object,
   Query: PropTypes.object,
+  author: PropTypes.string,
 };
 
 ManageSavedQueryRow.defaultProps = {
@@ -314,6 +315,7 @@ SavedQueriesList.propTypes = {
   queriesLoaded: PropTypes.bool,
   onSelectQuery: PropTypes.func,
   globalQueries: PropTypes.array,
+  author: PropTypes.string,
 };
 SavedQueriesList.defaultProps = {
   queryDetails: {},


### PR DESCRIPTION
Another PR that was sent before PropTypes were mandatory was merged, causing the main branch to fail. This adds the missing PropTypes.