### PR TITLE
[dqt] Fix new warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
     "react",
     "no-jquery",
     "jsdoc"
-
   ],
   "settings": {
     "react": {
@@ -85,7 +84,8 @@
     }],
     "jsdoc/require-param-description": "off",
     "jsdoc/require-returns": "off",
-    "jsdoc/require-returns-description": "off"
+    "jsdoc/require-returns-description": "off",
+    "jsdoc/check-tag-names": "error"
   },
   "overrides": [
     {

--- a/modules/dqt/jsx/react.savedqueries.js
+++ b/modules/dqt/jsx/react.savedqueries.js
@@ -71,9 +71,6 @@ const ManageSavedQueryFilters = (props) => {
 const ManageSavedQueryRow = (props) => {
   const [fieldsVisible, setFields] = useState(null);
   const [filtersVisible, setFilters] = useState(null);
-  /**
-   * @deleteclick
-   */
 function publicquerydelete() {
            const id = props.Query['_id'];
           swal.fire({

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -1199,9 +1199,6 @@ class ManageSavedQueryRow extends Component {
     super(props);
     this.state = {};
   }
-  /**
-   * @deleteclick
-   */
          deleteclick() {
           let id = this.props.Query['_id'];
           swal.fire({


### PR DESCRIPTION
2 new warnings of the type:

```
"Invalid JSDoc tag name "deleteclick"   jsdoc/check-tag-names
```

snuck in with PR#8078.

This removes the lines causing the warnings. Since we don't have any other warnings of this type, it also upgrades the level of check-tag-names from warning to error.