### PR TITLE
Fix PropsTypes for children

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -83,7 +83,7 @@ Card.propTypes = {
   initCollapsed: PropTypes.bool,
   style: PropTypes.object,
   cardSize: PropTypes.string,
-  children: PropTypes.array,
+  children: PropTypes.node,
   collapsing: PropTypes.bool,
 };
 

--- a/jsx/FilterForm.js
+++ b/jsx/FilterForm.js
@@ -227,7 +227,7 @@ FilterForm.propTypes = {
   height: PropTypes.string,
   title: PropTypes.string,
   onUpdate: PropTypes.func,
-  children: PropTypes.element,
+  children: PropTypes.node,
   formElements: PropTypes.object,
 };
 

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -194,7 +194,7 @@ FilterableDataTable.propTypes = {
   getMappedCell: PropTypes.array,
   folder: PropTypes.element,
   nullTableShow: PropTypes.element,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 export default FilterableDataTable;

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -148,7 +148,7 @@ FormElement.propTypes = {
   }),
   onSubmit: PropTypes.func,
   onUserInput: PropTypes.func,
-  children: PropTypes.array,
+  children: PropTypes.node,
   fileUpload: PropTypes.bool,
 };
 
@@ -239,7 +239,7 @@ FieldsetElement.propTypes = {
   columns: PropTypes.number,
   name: PropTypes.string,
   legend: PropTypes.string,
-  children: PropTypes.array,
+  children: PropTypes.node,
 };
 
 FieldsetElement.defaultProps = {

--- a/jsx/InfoPanel.js
+++ b/jsx/InfoPanel.js
@@ -31,7 +31,7 @@ function InfoPanel(props) {
    );
 }
 InfoPanel.propTypes = {
-    children: PropTypes.array,
+    children: PropTypes.node,
 };
 
 export default InfoPanel;

--- a/jsx/Modal.js
+++ b/jsx/Modal.js
@@ -173,7 +173,7 @@ Modal.propTypes = {
   onClose: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   throwWarning: PropTypes.bool,
-  children: PropTypes.element,
+  children: PropTypes.node,
   width: PropTypes.string,
 };
 

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -115,7 +115,7 @@ Panel.propTypes = {
   bold: PropTypes.bool,
   panelSize: PropTypes.string,
   style: PropTypes.object,
-  children: PropTypes.array,
+  children: PropTypes.node,
 };
 Panel.defaultProps = {
   initCollapsed: false,

--- a/jsx/Tabs.js
+++ b/jsx/Tabs.js
@@ -167,7 +167,7 @@ Tabs.propTypes = {
   defaultTab: PropTypes.string,
   updateURL: PropTypes.bool,
   onTabChange: PropTypes.func,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 Tabs.defaultProps = {
   onTabChange: function() {},
@@ -322,7 +322,7 @@ VerticalTabs.propTypes = {
   defaultTab: PropTypes.string,
   updateURL: PropTypes.bool,
   onTabChange: PropTypes.func,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 VerticalTabs.defaultProps = {
   onTabChange: function() {},
@@ -364,7 +364,7 @@ TabPane.propTypes = {
   TabId: PropTypes.string.isRequired,
   Title: PropTypes.string,
   activeTab: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 export {

--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -35,7 +35,7 @@ class SliderPanel extends Component {
 }
 SliderPanel.propTypes = {
   pscid: PropTypes.string,
-  children: PropTypes.array,
+  children: PropTypes.node,
 };
 
 
@@ -506,7 +506,7 @@ class AccordionPanel extends Component {
 }
 AccordionPanel.propTypes = {
   title: PropTypes.string,
-  children: PropTypes.object,
+  children: PropTypes.node,
 };
 
 

--- a/modules/document_repository/jsx/NullFilterableDataTable.js
+++ b/modules/document_repository/jsx/NullFilterableDataTable.js
@@ -27,7 +27,7 @@ class NullFilterableDataTable extends Component {
   }
 }
 NullFilterableDataTable.propTypes = {
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 export default NullFilterableDataTable;

--- a/modules/dqt/jsx/react.sidebar.js
+++ b/modules/dqt/jsx/react.sidebar.js
@@ -61,7 +61,7 @@ class Sidebar extends Component {
 }
 Sidebar.propTypes = {
   Name: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 /**

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -72,7 +72,7 @@ TabPane.propTypes = {
   Loading: PropTypes.bool,
   TabId: PropTypes.string,
   Title: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 /**

--- a/modules/electrophysiology_browser/jsx/components/electrophysiology_session_panels.js
+++ b/modules/electrophysiology_browser/jsx/components/electrophysiology_session_panels.js
@@ -101,7 +101,7 @@ FilePanel.propTypes = {
     id: PropTypes.string,
     title: PropTypes.string,
     data: PropTypes.array,
-    children: PropTypes.array,
+    children: PropTypes.node,
 };
 
 FilePanel.defaultProps = {


### PR DESCRIPTION
- Proptypes.element does not allow multiple children
- Proptypes.array/Proptypes.object is too vague

Proptypes.node is a compound type for any renderable object: nothing, string, single element, several elements, fragment, component.