### PR TITLE
[eslint] Remove useless overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -196,8 +196,6 @@
     {
       "files": [
         "modules/candidate_parameters/**",
-        "modules/bvl_feedback/**",
-        "modules/dataquery/**",
         "modules/dqt/**",
         "modules/configuration/jsx/configuration_helper.js"
       ],


### PR DESCRIPTION
The dataquery module doesn't exist and shouldn't be overridden to downgrade the errors from error to warning that were put in place when eslint was added so that our code would compile. (The dqt module still has the overrides and produces warnings).

bvl_feedback is not generating any warnings, so does not need to be overridden.

This removes them from the override and enforces the full eslint ruleset consistently on them.