### PR TITLE
[eslint] Enable no-find-dom-node rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,7 @@
     "react/no-direct-mutation-state": "off",
     "react/jsx-no-target-blank": "off",
     "react/no-unknown-property": "off",
-    "react/no-find-dom-node": "off",
+    "react/no-find-dom-node": "error",
     "no-empty": "off",
     "no-redeclare": "off",
     "no-inner-declarations": "off",


### PR DESCRIPTION
There are no violations currently, there's no reason to disable the rule and let them sneak in in the future.