### PR TITLE
[eslint] enable no-fallthrough rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,7 @@
     "react/no-deprecated": "off",
     "react/no-string-refs": "off",
     "no-case-declarations": "off",
-    "no-fallthrough": "off",
+    "no-fallthrough": "error",
     "react/jsx-no-undef": "off",
     "react/prop-types": "error",
     "no-undef": "error",

--- a/modules/battery_manager/jsx/batteryManagerIndex.js
+++ b/modules/battery_manager/jsx/batteryManagerIndex.js
@@ -126,6 +126,7 @@ class BatteryManagerIndex extends Component {
           case 'N':
             return 'No';
         }
+        break;
       case 'Active':
         switch (value) {
           case 'Y':
@@ -133,6 +134,7 @@ class BatteryManagerIndex extends Component {
           case 'N':
             return 'No';
         }
+        break;
       case 'Change Status':
         return '';
       case 'Edit Metadata':

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/channels.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/channels.tsx
@@ -45,6 +45,7 @@ export const channelsReducer = (
           state
         );
       }
+      break;
     }
     case SET_CHANNELS: {
       return action.payload;

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -44,6 +44,7 @@ class ImagingQCIndex extends Component {
                        + row.DCCID;
           result = <td><a href={mpfURL}>{cell}</a></td>;
         }
+        break;
       case 'Scan Location':
         if (cell == 'In Imaging Browser') {
           let imgURL = loris.BaseURL
@@ -51,6 +52,7 @@ class ImagingQCIndex extends Component {
                        + row['Session ID'];
           result = <td><a href={imgURL}>{cell}</a></td>;
         }
+        break;
       case 'Tarchive':
         if (cell == 'In DICOM') {
           let tarchiveURL = loris.BaseURL +

--- a/modules/mri_violations/jsx/mriViolationsIndex.js
+++ b/modules/mri_violations/jsx/mriViolationsIndex.js
@@ -123,14 +123,17 @@ function columnMapper(fieldOptions) {
             if (fieldOptions.projects) {
                 return fieldOptions.projects[value];
             }
+            break;
         case 'Cohort':
             if (fieldOptions.cohorts) {
                 return fieldOptions.cohorts[value];
             }
+            break;
         case 'Site':
             if (fieldOptions.sites) {
                 return fieldOptions.sites[value];
             }
+            break;
         }
         return value;
     };


### PR DESCRIPTION
Forgetting a "break" in a switch statement is a common developer error. For instance, most of the places caught by this rule which is currently disabled.