### PR TITLE
[Genomic Browser] UserSiteMatch fix

### DIFF
--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 
+use \LORIS\Data\DataInstance;
+use \LORIS\StudyEntities\SiteHaver;
+
 /**
  * A CnvDTO represents an CNV in the genomic browser module.
  * It is doing the mapping between the profile table columns
@@ -16,9 +19,9 @@ namespace LORIS\genomic_browser\Models;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
-class CnvDTO implements \LORIS\Data\DataInstance
+class CnvDTO implements DataInstance, SiteHaver
 {
     /**
      * The centerID
@@ -248,20 +251,20 @@ class CnvDTO implements \LORIS\Data\DataInstance
     /**
      * Returns the CenterID for this row
      *
-     * @return integer The CenterID
+     * @return \CenterID The CenterID
      */
-    public function getCenterID(): int
+    public function getCenterID(): \CenterID
     {
-        return (int) $this->_centerID;
+        return new \CenterID(strval($this->_centerID));
     }
 
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
-        return (int) $this->_projectID;
+        return new \ProjectID(strval($this->_projectID));
     }
 }

--- a/modules/genomic_browser/php/models/filesdto.class.inc
+++ b/modules/genomic_browser/php/models/filesdto.class.inc
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 
+use \LORIS\Data\DataInstance;
+
 /**
  * A FilesDTO represents an Files in the genomic browser module.
  * It is doing the mapping between the profile table columns
@@ -16,9 +18,9 @@ namespace LORIS\genomic_browser\Models;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
-class FilesDTO implements \LORIS\Data\DataInstance
+class FilesDTO implements DataInstance
 {
     /**
      * The GenomicFileID

--- a/modules/genomic_browser/php/models/gwasdto.class.inc
+++ b/modules/genomic_browser/php/models/gwasdto.class.inc
@@ -7,10 +7,12 @@
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 
 namespace LORIS\genomic_browser\Models;
+
+use \LORIS\Data\DataInstance;
 
 /**
  * A GwasDTO represents an GWAS in the genomic browser module.
@@ -25,9 +27,9 @@ namespace LORIS\genomic_browser\Models;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
-class GwasDTO implements \LORIS\Data\DataInstance
+class GwasDTO implements DataInstance
 {
     /**
      * The SNP_ID

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 
+use \LORIS\Data\DataInstance;
+use \LORIS\StudyEntities\SiteHaver;
+
 /**
  * A MethylationDTO represents an Methylation in the genomic browser module.
  * It is doing the mapping between the profile table columns
@@ -16,9 +19,9 @@ namespace LORIS\genomic_browser\Models;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
-class MethylationDTO implements \LORIS\Data\DataInstance
+class MethylationDTO implements DataInstance, SiteHaver
 {
     /**
      * The centerID
@@ -312,20 +315,20 @@ class MethylationDTO implements \LORIS\Data\DataInstance
     /**
      * Returns the CenterID for this row
      *
-     * @return integer The CenterID
+     * @return \CenterID The CenterID
      */
-    public function getCenterID(): int
+    public function getCenterID(): \CenterID
     {
-        return (int) $this->_centerID;
+        return new \CenterID(strval($this->_centerID));
     }
 
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
-        return (int) $this->_projectID;
+        return new \ProjectID(strval($this->_projectID));
     }
 }

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -7,10 +7,13 @@
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 
 namespace LORIS\genomic_browser\Models;
+
+use \LORIS\Data\DataInstance;
+use \LORIS\StudyEntities\SiteHaver;
 
 /**
  * A ProfileDTO represents an profile in the genomic browser module.
@@ -25,9 +28,9 @@ namespace LORIS\genomic_browser\Models;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
-class ProfileDTO implements \LORIS\Data\DataInstance
+class ProfileDTO implements DataInstance, SiteHaver
 {
 
     /**
@@ -146,20 +149,20 @@ class ProfileDTO implements \LORIS\Data\DataInstance
     /**
      * Returns the CenterID for this row
      *
-     * @return integer The CenterID
+     * @return \CenterID The CenterID
      */
-    public function getCenterID(): int
+    public function getCenterID(): \CenterID
     {
-        return (int) $this->_centerID;
+        return new \CenterID(strval($this->_centerID));
     }
 
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
-        return (int) $this->_projectID;
+        return new \ProjectID(strval($this->_projectID));
     }
 }

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -7,10 +7,13 @@
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 
 namespace LORIS\genomic_browser\Models;
+
+use \LORIS\Data\DataInstance;
+use \LORIS\StudyEntities\SiteHaver;
 
 /**
  * A SnpDTO represents an SNP in the genomic browser module.
@@ -27,7 +30,7 @@ namespace LORIS\genomic_browser\Models;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris-Trunk
  */
-class SnpDTO implements \LORIS\Data\DataInstance
+class SnpDTO implements DataInstance, SiteHaver
 {
     /**
      * The centerID
@@ -297,20 +300,20 @@ class SnpDTO implements \LORIS\Data\DataInstance
     /**
      * Returns the CenterID for this row
      *
-     * @return integer The CenterID
+     * @return \CenterID The CenterID
      */
-    public function getCenterID(): int
+    public function getCenterID(): \CenterID
     {
-        return (int) $this->_centerID;
+        return new \CenterID(strval($this->_centerID));
     }
 
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
-        return (int) $this->_projectID;
+        return new \ProjectID(strval($this->_projectID));
     }
 }


### PR DESCRIPTION
Fix a Fatal error on the Genomic Browser tabs:` [ERROR] Can not implement UserSiteMatch on a resource type that has no sites.`

To test:
Use a user that have permission `Genomic Browser: View Genomic Data - Own Sites` but do not have  `genomic_browser_view_allsites`. Visit the Genomic Browser and check that the tabs loads without error.

Fixes #7589