### PR TITLE
Clean redundant recommended rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,8 +51,6 @@
     "no-dupe-keys": "off",
     "react/no-direct-mutation-state": "off",
     "react/jsx-no-target-blank": "off",
-    "react/no-unknown-property": "error",
-    "react/no-find-dom-node": "error",
     "no-empty": "off",
     "no-redeclare": "off",
     "no-inner-declarations": "off",
@@ -60,15 +58,9 @@
     "react/no-deprecated": "off",
     "react/no-string-refs": "off",
     "no-case-declarations": "off",
-    "no-fallthrough": "error",
     "react/jsx-no-undef": "off",
-    "react/prop-types": "error",
-    "no-undef": "error",
     "react/jsx-key": "off",
-    "no-extra-semi": "error",
     "no-prototype-builtins": "off",
-    "react/jsx-uses-react": "error",
-    "react/jsx-uses-vars": "error",
     "prefer-rest-params": "error",
     "array-callback-return": "off",
     "require-jsdoc": "off",
@@ -84,8 +76,7 @@
     }],
     "jsdoc/require-param-description": "off",
     "jsdoc/require-returns": "off",
-    "jsdoc/require-returns-description": "off",
-    "jsdoc/check-tag-names": "error"
+    "jsdoc/require-returns-description": "off"
   },
   "overrides": [
     {
@@ -107,7 +98,6 @@
         "jsdoc/require-param-description": "error",
         "jsdoc/require-returns": "error",
         "jsdoc/require-returns-description": "error",
-        "no-undef": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off"
       }


### PR DESCRIPTION
Some specific rules in eslintrc.json were added but are duplicating rules from a recommended set. Removing those specific rules avoid an unnecessary redundancy.