### PR TITLE
[EEG] Electrodes query and file download fix

### DIFF
--- a/modules/electrophysiology_browser/css/electrophysiology_browser.css
+++ b/modules/electrophysiology_browser/css/electrophysiology_browser.css
@@ -45,7 +45,7 @@ svg {
 .list-group-item {
   position: relative;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
   align-items: center;
 }
@@ -65,13 +65,14 @@ svg {
   justify-content: center;
   align-items: center;
   position: absolute;
-  right: 0;
+  right: 10px;
 }
 
 .epoch-tag {
   padding: 5px;
   background: #e7e4e4;
   border-left: 5px solid #797878;
+  width: 100%;
 }
 
 .epoch-tag p {

--- a/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
+++ b/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
@@ -95,7 +95,6 @@ class DownloadPanel extends Component {
                                 : '/mri/jiv/get_file.php?file=' + download.file
                             }
                             target='_blank'
-                            download
                             style={{
                               margin: 0,
                             }}

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
@@ -187,9 +187,6 @@ const EventManager = ({
                   (epoch.type == 'Annotation' ? 'annotation ' : '')
                   + 'list-group-item list-group-item-action'
                 }
-                style={{
-                  position: 'relative',
-                }}
               >
                 <div
                   className="epoch-details"

--- a/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioannotations.class.inc
@@ -145,6 +145,8 @@ class ElectrophysioAnnotations
 
             //Insert new files and data into DB
             if (empty($annotationFIDs)) {
+                //Create new annotation files
+                $this->_createFiles();
 
                 //Get new annotation file ID
                 $annotation_tsv_ID = $db->pselectOne(
@@ -164,8 +166,6 @@ class ElectrophysioAnnotations
                 );
 
                 $metadata['AnnotationFileID'] = $annotation_json_ID;
-                $instance['AnnotationFileID'] = $annotation_tsv_ID;
-
                 $db->insert("physiological_annotation_parameter", $metadata);
 
                 //Get new metadata file ID
@@ -176,8 +176,8 @@ class ElectrophysioAnnotations
                     ['annotation_ID' => $annotation_json_ID]
                 );
 
+                $instance['AnnotationFileID']      = $annotation_tsv_ID;
                 $instance['AnnotationParameterID'] = $metadata_ID;
-
                 $db->insert("physiological_annotation_instance", $instance);
 
             } else {
@@ -584,8 +584,10 @@ class ElectrophysioAnnotations
                 WHERE PhysiologicalFileID=:PFID",
                 ['PFID' => $this->_physioFileID]
             );
-            $filepath = $dataDir.$filepath;
-
+            if (!$filepath) {
+                continue;
+            }
+            $filepath  = $dataDir.$filepath;
             $arch_file = new \PharData($filepath);
             foreach ($paths as $path) {
                 $arch_file->addFile($path, basename($path));

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -229,7 +229,7 @@ class Sessions extends \NDB_Page
         $params['SID']  = $this->sessionID;
         $query          = 'SELECT
                          pf.PhysiologicalFileID
-                       FROM
+                         FROM
                          physiological_file pf ';
 
         if ($outputType != 'all_types') {
@@ -583,7 +583,6 @@ class Sessions extends \NDB_Page
         // Metadata
 
         $queries = [
-            'physiological_electrode'          => 'physiological_electrode_file',
             'physiological_channel'            => 'physiological_channel_file',
             'physiological_event_archive'      => 'physiological_event_files',
             'physiological_annotation_archive' => 'physiological_annotation_files',
@@ -616,6 +615,7 @@ class Sessions extends \NDB_Page
                 $query_statement,
                 ['PFID' => $physioFileID]
             );
+
             if ($query_statement) {
                 $downloadLinks[$query_value] = [
                     'file'  => $query_statement['FilePath'],
@@ -629,6 +629,28 @@ class Sessions extends \NDB_Page
             }
         }
 
+        // Electrodes
+        $file_name = 'physiological_electrode_file';
+        // TODO: If we plan to support multiple electrode spaces
+        // the LIMIT logic should be revisited
+        $query_statement = "SELECT DISTINCT(FilePath)
+                            FROM physiological_electrode
+                            JOIN physiological_coord_system_electrode_rel
+                                USING (PhysiologicalElectrodeID)
+                            WHERE PhysiologicalFileID=:PFID
+                            LIMIT 1";
+        $query_statement = $db->pselect(
+            $query_statement,
+            ['PFID' => $physioFileID]
+        );
+
+        $downloadLinks[$file_name] = [
+            'file'  => '',
+            'label' => $labels[$file_name],
+        ];
+        if (count($query_statement) > 0) {
+            $downloadLinks[$file_name]['file'] = $query_statement[0]['FilePath'];
+        }
         return $downloadLinks;
     }
 


### PR DESCRIPTION
PR #8242 modified the electrodes DB schemas and since then, the EEG Browser is broken. 
This fixes the issue by rewriting the query logic. 
Also fixes a few issues with the download buttons and the layout.

To test:
----------- 
- Make sure the EEG Browser loads
- Create a new annotation
- Check that the comment section of the new comment is displayed without any layout issues
- Make sure the annotations, electrodes and all files are downloadable.