### PR TITLE
[Webpack] build/make fix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ const optimization = {
           compress: false,
           ecma: 6,
           mangle: false,
-          extractComments: false,
         },
+        extractComments: false,
       }).apply(compiler);
     },
   ],


### PR DESCRIPTION
A change required in webpack to prevent generation of LICENSE.txt files was incorrectly added at the wrong place, breaking compilation for the production mode (npm run build or make). This fixes the issue.