### PR TITLE
[Tools] double_escape_report tool breaking on non-string values

### DIFF
--- a/tools/single_use/instrument_double_escape_report.php
+++ b/tools/single_use/instrument_double_escape_report.php
@@ -123,7 +123,7 @@ foreach($instrumentNames as $instrumentName) {
     foreach ($instrumentData as $cid => $instrumentCandData) {
         foreach ($instrumentCandData as $field => $value) {
             // regex detecting any escaped character in the database
-            if (!empty($value) && preg_match('/&(amp;)+(gt;|lt;|quot;|amp;)/', $value)) {
+            if (!empty($value) && is_string($value) && preg_match('/&(amp;)+(gt;|lt;|quot;|amp;)/', $value)) {
                 $escapedEntries[$tableName][$cid][$field] = $value;
                 $escapedFields[$tableName][] = $field;
                 $errorsDetected = true;


### PR DESCRIPTION
## Brief summary of changes
This tool tries to run pregmatch on every value pulled from the instrument Data. there is a possibility that values coming from `json_decode()` are decoded into floats or arrays if that is how they have been saved. if it's the case the script should just skip them and not fail