### PR TITLE
[battery_manager] use visit controller to fetch visit list

### DIFF
--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -63,7 +63,9 @@ class TestOptionsEndpoint extends \NDB_Page
             $this->loris->getDatabaseConnection()
         );
         return [
-            'instruments' => \Utility::getAllInstruments(),
+            'instruments' => \NDB_BVL_Instrument::getInstrumentNamesList(
+                $this->loris
+            ),
             'stages'      => $this->_getStageList(),
             'subprojects' => \Utility::getSubprojectList(null),
             'visits'      => $visitController->getAllVisits(),

--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -11,6 +11,7 @@
  * @link     https://www.github.com/aces/Loris/
  */
 namespace LORIS\battery_manager;
+use LORIS\VisitController;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 
@@ -58,11 +59,14 @@ class TestOptionsEndpoint extends \NDB_Page
      */
     private function _getOptions() : array
     {
+        $visitController = new VisitController(
+            $this->loris->getDatabaseConnection()
+        );
         return [
             'instruments' => \Utility::getAllInstruments(),
             'stages'      => $this->_getStageList(),
             'subprojects' => \Utility::getSubprojectList(null),
-            'visits'      => \Utility::getVisitList(),
+            'visits'      => $visitController->getAllVisits(),
             'sites'       => \Utility::getSiteList(false),
             'firstVisit'  => $this->_getYesNoList(),
             'active'      => $this->_getYesNoList(),

--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -68,7 +68,7 @@ class TestOptionsEndpoint extends \NDB_Page
             ),
             'stages'      => $this->_getStageList(),
             'subprojects' => \Utility::getSubprojectList(null),
-            'visits'      => $visitController->getAllVisits(),
+            'visits'      => $visitController->getVisitlabels(),
             'sites'       => \Utility::getSiteList(false),
             'firstVisit'  => $this->_getYesNoList(),
             'active'      => $this->_getYesNoList(),

--- a/php/libraries/VisitController.class.inc
+++ b/php/libraries/VisitController.class.inc
@@ -54,20 +54,29 @@ class VisitController
         return array_map(
             function ($row) {
                 return new \LORIS\Visit(
-                    $row['name'],
-                    $row['ID']
+                    $row['VisitName'],
+                    $row['VisitLabel']
                 );
             },
             $this->database->pselect(
-                'SELECT
-                 v.VisitID as "ID", v.VisitName as "name"
-                FROM
-                 visit v
-ORDER BY ID
-                ',
+                'SELECT VisitName, VisitLabel FROM visit ORDER BY VisitName',
                 []
             )
         );
+    }
+
+    /**
+     * Get an associative array of the type
+     *
+     * @return array
+     */
+    public function getVisitlabels(): array
+    {
+        $visitLabels = [];
+        foreach ($this->getAllVisits() as $visitObj) {
+            $visitLabels[$visitObj->getName()] = $visitObj->getLabel();
+        }
+        return $visitLabels;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
The battery manager currently uses the `Utility::getVisitList()` function to list the visits available. That utility function queries the session table for existing visitlabels used in at least one session. That is problematic when you are creating a new visit and new instruments and want to assign instruments to the new visit, it simply does not show up in the drop down.

This PR fixes that problem and removes the use of Utility::getInstrumentList to get an accurate list of full names for instruments and get rid of deprecation warnings 

* Resolves #8459
