### PR TITLE
[Issue Tracker] deleting attachment leaves no record of the attachment history

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1701,7 +1701,7 @@ CREATE TABLE `issues_attachments` (
     `description` text DEFAULT NULL,
     `file_size` int(20) DEFAULT NULL,
     `mime_type` varchar(255) NOT NULL DEFAULT '',
-    `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `date_deleted` timestamp NULL DEFAULT NULL,
     CONSTRAINT `fk_issues_attachments_issue` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`),
     PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1701,7 +1701,7 @@ CREATE TABLE `issues_attachments` (
     `description` text DEFAULT NULL,
     `file_size` int(20) DEFAULT NULL,
     `mime_type` varchar(255) NOT NULL DEFAULT '',
-    `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
+    `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT `fk_issues_attachments_issue` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`),
     PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1697,7 +1697,6 @@ CREATE TABLE `issues_attachments` (
     `file_hash` varchar(64) NOT NULL,
     `date_added` timestamp NOT NULL DEFAULT current_timestamp(),
     `file_name` varchar(255) NOT NULL DEFAULT '',
-    `deleted` tinyint(1) NOT NULL DEFAULT 0,
     `user` varchar(255) NOT NULL DEFAULT '',
     `description` text DEFAULT NULL,
     `file_size` int(20) DEFAULT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1702,6 +1702,7 @@ CREATE TABLE `issues_attachments` (
     `description` text DEFAULT NULL,
     `file_size` int(20) DEFAULT NULL,
     `mime_type` varchar(255) NOT NULL DEFAULT '',
+    `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
     CONSTRAINT `fk_issues_attachments_issue` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`),
     PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/SQL/New_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
+++ b/SQL/New_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issues_attachments ADD COLUMN `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/SQL/New_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
+++ b/SQL/New_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
@@ -1,1 +1,7 @@
-ALTER TABLE issues_attachments ADD COLUMN `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE issues_attachments ADD COLUMN `date_deleted` timestamp NULL DEFAULT NULL;
+
+UPDATE issues_attachments
+SET date_deleted = '1999-12-31 00:00:00'
+WHERE deleted = 1;
+
+ALTER TABLE issues_attachments DROP COLUMN deleted;

--- a/SQL/Release_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
+++ b/SQL/Release_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issues_attachments ADD COLUMN `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/SQL/Release_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
+++ b/SQL/Release_patches/2023-04-03_Add_Column_to_issues_attachments_table.sql
@@ -1,1 +1,0 @@
-ALTER TABLE issues_attachments ADD COLUMN `date_deleted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -208,7 +208,7 @@ class AttachmentsList extends Component {
         <div style={footerCSS}>
           <ButtonElement
             onUserInput={this.deleteAttachment}
-            label={'Delete attachments'}
+            label={t('Delete attachment', {ns: 'issue_tracker'})}
           />
         </div>
       </Modal>
@@ -224,48 +224,9 @@ class AttachmentsList extends Component {
         );
         // Hide "soft" deleted attachments
         if (parseInt(item.deleted) === 1) {
-            attachmentsRows.unshift(
-              <Fragment key={key}>
-            <div className='row'>
-              <hr/>
-              <div className='col-md-3'>
-                <div className='col-md-5'><b>Date of attachment: </b></div>
-                <div className='col-md-7'>{item.date_added}</div>
-              </div>
-              <div className='col-md-8'>
-                <div className='col-md-1'><b>File: </b></div>
-                <div className='col-md-7'>{item.file_name}</div>
-              </div>
-            </div>
-            <div className='row'>
-              <div className='col-md-3'>
-                <div className='col-md-5'><b>Date of deletion: </b></div>
-                <div className='col-md-7'>{item.date_deleted}
-              </div>
-              </div>
-              <div className='col-md-8'>
-                <div className='col-md-1'><b>Status: </b></div>
-                <div className='col-md-7'>Attachment has been deleted</div>
-              </div>
-            </div>
-            <div className='row'>
-              <div className='col-md-3'>
-                <div className='col-md-5'><b>User: </b></div>
-                <div className='col-md-7'>{item.user}</div>
-              </div>
-              <div className='col-md-8'>
-                {item.description ? (
-                  <>
-                    <div className='col-md-2'><b>Description: </b></div>
-                    <div className='col-md-10'>{item.description}</div>
-                  </>
-                ) : null}
-              </div>
-            </div>
-           </Fragment>
-        );
-        } else {
-          attachmentsRows.unshift(
+          continue;
+        }
+        attachmentsRows.unshift(
           <Fragment key={key}>
             <div className='row'>
               <hr/>
@@ -276,9 +237,30 @@ class AttachmentsList extends Component {
                 <div className='col-md-7'>{item.date_added}</div>
               </div>
               <div className='col-md-8'>
-                <div className='col-md-1'><b>File: </b></div>
+                <div className='col-md-1'>
+                  <b>{t('File: ', {ns: 'issue_tracker'})}</b>
+                </div>
                 <div className='col-md-11'>
                   <i>{item.file_name}</i>
+                  {regexImg.test(item.mime_type) ?
+                    (<img
+                      src={this.props.baseURL +
+                      '/issue_tracker/Attachment' +
+                      '?ID=' + item.ID +
+                      '&file_hash=' + item.file_hash +
+                      '&issue=' + this.props.issue +
+                      '&filename=' + item.file_name +
+                      '&mime_type=' +
+                      item.mime_type
+                      }
+                      width='100%'
+                      height='100%'
+                      onError={this.displayNone}
+                    >
+                    </img>)
+                    :
+                    null
+                  }
                 </div>
               </div>
             </div>
@@ -303,7 +285,6 @@ class AttachmentsList extends Component {
             {this.displayAttachmentOptions(deleteData, item)}
           </Fragment>
         );
-       }
       }
     }
     const issueAttachments = attachmentsRows.length > 0 ? (

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -208,7 +208,7 @@ class AttachmentsList extends Component {
         <div style={footerCSS}>
           <ButtonElement
             onUserInput={this.deleteAttachment}
-            label={t('Delete attachment', {ns: 'issue_tracker'})}
+            label={'Delete attachments'}
           />
         </div>
       </Modal>
@@ -224,9 +224,48 @@ class AttachmentsList extends Component {
         );
         // Hide "soft" deleted attachments
         if (parseInt(item.deleted) === 1) {
-          continue;
-        }
-        attachmentsRows.unshift(
+            attachmentsRows.unshift(
+              <Fragment key={key}>
+            <div className='row'>
+              <hr/>
+              <div className='col-md-3'>
+                <div className='col-md-5'><b>Date of attachment: </b></div>
+                <div className='col-md-7'>{item.date_added}</div>
+              </div>
+              <div className='col-md-8'>
+                <div className='col-md-1'><b>File: </b></div>
+                <div className='col-md-7'>{item.file_name}</div>
+              </div>
+            </div>
+            <div className='row'>
+              <div className='col-md-3'>
+                <div className='col-md-5'><b>Date of deletion: </b></div>
+                <div className='col-md-7'>{item.date_deleted}
+              </div>
+              </div>
+              <div className='col-md-8'>
+                <div className='col-md-1'><b>Status: </b></div>
+                <div className='col-md-7'>Attachment has been deleted</div>
+              </div>
+            </div>
+            <div className='row'>
+              <div className='col-md-3'>
+                <div className='col-md-5'><b>User: </b></div>
+                <div className='col-md-7'>{item.user}</div>
+              </div>
+              <div className='col-md-8'>
+                {item.description ? (
+                  <>
+                    <div className='col-md-2'><b>Description: </b></div>
+                    <div className='col-md-10'>{item.description}</div>
+                  </>
+                ) : null}
+              </div>
+            </div>
+           </Fragment>
+        );
+        } else {
+          attachmentsRows.unshift(
           <Fragment key={key}>
             <div className='row'>
               <hr/>
@@ -237,30 +276,9 @@ class AttachmentsList extends Component {
                 <div className='col-md-7'>{item.date_added}</div>
               </div>
               <div className='col-md-8'>
-                <div className='col-md-1'>
-                  <b>{t('File: ', {ns: 'issue_tracker'})}</b>
-                </div>
+                <div className='col-md-1'><b>File: </b></div>
                 <div className='col-md-11'>
                   <i>{item.file_name}</i>
-                  {regexImg.test(item.mime_type) ?
-                    (<img
-                      src={this.props.baseURL +
-                      '/issue_tracker/Attachment' +
-                      '?ID=' + item.ID +
-                      '&file_hash=' + item.file_hash +
-                      '&issue=' + this.props.issue +
-                      '&filename=' + item.file_name +
-                      '&mime_type=' +
-                      item.mime_type
-                      }
-                      width='100%'
-                      height='100%'
-                      onError={this.displayNone}
-                    >
-                    </img>)
-                    :
-                    null
-                  }
                 </div>
               </div>
             </div>
@@ -285,6 +303,7 @@ class AttachmentsList extends Component {
             {this.displayAttachmentOptions(deleteData, item)}
           </Fragment>
         );
+       }
       }
     }
     const issueAttachments = attachmentsRows.length > 0 ? (

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -222,10 +222,7 @@ class AttachmentsList extends Component {
         const deleteData = JSON.stringify(
           item
         );
-        // Hide "soft" deleted attachments
-        if (parseInt(item.deleted) === 1) {
-          continue;
-        }
+        const isDeleted = Boolean(item.date_deleted);
         attachmentsRows.unshift(
           <Fragment key={key}>
             <div className='row'>
@@ -242,7 +239,7 @@ class AttachmentsList extends Component {
                 </div>
                 <div className='col-md-11'>
                   <i>{item.file_name}</i>
-                  {regexImg.test(item.mime_type) ?
+                  {!isDeleted && regexImg.test(item.mime_type) ?
                     (<img
                       src={this.props.baseURL +
                       '/issue_tracker/Attachment' +
@@ -264,6 +261,27 @@ class AttachmentsList extends Component {
                 </div>
               </div>
             </div>
+            {isDeleted ? (
+              <div className='row'>
+                <div className='col-md-3'>
+                  <div className='col-md-5'>
+                    <b>{t('Date of deletion: ', {ns: 'issue_tracker'})}</b>
+                  </div>
+                  <div className='col-md-7'>{item.date_deleted}</div>
+                </div>
+                <div className='col-md-8'>
+                  <div className='col-md-1'>
+                    <b>{t('Status', {ns: 'loris'})}: </b>
+                  </div>
+                  <div className='col-md-11'>
+                    {t(
+                      'Attachment has been deleted',
+                      {ns: 'issue_tracker'}
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : null}
             <div className='row'>
               <div className='col-md-3'>
                 <div className='col-md-5'>
@@ -282,7 +300,7 @@ class AttachmentsList extends Component {
                 ) : null}
               </div>
             </div>
-            {this.displayAttachmentOptions(deleteData, item)}
+            {isDeleted ? null : this.displayAttachmentOptions(deleteData, item)}
           </Fragment>
         );
       }

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -148,7 +148,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
             $DB      = $factory->database();
             $DB->update(
                 'issues_attachments',
-                ['deleted' => 1],
+                ['deleted' => 1, 'date_deleted' => date('Y-m-d H:i:s')],
                 ['ID' => $ID]
             );
             return new \LORIS\Http\Response\JsonResponse(

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -148,7 +148,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
             $DB      = $factory->database();
             $DB->update(
                 'issues_attachments',
-                ['deleted' => 1, 'date_deleted' => date('Y-m-d H:i:s')],
+                ['date_deleted' => date('Y-m-d H:i:s', time())],
                 ['ID' => $ID]
             );
             return new \LORIS\Http\Response\JsonResponse(

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -33,7 +33,7 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
     public string $file_hash;
     public string $date_added;
     public string $file_name;
-    public int $deleted;
+    public ?string $date_deleted;
     public string $user;
     public string $description;
     public int $file_size;
@@ -51,8 +51,8 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
             'issueID'     => $this->issueID,
             'file_hash'   => $this->file_hash,
             'date_added'  => $this->date_added,
+            'date_deleted' => $this->date_deleted,
             'file_name'   => $this->file_name,
-            'deleted'     => $this->deleted,
             'user'        => $this->user,
             'description' => $this->description,
             'file_size'   => $this->file_size,

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -47,16 +47,16 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
     public function jsonSerialize() : array
     {
         return [
-            'ID'          => $this->ID,
-            'issueID'     => $this->issueID,
-            'file_hash'   => $this->file_hash,
-            'date_added'  => $this->date_added,
+            'ID'           => $this->ID,
+            'issueID'      => $this->issueID,
+            'file_hash'    => $this->file_hash,
+            'date_added'   => $this->date_added,
             'date_deleted' => $this->date_deleted,
-            'file_name'   => $this->file_name,
-            'user'        => $this->user,
-            'description' => $this->description,
-            'file_size'   => $this->file_size,
-            'mime_type'   => $this->mime_type,
+            'file_name'    => $this->file_name,
+            'user'         => $this->user,
+            'description'  => $this->description,
+            'file_size'    => $this->file_size,
+            'mime_type'    => $this->mime_type,
         ];
     }
 }

--- a/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
+++ b/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
@@ -43,8 +43,9 @@ class AttachmentProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
                 deleted,
                 user,
                 description,
-                file_size,
-                mime_type
+		file_size,
+                date_deleted,
+		mime_type
             FROM
                 issues_attachments
             WHERE

--- a/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
+++ b/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
@@ -40,7 +40,6 @@ class AttachmentProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
                 file_hash,
                 date_added,
                 file_name,
-                deleted,
                 user,
                 description,
 		file_size,

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -161,14 +161,14 @@ class UploadHelper
     {
         $DB     = \NDB_Factory::singleton()->database();
         $values = [
-            'issueID'      => $this->_values['issueID'],
-            'file_hash'    => $fileToUpload->file_hash,
-            'date_added'   => date('Y-m-d H:i:s', time()),
-            'file_name'    => $fileToUpload->file,
-            'user'         => $fileToUpload->inserted_by,
-            'description'  => $fileToUpload->description,
-            'file_size'    => $fileToUpload->size,
-            'mime_type'    => $fileToUpload->mime_type
+            'issueID'     => $this->_values['issueID'],
+            'file_hash'   => $fileToUpload->file_hash,
+            'date_added'  => date('Y-m-d H:i:s', time()),
+            'file_name'   => $fileToUpload->file,
+            'user'        => $fileToUpload->inserted_by,
+            'description' => $fileToUpload->description,
+            'file_size'   => $fileToUpload->size,
+            'mime_type'   => $fileToUpload->mime_type
         ];
         try {
             $DB->insert('issues_attachments', $values);

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -163,13 +163,11 @@ class UploadHelper
         $values = [
             'issueID'      => $this->_values['issueID'],
             'file_hash'    => $fileToUpload->file_hash,
-            'date_added'   => date('Y-m-d h:i:s', time()),
+            'date_added'   => date('Y-m-d H:i:s', time()),
             'file_name'    => $fileToUpload->file,
-            'deleted'      => 0,
             'user'         => $fileToUpload->inserted_by,
             'description'  => $fileToUpload->description,
             'file_size'    => $fileToUpload->size,
-            'date_deleted' => date('Y-m-d h:i:s', time()),
             'mime_type'    => $fileToUpload->mime_type
         ];
         try {

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -168,7 +168,8 @@ class UploadHelper
             'deleted'     => 0,
             'user'        => $fileToUpload->inserted_by,
             'description' => $fileToUpload->description,
-            'file_size'   => $fileToUpload->size,
+	    'file_size'   => $fileToUpload->size,
+	    'date_deleted'=> date('Y-m-d h:i:s', time()),
             'mime_type'   => $fileToUpload->mime_type
         ];
         try {

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -161,16 +161,16 @@ class UploadHelper
     {
         $DB     = \NDB_Factory::singleton()->database();
         $values = [
-            'issueID'     => $this->_values['issueID'],
-            'file_hash'   => $fileToUpload->file_hash,
-            'date_added'  => date('Y-m-d h:i:s', time()),
-            'file_name'   => $fileToUpload->file,
-            'deleted'     => 0,
-            'user'        => $fileToUpload->inserted_by,
-            'description' => $fileToUpload->description,
-	    'file_size'   => $fileToUpload->size,
-	    'date_deleted'=> date('Y-m-d h:i:s', time()),
-            'mime_type'   => $fileToUpload->mime_type
+            'issueID'      => $this->_values['issueID'],
+            'file_hash'    => $fileToUpload->file_hash,
+            'date_added'   => date('Y-m-d h:i:s', time()),
+            'file_name'    => $fileToUpload->file,
+            'deleted'      => 0,
+            'user'         => $fileToUpload->inserted_by,
+            'description'  => $fileToUpload->description,
+            'file_size'    => $fileToUpload->size,
+            'date_deleted' => date('Y-m-d h:i:s', time()),
+            'mime_type'    => $fileToUpload->mime_type
         ];
         try {
             $DB->insert('issues_attachments', $values);


### PR DESCRIPTION
- Adding a new feature to the `Issue Tracker` module for the `Attachment History`, when deleting the log on the 'Attachment History' should appear.
- Adding a new line called `Date of deletion` to the `Attachment History` when it is deleted. It will show the user when they deleted the uploaded file (Attachment).

#### Testing instructions (if applicable):
1. Create a new issue under the issue tracker.
2. Add attachment.
3. Upload attachment.
4. Delete the attachment when it appears.
5. The `Attachment History` should appear.

### Note: The Attachment History Section needs to be translated. 

Related To: https://github.com/aces/Loris/issues/7882