### PR TITLE
[conflict_resolver/candidate_profile] Fix loading of conflict widget

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -258,7 +258,7 @@ const lorisModules = {
     'ConsentWidget',
   ],
   configuration: ['CohortRelations', 'configuration_helper'],
-  conflict_resolver: ['conflict_resolver'],
+  conflict_resolver: ['conflict_resolver', 'CandidateConflictsWidget'],
   battery_manager: ['batteryManagerIndex'],
   bvl_feedback: ['react.behavioural_feedback_panel'],
   behavioural_qc: ['behaviouralQCIndex'],


### PR DESCRIPTION
The conflict resolver wasn't being compiled, causing the candidate profile of any candidate with conflicts to not load. This fixes the issue so that the page now loads.

Resolves #8568