### PR TITLE
Fix main.css broken link

### DIFF
--- a/src/Middleware/AnonymousPageDecorationMiddleware.php
+++ b/src/Middleware/AnonymousPageDecorationMiddleware.php
@@ -39,7 +39,7 @@ class AnonymousPageDecorationMiddleware implements MiddlewareInterface
                      'sandbox'     => ($this->Config->getSetting("sandbox") === '1'),
                     );
 
-        $tpl_data['css'] = $this->BaseURL . '/main.css';
+        $tpl_data['css'] = 'main.css';
 
         //Display the footer links, as specified in the config file
         $links =$this->Config->getExternalLinks('FooterLink');

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -131,7 +131,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         // Stuff that probably shouldn't be here, but exists because it was in
         // main.php
-        $tpl_data['css'] = $this->BaseURL . '/main.css';
+        $tpl_data['css'] = 'main.css';
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 


### PR DESCRIPTION
Since PR #8397, the main.css. is broken since it includes the base_url twice:
https://github.com/aces/Loris/pull/8397/files#diff-d4b838452a61b616f3f7e797208ebad8d83d2f7ec9412183f691f2631cdadf64R42

https://github.com/aces/Loris/blob/main/smarty/templates/main.tpl#L5

This should fix the styling issues for the help tooltip and the user page.