### PR TITLE
[api_docs] Fix permissions access

### DIFF
--- a/modules/api_docs/php/api_docs.class.inc
+++ b/modules/api_docs/php/api_docs.class.inc
@@ -27,18 +27,6 @@ use \Psr\Http\Message\ResponseInterface;
 class API_Docs extends \NDB_Page
 {
     /**
-     * Determine whether the user has permission to view this page
-     *
-     * @param \User $user The user whose access is being checked
-     *
-     * @return bool whether the user has access
-     */
-    public function hasAccess(\User $user): bool
-    {
-        return $user->hasPermission('api_docs');
-    }
-
-    /**
      * This handler populates tmp_data before calling display on itself.
      *
      * The `schema_urls` template variable is meant to provide a value to the

--- a/modules/api_docs/php/module.class.inc
+++ b/modules/api_docs/php/module.class.inc
@@ -22,6 +22,18 @@ namespace LORIS\api_docs;
 class Module extends \Module
 {
     /**
+     * Determine whether the user has permission to view this page
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool whether the user has access
+     */
+    public function hasAccess(\User $user): bool
+    {
+        return parent::hasAccess($user) && $user->hasPermission('api_docs');
+    }
+
+    /**
      * Return the long name of this module. The long name is intended
      * to be the friendly, human-readable name and can not be automatically
      * derived. It may contain spaces, punctuation, or capitalization. The

--- a/modules/api_docs/test/api_docsTest.php
+++ b/modules/api_docs/test/api_docsTest.php
@@ -28,9 +28,9 @@ class APIDocsTestIntegrationTest extends \LorisIntegrationTest
      *
      * @return void
      */
-    function testAnonymousUserDoesPageLoad()
+    function testDoesPageLoad()
     {
-        $this->setupPermissions([]);
+        $this->setupPermissions(['api_docs']);
         $this->safeGet($this->url . "/api_docs");
         $selectOptions = null;
         try {
@@ -44,5 +44,21 @@ class APIDocsTestIntegrationTest extends \LorisIntegrationTest
             $this->fail('Can`t find select element. Found: ' . $content->getText());
         }
         $this->assertNotEmpty($selectOptions);
+    }
+
+    /**
+     * Tests that, when loading the api_docs module without permission, the spec
+     * is unavailable.
+     *
+     * @return void
+     */
+    function testAnonymousUserDoesPageLoad()
+    {
+        $this->setupPermissions([]);
+        $this->safeGet($this->url . "/api_docs");
+        $accessText = $this->safeFindElement(
+            WebDriverBy::id("lorisworkspace")
+        )->getText();
+        $this->assertStringContainsString("You do not have access to this page", $accessText);
     }
 }

--- a/modules/api_docs/test/api_docsTest.php
+++ b/modules/api_docs/test/api_docsTest.php
@@ -59,6 +59,9 @@ class APIDocsTestIntegrationTest extends \LorisIntegrationTest
         $accessText = $this->safeFindElement(
             WebDriverBy::id("lorisworkspace")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page", $accessText);
+        $this->assertStringContainsString(
+            "You do not have access to this page",
+            $accessText
+        );
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Currently, the API Docs module is accessible even if you don't have the 'api_docs' (API Documentation: View LORIS API Manual) permission. This PR fixes that by moving the hasAccess function from the NDB Page to the module class

#### Testing instructions (if applicable)

1. Make sure that the module page is only accessible if the user has the "API Documentation: View LORIS API Manual" permission selected.
2. Make sure that the 'API Documentation' item is available in the navigation bar's 'Tools' tab only if the user has the "API Documentation: View LORIS API Manual" permission selected.

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/8602
