### PR TITLE
[Core] StaticDataTable column freeze fix

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -68,9 +68,6 @@ class StaticDataTable extends Component {
       } else {
         $('#dynamictable').DynamicTable();
       }
-      if (this.state.Hide.defaultColumn) {
-        $('#dynamictable').find('tbody td:eq(0)').hide();
-      }
     }
     if (!this.props.DisableFilter) {
       // Retrieve module preferences


### PR DESCRIPTION
Fixes a regression introduced by #7473. 
https://github.com/aces/Loris/pull/7473/files#diff-a2dad6817e8e695e9b53e19bc1bd4195daae329095623a068992de999568828fR555

Notice that the PSCID value is hidden and the columns shifted to the left.

<img width="1231" alt="Screenshot 2023-04-11 at 5 47 36 PM" src="https://user-images.githubusercontent.com/32041423/231295444-0d727724-0b09-4d4b-9bf9-8b658b0d6e0e.png">
