### PR TITLE
[issue_tracker] Fix warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,8 @@
     "jsdoc/require-param-description": "off",
     "jsdoc/require-returns": "off",
     "jsdoc/require-returns-description": "off",
-    "jsdoc/check-tag-names": "error"
+    "jsdoc/check-tag-names": "error",
+    "jsdoc/check-types": "error"
   },
   "overrides": [
     {

--- a/modules/issue_tracker/jsx/attachments/attachmentsList.js
+++ b/modules/issue_tracker/jsx/attachments/attachmentsList.js
@@ -154,7 +154,7 @@ class AttachmentsList extends Component {
   /**
    * Sets event target src to null
    *
-   * @param {Object} event
+   * @param {object} event
    */
   displayNone(event) {
     event.target.src = null;


### PR DESCRIPTION
40f4d594d3f6d21b8d843b432f013755c70b759b introduced a regression in eslint warnings

where the warning:

```
modules/issue_tracker/jsx/attachments/attachmentsList.js
  157:1  warning  Invalid JSDoc @param "event" type "Object"; prefer: "object"  jsdoc/check-types
```

was introduced.

Fix the warning and upgrade the error type from warning to error so warnings of this type don't get missed in the future, since there are no other instances.