### PR TITLE
[data_release] Fix console warnings in data_release modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ check: checkstatic unittests
 testdata:
 	php tools/raisinbread_refresh.php
 
+data_release:
+	target=data_release npm run compile
+
 instrument_manager:
 	target=instrument_manager npm run compile
 

--- a/modules/data_release/jsx/managePermissionsForm.js
+++ b/modules/data_release/jsx/managePermissionsForm.js
@@ -82,12 +82,10 @@ class ManagePermissionsForm extends Component {
         onClose={this.props.onClose}
         onSubmit={this.handleSubmit}
       >
-        <FormElement>
-          {Object.entries(data).map(([userId, user]) =>
-            <StaticElement
-              label={user.name}
-              text={Object.values(options.versions).map((version) =>
-                <div>
+        <FormElement name="manage_permissions">
+          {Object.entries(data).map(([userId, user]) => {
+            const versions = Object.values(options.versions).map((version) =>
+                <div key={version}>
                   <CheckboxElement
                     name={version}
                     label={version || 'Unversioned'}
@@ -97,9 +95,14 @@ class ManagePermissionsForm extends Component {
                     }
                   /><br/>
                 </div>
-              )}
-            />
-          )}
+            );
+
+            return <StaticElement
+                      key={userId}
+                      label={user.name}
+                      text={<div>{versions}</div>}
+                   />;
+         })};
         </FormElement>
       </Modal>
     );


### PR DESCRIPTION
This fixes the console warnings (which were mostly proptype errors) in the data_release module.