### PR TITLE
[api] add new integration tests for API project endpoint

### DIFF
--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -535,7 +535,9 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $instrumentProjectArray = json_decode(
-            (string) $response->getBody(),
+            (string) utf8_encode(
+                $response->getBody()->getContents()
+            ),
             true
         );
 

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -1,4 +1,5 @@
 <?php
+use function PHPUnit\Framework\assertSame;
 
 require_once __DIR__ . "/LorisApiAuthenticatedTest.php";
 
@@ -535,8 +536,10 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $instrumentProjectArray = json_decode(
-            (string) utf8_encode(
-                $response->getBody()->getContents()
+            mb_convert_encoding(
+                $response->getBody()->getContents(), 
+                'UTF-8', 
+                'ISO-8859-1'
             ),
             true
         );
@@ -747,8 +750,10 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $projectsRecordingsArray = json_decode(
-            (string) utf8_encode(
-                $response->getBody()->getContents()
+            mb_convert_encoding(
+                $response->getBody()->getContents(), 
+                'UTF-8', 
+                'ISO-8859-1'
             ),
             true
         );

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -654,17 +654,25 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             'textarea',
             'time',
         ];
+
+        $this->assertArrayHasKey(
+            'Type',
+            $elementGroup
+        );
+        $this->assertSame(
+            gettype($elementGroup['Type']),
+            'string'
+        );
         $this->assertContains(
             $elementGroup['Type'],
             $elementType
         );
-
         $this->assertArrayHasKey(
-            'GroupType',
+            'Name',
             $elementGroup
         );
         $this->assertSame(
-            gettype($elementGroup['GroupType']),
+            gettype($elementGroup['Name']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -676,52 +684,11 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             'string'
         );
         $this->assertArrayHasKey(
-            'Elements',
+            'Options',
             $elementGroup
         );
         $this->assertSame(
-            gettype($elementGroup['Elements']),
-            'array'
-        );
-
-        // == sub elements
-
-        $groupSubElements = $elementGroup['Elements'];
-
-        $this->assertArrayHasKey(
-            'Type',
-            $groupSubElements
-        );
-        $this->assertSame(
-            gettype($groupSubElements['Type']),
-            'string'
-        );
-        $this->assertContains(
-            $groupSubElements['Type'],
-            $elementType
-        );
-        $this->assertArrayHasKey(
-            'Name',
-            $groupSubElements
-        );
-        $this->assertSame(
-            gettype($groupSubElements['Name']),
-            'string'
-        );
-        $this->assertArrayHasKey(
-            'Description',
-            $groupSubElements
-        );
-        $this->assertSame(
-            gettype($groupSubElements['Description']),
-            'string'
-        );
-        $this->assertArrayHasKey(
-            'Options',
-            $groupSubElements
-        );
-        $this->assertSame(
-            gettype($groupSubElements['Options']),
+            gettype($elementGroup['Options']),
             'array'
         );
     }

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -20,7 +20,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
 {
     protected $projectName = "Pumpernickel";
 
-    protected $instrumentName = "bmi";
+    protected $instrumentName = "testtest";
 
     /**
      * Tests the HTTP GET request for the endpoint /projects
@@ -533,8 +533,6 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         // Verify the endpoint has a body
         $body = $response->getBody();
         $this->assertNotEmpty($body);
-
-        print_r($body);
 
         $instrumentProjectArray = json_decode(
             (string) utf8_encode(

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -543,17 +543,17 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             true
         );
 
-        // $this->assertSame(
-        //     gettype($instrumentProjectArray),
-        //     'array'
-        // );
+        $this->assertSame(
+            gettype($instrumentProjectArray),
+            'array'
+        );
 
         // == Meta tag
 
-        // $this->assertArrayHasKey(
-        //     'Meta',
-        //     $instrumentProjectArray
-        // );
+        $this->assertArrayHasKey(
+            'Meta',
+            $instrumentProjectArray
+        );
 
         $instrumentMeta = $instrumentProjectArray['Meta'];
 

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -684,9 +684,14 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             'array'
         );
 
+        $this->assertArrayHasKey(
+            '0',
+            $elementGroup['Elements']
+        );
+
         // == sub elements
 
-        $groupSubElements = $elementGroup['Elements'];
+        $groupSubElements = $elementGroup['Elements']['0'];
 
         $this->assertArrayHasKey(
             'Type',

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -740,7 +740,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
     {
         $response = $this->client->request(
             'GET',
-            "projects/$this->projectName",
+            "projects/$this->projectName/recordings",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -534,6 +534,8 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $body = $response->getBody();
         $this->assertNotEmpty($body);
 
+        print_r($body);
+
         $instrumentProjectArray = json_decode(
             (string) utf8_encode(
                 $response->getBody()->getContents()

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -783,7 +783,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Candidate'],
+            gettype($recordings['Candidate']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -791,7 +791,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['PSCID'],
+            gettype($recordings['PSCID']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -799,7 +799,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Visit'],
+            gettype($recordings['Visit']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -807,7 +807,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Visit_date'],
+            gettype($recordings['Visit_date']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -815,7 +815,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Site'],
+            gettype($recordings['Site']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -823,7 +823,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['File'],
+            gettype($recordings['File']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -831,7 +831,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Modality'],
+            gettype($recordings['Modality']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -839,7 +839,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['InsertTime'],
+            gettype($recordings['InsertTime']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -847,7 +847,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Link'],
+            gettype($recordings['Link']),
             'string'
         );
     }

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -737,7 +737,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
     {
         $response = $this->client->request(
             'GET',
-            "projects/$this->projectName",
+            "projects/$this->projectName/recordings",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -20,7 +20,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
 {
     protected $projectName = "Pumpernickel";
 
-    protected $instrumentName = "aosi";
+    protected $instrumentName = "bmi";
 
     /**
      * Tests the HTTP GET request for the endpoint /projects
@@ -536,7 +536,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
 
         $instrumentProjectArray = json_decode(
             (string) utf8_encode(
-                $response->getBody()->getContents()
+                strstr($response->getBody()->getContents(),"{")
             ),
             true
         );
@@ -747,10 +747,8 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $projectsRecordingsArray = json_decode(
-            mb_convert_encoding(
-                $response->getBody()->getContents(), 
-                'UTF-8', 
-                'ISO-8859-1'
+            (string) utf8_encode(
+                strstr($response->getBody()->getContents(),"{")
             ),
             true
         );

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -779,7 +779,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Candidate'],
+            gettype($recordings['Candidate']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -787,7 +787,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['PSCID'],
+            gettype($recordings['PSCID']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -795,7 +795,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Visit'],
+            gettype($recordings['Visit']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -803,7 +803,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Visit_date'],
+            gettype($recordings['Visit_date']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -811,7 +811,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Site'],
+            gettype($recordings['Site']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -819,7 +819,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['File'],
+            gettype($recordings['File']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -827,7 +827,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Modality'],
+            gettype($recordings['Modality']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -835,7 +835,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['InsertTime'],
+            gettype($recordings['InsertTime']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -843,7 +843,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            $recordings['Link'],
+            gettype($recordings['Link']),
             'string'
         );
     }

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -535,11 +535,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $instrumentProjectArray = json_decode(
-            mb_convert_encoding(
-                $response->getBody()->getContents(), 
-                'UTF-8', 
-                'ISO-8859-1'
-            ),
+            (string) $response->getBody(),
             true
         );
 
@@ -737,7 +733,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
     {
         $response = $this->client->request(
             'GET',
-            "projects/$this->projectName/recordings",
+            "projects/$this->projectName",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers
@@ -783,7 +779,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Candidate']),
+            $recordings['Candidate'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -791,7 +787,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['PSCID']),
+            $recordings['PSCID'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -799,7 +795,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Visit']),
+            $recordings['Visit'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -807,7 +803,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Visit_date']),
+            $recordings['Visit_date'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -815,7 +811,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Site']),
+            $recordings['Site'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -823,7 +819,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['File']),
+            $recordings['File'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -831,7 +827,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Modality']),
+            $recordings['Modality'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -839,7 +835,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['InsertTime']),
+            $recordings['InsertTime'],
             'string'
         );
         $this->assertArrayHasKey(
@@ -847,7 +843,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             $recordings
         );
         $this->assertSame(
-            gettype($recordings['Link']),
+            $recordings['Link'],
             'string'
         );
     }

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -1,5 +1,4 @@
 <?php
-use function PHPUnit\Framework\assertSame;
 
 require_once __DIR__ . "/LorisApiAuthenticatedTest.php";
 

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -541,6 +541,11 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             true
         );
 
+        $this->assertSame(
+            gettype($instrumentProjectArray),
+            'array'
+        );
+
         // == Meta tag
 
         $this->assertArrayHasKey(
@@ -746,6 +751,11 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
                 $response->getBody()->getContents()
             ),
             true
+        );
+
+        $this->assertSame(
+            gettype($projectsRecordingsArray),
+            'array'
         );
 
         $this->assertArrayHasKey(

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -20,6 +20,8 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
 {
     protected $projectName = "Pumpernickel";
 
+    protected $instrumentName = "bmi";
+
     /**
      * Tests the HTTP GET request for the endpoint /projects
      *
@@ -519,6 +521,320 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
      */
     public function testGetProjectsProjectInstrumentsInstrument(): void
     {
-        $this->markTestSkipped('Missing data in docker image');
+        $response = $this->client->request(
+            'GET',
+            "projects/$this->projectName/instruments/$this->instrumentName",
+            [
+                'http_errors' => false,
+                'headers'     => $this->headers
+            ]
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $instrumentProjectArray = json_decode(
+            (string) utf8_encode(
+                $response->getBody()->getContents()
+            ),
+            true
+        );
+
+        // == Meta tag
+
+        $this->assertArrayHasKey(
+            'Meta',
+            $instrumentProjectArray
+        );
+
+        $instrumentMeta = $instrumentProjectArray['Meta'];
+
+        $this->assertSame(
+            gettype($instrumentMeta),
+            'array'
+        );
+
+        $this->assertArrayHasKey(
+            'InstrumentVersion',
+            $instrumentMeta
+        );
+        $this->assertSame(
+            gettype($instrumentMeta['InstrumentVersion']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'InstrumentFormatVersion',
+            $instrumentMeta
+        );
+        $this->assertSame(
+            gettype($instrumentMeta['InstrumentFormatVersion']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'ShortName',
+            $instrumentMeta
+        );
+        $this->assertSame(
+            gettype($instrumentMeta['ShortName']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'LongName',
+            $instrumentMeta
+        );
+        $this->assertSame(
+            gettype($instrumentMeta['LongName']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'IncludeMetaDataFields',
+            $instrumentMeta
+        );
+        $this->assertSame(
+            gettype($instrumentMeta['IncludeMetaDataFields']),
+            'string'
+        );
+
+        // == Elements tag
+
+        $this->assertArrayHasKey(
+            'Elements',
+            $instrumentProjectArray
+        );
+        $this->assertSame(
+            gettype($instrumentProjectArray['Elements']),
+            'array'
+        );
+
+        $this->assertArrayHasKey(
+            '0',
+            $instrumentProjectArray['Elements']
+        );
+
+        $elementGroup = $instrumentProjectArray['Elements']['0'];
+
+        $this->assertSame(
+            gettype($elementGroup),
+            'array'
+        );
+
+        $this->assertArrayHasKey(
+            'Type',
+            $elementGroup
+        );
+        $this->assertSame(
+            gettype($elementGroup['Type']),
+            'string'
+        );
+
+        $elementType = [
+            // a group of elements...
+            'ElementGroup',
+            // ... or one element type
+            'advcheckbox',
+            'date',
+            'file',
+            'group',
+            'header',
+            'hidden',
+            'link',
+            'page',
+            'password',
+            'radio',
+            'select',
+            'static',
+            'submit',
+            'text',
+            'textarea',
+            'time',
+        ];
+        $this->assertContains(
+            $elementGroup['Type'],
+            $elementType
+        );
+
+        $this->assertArrayHasKey(
+            'GroupType',
+            $elementGroup
+        );
+        $this->assertSame(
+            gettype($elementGroup['GroupType']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Description',
+            $elementGroup
+        );
+        $this->assertSame(
+            gettype($elementGroup['Description']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Elements',
+            $elementGroup
+        );
+        $this->assertSame(
+            gettype($elementGroup['Elements']),
+            'array'
+        );
+
+        // == sub elements
+
+        $groupSubElements = $elementGroup['Elements'];
+
+        $this->assertArrayHasKey(
+            'Type',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Type']),
+            'string'
+        );
+        $this->assertContains(
+            $groupSubElements['Type'],
+            $elementType
+        );
+        $this->assertArrayHasKey(
+            'Name',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Name']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Description',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Description']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Options',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Options']),
+            'array'
+        );
+    }
+
+    /**
+     * Tests the HTTP GET request for the endpoint /projects/{project}/recordings
+     *
+     * @return void
+     */
+    public function testGetProjectsRecordings(): void
+    {
+        $response = $this->client->request(
+            'GET',
+            "projects/$this->projectName",
+            [
+                'http_errors' => false,
+                'headers'     => $this->headers
+            ]
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $projectsRecordingsArray = json_decode(
+            (string) utf8_encode(
+                $response->getBody()->getContents()
+            ),
+            true
+        );
+
+        $this->assertArrayHasKey(
+            'Recordings',
+            $projectsRecordingsArray
+        );
+        $this->assertSame(
+            gettype($projectsRecordingsArray['Recordings']),
+            'array'
+        );
+
+        $this->assertArrayHasKey(
+            '0',
+            $projectsRecordingsArray['Recordings']
+        );
+
+        $recordings = $projectsRecordingsArray['Recordings']['0'];
+
+        $this->assertArrayHasKey(
+            'Candidate',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Candidate'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'PSCID',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['PSCID'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Visit',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Visit'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Visit_date',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Visit_date'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Site',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Site'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'File',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['File'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Modality',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Modality'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'InsertTime',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['InsertTime'],
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Link',
+            $recordings
+        );
+        $this->assertSame(
+            $recordings['Link'],
+            'string'
+        );
     }
 }

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -543,17 +543,17 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             true
         );
 
-        $this->assertSame(
-            gettype($instrumentProjectArray),
-            'array'
-        );
+        // $this->assertSame(
+        //     gettype($instrumentProjectArray),
+        //     'array'
+        // );
 
         // == Meta tag
 
-        $this->assertArrayHasKey(
-            'Meta',
-            $instrumentProjectArray
-        );
+        // $this->assertArrayHasKey(
+        //     'Meta',
+        //     $instrumentProjectArray
+        // );
 
         $instrumentMeta = $instrumentProjectArray['Meta'];
 

--- a/raisinbread/test/api/LorisApiProjectsTest.php
+++ b/raisinbread/test/api/LorisApiProjectsTest.php
@@ -20,7 +20,7 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
 {
     protected $projectName = "Pumpernickel";
 
-    protected $instrumentName = "testtest";
+    protected $instrumentName = "aosi";
 
     /**
      * Tests the HTTP GET request for the endpoint /projects
@@ -654,25 +654,17 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             'textarea',
             'time',
         ];
-
-        $this->assertArrayHasKey(
-            'Type',
-            $elementGroup
-        );
-        $this->assertSame(
-            gettype($elementGroup['Type']),
-            'string'
-        );
         $this->assertContains(
             $elementGroup['Type'],
             $elementType
         );
+
         $this->assertArrayHasKey(
-            'Name',
+            'GroupType',
             $elementGroup
         );
         $this->assertSame(
-            gettype($elementGroup['Name']),
+            gettype($elementGroup['GroupType']),
             'string'
         );
         $this->assertArrayHasKey(
@@ -684,11 +676,52 @@ class LorisApiProjectsTest extends LorisApiAuthenticatedTest
             'string'
         );
         $this->assertArrayHasKey(
-            'Options',
+            'Elements',
             $elementGroup
         );
         $this->assertSame(
-            gettype($elementGroup['Options']),
+            gettype($elementGroup['Elements']),
+            'array'
+        );
+
+        // == sub elements
+
+        $groupSubElements = $elementGroup['Elements'];
+
+        $this->assertArrayHasKey(
+            'Type',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Type']),
+            'string'
+        );
+        $this->assertContains(
+            $groupSubElements['Type'],
+            $elementType
+        );
+        $this->assertArrayHasKey(
+            'Name',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Name']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Description',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Description']),
+            'string'
+        );
+        $this->assertArrayHasKey(
+            'Options',
+            $groupSubElements
+        );
+        $this->assertSame(
+            gettype($groupSubElements['Options']),
             'array'
         );
     }


### PR DESCRIPTION
## Brief summary of changes

Add two endpoint integration tests:

- `/projects/{project}/instruments/{instrument}`
- `/projects/{project}/recordings`

#### Link(s) to related issue(s)

* Resolves #8617
