### PR TITLE
[mri_violations] Added spacing between description items

### DIFF
--- a/modules/mri_violations/css/mri_violations.css
+++ b/modules/mri_violations/css/mri_violations.css
@@ -1,9 +1,13 @@
 .violation-description-list {
   display: flex;
   width: 100%;
-  justify-content: space-around;
+  justify-content: space-between;
 }
 
 .violation-description-list > div {
   margin: 0 5px;
+}
+
+.violation-description-list > div:not(:nth-child(-n+2)) > dd {
+  overflow-wrap: anywhere;
 }

--- a/modules/mri_violations/css/mri_violations.css
+++ b/modules/mri_violations/css/mri_violations.css
@@ -1,0 +1,9 @@
+.violation-description-list {
+  display: flex;
+  width: 100%;
+  justify-content: space-around;
+}
+
+.violation-description-list > div {
+  margin: 0 5px;
+}

--- a/modules/mri_violations/jsx/protocolModal.js
+++ b/modules/mri_violations/jsx/protocolModal.js
@@ -62,9 +62,7 @@ function ProtocolViolationModal(props) {
       title = 'Violations for ' + violation[4];
       violations.push(
         <div key={violation[4]}>
-          <dl style={{display: 'flex', width: '100%',
-                      justifyContent: 'space-around',
-          }}>
+          <dl className="violation-description-list">
             <div>
               <dt>CandID</dt>
               <dd>{violation[0]}</dd>

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -69,7 +69,7 @@ class Mri_Violations extends \DataFrameworkMenu
         $problemTypes = array_column(
             $db->pselect(
                 "SELECT DISTINCT MRICandidateErrors.Reason FROM MRICandidateErrors
-                    UNION 
+                    UNION
                  SELECT DISTINCT 'Could not identify scan type'
                       FROM mri_protocol_violated_scans
                     UNION
@@ -174,6 +174,24 @@ class Mri_Violations extends \DataFrameworkMenu
             $deps,
             [
                 $baseURL . "/mri_violations/js/mriViolationsIndex.js",
+            ]
+        );
+    }
+
+    /**
+     * Include additional CSS files:
+     *
+     * @return array of css to be inserted
+     */
+    function getCSSDependencies() : array
+    {
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getCSSDependencies();
+        return array_merge(
+            $deps,
+            [
+                $baseURL . "/mri_violations/css/mri_violations.css",
             ]
         );
     }


### PR DESCRIPTION
This PR adds spacing between the description items, as requested in #8627. 

I avoided redundancy by adding the attributes required on several child elements via css selectors.
The selectors needed to be declared in a css file, which this module did not have yet.

This PR also adds a css file.