### PR TITLE
[new_profile/sex] Remove strtolower() and force uppercase

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -142,9 +142,9 @@ class New_Profile extends \NDB_Form
         $dobFormat = $config->getSetting('dobFormat');
         $edc       = $config->getSetting('useEDC');
         $sex       = [
-            'male'   => 'Male',
-            'female' => 'Female',
-            'other'  => 'Other',
+            'Male'   => 'Male',
+            'Female' => 'Female',
+            'Other'  => 'Other',
         ];
         $pscidSet  = "false";
         $minYear   = (isset($startYear, $ageMax)) ? $startYear - $ageMax : null;

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -77,7 +77,7 @@ class NewProfileTestIntegrationTest extends LorisIntegrationTest
         // send a key to sex
         $sexElement = $this->safeFindElement(WebDriverBy::Name('sex'));
         $sexOption  = new WebDriverSelect($sexElement);
-        $sexOption->selectByValue("male");
+        $sexOption->selectByValue("Male");
         $sexElement = $this->safeFindElement(WebDriverBy::Name('site'));
         $sexOption  = new WebDriverSelect($sexElement);
         $sexOption->selectByValue("1");

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -29,9 +29,9 @@ class Sex implements \JsonSerializable
     public $value;
 
     private const VALID_VALUES = array(
-                                  'male',
-                                  'female',
-                                  'other',
+                                  'Male',
+                                  'Female',
+                                  'Other',
                                  );
 
     /**
@@ -61,7 +61,7 @@ class Sex implements \JsonSerializable
      */
     public static function validate(string $value): bool
     {
-        return in_array(strtolower($value), self::VALID_VALUES, true);
+        return in_array($value, self::VALID_VALUES, true);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

the keys in the new_profile module were lower case which forces the Sex library class to use a `strtolower()` function to validate the value and then submits the lowercase value in the SQL insert statement where SQL implicitly converts it to uppercase. This workflow is very risky as different versions of SQL or different databases may not recognise the lowercase and uppercase as the same word and treat it as a truncation. This is also simply bad practice and unnecessary here.



#### Testing instructions (if applicable)

1. Make sure new profile still works properly and that the sex loads properly on other modules (i.e. candidate_list, timepoint list...)
