### PR TITLE
[webpack] remove util shortcut as it is unused and causes conflicts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,6 @@ const optimization = {
 
 const resolve = {
   alias: {
-    util: path.resolve(__dirname, './htdocs/js/util'),
     jsx: path.resolve(__dirname, './jsx'),
     jslib: path.resolve(__dirname, './jslib'),
     Breadcrumbs: path.resolve(__dirname, './jsx/Breadcrumbs'),


### PR DESCRIPTION
## Brief summary of changes
The util shortcut seems to be completely unused in the code, the only place using the content of that directory references the whole path of the directory

https://github.com/aces/Loris/blob/2df7893ae4e7376ebd4ae93a6c5d3111ef2519bb/php/libraries/NDB_Page.class.inc#L872

the existence of util is also problematic for some third party project dependencies and cause these errors
```
Child
    
    ERROR in ./project/modules/new_profile/node_modules/readable-stream/lib/_stream_readable.js
    Module not found: Error: Can't resolve 'util' in '/var/www/loris/project/modules/new_profile/node_modules/readable-stream/lib'
    
    ERROR in ./project/modules/new_profile/node_modules/readable-stream/lib/internal/streams/buffer_list.js
    Module not found: Error: Can't resolve 'util' in '/var/www/loris/project/modules/new_profile/node_modules/readable-stream/lib/internal/streams'
```


#### Testing instructions (if applicable)

1. make sure pages load normally (since the only usage of that file is in ndb_page)

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/8577
