### PR TITLE
[my_preference] - missing error for invalid email syntax #8550

### DIFF
--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -258,14 +258,11 @@ class My_Preferences extends \NDB_Form
         );
 
         // email address
-        $this->addBasicText(
+        $this->addBasicEmail(
             'Email',
             'Email address',
             [],
-            [
-                'oninvalid' => "this.setCustomValidity('Email address is required')",
-                'onchange'  => "this.setCustomValidity('')",
-            ]
+            []
         );
 
         // email address rules

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1573,10 +1573,9 @@ class LorisForm
     /**
      * Generates the HTML for a email type element
      *
-     * @param array $el An array of the form used by $this->form
-     *                  for a email
-     *
-     *@param string $type Email type
+     * @param array  $el   An array of the form used by $this->form
+     *                     for a email
+     * @param string $type Email type
      *
      * @return string The HTML for the given email element
      */

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -224,6 +224,16 @@ class LorisForm
         $el['type'] = 'text';
         return $el;
     }
+    /**
+     * Reimplementation of HTML_QuickForm's "addEmail" API.
+     *
+     * @param string $name    The element name.
+     * @param string $label   The label to attach to this element.
+     * @param array  $attribs An array of other attributes that should
+     *                        get added.
+     *
+     * @return &array
+     */
     public function addEmail($name, $label, $attribs=[])
     {
         $el         =& $this->addBase($name, $label, $attribs);
@@ -427,10 +437,10 @@ class LorisForm
             break;
         case 'static':
             $el = $this->addStatic($name, $label);
-	    break;
+            break;
         case 'email':
-            $el = $this->addEmail($name, $label,$attribs);
-            break;	    
+            $el = $this->addEmail($name, $label, $attribs);
+            break;
         case 'textarea':
             $el = $this->addTextArea($name, $label, $attribs);
             break;
@@ -1552,14 +1562,24 @@ class LorisForm
         case 'time':
             return $this->timeHTML($el);
         case 'link':
-		return $this->linkHTML($el);
+            return $this->linkHTML($el);
         case 'email':
-            return $this->emailHTML($el);		
+            return $this->emailHTML($el);
         }
         throw new LorisException(
             "Unsupported element type $el[type] in renderElement"
         );
     }
+    /**
+     * Generates the HTML for a email type element
+     *
+     * @param array $el An array of the form used by $this->form
+     *                  for a email
+     *
+     *@param string $type Email type
+     *
+     * @return string The HTML for the given email element
+     */
     function emailHTML($el, $type='email')
     {
         $cls      = '';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -224,7 +224,12 @@ class LorisForm
         $el['type'] = 'text';
         return $el;
     }
-
+    public function addEmail($name, $label, $attribs=[])
+    {
+        $el         =& $this->addBase($name, $label, $attribs);
+        $el['type'] = 'email';
+        return $el;
+    }
     /**
      * Reimplementation of HTML_QuickForm's "addTextArea" API.
      *
@@ -422,7 +427,10 @@ class LorisForm
             break;
         case 'static':
             $el = $this->addStatic($name, $label);
-            break;
+	    break;
+        case 'email':
+            $el = $this->addEmail($name, $label,$attribs);
+            break;	    
         case 'textarea':
             $el = $this->addTextArea($name, $label, $attribs);
             break;
@@ -1544,13 +1552,61 @@ class LorisForm
         case 'time':
             return $this->timeHTML($el);
         case 'link':
-            return $this->linkHTML($el);
+		return $this->linkHTML($el);
+        case 'email':
+            return $this->emailHTML($el);		
         }
         throw new LorisException(
             "Unsupported element type $el[type] in renderElement"
         );
     }
+    function emailHTML($el, $type='email')
+    {
+        $cls      = '';
+        $disabled = '';
+        $readonly = '';
+        if (isset($el['class'])) {
+            $cls = "class=\"$el[class]\"";
+        }
+        if (isset($el['disabled']) || $this->frozen) {
+            $disabled = 'disabled';
+        }
+        if (isset($el['readonly'])) {
+            $readonly = 'readonly';
+        }
+        $value = $this->getValue($el['name']);
+        return "<input name=\"$el[name]\" type=\"$type\" $cls"
+            . (
+                isset($el['onchange']) && $el['onchange']
+                ? " onchange=\"{$el['onchange']}\"" : ''
+              )
+            . (
+                isset($el['oninvalid']) && $el['oninvalid']
+                ? " oninvalid=\"{$el['oninvalid']}\"" : ''
+              )
+            . (
+                isset($el['pattern']) && $el['pattern']
+                ? " pattern=\"{$el['pattern']}\"" : ''
+              )
+            . (
+                isset($el['required']) && $el['required']
+                ? ' required' : ''
+              )
+            . (
+                isset($el['placeholder']) && $el['placeholder']
+                ? " placeholder=\"{$el['placeholder']}\"" : ''
+              )
 
+            . (
+                (!empty($value) || $value === '0')
+                ? ' value="' . $this->getValue($el['name']) . '"'
+                : ''
+              )
+            . $disabled
+            . ' '
+            . $readonly
+            .">";
+    }
     /**
      * Generates the HTML for a header type element
      *

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -268,7 +268,22 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
         $attribs = array_merge(['class' => 'form-control input-sm'], $attribs);
         $this->form->addElement('text', $field, $label, $options, $attribs);
     }
-
+    /**
+     * Adds a email element to the current page with no accompanying
+     * not answered option
+     *
+     * @param string $field   The name of the text element to add
+     * @param string $label   Label to attach to the text element
+     * @param array  $options QuickForm options to pass to addElement
+     * @param array  $attribs QuickForm attributes to pass to addElement
+     *
+     * @return void
+     */
+    function addBasicEmail($field, $label, $options=[], $attribs=[])
+    {
+        $attribs = array_merge(['class' => 'form-control input-sm'], $attribs);
+        $this->form->addElement('email', $field, $label, $options, $attribs);
+    }
     /**
      * Adds a text area to the current page with no accompanying not answered
      * option.


### PR DESCRIPTION
## Brief summary of changes

[my_preference] - missing error for invalid email syntax #8550

#### Testing instructions (if applicable)
[my_preference] - input an invalid email address, it will show you error message.


#### Link(s) to related issue

[my_preference] - missing error for invalid email syntax #8550
