### PR TITLE
fix data release sort issue

### DIFF
--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -61,7 +61,7 @@ class Data_Release extends \NDB_Menu_Filter
         // set the class variables
         $this->columns = [
             'file_name AS fileName',
-            'IFNULL(version,"Unversioned")',
+            'IFNULL(NULLIF(version, "" ), "Unversioned" ) AS version',
             'upload_date AS uploadDate',
             'dr.id as dataReleaseID',
         ];

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -61,7 +61,7 @@ class Data_Release extends \NDB_Menu_Filter
         // set the class variables
         $this->columns = [
             'file_name AS fileName',
-            'IF(version is null or version ="","Unversioned", version) AS version',
+            'IFNULL(version,"Unversioned")',
             'upload_date AS uploadDate',
             'dr.id as dataReleaseID',
         ];


### PR DESCRIPTION
## Brief summary of changes

[data_release] Can not sort by version #8621

#### Testing instructions (if applicable)

sort the data_release table by version (Unversioned)

#### Link(s) to related issue(s)

[data_release] Can not sort by version #8621
