### PR TITLE
[Survey] Fix loading of survey instruments

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -86,7 +86,10 @@ class DirectDataEntryMainPage
         $this->loris     = new \LORIS\LorisInstance(
             $DB,
             $config,
-            []
+            [
+                __DIR__ . "/../project/modules",
+                __DIR__ . "/../modules/",
+            ]
         );
         $this->TestName  = $DB->pselectOne(
             "SELECT Test_name FROM participant_accounts


### PR DESCRIPTION
The module search path for survey instruments was incorrect. Set to the same search path as in tools/generic_includes.php

Resolves #8546