### PR TITLE
[candidate] Allow dob format Y-m

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -284,7 +284,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         // Get expected format from config
         $dobFormat = $config->getSetting('dobFormat');
         $dobFormat = '!' . implode("-", str_split($dobFormat, 1));
-        $dob = DateTime::createFromFormat($dobFormat, $dateOfBirth);
+        $dob       = DateTime::createFromFormat($dobFormat, $dateOfBirth);
 
         if ($dob === false) {
             throw new InvalidArgumentException(

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -280,12 +280,23 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 DOB_NOT_SPECIFIED
             );
         }
-        $dob = DateTime::createFromFormat('!Y-m-d', $dateOfBirth);
+
+        // Get expected format from config
+        $dobFormat = $config->getSetting('dobFormat');
+        $dobFormat = '!' . implode("-", str_split($dobFormat, 1));
+        $dob = DateTime::createFromFormat($dobFormat, $dateOfBirth);
+
         if ($dob === false) {
             throw new InvalidArgumentException(
                 "Date of Birth is invalid (expected format: YYYY-MM-DD)",
                 DOB_INVALID
             );
+        }
+
+        // Add day as first of the month if Y-m dob format
+        // This allows insert into sql candidate table
+        if ($dobFormat === '!Y-m') {
+            $dateOfBirth .= '-01';
         }
 
         if ($PSCIDSettings['generation'] == 'user') {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -296,7 +296,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         // Add day as first of the month if Y-m dob format
         // This allows insert into sql candidate table
         if ($dobFormat === '!Y-m') {
-            $dateOfBirth .= '-01';
+            $dateOfBirth .= '-15';
         }
 
         if ($PSCIDSettings['generation'] == 'user') {


### PR DESCRIPTION
## Brief summary of changes
When a dob Format of Ym (year and month without day) is set in the config module, candidates could not be created for 2 reasons. 
1. The wrong format (`!Y-m-d`) was being passed through the function `DateTime::createFromFormat` in the `createNew` function of the candidate class, which gave a wrong format error to the user even if they were passing through the expected format of Year-month
2. Even if this was fixed, the date was inserted into the candidate table as YYYY-MM, but this is not compatible with the SQL Type `date`

This PR fixes this issue by getting the date format from config, processing it to the right format and passing it through to `DateTime::createFromFormat`, as well as adding a '-01' to the end of the date if Ym format is selected in the configuration. This inserts the first of the month as the arbitrary date for a candidate.

- [ ] Have you updated related documentation?

Would someone be able to help me out as to whether this should be added to the changelog? I'm not sure if this is a bug introduced in 25 but I would be surprised if it existed in previous versions since it is so critical.

#### Testing instructions (if applicable)

1. Attempt to create a candidate with both 'Ymd' and 'Ym' selected as dob format in the configuration module.
 
#### Link(s) to related issue(s)

* Resolves #8586
