### PR TITLE
[candidate_parameters] Fix permission issue.

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -14,15 +14,31 @@
  */
 use \LORIS\StudyEntities\Candidate\CandID;
 
-$user = \User::singleton();
-if (!$user->hasPermission('candidate_parameter_edit')) {
-    header("HTTP/1.1 403 Forbidden");
-    exit;
-}
-
 $tab = $_POST['tab'] ?? '';
 if ($tab === '') {
     header("HTTP/1.1 400 Bad Request");
+    exit;
+}
+
+$user = \User::singleton();
+if (
+    ($tab == 'candidateDOB') &&
+    (!$user->hasPermission('candidate_dob_edit'))
+   ) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+} elseif (
+    ($tab == 'candidateDOD') &&
+    (!$user->hasPermission('candidate_dod_edit'))
+) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+} elseif (
+    ($tab != 'candidateDOB') &&
+    ($tab != 'candidateDOD') &&
+    !$user->hasPermission('candidate_parameter_edit')
+) {
+    header("HTTP/1.1 403 Forbidden");
     exit;
 }
 
@@ -52,7 +68,6 @@ case 'participantStatus':
 case 'consentStatus':
     editConsentStatusFields($db);
     break;
-
 
 case 'candidateDOB':
     editCandidateDOB($db);

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -21,22 +21,19 @@ if ($tab === '') {
 }
 
 $user = \User::singleton();
-if (
-    ($tab == 'candidateDOB') &&
-    (!$user->hasPermission('candidate_dob_edit'))
-   ) {
-    header("HTTP/1.1 403 Forbidden");
-    exit;
-} elseif (
-    ($tab == 'candidateDOD') &&
-    (!$user->hasPermission('candidate_dod_edit'))
+if (($tab == 'candidateDOB')
+    && (!$user->hasPermission('candidate_dob_edit'))
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;
-} elseif (
-    ($tab != 'candidateDOB') &&
-    ($tab != 'candidateDOD') &&
-    !$user->hasPermission('candidate_parameter_edit')
+} elseif (($tab == 'candidateDOD')
+    && (!$user->hasPermission('candidate_dod_edit'))
+) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+} elseif (($tab != 'candidateDOB')
+    && ($tab != 'candidateDOD')
+    && !$user->hasPermission('candidate_parameter_edit')
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;


### PR DESCRIPTION
## Brief summary of changes
- The permissions checks were updated on **modules/candidate_parameters/ajax/formHandler.php**
- Now a user with the permission "candidate_dob_edit" and without "candidate_parameter_edit" should be able to "Edit date of birth".
- Also for the "Edit date of Death".

The rest of the behaviour should not be affected. 

- [X ] Have you updated related documentation?
 Not needed in this case.

#### Testing instructions (if applicable)

1. Go to candidate parameter
2. Click on date of birth
3. Edit date of birth
3a. Edit date of death
4. The issue reported in https://github.com/aces/Loris/issues/8574 should be fixed.

#### Link(s) to related issue(s)

* Resolves #  https://github.com/aces/Loris/issues/8574
