### PR TITLE
[api] Recordings endpoints integration tests update

### DIFF
--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -357,8 +357,10 @@ class Recording
                          USING (PhysiologicalElectrodeMaterialID)
                        JOIN point_3d po
                          USING (Point3DID)
+                       JOIN physiological_coord_system_electrode_rel pcser
+                         USING (PhysiologicalElectrodeID)
                        WHERE
-                         pe.PhysiologicalFileID = :v_fileid
+                        pcser.PhysiologicalFileID = :v_fileid
                       ',
                 ['v_fileid' => $this->_fileid]
             );

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -85,16 +85,18 @@ class Recording
                      ) pc
                        ON (pc.PhysiologicalFileID = f.PhysiologicalFileID)
                      LEFT JOIN (
-                       SELECT pcser.PhysiologicalFileID, pe.FilePath
-                       FROM physiological_electrode pe
-                        INNER JOIN physiological_coord_system_electrode_rel pcser 
-                          USING (PhysiologicalElectrodeID)
+                       SELECT pcser.PhysiologicalFileID, pe2.FilePath
+                       FROM physiological_electrode pe2,
+                        physiological_coord_system_electrode_rel pcser
+                       WHERE pe2.PhysiologicalElectrodeID=pcser.PhysiologicalElectrodeID
                        LIMIT 1
                      ) pe
                        ON (pe.PhysiologicalFileID = f.PhysiologicalFileID)
                      LEFT JOIN (
-                       SELECT PhysiologicalFileID, FilePath
-                       FROM physiological_task_event
+                       SELECT pte.PhysiologicalFileID, pef.FilePath
+                       FROM physiological_task_event pte
+                        INNER JOIN physiological_event_file pef
+                        USING (EventFileID)
                        LIMIT 1
                      ) pte
                        ON (pte.PhysiologicalFileID = f.PhysiologicalFileID)

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -87,7 +87,8 @@ class Recording
                      LEFT JOIN (
                        SELECT pcser.PhysiologicalFileID, pe.FilePath
                        FROM physiological_electrode pe
-                        INNER JOIN physiological_coord_system_electrode_rel pcser USING (PhysiologicalElectrodeID)
+                        INNER JOIN physiological_coord_system_electrode_rel pcser 
+                          USING (PhysiologicalElectrodeID)
                        LIMIT 1
                      ) pe
                        ON (pe.PhysiologicalFileID = f.PhysiologicalFileID)

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -344,9 +344,9 @@ class Recording
                          pe.Name                as electrodename,
                          pet.ElectrodeType      as electrodetype,
                          pem.ElectrodeMaterial  as electrodematerial,
-                         pe.X                   as x,
-                         pe.Y                   as y,
-                         pe.Z                   as z,
+                         po.X                   as x,
+                         po.Y                   as y,
+                         po.Z                   as z,
                          pe.Impedance           as Impedance,
                          pe.FilePath            as filepath
                        FROM
@@ -355,6 +355,8 @@ class Recording
                          USING (PhysiologicalElectrodeTypeID)
                        JOIN physiological_electrode_material pem
                          USING (PhysiologicalElectrodeMaterialID)
+                       JOIN point_3d po
+                         USING (Point3DID)
                        WHERE
                          pe.PhysiologicalFileID = :v_fileid
                       ',
@@ -389,9 +391,11 @@ class Recording
                          pte.EventType    as eventtype,
                          pte.TrialType    as trialtype,
                          pte.ResponseTime as responsetime,
-                         pte.FilePath     as filepath
+                         pef.FilePath     as filepath
                        FROM
-                         physiological_task_event pte 
+                         physiological_task_event pte
+                        JOIN physiological_event_file pef
+                         USING (EventFileID)
                        WHERE
                          pte.PhysiologicalFileID = :v_fileid
                       ',

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -85,8 +85,9 @@ class Recording
                      ) pc
                        ON (pc.PhysiologicalFileID = f.PhysiologicalFileID)
                      LEFT JOIN (
-                       SELECT PhysiologicalFileID, FilePath
-                       FROM physiological_electrode
+                       SELECT pcser.PhysiologicalFileID, pe.FilePath
+                       FROM physiological_electrode pe
+                        INNER JOIN physiological_coord_system_electrode_rel pcser USING (PhysiologicalElectrodeID)
                        LIMIT 1
                      ) pe
                        ON (pe.PhysiologicalFileID = f.PhysiologicalFileID)

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -86,9 +86,9 @@ class Recording
                        ON (pc.PhysiologicalFileID = f.PhysiologicalFileID)
                      LEFT JOIN (
                        SELECT pcser.PhysiologicalFileID, pe2.FilePath
-                       FROM physiological_electrode pe2,
-                        physiological_coord_system_electrode_rel pcser
-                       WHERE pe2.PhysiologicalElectrodeID=pcser.PhysiologicalElectrodeID
+                       FROM physiological_electrode pe2
+                        INNER JOIN physiological_coord_system_electrode_rel pcser
+                        USING (PhysiologicalElectrodeID)
                        LIMIT 1
                      ) pe
                        ON (pe.PhysiologicalFileID = f.PhysiologicalFileID)

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -35,9 +35,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordings(): void
     {
-        $this->markTestIncomplete(
-            "rewrite after #8036 [EEG] Database Architecture for HED Tags"
-        );
         $response = $this->client->request(
             'GET',
             "candidates/$this->candidTest/$this->visitTest/recordings",
@@ -411,9 +408,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileElectrodes(): void
     {
-            // $this->markTestIncomplete(
-            //   "rewrite"
-            // );
         $response = $this->client->request(
             'GET',
             "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/electrodes",
@@ -553,9 +547,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileEvents(): void
     {
-            // $this->markTestIncomplete(
-            //   "rewrite"
-            // );
         $response = $this->client->request(
             'GET',
             "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/events",

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -210,8 +210,8 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
         $this->assertSame(gettype($meta['CandID']), 'string');
         $this->assertArrayHasKey('Visit', $meta);
         $this->assertSame(gettype($meta['Visit']), 'string');
-        $this->assertArrayHasKey('Filename', $meta);
-        $this->assertSame(gettype($meta['Filename']), 'string');
+        $this->assertArrayHasKey('File', $meta);
+        $this->assertSame(gettype($meta['File']), 'string');
         $this->assertArrayHasKey('Header', $meta);
         $this->assertSame(gettype($meta['Header']), 'string');
 

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -21,6 +21,7 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     protected $frecordTest     = "sub-OTT174_ses-V1_task-faceO_eeg.edf";
     protected $candidTest      = "300174";
     protected $visitTest       = "V1";
+    protected $headernameTest  = "TODO";
 
     /**
      * Tests the HTTP GET request for the
@@ -117,6 +118,103 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
         $this->assertNotEmpty($body);
 
         $this->assertFileIsReadable($this->frecordTest);
+    }
+
+    /**
+     * TODO: validate test
+     * Tests the HTTP GET request for the
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/metadata
+     *
+     * @return void
+     */
+    public function testGetCandidatesCandidVisitRecordingsEdfFileMetadata(): void
+    {
+        $response = $this->client->request(
+            'GET',
+            "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/metadata",
+            [
+                'http_errors' => false,
+                'headers'     => $this->headers
+            ]
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+        $recordingsArray = json_decode(
+            (string) utf8_encode(
+                $response->getBody()->getContents()
+            ),
+            true
+        );
+
+        $this->assertSame(gettype($recordingsArray), 'array');
+
+        $this->assertArrayHasKey('Meta', $recordingsArray);
+        $meta = $recordingsArray['Meta'];
+        $this->assertSame(gettype($meta), 'array');
+
+        $this->assertArrayHasKey('CandID', $meta);
+        $this->assertSame(gettype($meta['CandID']), 'string');
+        $this->assertArrayHasKey('Visit', $meta);
+        $this->assertSame(gettype($meta['Visit']), 'string');
+        $this->assertArrayHasKey('File', $meta);
+        $this->assertSame(gettype($meta['File']), 'string');
+
+        $this->assertArrayHasKey('Data', $recordingsArray);
+        $data = $recordingsArray['Data'];
+        $this->assertSame(gettype($data), 'array');
+
+        foreach ($data as $value) {
+            $this->assertSame(gettype($value), 'string');
+        }
+    }
+
+    /**
+     * TODO: validate test + header name value
+     * Tests the HTTP GET request for the
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/metadata/{headername}
+     *
+     * @return void
+     */
+    public function testGetCandidatesCandidVisitRecordingsEdfFileMetadataHeadername(): void
+    {
+        $response = $this->client->request(
+            'GET',
+            "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/metadata/$this->headernameTest",
+            [
+                'http_errors' => false,
+                'headers'     => $this->headers
+            ]
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+        $recordingsArray = json_decode(
+            (string) utf8_encode(
+                $response->getBody()->getContents()
+            ),
+            true
+        );
+
+        $this->assertSame(gettype($recordingsArray), 'array');
+
+        $this->assertArrayHasKey('Meta', $recordingsArray);
+        $meta = $recordingsArray['Meta'];
+        $this->assertSame(gettype($meta), 'array');
+
+        $this->assertArrayHasKey('CandID', $meta);
+        $this->assertSame(gettype($meta['CandID']), 'string');
+        $this->assertArrayHasKey('Visit', $meta);
+        $this->assertSame(gettype($meta['Visit']), 'string');
+        $this->assertArrayHasKey('Filename', $meta);
+        $this->assertSame(gettype($meta['Filename']), 'string');
+        $this->assertArrayHasKey('Header', $meta);
+        $this->assertSame(gettype($meta['Header']), 'string');
+
+        $this->assertArrayHasKey('Value', $recordingsArray);
+        $this->assertSame(gettype($recordingsArray['Value']), 'string');
     }
 
     /**
@@ -306,192 +404,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
 
     /**
      * Tests the HTTP GET request for the
-     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/channels/meta
-     *
-     * @return void
-     */
-    public function testGetCandidatesCandidVisitRecordingsEdffileChannelsMeta():
-    void
-    {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
-        $response = $this->client->request(
-            'GET',
-            "candidates/$this->candidTest/$this->visitTest/recordings/" .
-            "$this->frecordTest/channels/meta",
-            [
-                'http_errors' => false,
-                'headers'     => $this->headers
-            ]
-        );
-        $this->assertEquals(200, $response->getStatusCode());
-        // Verify the endpoint has a body
-        $body = $response->getBody();
-        $this->assertNotEmpty($body);
-
-        $recChannelsMetaArray = json_decode(
-            (string) utf8_encode(
-                $response->getBody()->getContents()
-            ),
-            true
-        );
-
-        $this->assertSame(
-            gettype($recChannelsMetaArray),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']['CandID']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']['Visit']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['ChannelName']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['ChannelDescription']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype(
-                $recChannelsMetaArray['Channels']['0']['ChannelTypeDescription']
-            ),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['ChannelStatus']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['StatusDescription']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['SamplingFrequency']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['LowCutoff']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['HighCutoff']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['ManualFlag']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['Notch']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['Reference']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['Unit']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Channels']['0']['ChannelFilePath']),
-            'string'
-        );
-
-        $this->assertArrayHasKey(
-            'Meta',
-            $recChannelsMetaArray
-        );
-        $this->assertArrayHasKey(
-            'CandID',
-            $recChannelsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'Visit',
-            $recChannelsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'Channels',
-            $recChannelsMetaArray
-        );
-        $this->assertArrayHasKey(
-            '0',
-            $recChannelsMetaArray['Channels']
-        );
-        $this->assertArrayHasKey(
-            'ChannelName',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'ChannelDescription',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'ChannelTypeDescription',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'ChannelStatus',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'StatusDescription',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'SamplingFrequency',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'LowCutoff',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'HighCutoff',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'ManualFlag',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'Notch',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'Reference',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'Unit',
-            $recChannelsMetaArray['Channels']['0']
-        );
-        $this->assertArrayHasKey(
-            'ChannelFilePath',
-            $recChannelsMetaArray['Channels']['0']
-        );
-    }
-
-    /**
-     * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/electrodes
      *
      * @return void
@@ -630,150 +542,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
         $this->assertArrayHasKey(
             'ElectrodeFilePath',
             $recChannelsArray['Electrodes']['0']
-        );
-    }
-
-    /**
-     * Tests the HTTP GET request for the
-     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/electrodes/meta
-     *
-     * @return void
-     */
-    public function testGetCandidatesCandidVisitRecordingsEdfFileElectrodesMeta():
-    void
-    {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
-        $response = $this->client->request(
-            'GET',
-            "candidates/$this->candidTest/$this->visitTest/recordings/" .
-            "$this->frecordTest/electrodes/meta",
-            [
-                'http_errors' => false,
-                'headers'     => $this->headers
-            ]
-        );
-        $this->assertEquals(200, $response->getStatusCode());
-        // Verify the endpoint has a body
-        $body = $response->getBody();
-        $this->assertNotEmpty($body);
-
-        $recChannelsMetaArray = json_decode(
-            (string) utf8_encode(
-                $response->getBody()->getContents()
-            ),
-            true
-        );
-
-        $this->assertSame(
-            gettype($recChannelsMetaArray),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']['CandID']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Meta']['Visit']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['ElectrodeName']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['ElectrodeType']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['ElectrodeMaterial']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['X']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['Y']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['Z']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['Impedance']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recChannelsMetaArray['Electrodes']['0']['ElectrodeFilePath']),
-            'string'
-        );
-
-        $this->assertArrayHasKey(
-            'Meta',
-            $recChannelsMetaArray
-        );
-        $this->assertArrayHasKey(
-            'CandID',
-            $recChannelsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'Visit',
-            $recChannelsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'Electrodes',
-            $recChannelsMetaArray
-        );
-        $this->assertArrayHasKey(
-            '0',
-            $recChannelsMetaArray['Electrodes']
-        );
-        $this->assertArrayHasKey(
-            'ElectrodeName',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'ElectrodeType',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'ElectrodeMaterial',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'X',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'Y',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'Z',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'Impedance',
-            $recChannelsMetaArray['Electrodes']['0']
-        );
-        $this->assertArrayHasKey(
-            'ElectrodeFilePath',
-            $recChannelsMetaArray['Electrodes']['0']
         );
     }
 
@@ -919,147 +687,52 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
             $recordingsEventsArray['TaskEvents']['0']
         );
     }
-
+    
     /**
+     * TODO
      * Tests the HTTP GET request for the
-     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/events/meta
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/archive
      *
      * @return void
      */
-    public function testGetCandidatesCandidVisitRecordingsEdfFileEventsMeta(): void
+    public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesArchive(): void
     {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
-        $response = $this->client->request(
-            'GET',
-            "candidates/$this->candidTest/$this->visitTest/recordings/" .
-            "$this->frecordTest/events/meta",
-            [
-                'http_errors' => false,
-                'headers'     => $this->headers
-            ]
-        );
-        $this->assertEquals(200, $response->getStatusCode());
-        // Verify the endpoint has a body
-        $body = $response->getBody();
-        $this->assertNotEmpty($body);
+        $this->markTestSkipped("Not ready");
+    }
 
-        $recordingsEventsMetaArray = json_decode(
-            (string) utf8_encode(
-                $response->getBody()->getContents()
-            ),
-            true
-        );
+    /**
+     * TODO
+     * Tests the HTTP GET request for the
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/channels
+     *
+     * @return void
+     */
+    public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesChannels(): void
+    {
+        $this->markTestSkipped("Not ready");
+    }
 
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['Meta']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['Meta']['CandID']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['Meta']['Visit']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']),
-            'array'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['Onset']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['Duration']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['EventCode']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['EventSample']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['EventType']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['TrialType']),
-            'string'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['ResponseTime']),
-            'NULL'
-        );
-        $this->assertSame(
-            gettype($recordingsEventsMetaArray['TaskEvents']['0']['EventFilePath']),
-            'string'
-        );
+    /**
+     * TODO
+     * Tests the HTTP GET request for the
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/electrodes
+     *
+     * @return void
+     */
+    public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesElectrodes(): void
+    {
+        $this->markTestSkipped("Not ready");
+    }
 
-        $this->assertArrayHasKey(
-            'Meta',
-            $recordingsEventsMetaArray
-        );
-        $this->assertArrayHasKey(
-            'CandID',
-            $recordingsEventsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'Visit',
-            $recordingsEventsMetaArray['Meta']
-        );
-        $this->assertArrayHasKey(
-            'TaskEvents',
-            $recordingsEventsMetaArray
-        );
-        $this->assertArrayHasKey(
-            '0',
-            $recordingsEventsMetaArray['TaskEvents']
-        );
-        $this->assertArrayHasKey(
-            'Onset',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'Duration',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'EventCode',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'EventSample',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'EventType',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'TrialType',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'ResponseTime',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
-        $this->assertArrayHasKey(
-            'EventFilePath',
-            $recordingsEventsMetaArray['TaskEvents']['0']
-        );
+    /**
+     * TODO
+     * Tests the HTTP GET request for the
+     * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/events
+     *
+     * @return void
+     */
+    public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesEvents(): void
+    {
+        $this->markTestSkipped("Not ready");
     }
 }

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -35,9 +35,9 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordings(): void
     {
-            $this->markTestIncomplete(
-              "rewrite after #8036 [EEG] Database Architecture for HED Tags"
-            );
+        $this->markTestIncomplete(
+            "rewrite after #8036 [EEG] Database Architecture for HED Tags"
+        );
         $response = $this->client->request(
             'GET',
             "candidates/$this->candidTest/$this->visitTest/recordings",
@@ -125,7 +125,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
 
     /**
-     * TODO: validate test
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/metadata
      *
@@ -175,7 +174,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
 
     /**
-     * TODO: validate test + header name value
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/metadata/{headername}
      *
@@ -229,13 +227,12 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdffileChannels(): void
     {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
+            // $this->markTestIncomplete(
+            //   "rewrite"
+            // );
         $response = $this->client->request(
             'GET',
-            "candidates/$this->candidTest/$this->visitTest/" .
-            "recordings/$this->frecordTest/channels",
+            "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/channels",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers
@@ -414,13 +411,12 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileElectrodes(): void
     {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
+            // $this->markTestIncomplete(
+            //   "rewrite"
+            // );
         $response = $this->client->request(
             'GET',
-            "candidates/$this->candidTest/$this->visitTest/recordings/" .
-            "$this->frecordTest/electrodes",
+            "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/electrodes",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers
@@ -557,13 +553,12 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileEvents(): void
     {
-            $this->markTestIncomplete(
-              "rewrite"
-            );
+            // $this->markTestIncomplete(
+            //   "rewrite"
+            // );
         $response = $this->client->request(
             'GET',
-            "candidates/$this->candidTest/$this->visitTest/recordings/" .
-            "$this->frecordTest/events/meta",
+            "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/events",
             [
                 'http_errors' => false,
                 'headers'     => $this->headers
@@ -693,7 +688,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
     
     /**
-     * TODO
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/archive
      *
@@ -733,7 +727,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
 
     /**
-     * TODO
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/channels
      *
@@ -773,7 +766,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
 
     /**
-     * TODO
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/electrodes
      *
@@ -813,7 +805,6 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     }
 
     /**
-     * TODO
      * Tests the HTTP GET request for the
      * endpoint /candidates/{candid}/{visit}/recordings/{edffile}/bidsfiles/events
      *

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -21,7 +21,7 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
     protected $frecordTest         = "sub-OTT174_ses-V1_task-faceO_eeg.edf";
     protected $candidTest          = "300174";
     protected $visitTest           = "V1";
-    protected $headernameTest      = "TODO";
+    protected $headernameTest      = "json_file";
     protected $fBIDSArchiveTest    = "archive_bids.tsv";
     protected $fBIDSChannelsTest   = "channels_bids.tsv";
     protected $fBIDSElectrodesTest = "electrodes_bids.tsv";

--- a/raisinbread/test/api/LorisApiRecordingsTest.php
+++ b/raisinbread/test/api/LorisApiRecordingsTest.php
@@ -18,10 +18,14 @@ require_once __DIR__ . "/LorisApiAuthenticatedTest.php";
  */
 class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
 {
-    protected $frecordTest     = "sub-OTT174_ses-V1_task-faceO_eeg.edf";
-    protected $candidTest      = "300174";
-    protected $visitTest       = "V1";
-    protected $headernameTest  = "TODO";
+    protected $frecordTest         = "sub-OTT174_ses-V1_task-faceO_eeg.edf";
+    protected $candidTest          = "300174";
+    protected $visitTest           = "V1";
+    protected $headernameTest      = "TODO";
+    protected $fBIDSArchiveTest    = "archive_bids.tsv";
+    protected $fBIDSChannelsTest   = "channels_bids.tsv";
+    protected $fBIDSElectrodesTest = "electrodes_bids.tsv";
+    protected $fBIDSEventsTest     = "events_bids.tsv";
 
     /**
      * Tests the HTTP GET request for the
@@ -697,7 +701,35 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesArchive(): void
     {
-        $this->markTestSkipped("Not ready");
+        try {
+            $resource = \GuzzleHttp\Psr7\Utils::tryFopen($this->fBIDSArchiveTest, 'w');
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "File cannot be opened: " . $this->fBIDSArchiveTest
+            );
+        }
+        $stream   = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        try {
+            $response = $this->client->request(
+                'GET',
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+                [
+                    'headers' => $this->headers,
+                    'save_to' => $stream
+                ]
+            );
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "Endpoint not found: " .
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+            );
+        }
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $this->assertFileIsReadable($this->fBIDSArchiveTest);
     }
 
     /**
@@ -709,7 +741,35 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesChannels(): void
     {
-        $this->markTestSkipped("Not ready");
+        try {
+            $resource = \GuzzleHttp\Psr7\Utils::tryFopen($this->fBIDSChannelsTest, 'w');
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "File cannot be opened: " . $this->fBIDSChannelsTest
+            );
+        }
+        $stream   = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        try {
+            $response = $this->client->request(
+                'GET',
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+                [
+                    'headers' => $this->headers,
+                    'save_to' => $stream
+                ]
+            );
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "Endpoint not found: " .
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+            );
+        }
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $this->assertFileIsReadable($this->fBIDSChannelsTest);
     }
 
     /**
@@ -721,7 +781,35 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesElectrodes(): void
     {
-        $this->markTestSkipped("Not ready");
+        try {
+            $resource = \GuzzleHttp\Psr7\Utils::tryFopen($this->fBIDSElectrodesTest, 'w');
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "File cannot be opened: " . $this->fBIDSElectrodesTest
+            );
+        }
+        $stream   = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        try {
+            $response = $this->client->request(
+                'GET',
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+                [
+                    'headers' => $this->headers,
+                    'save_to' => $stream
+                ]
+            );
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "Endpoint not found: " .
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+            );
+        }
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $this->assertFileIsReadable($this->fBIDSElectrodesTest);
     }
 
     /**
@@ -733,6 +821,34 @@ class LorisApiRecordingsTest extends LorisApiAuthenticatedTest
      */
     public function testGetCandidatesCandidVisitRecordingsEdfFileBidsfilesEvents(): void
     {
-        $this->markTestSkipped("Not ready");
+        try {
+            $resource = \GuzzleHttp\Psr7\Utils::tryFopen($this->fBIDSEventsTest, 'w');
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "File cannot be opened: " . $this->fBIDSEventsTest
+            );
+        }
+        $stream   = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        try {
+            $response = $this->client->request(
+                'GET',
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+                [
+                    'headers' => $this->headers,
+                    'save_to' => $stream
+                ]
+            );
+        } catch (Exception $e) {
+            $this->markTestIncomplete(
+                "Endpoint not found: " .
+                "candidates/$this->candidTest/$this->visitTest/recordings/$this->frecordTest/bidsfiles/archive",
+            );
+        }
+        $this->assertEquals(200, $response->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response->getBody();
+        $this->assertNotEmpty($body);
+
+        $this->assertFileIsReadable($this->fBIDSEventsTest);
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Update the metadata recording endpoints:
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/metadata`
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/metadata/{headername}`
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/bidsfiles/archive`
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/bidsfiles/channels`
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/bidsfiles/electrodes`
- [x] `/candidates/{candid}/{visit}/recordings/{filename}/bidsfiles/events`

#### Link(s) to related issue(s)

#8616
