### PR TITLE
[MRI violations] Fix multiple rows for file protocol violations not resolvable

### DIFF
--- a/modules/mri_violations/php/provisioner.class.inc
+++ b/modules/mri_violations/php/provisioner.class.inc
@@ -93,7 +93,7 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                            PhaseEncodingDirection,EchoTime,EchoNumber
                          )
                        ) AS hash,
-                       mrl.LogID AS join_id,
+                       MIN(mrl.LogID) AS join_id,
                        p.CenterID AS Site,
                        COALESCE(
                          violations_resolved.Resolved, 'unresolved'
@@ -112,6 +112,9 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                   mrl.Visit_label = s.Visit_label AND mrl.CandID=s.CandID
                 )
                 LEFT JOIN psc p ON (p.CenterID = s.CenterID)
+                GROUP BY PatientName, TimeRun, Project, Cohort, MincFile,
+                  Scan_type, SeriesUID, Site, hash, Resolved, TarchiveID,
+                  CandID, PSCID
               UNION
                   SELECT PatientName,
                          TimeRun,

--- a/modules/mri_violations/php/resolve.class.inc
+++ b/modules/mri_violations/php/resolve.class.inc
@@ -107,26 +107,10 @@ class Resolve extends \NDB_Page
             if (!empty($ID_mri_protocol_violated_scans)) {
                 $newlyResolved['TypeTable'] = 'mri_protocol_violated_scans';
                 $newlyResolved['ExtID']     = $ID_mri_protocol_violated_scans;
+                $DB->insert('violations_resolved', $newlyResolved);
             }
 
-            // Table 2: mri_violations_log
-            $ID_mri_violations_log = $DB->pselectOne(
-                "SELECT LogID
-                FROM mri_violations_log
-                WHERE (:hash = md5(concat_WS(
-                                ':',MincFile,PatientName,SeriesUID,TimeRun,
-                                PhaseEncodingDirection,EchoTime,EchoNumber)
-                               )
-                )",
-                ['hash' => $hash]
-            );
-
-            if (!empty($ID_mri_violations_log)) {
-                $newlyResolved['TypeTable'] = 'mri_violations_log';
-                $newlyResolved['ExtID']     = $ID_mri_violations_log;
-            }
-
-            // Table 3: MRICandidateErrors
+            // Table 2: MRICandidateErrors
             $ID_MRICandidateErrors = $DB->pselectOne(
                 "SELECT ID
                 FROM MRICandidateErrors
@@ -141,8 +125,27 @@ class Resolve extends \NDB_Page
             if (!empty($ID_MRICandidateErrors)) {
                 $newlyResolved['TypeTable'] = 'MRICandidateErrors';
                 $newlyResolved['ExtID']     = $ID_MRICandidateErrors;
+                $DB->insert('violations_resolved', $newlyResolved);
             }
-            $DB->insert('violations_resolved', $newlyResolved);
+
+            // Table 3: mri_violations_log
+            $mri_violations_log_ID_list = $DB->pselect(
+                "SELECT LogID
+                FROM mri_violations_log
+                WHERE (:hash = md5(concat_WS(
+                                ':',MincFile,PatientName,SeriesUID,TimeRun,
+                                PhaseEncodingDirection,EchoTime,EchoNumber)
+                               )
+                )",
+                ['hash' => $hash]
+            );
+            error_log(print_r($mri_violations_log_ID_list, true));
+
+            foreach ($mri_violations_log_ID_list as $entry) {
+                $newlyResolved['TypeTable'] = 'mri_violations_log';
+                $newlyResolved['ExtID']     = $entry['LogID'];
+                $DB->insert('violations_resolved', $newlyResolved);
+            }
 
             // Created
             $response = $response->withStatus(201);

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -386,12 +386,12 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             ]
         );
         $this->safeGet($this->url . '/dashboard/');
-        // Raisin bread has 173 unresolved violated scans. We are adding three
-        // in setup(): one resolved, and two unresolved. The total
-        // number of unresolved violations is thus 175
+        // Raisin bread has 169 unique unresolved violated scans. We are adding
+        // three in setup(): one resolved, and two unresolved. The total
+        // number of unresolved violations is thus 172
         $this->_testMytaskPanelAndLink(
             ".mri_violations",
-            "175",
+            "172",
             "- MRI Violated Scans"
         );
         $this->resetPermissions();


### PR DESCRIPTION
## Brief summary of changes

This fixes a bug where the violation could not be resolved when there is more than one `Protocol Violation` returned for a file/timerun combination. The fixes include the following:
- only show one row per pname/timeRun/mincFile/scanType in the main menu filter table when there are multiple `Protocol Violation` for a given file (the list of violations will be displayed when clicking on the `Protocol Violation` link.
- when selecting a resolution, loop through all entries in `mri_violations_log` matching the `timeRun/mincFile` and update the resolution status for all matching entries in the `violations_resolved` table.

#### Testing instructions 

For the raisinbread dataset, the following images match what this PR is fixing: 
- `assembly/300170/V1/mri/native/demo_300170_V1_dwi65_001.mnc`
- `assembly/300170/V1/mri/native/demo_300170_V1_dwi25_001.mnc`

In current 25 code, should see two rows displayed in the main menu filter with the same content for the example images listed above and it should not be possible to save the resolution status for those files.

In code pulled from this PR, only one row per file will be displayed in the main menu filter and the resolution status will save. Look into the violations_resolved table and you should see 2 entries added for the file that was resolved.

#### Link(s) to related issue(s)

* Resolves #8626