### PR TITLE
[MRI violations] Fix hashing of MRI violation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ Now the options correctly display in order of how they are defined in the instru
 #### Dashboard
 - Reactification (PR #8476)
 
+#### MRI violation
+- Reactification (PR #7473)
+- Fixes links to BrainBrowser from the MRI violations module (PR #8392)
+- Remove MRI violation module tabs (PR #8399)
+- Fix multiple rows for file protocol violations not resolvable (PR #8661)
+- Fix hashing algorithm for `violations_resolved` table's `hash` column (PR #8664)
+
 #### Statistics
 - Reactification (PR #8476)
 
@@ -105,6 +112,10 @@ SQL schema, and automated testing (PR #8313)
 - API: Modified in v0.0.4-dev the candidate instrument data format returned by a GET request or
 provided as the body of a PUT/PATCH request. The values of all fields are now defined by
 the `Data` key instead of `$InstrumentName` (PR #7857)
+- Run the script `tools/single_use/update_violations_resolved_hashes.sql.php` to update hashes
+  for the `violations_resolved` table according to the new hashing nomenclature. Not doing so 
+  will result in duplication of data in the `violations_resolved` table when users update
+  a resolution status for a violation.
 
 ### Notes For Developers
 - Require jsodc comments to have correct `@return` and `@param` values in javascript (PR #8266)

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -940,6 +940,8 @@ CREATE TABLE `MRICandidateErrors` (
   `PatientName` varchar(255) DEFAULT NULL,
   `Reason` varchar(255) DEFAULT NULL,
   `EchoTime` double DEFAULT NULL,
+  `PhaseEncodingDirection` VARCHAR(3)  DEFAULT NULL,
+  `EchoNumber`             VARCHAR(20) DEFAULT NULL,
   PRIMARY KEY (`ID`),
   CONSTRAINT `FK_tarchive_MRICandidateError_1`
     FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`)

--- a/SQL/New_patches/2023-04-24_add_phase_enc_dir_and_echo_number_to_MRICandidateErrors.sql
+++ b/SQL/New_patches/2023-04-24_add_phase_enc_dir_and_echo_number_to_MRICandidateErrors.sql
@@ -1,0 +1,5 @@
+-- ---------------------------------------------------------------------------------------------
+-- alter MRICandidateErrors table to add PhaseEncodingDirection and EchoNumber
+-- ---------------------------------------------------------------------------------------------
+ALTER TABLE MRICandidateErrors ADD COLUMN `PhaseEncodingDirection` VARCHAR(3)  DEFAULT NULL;
+ALTER TABLE MRICandidateErrors ADD COLUMN `EchoNumber`             VARCHAR(20) DEFAULT NULL;

--- a/modules/mri_violations/php/provisioner.class.inc
+++ b/modules/mri_violations/php/provisioner.class.inc
@@ -55,7 +55,8 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                        SeriesUID,
                        md5(
                          concat_WS(
-                           ':',minc_location,PatientName,SeriesUID,time_run
+                           ':',minc_location,PatientName,SeriesUID,time_run,
+                           PhaseEncodingDirection,EchoTime,EchoNumber
                          )
                        ) AS hash,
                        mpvs.ID AS join_id,
@@ -87,7 +88,10 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                        'Protocol Violation',
                        SeriesUID,
                        md5(
-                         concat_WS(':', MincFile, PatientName, SeriesUID, TimeRun)
+                         concat_WS(
+                           ':', MincFile, PatientName, SeriesUID, TimeRun,
+                           PhaseEncodingDirection,EchoTime,EchoNumber
+                         )
                        ) AS hash,
                        mrl.LogID AS join_id,
                        p.CenterID AS Site,
@@ -118,7 +122,10 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                          Reason,
                          SeriesUID,
                          md5(
-                           concat_WS(':', MincFile, PatientName, SeriesUID, TimeRun)
+                           concat_WS(
+                             ':', MincFile, PatientName, SeriesUID, TimeRun,
+                             PhaseEncodingDirection,EchoTime,EchoNumber
+                           )
                          ) AS hash,
                          MRICandidateErrors.ID AS join_id,
                          null,

--- a/modules/mri_violations/php/provisioner.class.inc
+++ b/modules/mri_violations/php/provisioner.class.inc
@@ -56,7 +56,7 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                        md5(
                          concat_WS(
                            ':',minc_location,PatientName,SeriesUID,time_run,
-                           PhaseEncodingDirection,EchoTime,EchoNumber
+                           PhaseEncodingDirection,TE_range,EchoNumber
                          )
                        ) AS hash,
                        mpvs.ID AS join_id,

--- a/modules/mri_violations/php/resolve.class.inc
+++ b/modules/mri_violations/php/resolve.class.inc
@@ -98,7 +98,8 @@ class Resolve extends \NDB_Page
                 "SELECT ID
                 FROM mri_protocol_violated_scans
                 WHERE (:hash = md5(concat_WS(
-                          ':',minc_location,PatientName,SeriesUID,time_run)
+                          ':',minc_location,PatientName,SeriesUID,time_run,
+                                PhaseEncodingDirection,EchoTime,EchoNumber)
                                )
                 )",
                 ['hash' => $hash]
@@ -113,7 +114,8 @@ class Resolve extends \NDB_Page
                 "SELECT LogID
                 FROM mri_violations_log
                 WHERE (:hash = md5(concat_WS(
-                                ':',MincFile,PatientName,SeriesUID,TimeRun)
+                                ':',MincFile,PatientName,SeriesUID,TimeRun,
+                                PhaseEncodingDirection,EchoTime,EchoNumber)
                                )
                 )",
                 ['hash' => $hash]
@@ -129,7 +131,8 @@ class Resolve extends \NDB_Page
                 "SELECT ID
                 FROM MRICandidateErrors
                 WHERE (:hash = md5(concat_WS(
-                                ':',MincFile,PatientName,SeriesUID,TimeRun)
+                                ':',MincFile,PatientName,SeriesUID,TimeRun,
+                                PhaseEncodingDirection,EchoTime,EchoNumber)
                                )
                 )",
                 ['hash' => $hash]

--- a/modules/mri_violations/php/resolve.class.inc
+++ b/modules/mri_violations/php/resolve.class.inc
@@ -99,7 +99,7 @@ class Resolve extends \NDB_Page
                 FROM mri_protocol_violated_scans
                 WHERE (:hash = md5(concat_WS(
                           ':',minc_location,PatientName,SeriesUID,time_run,
-                                PhaseEncodingDirection,EchoTime,EchoNumber)
+                                PhaseEncodingDirection,TE_range,EchoNumber)
                                )
                 )",
                 ['hash' => $hash]

--- a/tools/single_use/update_violations_resolved_hashes.sql.php
+++ b/tools/single_use/update_violations_resolved_hashes.sql.php
@@ -41,7 +41,9 @@ foreach ($resolvedViolationsList as $violationArr) {
 /**
  * Selects all violations resolved and new hash.
  *
- * @return array of seriesUID without Scan_type set in mri_violations_log
+ * @param Database $db database handler
+ *
+ * @return array of violation resolved and new hash details
  * @throws DatabaseException
  */
 function selectViolationsResolved($db)

--- a/tools/single_use/update_violations_resolved_hashes.sql.php
+++ b/tools/single_use/update_violations_resolved_hashes.sql.php
@@ -1,0 +1,88 @@
+<?php
+
+
+
+/**
+ * This script is written for a one time use only to update the hashes
+ * stored in the violations_resolved table with proper hashes that
+ * use the PhaseEncodingDirection, EchoNumber and EchoTime fields in
+ * addition to the SeriesUID and TimeRun to create the hashes.
+ *
+ * This script updates the hash field violations_resolved based on the
+ * hash produced by the combo of SeriesUID/EchoNumber/EchoTime/TimeRun
+ * for each resolved violations.
+ *
+ * affected table:
+ * - violations_resolved
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
+ * @license  Loris license
+ * @link     https://github.com/aces/Loris
+ */
+require_once __DIR__ . '/../generic_includes.php';
+
+// select all violations resolved with new hash from violations_resolved
+// on table mri_protocol_violated_scans
+$db = $lorisInstance->getDatabaseConnection();
+$resolvedViolationsList = selectViolationsResolved($db);
+// loop through all resolved violations and update the hash in violations_resolved
+foreach ($resolvedViolationsList as $violationArr) {
+    $db->update(
+        'violations_resolved',
+        ['hash' => $violationArr['new_hash']],
+        ['ID' => $violationArr['ViolResolvedID']]
+    );
+}
+
+/**
+ * Selects all violations resolved and new hash.
+ *
+ * @return array of seriesUID without Scan_type set in mri_violations_log
+ * @throws DatabaseException
+ */
+function selectViolationsResolved($db)
+{
+    $query = "(
+                SELECT vr.ID AS ViolResolvedID, hash, md5(
+                         concat_WS(
+                           ':',minc_location,PatientName,SeriesUID,time_run,
+                           PhaseEncodingDirection,TE_range,EchoNumber
+                         )
+                       ) AS new_hash
+                FROM mri_protocol_violated_scans AS mpvs
+                  JOIN violations_resolved vr ON (
+                    vr.ExtID=mpvs.ID
+                    AND vr.TypeTable='mri_protocol_violated_scans'
+                  )
+              ) UNION (
+                SELECT vr.ID AS ViolResolvedID, hash, md5(
+                         concat_WS(
+                           ':',MincFile,PatientName,SeriesUID,TimeRun,
+                           PhaseEncodingDirection,EchoTime,EchoNumber
+                         )
+                       ) AS new_hash
+                FROM mri_violations_log AS mvl
+                  JOIN violations_resolved vr ON (
+                    vr.ExtID=mvl.LogID
+                    AND vr.TypeTable='mri_violations_log'
+                  )
+              ) UNION (
+                SELECT vr.ID AS ViolResolvedID, hash, md5(
+                         concat_WS(
+                           ':',MincFile,PatientName,SeriesUID,TimeRun,
+                           PhaseEncodingDirection,EchoTime,EchoNumber
+                         )
+                       ) AS new_hash
+                FROM MRICandidateErrors AS mce
+                  JOIN violations_resolved vr ON (
+                    vr.ExtID=mce.ID
+                    AND vr.TypeTable='mri_violations_log'
+                  )
+              )";
+
+    return $db->pselect($query, []);
+}


### PR DESCRIPTION
## Brief summary of changes

In the MRI violation module, the hash generated for the violations_resolved table was created under the assumption that `SeriesUID` is enough to determine a unique image file. Unfortunately, this is not true anymore and multiple files with the same `SeriesUID` can be generated. The new unique criteria for a file is `SeriesUID/EchoTime/EchoNumber/PhaseEncodingDirection` combo. This PR:
- Updates the `MRICandidateErrors` table to add the missing columns `PhaseEncodingDirection` and `EchoNumber`
- Updates the MRI Violation module to use the new hashing algorithm for resolved violations:
```
md5(
  concat_WS(
     ':',MincFile,PatientName,SeriesUID,TimeRun,
     PhaseEncodingDirection,EchoTime,EchoNumber
)
```
- Add a single use tool script to run at the time of upgrade.

#### Testing instructions 

1. Check out the code from this PR
2. Save a previously violation resolved (A.K.A. not marked as `Unresolved`) with a different status than previous resolution status. Notice that instead of updating the existing row for the resolved violation, it inserts a new row in violations_resolved (resulting in two rows in the main menu filter for the same file with different resolution status)
3. Delete the added resolution status from the violations_resolved to clear out this entry that should not have been made
4. Run the `tools/single_use/update_violations_resolved_hashes.sql.php` script to save the new hashes
5. Save a violation previously resolved A.K.A. not marked as `Unresolved`) with a different status than previous resolution status. Notice that this time the correct entry has been updated and no new row has been inserted in `violations_resolved`

#### Link(s) to related issue(s)

* Resolves #8663 
