### PR TITLE
changed permision check to media_read to enable media downloads

### DIFF
--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -17,7 +17,7 @@
 $user =& User::singleton();
 //NOTE Should this be 'media_read' instead? It seems that downloading files
 //should be a read permission, not write.
-if (!$user->hasPermission('media_write')) {
+if (!$user->hasPermission('media_read')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }


### PR DESCRIPTION
## Brief summary of changes

 Changed permission check in filedownload.php so that files in the media widget download when the user has media_read permission.

https://github.com/aces/Loris/issues/8583


