### PR TITLE
[instruments] Fix properly disabling/enabling 'Delete instrument data' button display

### DIFF
--- a/modules/instruments/test/TestPlan.md
+++ b/modules/instruments/test/TestPlan.md
@@ -19,7 +19,8 @@ is correct.
 5. If the instrument has multiple pages (on the left pane), move from page to page and check that the
 saved data stays the same. The data that wasn't saved should be lost.
 6. Make sure that the 'Delete instrument data' button on the left pane is only visible when the user
-has the 'Send to DCC' permission.
+has the 'Send to DCC' permission, and the configuration `InstrumentResetting` (_"Instrument Resetting"_) is set to
+'Yes' in the Configuration module.
 7. Click on the 'Delete instrument data' button and check if the instrument's data is cleared.
 8. Select a candidate with a Date Of Death (DoD) or put one in for a candidate as needed, then select an
 instrument for that candidate. Enter a date (same a step 4) posterior to the DoD. Refresh the page and check that the 

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -143,7 +143,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                 $this->tpl_data['access']['validity'] = $this->_displayValidity();
             }
 
-            if ($config->getSetting('InstrumentResetting')
+            if ($config->settingEnabled('InstrumentResetting')
                 && $this->getDataEntryStatus() != 'Complete'
             ) {
                 $user = User::singleton();


### PR DESCRIPTION
## Brief summary of changes

Currently, if the 'InstrumentResetting' config is set to 'No', the 'Delete instrument data' button is displayed and the user is able to clear the instrument. This PR fixes that by letting the if statement check a true boolean instead of string "true" by calling 'settingEnabled'. The PR also modifies the testing plan so this is tested in the future.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
