### PR TITLE
[instruments] Fix LINST metadata fields not in data dictionary

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -85,18 +85,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         $this->dateOptions = $dateOptions;
 
         $this->addBasicDate('Date_taken', 'Date of Administration', $dateOptions);
-        $this->dictionary = array_merge(
-            $this->dictionary,
-            [
-                new DictionaryItem(
-                    $this->testName.'_Date_taken',
-                    'Date of Administration',
-                    $scope,
-                    new \LORIS\Data\Types\DateType(),
-                    new Cardinality(Cardinality::SINGLE),
-                ),
-            ]
-        );
 
         if (strrpos($this->testName ?? '', '_proband') === false) {
             if (!$this->postMortem) {
@@ -104,52 +92,15 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     'Candidate_Age',
                     'Candidate Age (Months)'
                 );
-                $this->dictionary = array_merge(
-                    $this->dictionary,
-                    [
-                        new DictionaryItem(
-                            $this->testName.'_Candidate_Age',
-                            'Candidate Age (Months)',
-                            $scope,
-                            new \LORIS\Data\Types\Duration(),
-                            new Cardinality(Cardinality::SINGLE),
-                        ),
-                    ]
-                );
-
             } else {
                 $this->addScoreColumn(
                     'Candidate_Age',
                     'Candidate Age at Death (Months)'
                 );
-                $this->dictionary = array_merge(
-                    $this->dictionary,
-                    [
-                        new DictionaryItem(
-                            $this->testName.'_Candidate_Age',
-                            'Candidate Age at Death (Months)',
-                            $scope,
-                            new \LORIS\Data\Types\Duration(),
-                            new Cardinality(Cardinality::SINGLE),
-                        ),
-                    ]
-                );
             }
             $this->addScoreColumn(
                 'Window_Difference',
                 'Window Difference (+/- Days)'
-            );
-            $this->dictionary = array_merge(
-                $this->dictionary,
-                [
-                    new DictionaryItem(
-                        $this->testName.'_Window_Difference',
-                        'Window difference from test battery (days)',
-                        $scope,
-                        new \LORIS\Data\Types\Duration(),
-                        new Cardinality(Cardinality::SINGLE),
-                    ),
-                ]
             );
         }
         $examiners = $this->_getExaminerNames();
@@ -162,22 +113,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         );
 
         $this->addRule('Examiner', 'Examiner is required', 'required');
-
-        $this->dictionary = array_merge(
-            $this->dictionary,
-            [
-                new DictionaryItem(
-                    $this->testName.'_Examiner',
-                    'Examiner',
-                    $scope,
-                    // This should be an enum of examiners, but
-                    // getExaminerNames currently returns an empty
-                    // array if CommentID is not set.
-                    new StringType(255),
-                    new Cardinality(Cardinality::SINGLE),
-                ),
-            ]
-        );
     }
 
     /**
@@ -558,6 +493,74 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         );
                         $this->_addMetadataFields();
                     }
+                    $this->dictionary = array_merge(
+                        $this->dictionary,
+                        [
+                            new DictionaryItem(
+                                $this->testName.'_Date_taken',
+                                'Date of Administration',
+                                $scope,
+                                new \LORIS\Data\Types\DateType(),
+                                new Cardinality(Cardinality::SINGLE),
+                            ),
+                        ]
+                    );
+                    if (strrpos($this->testName ?? '', '_proband') === false) {
+                        if (!$this->postMortem) {
+                            $this->dictionary = array_merge(
+                                $this->dictionary,
+                                [
+                                    new DictionaryItem(
+                                        $this->testName.'_Candidate_Age',
+                                        'Candidate Age (Months)',
+                                        $scope,
+                                        new \LORIS\Data\Types\Duration(),
+                                        new Cardinality(Cardinality::SINGLE),
+                                    ),
+                                ]
+                            );
+                        } else {
+                            $this->dictionary = array_merge(
+                                $this->dictionary,
+                                [
+                                    new DictionaryItem(
+                                        $this->testName.'_Candidate_Age',
+                                        'Candidate Age at Death (Months)',
+                                        $scope,
+                                        new \LORIS\Data\Types\Duration(),
+                                        new Cardinality(Cardinality::SINGLE),
+                                    ),
+                                ]
+                            );
+                        }
+                        $this->dictionary = array_merge(
+                            $this->dictionary,
+                            [
+                                new DictionaryItem(
+                                    $this->testName.'_Window_Difference',
+                                    'Window difference from test battery (days)',
+                                    $scope,
+                                    new \LORIS\Data\Types\Duration(),
+                                    new Cardinality(Cardinality::SINGLE),
+                                ),
+                            ]
+                        );
+                    }
+                    $this->dictionary = array_merge(
+                        $this->dictionary,
+                        [
+                            new DictionaryItem(
+                                $this->testName.'_Examiner',
+                                'Examiner',
+                                $scope,
+                                // This should be an enum of examiners, but
+                                // getExaminerNames currently returns an empty
+                                // array if CommentID is not set.
+                                new StringType(255),
+                                new Cardinality(Cardinality::SINGLE),
+                            ),
+                        ]
+                    );
                     break;
                 case 'begingroup':
                     if ($addElements) {

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -71,8 +71,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         $factory = \NDB_Factory::singleton();
         $config  = $factory->config();
 
-        $scope = new Scope(Scope::SESSION);
-
         $dateOptions = [
             'language'         => 'en',
             'format'           => 'YMd',


### PR DESCRIPTION
## Brief summary of changes

Currently, the metadata fields are only defined in the LINST instrument's data dictionary for the 'top' page, causing an error when trying to access those fields' values from other subtests. This is happening because the data dictionary definition is being called only when the fields' input elements are being added to the page in `_addMetadataFields` function. This PR changes to logic to follow the data dictionary definition for all other fields which get called whether or not the fields' input element is being added to the current page i.e. outside of `if ($addElements) { }` block

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
