### PR TITLE
[NDB_BVL_Feedback] Fixing 500 error on instrument list page

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -489,7 +489,7 @@ class NDB_BVL_Feedback
         if (!empty($this->_feedbackObjectInfo['SessionID'])) {
             $query            .= " AND ft.SessionID = :SID";
             $qparams['SID']    = $this->_feedbackObjectInfo['SessionID'];
-            $timepoint         = Timepoint::singleton(
+            $timepoint         = TimePoint::singleton(
                 new SessionID($qparams['SID'])
             );
             $hasReadPermission = (
@@ -580,7 +580,7 @@ class NDB_BVL_Feedback
         } elseif (!empty($this->_feedbackObjectInfo['SessionID'])) {
             $query            .= " AND ft.SessionID = :SID AND ft.CommentID is null";
             $qparams['SID']    = $this->_feedbackObjectInfo['SessionID'];
-            $timepoint         = Timepoint::singleton(
+            $timepoint         = TimePoint::singleton(
                 new SessionID($qparams['SID'])
             );
             $hasReadPermission = (


### PR DESCRIPTION
A recent change (#7826) to the NDB_BVL_Feedback class causes the following 500 Error to appear when the instrument_list page is loaded. This is because references are made to `Timepoint::singleton` instead of `TimePoint::singleton`

<img width="724" alt="Screenshot 2023-05-10 at 18 40 45" src="https://github.com/aces/Loris/assets/35467361/7ed66ff9-3c0f-46ec-b4f0-6bf5429b4c61">


#### To replicate bug:

1. Checkout the branch aces/24.1-release, go to any candidate's page and click on a timepoint. When the instrument_list page loads, you should see an error both in the console and in your Apache log.

#### Testing:
1. Checkout this branch and go to any candidate's instrument list page. The error should no longer appear.

