### PR TITLE
[electrophysiology_browser] Event Panel title fix

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
@@ -142,8 +142,7 @@ const EventManager = ({
       >
         <p style={{margin: '0px'}}>
           <strong>
-            {`${epochType}s&nbsp;
-            (${visibleEpochsInRange.length}/${epochsInRange.length})`}
+            {`${epochType}s (${visibleEpochsInRange.length}/${epochsInRange.length})`}
           </strong>
           <span style={{fontSize: '0.75em'}}>
             <br />in timeline view [Total: {totalEpochs}]


### PR DESCRIPTION
Changed &nbsp to regular white space so that the Event Panel title renders correctly.

Closes #8690.