### PR TITLE
[candidate_list] fix error message not displaying if entered wrong IDs in the 'Open Profile' tab

### DIFF
--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -101,13 +101,13 @@ class ValidateIDs extends \NDB_Page
         {
             return (new \LORIS\Http\Response())
             ->withStatus(200)
-                ->withHeader("Content-Type", "text/plain")
-                ->withBody(new \LORIS\Http\StringStream('0'));
-                } finally {
+            ->withHeader("Content-Type", "text/plain")
+            ->withBody(new \LORIS\Http\StringStream('0'));
+        } finally {
             return (new \LORIS\Http\Response())
             ->withStatus(200)
-                ->withHeader("Content-Type", "text/plain")
-                ->withBody(new \LORIS\Http\StringStream('0'));
-                } 
+            ->withHeader("Content-Type", "text/plain")
+            ->withBody(new \LORIS\Http\StringStream('0'));
+        } 
     }
 }

--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -93,13 +93,13 @@ class ValidateIDs extends \NDB_Page
                 new CandID($gets['CandID']),
                 $gets['PSCID']
             ) ? "1" : "0";
-        } catch (\Exception $e) { 
+        } catch (\Exception $e) {
             $exists = "0";
         }
 
         return (new \LORIS\Http\Response())
-        ->withStatus(200)
-        ->withHeader("Content-Type", "text/plain")
-        ->withBody(new \LORIS\Http\StringStream($exists));
+            ->withStatus(200)
+            ->withHeader("Content-Type", "text/plain")
+            ->withBody(new \LORIS\Http\StringStream($exists));
     }
 }

--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -97,19 +97,17 @@ class ValidateIDs extends \NDB_Page
                 ->withStatus(200)
                 ->withHeader("Content-Type", "text/plain")
                 ->withBody(new \LORIS\Http\StringStream($exists));
-
         } catch (LorisException $e)
         {
             return (new \LORIS\Http\Response())
             ->withStatus(200)
-            ->withHeader("Content-Type", "text/plain")
-            ->withBody(new \LORIS\Http\StringStream('0'));
-        } finally {
+                ->withHeader("Content-Type", "text/plain")
+                ->withBody(new \LORIS\Http\StringStream('0'));
+                } finally {
             return (new \LORIS\Http\Response())
             ->withStatus(200)
-            ->withHeader("Content-Type", "text/plain")
-            ->withBody(new \LORIS\Http\StringStream('0'));
-        }
-        
+                ->withHeader("Content-Type", "text/plain")
+                ->withBody(new \LORIS\Http\StringStream('0'));
+                } 
     }
 }

--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -84,30 +84,22 @@ class ValidateIDs extends \NDB_Page
                 );
         }
 
-        // Return "0" or "1" based on whether it exists or not.
-        // We always return a 200 error code and not a 404, because
-        // even if the CandID doesn't exist or match, the validateids
-        // endpoint still exists and has a valid response.
         try {
+            // Return "0" or "1" based on whether it exists or not.
+            // We always return a 200 error code and not a 404, because
+            // even if the CandID doesn't exist or match, the validateids
+            // endpoint still exists and has a valid response.
             $exists = \Candidate::candidateExists(
-                new CandID(strval($gets['CandID'])),
+                new CandID($gets['CandID']),
                 $gets['PSCID']
             ) ? "1" : "0";
-            return (new \LORIS\Http\Response())
-                ->withStatus(200)
-                ->withHeader("Content-Type", "text/plain")
-                ->withBody(new \LORIS\Http\StringStream($exists));
-        } catch (LorisException $e)
-        {
-            return (new \LORIS\Http\Response())
-            ->withStatus(200)
-            ->withHeader("Content-Type", "text/plain")
-            ->withBody(new \LORIS\Http\StringStream('0'));
-        } finally {
-            return (new \LORIS\Http\Response())
-            ->withStatus(200)
-            ->withHeader("Content-Type", "text/plain")
-            ->withBody(new \LORIS\Http\StringStream('0'));
-        } 
+        } catch (\Exception $e) { 
+            $exists = "0";
+        }
+
+        return (new \LORIS\Http\Response())
+        ->withStatus(200)
+        ->withHeader("Content-Type", "text/plain")
+        ->withBody(new \LORIS\Http\StringStream($exists));
     }
 }

--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -88,14 +88,28 @@ class ValidateIDs extends \NDB_Page
         // We always return a 200 error code and not a 404, because
         // even if the CandID doesn't exist or match, the validateids
         // endpoint still exists and has a valid response.
-        $exists = \Candidate::candidateExists(
-            new CandID($gets['CandID']),
-            $gets['PSCID']
-        ) ? "1" : "0";
+        try {
+            $exists = \Candidate::candidateExists(
+                new CandID(strval($gets['CandID'])),
+                $gets['PSCID']
+            ) ? "1" : "0";
+            return (new \LORIS\Http\Response())
+                ->withStatus(200)
+                ->withHeader("Content-Type", "text/plain")
+                ->withBody(new \LORIS\Http\StringStream($exists));
 
-        return (new \LORIS\Http\Response())
+        } catch (LorisException $e)
+        {
+            return (new \LORIS\Http\Response())
             ->withStatus(200)
             ->withHeader("Content-Type", "text/plain")
-            ->withBody(new \LORIS\Http\StringStream($exists));
+            ->withBody(new \LORIS\Http\StringStream('0'));
+        } finally {
+            return (new \LORIS\Http\Response())
+            ->withStatus(200)
+            ->withHeader("Content-Type", "text/plain")
+            ->withBody(new \LORIS\Http\StringStream('0'));
+        }
+        
     }
 }


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Enter wrong PSCID & CandID

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
fixes #8590