### PR TITLE
Add an option to disable sortByValue on filter multiselects

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -74,6 +74,7 @@ function Filter(props) {
             element = (
               <SelectElement
                 options={filter.options}
+                sortByValue={filter.sortByValue}
                 multiple={true}
                 emptyOption={false}
               />


### PR DESCRIPTION
- adds a sortByValue option that can be set to false to disable the sortByValue default behaviour on multiselects.
- the sortByValue option is already available for selects
- set the default value to true to keep the default behaviour of the existing filters.