### PR TITLE
[LINST] Add .meta option to skip XIN rules

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -45,6 +45,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     protected $GroupElements = [];
 
     /**
+     * Do not require rules by default.
+     */
+    private $skipRules = false;
+
+    /**
      * Sets up the variables required for a LINST instrument to load
      *
      * @param string|null $commentID The CommentID being loaded
@@ -480,7 +485,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             }
             $this->formType = 'XIN';
 
-            $this->form->addFormRule([&$this, 'XINValidate']);
+            if (!$this->skipRules) {
+                $this->form->addFormRule([&$this, 'XINValidate']);
+            }
             $fp = fopen($filename, "r");
 
             // Add elements is only true if we're parsing the current page,
@@ -925,6 +932,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 break;
             case 'postmortem':
                 $this->postMortem = trim($pieces[1]) === 'true';
+                break;
+            case 'norules':
+                $this->skipRules = trim($pieces[1]) === 'true';
                 break;
             default:
                 break;


### PR DESCRIPTION
XIN rules default to requiring everything unless otherwise specified. This is not useful for all instruments (for instance, LINST files that are used to import data from other systems where we don't support their rule format) so this adds an option to disable the rules for an instrument in the .meta file.

#### Testing instructions (if applicable)

1. Add a `norules{@}true` line to a LINST file's corresponding .meta. Rules should no longer be enforced. 
