### PR TITLE
Fix "SELECT nonaggregated column error in mri_violation provisioner

### DIFF
--- a/modules/mri_violations/php/provisioner.class.inc
+++ b/modules/mri_violations/php/provisioner.class.inc
@@ -114,7 +114,7 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                 LEFT JOIN psc p ON (p.CenterID = s.CenterID)
                 GROUP BY PatientName, TimeRun, Project, Cohort, MincFile,
                   Scan_type, SeriesUID, Site, hash, Resolved, TarchiveID,
-                  CandID, PSCID
+                  CandID, PSCID, PhaseEncodingDirection, EchoTime, EchoNumber
               UNION
                   SELECT PatientName,
                          TimeRun,


### PR DESCRIPTION
Fix error

```
Syntax error or access violation: 1055 Expression #9 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test_dev_250.mrl.PhaseEncodingDirection' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

Fixes #8705, #8697