### PR TITLE
[Media] Fix Input callback not set

### DIFF
--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -183,7 +183,10 @@ class MediaEditForm extends Component {
             ref='hideFile'
             value={this.state.formData.hideFile}
           />
-          <ButtonElement label='Update File'/>
+          <ButtonElement 
+            label='Update File'
+            onUserInput = {() => {}}
+          />
         </FormElement>
       </div>
     );


### PR DESCRIPTION
## Brief summary of changes
Add a onUserInput prop to the "Update File" ButtonElement 

#### Testing instructions (if applicable)
1. Navigate to Media under Clinical in the menu with the media_write permission
2. In the Browse tab, click on Edit in the Edit Metadata column of a media's table row
3. Click Update File
4. Verify that warning "onUserInput() callback is not set" doesn't appear anymore

#### Link(s) to related issue(s)

* Resolves #8700
