### PR TITLE
[Media] Fix warning invalid prop options

### DIFF
--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -183,7 +183,6 @@ class MediaIndex extends Component {
     * queried columns in _setupVariables() in media.class.inc
     */
     const options = this.state.fieldOptions;
-    console.log(options);
     let fields = [
       {label: 'File Name', show: true, filter: {
         name: 'fileName',

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -103,7 +103,7 @@ class MediaIndex extends Component {
   formatColumn(column, cell, row) {
     cell = this.mapColumn(column, cell);
     // Set class to 'bg-danger' if file is hidden.
-    const style = (row['File Visibility'] === '1') ? 'bg-danger' : '';
+    const style = (row['File Visibility'] === 'hidden') ? 'bg-danger' : '';
     let result = <td className={style}>{cell}</td>;
     switch (column) {
     case 'File Name':
@@ -183,6 +183,7 @@ class MediaIndex extends Component {
     * queried columns in _setupVariables() in media.class.inc
     */
     const options = this.state.fieldOptions;
+    console.log(options);
     let fields = [
       {label: 'File Name', show: true, filter: {
         name: 'fileName',

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -118,8 +118,8 @@ class Media extends \DataFrameworkMenu
         $hiddenOptions = [];
         if (\User::singleton()->hasPermission('superuser')) {
             $hiddenOptions = [
-                0 => 'Visible only',
-                1 => 'Hidden only',
+                'visible' => 'Visible only',
+                'hidden'  => 'Hidden only',
             ];
         }
 

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -62,7 +62,10 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                		m.file_type as fileType,
                		s.CandID as candidateId,
                		s.ID as sessionId,
-               		m.hide_file as hideFile,
+                    CASE
+                        WHEN m.hide_file = 0 THEN 'visible'
+                        WHEN m.hide_file = 1 THEN 'hidden'
+                    END AS hideFile,
                		m.id
              FROM media m
              INNER JOIN session s ON m.session_id = s.ID


### PR DESCRIPTION
## Brief summary of changes

Update the prop option `hiddenOptions` for the `fileVisibility` SelectElement to be an object instead of an array.


#### Testing instructions (if applicable)

1. Select Clinical -> Media in the menu
2. Open console and warning below should not appear
![image](https://github.com/aces/Loris/assets/75381352/bb59c92d-09d2-4c39-8db3-923ed7801056)


#### Link(s) to related issue(s)

* Resolves #8696