### PR TITLE
[Timepoint List] Hide visits that are from user unaffiliated projects

### DIFF
--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -50,7 +50,7 @@ that widget (ie. the media module for CandID 587630 (DCC090) or CandID 300001 (M
 4. Ensure that, when the module which added the extra `CandidateInfo` terms
    is disabled, the terms from that module no longer show up in the
    `Candidate Info` card.
-5. Ensure that you cannot see visits from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
+5. Ensure that you can always only see visits from projects that you are affiliated with.
 
 All other widgets are part of other modules, and should be tested as
 part of that module's testing.

--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -50,7 +50,7 @@ that widget (ie. the media module for CandID 587630 (DCC090) or CandID 300001 (M
 4. Ensure that, when the module which added the extra `CandidateInfo` terms
    is disabled, the terms from that module no longer show up in the
    `Candidate Info` card.
-5. Ensure that you cannot access profiles from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
+5. Ensure that you cannot see visits from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
 
 All other widgets are part of other modules, and should be tested as
 part of that module's testing.

--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -50,6 +50,7 @@ that widget (ie. the media module for CandID 587630 (DCC090) or CandID 300001 (M
 4. Ensure that, when the module which added the extra `CandidateInfo` terms
    is disabled, the terms from that module no longer show up in the
    `Candidate Info` card.
+5. Ensure that you cannot access profiles from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
 
 All other widgets are part of other modules, and should be tested as
 part of that module's testing.

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -104,7 +104,9 @@ class Timepoint_List extends \NDB_Menu
             $listOfTimePoints = array_filter(
                 $listOfTimePoints,
                 function ($timePoint) use ($user) {
-                    return $timePoint->isAccessibleBy($user);
+                    return
+                    $timePoint->isAccessibleBy($user)
+                    && $user->hasProject($timePoint->getProjectID());
                 }
             );
         }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -105,8 +105,7 @@ class Timepoint_List extends \NDB_Menu
                 $listOfTimePoints,
                 function ($timePoint) use ($user) {
                     return
-                    $timePoint->isAccessibleBy($user)
-                    && $user->hasProject($timePoint->getProjectID());
+                    $timePoint->isAccessibleBy($user);
                 }
             );
         }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -99,7 +99,6 @@ class Timepoint_List extends \NDB_Menu
             },
             $listOfSessionIDs,
         );
-
         
         $listOfTimePoints = array_filter(
             $listOfTimePoints,

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -104,8 +104,7 @@ class Timepoint_List extends \NDB_Menu
             $listOfTimePoints = array_filter(
                 $listOfTimePoints,
                 function ($timePoint) use ($user) {
-                    return
-                    $timePoint->isAccessibleBy($user);
+                    return $timePoint->isAccessibleBy($user);
                 }
             );
         }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -99,7 +99,6 @@ class Timepoint_List extends \NDB_Menu
             },
             $listOfSessionIDs,
         );
-        
         $listOfTimePoints = array_filter(
             $listOfTimePoints,
             function ($timePoint) use ($user) {

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -100,14 +100,13 @@ class Timepoint_List extends \NDB_Menu
             $listOfSessionIDs,
         );
 
-        if ($user->hasPermission('access_all_profiles') === false) {
-            $listOfTimePoints = array_filter(
-                $listOfTimePoints,
-                function ($timePoint) use ($user) {
-                    return $timePoint->isAccessibleBy($user);
-                }
-            );
-        }
+        
+        $listOfTimePoints = array_filter(
+            $listOfTimePoints,
+            function ($timePoint) use ($user) {
+                return $timePoint->isAccessibleBy($user);
+            }
+        );
 
         /*
          * List of visits

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -5,7 +5,7 @@
     - For a candidate of a different site than your user, ensure that either 
         - `access_all_profiles` permission is required 
         - or that the candidate's registration site is the same as the user's site
-    - Ensure that you cannot access profiles from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
+    - Ensure that you cannot see visits from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
 2. **Action buttons** 
     - For a candidate of a different site than your user, attempt to access the timepoint list via the url. The page should load with a message of 'Permission Denied'.
     - For a candidate of the same site as your user, there should be up to 3 additional buttons:

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -5,7 +5,7 @@
     - For a candidate of a different site than your user, ensure that either 
         - `access_all_profiles` permission is required 
         - or that the candidate's registration site is the same as the user's site
-    - Ensure that you cannot see visits from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
+    - Ensure that you can always only see visits from projects that you are affiliated with.
 2. **Action buttons** 
     - For a candidate of a different site than your user, attempt to access the timepoint list via the url. The page should load with a message of 'Permission Denied'.
     - For a candidate of the same site as your user, there should be up to 3 additional buttons:

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -5,6 +5,7 @@
     - For a candidate of a different site than your user, ensure that either 
         - `access_all_profiles` permission is required 
         - or that the candidate's registration site is the same as the user's site
+    - Ensure that you cannot access profiles from projects that you are not affiliated with. This behaviour is still expected when you have permission `access_all_profiles`.
 2. **Action buttons** 
     - For a candidate of a different site than your user, attempt to access the timepoint list via the url. The page should load with a message of 'Permission Denied'.
     - For a candidate of the same site as your user, there should be up to 3 additional buttons:

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -664,14 +664,17 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $visitLabelArray = [];
 
         $candID = $this->getCandID();
+        $user = \User::singleton($_SESSION['State']->getUsername());
 
         // make a local reference to the Database object
         //
         $db = $factory->database();
 
-        $query  = "SELECT ID, Visit_label FROM session
+        $query  = "SELECT ID, Visit_label, ProjectID FROM session
             WHERE CandID=:Candidate AND Active='Y' ORDER BY ID";
         $result = $db->pselect($query, ['Candidate' => $candID]);
+
+        
 
         // map the array [VisitNo]=>Visit_label
         foreach ($result as $row) {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -664,17 +664,14 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $visitLabelArray = [];
 
         $candID = $this->getCandID();
-        $user = \User::singleton($_SESSION['State']->getUsername());
 
         // make a local reference to the Database object
         //
         $db = $factory->database();
 
-        $query  = "SELECT ID, Visit_label, ProjectID FROM session
+        $query  = "SELECT ID, Visit_label FROM session
             WHERE CandID=:Candidate AND Active='Y' ORDER BY ID";
         $result = $db->pselect($query, ['Candidate' => $candID]);
-
-        
 
         // map the array [VisitNo]=>Visit_label
         foreach ($result as $row) {


### PR DESCRIPTION
## Brief summary of changes

- Adjusted the Timepoint_List module to also filter out the visits of projects that are not affiliated to the current user when they have permission to all sites.
#### Testing instructions (if applicable)

1. Create a timepoint for a candidate for another project
2. Look at the candidate with a user that does not have permissions to that project
3. You should not see that timepoint
4. Confirm that visits with user affiliated projects do not disappear as well

#### Link(s) to related issue(s)

* Resolves #8710 

#### Example with user who does not have access to project Challah
**Before:**
<img width="952" alt="image" src="https://github.com/aces/Loris/assets/51128536/5b67db6e-4652-4254-92de-324dcee65c5e">
**After:** 
<img width="964" alt="image" src="https://github.com/aces/Loris/assets/51128536/b09dc2a6-53a2-4fe7-85aa-8c38ec0a4bc0">