### PR TITLE
[battery_manager] React warning messages in console

### DIFF
--- a/modules/battery_manager/jsx/batteryManagerForm.js
+++ b/modules/battery_manager/jsx/batteryManagerForm.js
@@ -67,8 +67,8 @@ class BatteryManagerForm extends Component {
           name="ageMinDays"
           label="Minimum age (days)"
           onUserInput={setTest}
-          min="0"
-          max="99999"
+          min={0}
+          max={99999}
           required={true}
           value={test.ageMinDays}
           errorMessage={errors.ageMinDays}
@@ -78,8 +78,8 @@ class BatteryManagerForm extends Component {
           name="ageMaxDays"
           label="Maximum age (days)"
           onUserInput={setTest}
-          min="0"
-          max="99999"
+          min={0}
+          max={99999}
           required={true}
           value={test.ageMaxDays}
           errorMessage={errors.ageMaxDays}
@@ -134,8 +134,8 @@ class BatteryManagerForm extends Component {
           label="Instrument Order"
           onUserInput={setTest}
           required={false}
-          min="0"
-          max="127" // max value allowed by default column type of instr_order
+          min={0}
+          max={127} // max value allowed by default column type of instr_order
           value={test.instrumentOrder}
         />
          <ButtonElement


### PR DESCRIPTION
## Brief summary of changes

- A few number values were being passed as Strings in the props to Form elements, I changed those to be numbers.

#### Testing instructions (if applicable)

1. Tools>Battery Manager>New Test
2. Observe that no errors appear in the console.

#### Link(s) to related issue(s)

* Resolves #8703 
