### PR TITLE
[module_manager] Visibility of 'My Preferences' in menu reflects state

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -155,11 +155,13 @@
                                     {$user.Real_name|escape} <b class="caret"></b>
                                 </a>
                                 <ul class="dropdown-menu">
+                                    {if $my_preferences|default}
                                     <li>
                                         <a href="{$baseurl}/my_preferences/">
                                             My Preferences
                                         </a>
                                     </li>
+                                    {/if}
                                     <li>
                                         <a href="{$baseurl}/?logout=true">
                                             Log Out

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -219,7 +219,10 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         }
         $tpl_data['userPerms'] = $realPerms;
 
-        //Display the footer links, as specified in the config file
+        // Do not show menu item if module not active
+        $tpl_data['my_preferences'] = $loris->hasModule("my_preferences");
+
+        // Display the footer links, as specified in the config file
         $links = $this->Config->getExternalLinks('FooterLink');
 
         $tpl_data['links'] = array();


### PR DESCRIPTION
The 'My Preferences' menu item is no longer visible if the `my_preferences` module is not `Active`. Closes #8695