### PR TITLE
[candidate_list] Multiselect for visit label, site, and cohort

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -201,7 +201,7 @@ class CandidateListIndex extends Component {
         show: false,
         filter: {
           name: 'visitLabel',
-          type: 'select',
+          type: 'multiselect',
           options: options.visitlabel,
         },
       },
@@ -210,7 +210,7 @@ class CandidateListIndex extends Component {
         show: true,
         filter: {
           name: 'site',
-          type: 'select',
+          type: 'multiselect',
           options: options.site,
         },
       },
@@ -219,7 +219,7 @@ class CandidateListIndex extends Component {
         'show': true,
         'filter': {
           name: 'cohort',
-          type: 'select',
+          type: 'multiselect',
           options: options.cohort,
         },
       },


### PR DESCRIPTION
## Brief summary of changes

The filters for site, cohort and visit label are now multiselect

#### Testing instructions (if applicable)

1. Go to Candidate -> Access Profiles page
2. Check that you can select multiple visit labels, cohorts, and visits

#### Note
This is a CCNA override - https://github.com/aces/CCNA/pull/3922
