### PR TITLE
[candidate_parameters] Participant status - mandatory comments if not active or complete

### DIFF
--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -147,6 +147,16 @@ class ParticipantStatus extends Component {
             suboptionsRequired = true;
         }
 
+        let commentsRequired  = false;
+	      let statusOpts = this.state.Data.statusOptions;
+	      if (
+          statusOpts &&
+          statusOpts[participantStatus] !== 'Active' &&
+          statusOpts[participantStatus] !== 'Complete'
+        ) {
+          commentsRequired = true;
+        }
+
         let formattedHistory = [];
         for (let statusKey in this.state.Data.history) {
             if (this.state.Data.history.hasOwnProperty(statusKey)) {
@@ -246,7 +256,7 @@ class ParticipantStatus extends Component {
             onUserInput={this.setFormData}
             ref="reasonSpecify"
             disabled={disabled}
-            required={false}
+            required={commentsRequired}
             />
             {updateButton}
             {formattedHistory}

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -148,8 +148,8 @@ class ParticipantStatus extends Component {
         }
 
         let commentsRequired  = false;
-	      let statusOpts = this.state.Data.statusOptions;
-	      if (
+        let statusOpts = this.state.Data.statusOptions;
+        if (
           statusOpts &&
           statusOpts[participantStatus] !== 'Active' &&
           statusOpts[participantStatus] !== 'Complete'

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -147,7 +147,7 @@ class ParticipantStatus extends Component {
             suboptionsRequired = true;
         }
 
-        let commentsRequired  = false;
+        let commentsRequired = false;
         let statusOpts = this.state.Data.statusOptions;
         if (
           statusOpts &&


### PR DESCRIPTION
## Brief summary of changes

For Participant Status, make comments mandatory when setting the status to anything other than "Active" or "Complete".

#### Testing instructions (if applicable)

1. Go to Candidate -> Access Profiles
2. Select any participant
3. Go to Candidate Info -> Participant Status
4. Try updating the participant status to "Active", then "Complete" and ensure comments aren't mandatory. 
5. Try updating the participant status to all other statuses and ensure comments are mandatory i.e., that an error message pops up when trying to update without comments.  

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/6311