### PR TITLE
[configuration] Use unsafeInsert/unsafeUpdate for saving values

### DIFF
--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -60,7 +60,7 @@ foreach ($_POST as $key => $value) {
                 }
             }
             // Update the config setting to the new value.
-            $DB->update(
+            $DB->unsafeUpdate(
                 'Config',
                 ['Value' => $value],
                 ['ID' => $key]
@@ -108,7 +108,7 @@ foreach ($_POST as $key => $value) {
                 }
             }
             // Add the new setting
-            $DB->insert(
+            $DB->unsafeInsert(
                 'Config',
                 [
                     'ConfigID' => $ConfigSettingsID, // FK to ConfigSettings.


### PR DESCRIPTION
The values get double-escaped when modified now if they contain HTML. Use unsafe variants of database calls so that the values to not get modified when re-saved.

Fixes #8748