### PR TITLE
[new_profile] Fix date requirements and formats with EDC

### DIFF
--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -101,7 +101,7 @@ class NewProfileIndex extends React.Component {
     };
 
     if (this.state.configData['edc'] === 'true') {
-      candidateObject.Candidate.EDC = formData.edc;
+      candidateObject.Candidate.EDC = formData.edcDate;
     }
     if (this.state.configData['pscidSet'] === 'true') {
       candidateObject.Candidate.PSCID = formData.pscid;

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -19,6 +19,7 @@ define('PSCID_INVALID_STRUCTURE', 4);
 define('EDC_NOT_SPECIFIED', 5);
 define('DOB_NOT_SPECIFIED', 6);
 define('DOB_INVALID', 7);
+define('EDC_INVALID', 8);
 
 /**
  * Wrapper around a candidate in Loris. Mostly, it gets information
@@ -268,35 +269,58 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $PSCIDSettings = $config->getSetting('PSCID');
         $useEDC        = $config->getSetting('useEDC');
 
-        if (($useEDC === '1' || $useEDC === 'true') && empty($edc)) {
-            throw new \LorisException(
-                "EDC must be specified",
-                EDC_NOT_SPECIFIED
-            );
-        }
-        if (empty($dateOfBirth)) {
-            throw new InvalidArgumentException(
-                "Date of Birth must be specified",
-                DOB_NOT_SPECIFIED
-            );
-        }
-
         // Get expected format from config
         $dobFormat = $config->getSetting('dobFormat');
         $dobFormat = '!' . implode("-", str_split($dobFormat, 1));
-        $dob       = DateTime::createFromFormat($dobFormat, $dateOfBirth);
 
-        if ($dob === false) {
-            throw new InvalidArgumentException(
-                "Date of Birth is invalid (expected format: YYYY-MM-DD)",
-                DOB_INVALID
-            );
+        if (($useEDC === '1' || $useEDC === 'true')) {
+            if (empty($edc)) {
+                throw new \LorisException(
+                    "EDC must be specified",
+                    EDC_NOT_SPECIFIED
+                );
+            } else {
+                // Check valid format
+                $edcDate       = DateTime::createFromFormat($dobFormat, $edc);
+                if ($edcDate === false) {
+                    throw new InvalidArgumentException(
+                        "EDC is invalid (expected format: YYYY-MM-DD)",
+                        EDC_INVALID
+                    );
+                }
+
+                // Add day as first of the month if Y-m dob format
+                // This allows insert into sql candidate table
+                if ($dobFormat === '!Y-m') {
+                    $edc .= '-15';
+                }
+            }
         }
 
-        // Add day as first of the month if Y-m dob format
-        // This allows insert into sql candidate table
-        if ($dobFormat === '!Y-m') {
-            $dateOfBirth .= '-15';
+        if (empty($dateOfBirth)) {
+            // DoB not required if useEDC is on
+            if (!($useEDC === '1' || $useEDC === 'true')) {
+                throw new InvalidArgumentException(
+                    "Date of Birth must be specified",
+                    DOB_NOT_SPECIFIED
+                );
+            } else {
+                $dateOfBirth = null;
+            }
+        } else {
+            $dob       = DateTime::createFromFormat($dobFormat, $dateOfBirth);
+            if ($dob === false) {
+                throw new InvalidArgumentException(
+                    "Date of Birth is invalid (expected format: YYYY-MM-DD)",
+                    DOB_INVALID
+                );
+            }
+
+            // Add day as first of the month if Y-m dob format
+            // This allows insert into sql candidate table
+            if ($dobFormat === '!Y-m') {
+                $dateOfBirth .= '-15';
+            }
         }
 
         if ($PSCIDSettings['generation'] == 'user') {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -281,7 +281,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 );
             } else {
                 // Check valid format
-                $edcDate       = DateTime::createFromFormat($dobFormat, $edc);
+                $edcDate = DateTime::createFromFormat($dobFormat, $edc);
                 if ($edcDate === false) {
                     throw new InvalidArgumentException(
                         "EDC is invalid (expected format: YYYY-MM-DD)",
@@ -308,7 +308,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $dateOfBirth = null;
             }
         } else {
-            $dob       = DateTime::createFromFormat($dobFormat, $dateOfBirth);
+            $dob = DateTime::createFromFormat($dobFormat, $dateOfBirth);
             if ($dob === false) {
                 throw new InvalidArgumentException(
                     "Date of Birth is invalid (expected format: YYYY-MM-DD)",


### PR DESCRIPTION
## Brief summary of changes

- Fixed NewProfileIndex to use the correct variable containing the EDC date
- To create a candidate, the date of birth for a candidate is now required only when useEDC = no in `Candidate.class.inc`. 
If useEDC = yes, DoB is `null` unless it's specified. 
- Added the validation of the EDC date format
- If the Ym format is selected in the configuration, added a '-15' to the end of the EDC date to be compatible with the SQL type date

#### Testing instructions (if applicable)

1. Attempt to create candidates with the following combinations from configuration
a. useEDC = no, DOB format = Ym
b. useEDC = no, DOB format = Ymd
c. useEDC = yes, DOB format = Ym - once with DoB not specified, once with DoB specified too
d. useEDC = yes, DOB format = Ymd - once with DoB not specified, once with DoB specified too

#### Link(s) to related issue(s)

* Resolves #8742 
