### PR TITLE
[data_release] Permission not added to unversioned files if version specified

### DIFF
--- a/modules/data_release/php/permissions.class.inc
+++ b/modules/data_release/php/permissions.class.inc
@@ -143,8 +143,7 @@ class Permissions extends \NDB_Page
             );
         } elseif (empty($releaseid) && !empty($version)) {
             // If there is no release id but there is a version, give
-            // access to every file with that version AND every file
-            // where there is no version.
+            // access to every file with that version.
             if ($version == 'Unversioned') {
                 $IDs = $DB->pselectCol(
                     "SELECT id FROM data_release WHERE
@@ -154,7 +153,7 @@ class Permissions extends \NDB_Page
             } else {
                 $IDs = $DB->pselectCol(
                     "SELECT id FROM data_release WHERE
-                        version IS NULL OR version=:drv",
+                        version=:drv",
                     ['drv' => $posted['data_release_version']],
                 );
             }


### PR DESCRIPTION
## Brief summary of changes

When adding version permissions for a user, permissions for unversioned files are no longer added 

#### Testing instructions (if applicable)

1. Go to data_release
2. Make sure that there is at least one file uploaded without a version (version will show up as "Unversioned"), and at least one file uploaded under a specified version
3. Add permissions for a user to give them permission to the specified version
4. See that the user now only has permission to the specified version, and not "Unversioned" too

#### Link(s) to related issue(s)

* Resolves #8741
