### PR TITLE
[api] Log filename in error message

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -159,7 +159,11 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $info = $image->getFileInfo();
 
         if (!$info->isFile()) {
-            error_log('file in database but not in file system');
+            error_log(
+                'file '
+                . $info->getPath() . '/' . $info->getFilename()
+                . ' in database but not in file system'
+            );
             return new \LORIS\Http\Response\JSON\NotFound();
         }
         if (!$info->isReadable()) {


### PR DESCRIPTION
There is an error message in the web server logs when a file is in the database but not on the filesystem but it doesn't tell you where it was looking on the filesystem. This adds the full path to make it easier to determine where LORIS is trying to find the file when ie. setting up raisinbread.