### PR TITLE
[instrument] norules meta instruction

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -45,6 +45,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     protected $GroupElements = [];
 
     /**
+     * Do not require rules by default.
+     */
+    private $skipRules = false;
+
+    /**
      * Sets up the variables required for a LINST instrument to load
      *
      * @param string|null $commentID The CommentID being loaded
@@ -480,7 +485,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             }
             $this->formType = 'XIN';
 
-            $this->form->addFormRule([&$this, 'XINValidate']);
+            if (!$this->skipRules) {
+                $this->form->addFormRule([&$this, 'XINValidate']);
+            }
             $fp = fopen($filename, "r");
 
             // Add elements is only true if we're parsing the current page,
@@ -922,6 +929,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 break;
             case 'jsondata':
                 $this->jsonData = trim($pieces[1]) === 'true';
+                break;
+            case 'norules':
+                $this->skipRules = trim($pieces[1]) === 'true';
                 break;
             default:
                 break;


### PR DESCRIPTION
## Brief summary of changes

Port #8714 to `24.1`.

#### Testing instructions (if applicable)

1. take one linst instrument.
2. add a `.meta` file and/or add one line inside it: `norules{@}true`.
3. go to the frontend > candidate list > choose a visit and timepoint with the corresponding instrument.
4. try entering/modifying a form value with an empty answer (e.g. a blank value in a dropdown).
5. This should save the form.
6. Remove the `norules{@}true` from the `meta file`.
7. try saving the form from the frontend again, it should make an error.
