### PR TITLE
[survey_accounts] Fix help text

### DIFF
--- a/modules/survey_accounts/help/survey_accounts.md
+++ b/modules/survey_accounts/help/survey_accounts.md
@@ -12,9 +12,9 @@ The resulting table will display your results, which includes a unique URL for e
 
 The *Status* column tells you whether the survey has been accessed. This column will display one of the following options:
 
-**Created**: Survey was created. This is the default status once a survey is created using the "Add Survey" page.<br>
-**Sent**: Survey was created, and an email with the unique survey URL was sent to the survey respondent. This is the default status once a survey is created and sent by email within LORIS.<br>
-**In Progress**: Survey was opened and accessed by anyone with the link, including study personnel (not just the intended respondent).<br>
+**Created**: Survey was created. This is the default status once a survey is created using the "Add Survey" page.  
+**Sent**: Survey was created, and an email with the unique survey URL was sent to the survey respondent. This is the default status once a survey is created and sent by email within LORIS.  
+**In Progress**: Survey was opened and accessed by anyone with the link, including study personnel (not just the intended respondent).  
 **Complete**: Survey was completed and submitted. After this stage, the respondent will not be able to go back and change any entries. No data will be visible via the URL once a survey is completed: clicking on the URL will display a page with the message *"Data has already been submitted"*
 
 ## Create Surveys


### PR DESCRIPTION
## Brief summary of changes

This PR replaces `<br>` tag with 2 spaces.

Before:
<img width="318" alt="Screenshot 2023-06-14 at 6 09 56 PM" src="https://github.com/aces/Loris/assets/17415878/8584f244-a33c-40c2-a95e-593c2184db9e">

After:
<img width="417" alt="Screenshot 2023-06-14 at 6 16 27 PM" src="https://github.com/aces/Loris/assets/17415878/0f2ce525-3030-4d0c-8e2a-f82c75fc3cc4">


- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
