### PR TITLE
[bvl_feedback] Edit comment section

### DIFF
--- a/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
@@ -60,7 +60,8 @@ if ($closethreadcount === 0) {
     exit;
 }
 
-header("HTTP/1.1 204 No Content");
+header("content-type:application/json");
+echo json_encode(['success' => true]);
 exit;
 
 

--- a/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
@@ -19,7 +19,7 @@ require "bvl_panel_ajax.php";
 $db =& Database::singleton();
 
 // DELETE the thread entries
-$db->delete('feedback_bvl_entry', array("ID" => $_POST['entryID']));
+$db->delete('feedback_bvl_entry', ["ID" => $_POST['entryID']]);
 
 print json_encode('success');
 

--- a/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
@@ -16,7 +16,7 @@ ini_set('default_charset', 'utf-8');
 
 require "bvl_panel_ajax.php";
 
-$db =& Database::singleton();
+$db =& NDB_Factory::singleton()->database();
 
 // DELETE the thread entries
 $db->delete('feedback_bvl_entry', ["ID" => $_POST['entryID']]);

--- a/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Used to delete an entry on a specific thread via the bvl feedback
+ * panel.
+ *
+ * PHP version 5
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Saagar Arya <saagar.arya@mcin.ca>
+ * @license  GPLv3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+ * @link     https://www.github.com/aces/Loris/
+ */
+header("content-type:application/json");
+ini_set('default_charset', 'utf-8');
+
+require "bvl_panel_ajax.php";
+
+$db =& Database::singleton();
+
+// DELETE the thread entries
+$db->delete('feedback_bvl_entry', array("ID" => $_POST['entryID']));
+
+print json_encode('success');
+
+exit();

--- a/modules/bvl_feedback/ajax/get_thread_entry_data.php
+++ b/modules/bvl_feedback/ajax/get_thread_entry_data.php
@@ -23,7 +23,7 @@ if (isset($_GET['feedbackID']) && !Empty($_GET['feedbackID'])) {
     // add username to threadentries
     foreach ($threadEntries as $key => $value) {
         $threadEntries[$key]['current_user'] = $username;
-        $threadEntries[$key]['editComment'] = false;
+        $threadEntries[$key]['editComment']  = false;
     }
     print json_encode($threadEntries);
 }

--- a/modules/bvl_feedback/ajax/get_thread_entry_data.php
+++ b/modules/bvl_feedback/ajax/get_thread_entry_data.php
@@ -15,8 +15,16 @@
 header("content-type:application/json");
 require "bvl_panel_ajax.php";
 
+$user     =& User::singleton();
+$username = $user->getUsername();
+
 if (isset($_GET['feedbackID']) && !Empty($_GET['feedbackID'])) {
     $threadEntries = NDB_BVL_Feedback::getThreadEntries($_GET['feedbackID']);
+    // add username to threadentries
+    foreach ($threadEntries as $key => $value) {
+        $threadEntries[$key]['current_user'] = $username;
+        $threadEntries[$key]['editComment'] = false;
+    }
     print json_encode($threadEntries);
 }
 

--- a/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
@@ -38,6 +38,7 @@ if ($openedthreadcount === 0) {
     exit;
 }
 
-header("HTTP/1.1 204 No Content");
+header("content-type:application/json");
+echo json_encode(['success' => true]);
 exit;
 

--- a/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
@@ -22,8 +22,8 @@ if (isset($_POST['entryID']) && isset($_POST['newComment'])) {
     $db->update(
         'feedback_bvl_entry',
         [
-            'Comment' => $_POST['newComment'],
-            'TestDate' => $_POST['date']
+            'Comment'   => $_POST['newComment'],
+            'TestDate'  => $_POST['date']
         ],
         ['ID' => $_POST['entryID']]
     );

--- a/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Used to create a new entry on a specific thread via the bvl feedback
+ * panel.
+ *
+ * PHP version 5
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Evan McIlroy <evanmcilroy@gmail.com>
+ * @license  GPLv3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+header("content-type:application/json");
+ini_set('default_charset', 'utf-8');
+
+require "bvl_panel_ajax.php";
+
+if (isset($_POST['entryID']) && isset($_POST['newComment'])) {
+    $db =& Database::singleton();
+
+    $db->update(
+        'feedback_bvl_entry',
+        [
+            'Comment' => $_POST['newComment'],
+            'TestDate' => $_POST['date']
+        ],
+        ['ID' => $_POST['entryID']]
+    );
+
+    print json_encode('success');
+} else {
+    print json_encode('error');
+    exit();
+}
+
+exit();

--- a/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
@@ -22,8 +22,8 @@ if (isset($_POST['entryID']) && isset($_POST['newComment'])) {
     $db->update(
         'feedback_bvl_entry',
         [
-            'Comment'   => $_POST['newComment'],
-            'TestDate'  => $_POST['date']
+            'Comment'  => $_POST['newComment'],
+            'TestDate' => $_POST['date']
         ],
         ['ID' => $_POST['entryID']]
     );

--- a/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
@@ -17,7 +17,7 @@ ini_set('default_charset', 'utf-8');
 require "bvl_panel_ajax.php";
 
 if (isset($_POST['entryID']) && isset($_POST['newComment'])) {
-    $db =& Database::singleton();
+    $db =& NDB_Factory::singleton()->database();
 
     $db->update(
         'feedback_bvl_entry',

--- a/modules/bvl_feedback/css/bvl_feedback_panel.css
+++ b/modules/bvl_feedback/css/bvl_feedback_panel.css
@@ -1,0 +1,53 @@
+/* Based on "loris/htdocs/css/panel.css" */
+
+#bvl_panel_wrapper .navmenu {
+    width: 800px;
+    position: fixed;
+    z-index: 1040;
+    top: 0;
+    bottom: 0;
+}
+
+#bvl_panel_wrapper .panel-wrapper {
+    margin-right: -800px;
+    right: 0;
+    width: 800px;
+    background: #F5F5F5;
+    height: 100%;
+    border-color: #064785;
+    border-left: 2px solid;
+    border-top: 2px solid;
+    overflow-y: scroll;
+    z-index: 998;
+    transition: all 0.4s ease 0s;
+    padding-bottom: 50px;
+}
+
+#bvl_panel_wrapper .bvl_panel {
+    padding-right: 800px;
+    transition: all 0.4s ease 0s;
+}
+
+#bvl_panel_wrapper .active_panel_footer {
+    padding-right: 800px;
+}
+
+#bvl_panel_wrapper .active_panel {
+    right: 800px;
+}
+
+@media (max-width: 884px) {
+    #bvl_panel_wrapper .panel-wrapper {
+        margin-right: -100%;
+        width: 100%;
+    }
+
+    #bvl_panel_wrapper .active_panel {
+        right: 100%;
+    }
+}
+
+#comment_author {
+    color: gray;
+    font-size: 12px
+}

--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -3,6 +3,8 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import '../css/bvl_feedback_panel.css';
+
 /**
  * Slider panel component
  */
@@ -188,12 +190,13 @@ class FeedbackPanelRow extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      threadEntriesToggled: false,
+      threadEntriesToggled: this.props.status === 'opened' ? true : false,
       threadEntriesLoaded: [],
     };
     this.loadServerState = this.loadServerState.bind(this);
     this.toggleEntries = this.toggleEntries.bind(this);
     this.newThreadEntry = this.newThreadEntry.bind(this);
+    this.updateThreadEntry = this.updateThreadEntry.bind(this);
   }
 
   /**
@@ -279,6 +282,44 @@ class FeedbackPanelRow extends Component {
     });
   }
 
+  updateThreadEntry(entryID, newComment, date) {
+    $.ajax({
+      type: 'POST',
+      url: loris.BaseURL + '/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php',
+      dataType: 'json',
+      data: {
+        entryID: entryID,
+        newComment: newComment,
+        date: date,
+      },
+      success: function(response) {
+        this.loadServerState();
+      }.bind(this),
+      error: function(xhr, desc, err) {
+        console.error(xhr);
+        console.error('Details: ' + desc + '\nError:' + err);
+      },
+    });
+  };
+
+  deleteThreadEntry(entryID) {
+    $.ajax({
+      type: 'POST',
+      url: loris.BaseURL + '/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php',
+      dataType: 'json',
+      data: {
+        entryID: entryID,
+      },
+      success: function(response) {
+        this.loadServerState();
+      }.bind(this),
+      error: function(xhr, desc, err) {
+        console.error(xhr);
+        console.error('Details: ' + desc + '\nError:' + err);
+      },
+    });
+  };
+
   /**
    * Renders the React component.
    *
@@ -295,14 +336,55 @@ class FeedbackPanelRow extends Component {
 
     if (this.state.threadEntriesToggled) {
       arrow = 'glyphicon glyphicon-chevron-down glyphs';
-      threadEntries = this.state.threadEntriesLoaded.map(function(entry, key) {
+      threadEntries = this.state.threadEntriesLoaded.map((entry, key) => {
+        let toggleEditComment = () => {
+          let tempThreadEntriesLoaded = [...this.state.threadEntriesLoaded];
+          tempThreadEntriesLoaded.forEach((threadEntry, index) => {
+            if (index == key) {
+              threadEntry.editComment = !threadEntry.editComment;
+            } else {
+              threadEntry.editComment = false;
+            }
+          });
+          this.setState({threadEntriesLoaded: tempThreadEntriesLoaded});
+          this.props.commentToggled = false;
+        }; 
         return (
-          <tr key={key} className='thread_entry'>
-            <td colSpan='100%'>
-              {entry.UserID} on {entry.TestDate} commented:<br/>
-              {entry.Comment}
-            </td>
-          </tr>
+          <>
+            <tr key={key} className='thread_entry'>
+              <td colSpan='70%'>
+                <span id='comment_author'>
+                  {entry.Date} {entry.UserID}:{' '}
+                </span>
+                {entry.Comment}
+                <span>
+                  {entry.UserID === entry.current_user && <>
+                    {' '}<a
+                      onClick={() => {
+                        toggleEditComment();
+                      }}
+                    >
+                      <span className='glyphicon glyphicon-pencil' />
+                    </a>{' '}
+                    <a onClick={() => {
+                      this.deleteThreadEntry(entry.EntryID);
+                    }}>
+                      <span className='glyphicon glyphicon-trash' />
+                    </a>
+                  </>}
+                </span>
+              </td>
+            </tr>
+            {entry.editComment ?
+              <CommentEntryForm
+              entryID={entry.EntryID}
+              onCommentSend={this.updateThreadEntry}
+              toggleThisThread={toggleEditComment}
+              value={entry.Comment}
+              date={entry.Date}
+              />
+            : null}
+          </>
         );
       });
     }
@@ -312,44 +394,47 @@ class FeedbackPanelRow extends Component {
       buttonClass = 'btn btn-danger dropdown-toggle btn-sm';
       dropdown = (<li><a onClick={this.props.onClickClose}>Close</a></li>);
       commentButton = (
-        <span className='glyphicon glyphicon-pencil'
-              onClick={this.props.commentToggle}/>
+        <span
+        className='glyphicon glyphicon-comment'
+        onClick={this.props.commentToggle}
+      />
       );
     }
 
     return (
       <tbody>
-      <tr>
-        {this.props.fieldname ?
-          <td>{this.props.fieldname}<br/>{this.props.type}</td> :
-          <td>{this.props.type}</td>}
-        <td>{this.props.author} on:<br/>{this.props.date}</td>
-        <td>
-          <div className='btn-group'>
-            <button name='thread_button' type='button' className={buttonClass}
-                    data-toggle='dropdown' aria-haspopup='true'
-                    aria-expanded='false'>
-              {buttonText}
-              <span className='caret'></span>
-            </button>
-            <ul className='dropdown-menu'>
-              {dropdown}
-            </ul>
-          </div>
-          <span className={arrow}
-                onClick={this.toggleEntries.bind(this, false)}></span>
-          {commentButton}
-        </td>
-      </tr>
-      {this.props.commentToggled ?
-        (<CommentEntryForm
-          user={this.props.user}
-          onCommentSend={this.newThreadEntry}
-          toggleThisThread={this.toggleEntries.bind(this, true)}
-        />) :
-        null
-      }
-      {threadEntries}
+        <tr>
+          {this.props.fieldname ?
+            <td>{this.props.fieldname}<br/>{this.props.type}</td> :
+            <td>{this.props.type}</td>}
+          <td>{this.props.author} on:<br/>{this.props.date}</td>
+          <td>
+            <div className='btn-group'>
+              <button name='thread_button' type='button' className={buttonClass}
+                data-toggle='dropdown' aria-haspopup='true'
+                aria-expanded='false'>
+                {buttonText}
+                <span className='caret'></span>
+              </button>
+              <ul className='dropdown-menu'>
+                {dropdown}
+              </ul>
+            </div>
+            <span className={arrow}
+              onClick={this.toggleEntries.bind(this, false)}></span>
+            {commentButton}
+          </td>
+        </tr>
+ 
+        {threadEntries}
+        {this.props.commentToggled ?
+          (<CommentEntryForm
+            user={this.props.user}
+            onCommentSend={this.newThreadEntry}
+            toggleThisThread={this.toggleEntries.bind(this, true)}
+          />) :
+          null
+        }
       </tbody>
     );
   }
@@ -382,18 +467,27 @@ class CommentEntryForm extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: '',
-      message: '',
+      value: props.value ? props.value : '',
+      entryID: -1,
+      date: '',
     };
     this.sendComment = this.sendComment.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    if (props.entryID) {
+      this.state.entryID = props.entryID;
+      this.state.date = props.date;
+    }
   }
 
   /**
    * Send comment
    */
   sendComment() {
-    this.props.onCommentSend(this.state.value);
+    if (this.state.entryID < 0) {
+      this.props.onCommentSend(this.state.value);
+    } else {
+      this.props.onCommentSend(this.state.entryID, this.state.value, this.state.date);
+    }
     this.setState({
       value: '',
       message: 'Comment added!',
@@ -418,7 +512,8 @@ class CommentEntryForm extends Component {
   render() {
     return (
       <tr>
-        <td colSpan='100%'>Add a thread entry:
+        <td colSpan='100%'>
+          {this.state.entryID < 0 ? <span> Add a comment: </span> : <span> Update comment: </span>}
           <div className='input-group' style={{width: '100%'}}>
             <textarea
               className='form-control'
@@ -432,7 +527,7 @@ class CommentEntryForm extends Component {
               className='input-group-addon btn btn-primary'
               onClick={this.sendComment}
             >
-              Send
+              Submit
             </span>
           </div>
           {this.state.message}
@@ -444,6 +539,8 @@ class CommentEntryForm extends Component {
 CommentEntryForm.propTypes = {
   onCommentSend: PropTypes.func,
   toggleThisThread: PropTypes.func,
+  entryID: PropTypes.int,
+  updateThreadEntry: PropTypes.func,
 };
 
 

--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -314,7 +314,7 @@ class FeedbackPanelRow extends Component {
     ).then(() => {
       this.loadServerState();
     }).catch((error) => {
-      console.log(error);
+      console.error(error);
     });
   }
 

--- a/modules/bvl_feedback/test/TestPlan.md
+++ b/modules/bvl_feedback/test/TestPlan.md
@@ -12,7 +12,7 @@
  * New profile level feedback
  * Feedback Threads
 5. Click on the chevron arrow on each section and make sure it toggles open/closed.
-6. Type something in the 'New profile level feedback' text box and choose a 'Feedback Type' from the dropdown. Click 'Save data'.
+6. Type something in the 'New profile level feedback' text box and choose a 'Feedback Type' from the dropdown. Click 'Create thread'.
 7. 'Open Thread Summary' and 'Feedback Threads' should update with the submitted thread.
  * Open Thread Summary
     * QC class should be what page the feedback was submitted on (i.e. profile, instrument)
@@ -20,14 +20,16 @@
     * Visit should be populated if QC class is not profile
     * "# Threads" should be the thread number
   * New visit level feedback
-    * Should have "The new thread has been submitted" appear in the text box
+    * Should have "The new thread has been submitted" appear below the text box
   * Feedback threads
     * The Feedback Type should appear under 'Type'
     * Current user and date should appear under 'Author'
     * 'Status' should be set to 'opened'
-8. Click on the chevron next to the status. You should be able to see the original text box thread entry.
-9. Click on the pencil button and 'Add a thread entry'. Click on 'Send'. Click on the chevron next to the status. You should be able to see the original text box thread entry and the one you just entered.
+8. You should be able to see the original text box thread entry. If you click the chevron the thread comments should be hidden.
+9. Click on the comment icon and 'Add a comment'. Click on 'Submit'. You should be able to see the original text box thread entry and the one you just entered.
 10. Click on 'opened' and choose a different status. Status should be updated.
+11. Click on the pencil icon and you should be able to update the comment. 
+12. Click on the delete icon and the comment should be deleted.
 
 ### Widget registration on the dashboard page
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -645,14 +645,14 @@ class NDB_BVL_Feedback
                   fe.FeedbackID,
                   fe.Comment,
                   fe.UserID as UserID,
-                  DATE_FORMAT(fe.Testdate, '%Y-%m-%d') as Date
+                  DATE_FORMAT(fe.Testdate, '%Y-%m-%d %H:%i:%s') as Date
              FROM feedback_bvl_thread as ft,
                   feedback_bvl_entry as fe,
                   feedback_bvl_type as ftp
              WHERE ft.FeedbackID = :FID
                    AND ft.FeedbackID = fe.FeedbackID
                    AND ft.Feedback_type = ftp.Feedback_type
-             ORDER BY ft.FeedbackID, fe.Testdate DESC";
+             ORDER BY ft.FeedbackID, fe.Testdate ASC";
 
         $result = $db->pselect($query, ['FID' => $feedbackID]);
 


### PR DESCRIPTION
## Brief summary of changes
- Moved [CCNA overrides to bvl_feedback module](https://github.com/aces/CCNA/pull/6360) to LORIS Core
- Switched Add Comment button from Pencil to a Comment (Original was confusing)
- Set threads to be shown automatically for open threads as having them hidden made the UI confusing.
- Added an Edit and Delete button for comments of which the author is the user viewing them
- Flipped the order of comments around so that the newer comments show up below. Makes more sense when reading the comments
- Made New Comment TextArea section show up below the thread, as that is where the new comment will appear
- Changed panel width to work on mobile devices

### Before:
#### Comment section
Behaviour:
- Defaults to closed
- Date is not shown
- Comments are ordered in a confusing way
<img width="479" alt="image" src="https://github.com/aces/Loris/assets/51128536/5f640ecd-ddc6-42a8-b1b0-54b421ea1f2d">

#### Mobile device
(Everything is cut off)
<img width="300" alt="image" src="https://github.com/aces/Loris/assets/51128536/409e9ab6-af40-465a-8942-b9fb4ddca46a">

### After:
Behaviour:
- Defaults to open
- Date is shown
- Comments are in an easier to read order
- Ability to delete and edit comments you wrote
<img width="500" alt="image" src="https://github.com/aces/Loris/assets/51128536/6504fc6c-2a0a-4665-8e73-a871ef532f62">

#### Mobile device

<img width="300" alt="image" src="https://github.com/aces/Loris/assets/51128536/135a717f-aa73-4a32-97e2-7dfcc9024e47">

