### PR TITLE
Fix candidate_parameters permission problem

### DIFF
--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -42,17 +42,15 @@ class Candidate_Parameters extends \NDB_Form
     {
         $candidate =& \Candidate::singleton(new CandID($this->identifier));
 
-        // User must either have 'access_all_profiles' permission, or
-        // one of the candidate_parameter permissions AND have the candidate's site.
-        return $user->hasPermission('access_all_profiles') ||
-            ($user->hasAnyPermission(
-                [
-                    'candidate_parameter_view',
-                    'candidate_parameter_edit',
-                ]
-            )
-                && $user->hasCenter($candidate->getCenterID())
-            );
+        /* User must have one of the candidate_parameter permissions
+        AND have the candidate's site. */
+        return ($user->hasAnyPermission(
+            [
+                'candidate_parameter_view',
+                'candidate_parameter_edit',
+            ]
+        ) && $user->hasCenter($candidate->getCenterID())
+        );
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
Remove unnecessary access_profiles permission check

#### Testing instructions 
1. Login with a user account without candidate_parameters permission.
2. Try accessing the URL of candidate profile of any candidate obtained from the admin account.
3. You should be able to see a permission denied note on the screen.

#### Link(s) to related issue(s)

* Resolves #8733 
