### PR TITLE
accessing CommentID using accessor function

### DIFF
--- a/modules/api/php/views/visit/instrument.class.inc
+++ b/modules/api/php/views/visit/instrument.class.inc
@@ -51,8 +51,9 @@ class Instrument
     {
         $instrumentname = $this->_instrument->testName;
         $instrumentdata = $this->_instrument->getInstanceData();
+        $commentid      = $this->_instrument->getCommentID() ?? '';
 
-        $isDDE = strpos($instrumentdata['CommentID'], 'DDE_') === 0;
+        $isDDE = strpos($commentid, 'DDE_') === 0;
 
         $meta = [
             'Candidate'  => $this->_timepoint->getCandID(),


### PR DESCRIPTION
Fixes the Fatal error thrown by the api when trying to access instrument data of a json instrument.