### PR TITLE
[GitHub Actions] Fix order of schema sourcing

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -45,7 +45,12 @@ jobs:
 
     - name: Source default schema and Raisinbread
       run: |
-        find SQL -name 0000-*.sql -exec sh -c "echo Sourcing {}; mysql ${{ env.DB_DATABASE}} -uroot -proot < {}" \;
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-00-schema.sql
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-01-Modules.sql
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-02-Permission.sql
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-03-ConfigTables.sql
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-04-Help.sql
+        mysql ${{ env.DB_DATABASE}} -uroot -proot < SQL/0000-00-05-ElectrophysiologyTables.sql
         find raisinbread/instruments/instrument_sql -name *.sql -exec sh -c "echo Sourcing {}; mysql ${{ env.DB_DATABASE}} -uroot -proot < {}" \;
         find raisinbread/RB_files/ -name *.sql -exec sh -c "echo Sourcing {}; mysql ${{ env.DB_DATABASE}} -uroot -proot < {}" \;
 


### PR DESCRIPTION
PR #8802 increased the speed of our test suite a little, and gives a better at-a-glance overview of our API status, but the order that `find` finds the schema patches is inconsistent and can sometimes be sourced out-of-order, causing sporadic test failures.

This sources them explicitly instead of using find, to ensure the order is always correct and test runs don't sporadically fail.