### PR TITLE
[Candidate_parameters] Date of consent only required for 'yes'

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -469,24 +469,32 @@ function editConsentStatusFields(\Database $db)
             // Giving 'no' status requires consent date and empty withdrawal date if
             // record does not already exist
             if (!$recordExists) {
-                if (!empty($date) && empty($withdrawal)) {
+                // ****************** CCNA OVERRIDE START ***************** //
+                if (empty($withdrawal)) {
+                // ****************** CCNA OVERRIDE END ***************** //
                     $validated = true;
                 } else {
                     http_response_code(400);
+                    // ****************** CCNA OVERRIDE START ***************** //
                     echo('Answering no to a consent type for the first time
-                          requires only the date of consent.');
+                          does not require a date of withdrawal.');
+                    // ****************** CCNA OVERRIDE END ***************** //
                     return;
                 }
             } else { // If no status stays no or record existed as NULL
                     // consent date required and withdrawal date unchanged
-                if (($oldStatus === null || $oldStatus === 'no') && !empty($date)
+                // ****************** CCNA OVERRIDE START ***************** //
+                if (($oldStatus === null || $oldStatus === 'no')
+                // ****************** CCNA OVERRIDE END ***************** //
                     && ((empty($oldWithdrawal) && empty($withdrawal))
                     || (!empty($oldWithdrawal) && !empty($withdrawal)))
                 ) {
                     $validated = true;
-                } else if ($oldStatus === 'yes' && !empty($date)
-                    && !empty($withdrawal)
-                ) { // Withdrawing from 'yes' status required consent date
+                // ****************** CCNA OVERRIDE START ***************** //
+                } else if ($oldStatus === 'yes' && !empty($withdrawal)
+			   || $oldStatus === 'not_applicable' && empty($withdrawal)) {
+                    // Withdrawing from 'yes' status required consent date
+                // ****************** CCNA OVERRIDE END ***************** //
                     // and withdrawal date
                     $validated = true;
                 } else {

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -332,8 +332,10 @@ class ConsentStatus extends Component {
         }
         // If answer to consent is 'no', require date of consent
         if (newConsent === 'no') {
-            responseDateDisabled = false;
-            dateRequired = true;
+	    responseDateDisabled = false;
+            // ***************** CCNA OVERRIDE START ****************** //
+            // dateRequired[i] = true;
+            // ***************** CCNA OVERRIDE END ****************** //
             // If answer was previously 'yes' and consent is now being withdrawn, enable and require withdrawal date
             // If consent was previously withdrawn and stays withdrawn, enable and require withdrawal date
             if (oldConsent === 'yes' ||


### PR DESCRIPTION
## Brief summary of changes

This PR makes the date of consent only required when consent is 'yes'. If the consent is 'no', users can still enter a date if they choose, but no error message is thrown and they are able to save if they do not enter dates. If they do enter dates, they still should not be able to save unless the dates match.

#### Testing instructions (if applicable)

See text plan

#### Link(s) to related issue(s)

This is a CCNA override - https://github.com/aces/CCNA/pull/3822
