### PR TITLE
Make upload error message more specific in issue tracker

### DIFF
--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -124,7 +124,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
         return new \LORIS\Http\Response\JsonResponse(
             $response
                 ? ['success' => 'upload succeeded']
-                : ['error' => 'upload failed']
+                : ['error' => $attachment->errorMessage]
         );
     }
 


### PR DESCRIPTION
## Brief summary of changes

- Changed the error message from "upload failed" to be more specific based on the problem

#### Link(s) to related issue(s)

* Resolves #8327