### PR TITLE
[tests] Increase speed by removing duplication of work between jobs

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -4,12 +4,97 @@ on:
   - push
   - pull_request
 
-env:
-  EEG_VIS_ENABLED: 'true'
 
 jobs:
+  buildjs:
+    env:
+      EEG_VIS_ENABLED: 'true'
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+
+      - name: Install EEG package dependencies
+      # We only need to install protobuf-compiler
+      # Other deps were added to fix an apt dependency issue introduced by a new github Ubuntu image
+      # (see https://github.com/actions/runner-images/blob/releases/ubuntu22/20230305/images/linux/Ubuntu2204-Readme.md)
+      # that updated the list of installed apt packages/apt repositories. That issue may disappear in future Ubuntu images.
+        run: |
+          sudo apt install -y imagemagick-6-common libmagickcore-6.q16-6 libmagickwand-6.q16-6 \
+             libprotobuf-dev libprotobuf23 libprotoc23 protobuf-compiler
+          cd modules/electrophysiology_browser/jsx/react-series-data-viewer/
+          protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/
+
+      - name: Install npm modules
+        run: npm ci
+
+      - name: Compile LORIS javascript
+        run: npm run compile
+
+      - name: Create LORIS JS tarball
+        run: tar cfvz lorisjs.tar.gz htdocs/js/components/ modules/*/js/*
+
+      - name: Create node_modules tarball
+        run: tar cfvz node_modules.tar.gz node_modules
+
+      - uses: actions/upload-artifact@v3
+        name: Upload node_modules artifact
+        with:
+          name: node_modules
+          path: node_modules.tar.gz
+
+      - uses: actions/upload-artifact@v3
+        name: Upload lorisjs.tar.gz artifact
+        with:
+          name: lorisjs
+          path: lorisjs.tar.gz
+
+  buildphp:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.1', '8.2']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: zip, php-ast
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Composer cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install composer dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Create vendor tarball
+        run: tar cfvz vendor-php${{matrix.php}}.tar.gz vendor
+
+      - uses: actions/upload-artifact@v3
+        name: Upload vendor-php${{matrix.php}}.tar.gz artifact
+        with:
+          name: vendor-php${{matrix.php}}
+          path: vendor-php${{matrix.php}}.tar.gz
+
   api:
     runs-on: ubuntu-latest
+    needs:
+      - buildjs
+      - buildphp 
+
     env:
       DB_DATABASE: LorisTest
       DB_USER: SQLTestUser
@@ -17,19 +102,43 @@ jobs:
       LORIS_DB_CONFIG: project/config.xml
       DOCKER_WEB_SERVER: http://localhost:8000/
     strategy:
-        fail-fast: false
-        matrix:
-            php: ['8.1','8.2']
-            apiversion: ['v0.0.3', 'v0.0.4-dev']
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2']
+        apiversion: ['v0.0.3', 'v0.0.4-dev']
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up MySQL
-      run: |
-        sudo /etc/init.d/mysql start
-        mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -uroot -proot
-        mysql -e "CREATE USER '${{env.DB_USER}}'@'localhost' IDENTIFIED BY '${{env.DB_PASSWORD}}'" -uroot -proot
-        mysql -e "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON ${{env.DB_DATABASE}}.* TO '${{env.DB_USER}}'@'localhost'" -uroot -proot
+    - uses: actions/download-artifact@v3
+      name: Download node_modules artifact
+      with:
+        name: node_modules
+        path: .
+
+    - uses: actions/download-artifact@v3
+      name: Download compiled LORIS javascript artifact
+      with:
+        name: lorisjs
+        path: .
+
+    - uses: actions/download-artifact@v3
+      name: Download PHP dependencies artifact
+      with:
+        name: vendor-php${{matrix.php}}
+        path: .
+
+
+    - name: Extract node_modules
+      run: tar xfvz node_modules.tar.gz
+
+    - name: Extract compiled JS
+      run: tar xfvz lorisjs.tar.gz
+
+    - name: Extract composer vendor directory
+      run: tar xfvz vendor-php${{matrix.php}}.tar.gz
+
+    - name: Generate VERSION file
+      run: make VERSION
 
     - name: Setup project/ directory
       run: |
@@ -42,6 +151,13 @@ jobs:
         sed -i 's/<adminPassword>TestPassword<\/adminPassword>/<adminPassword>root<\/adminPassword>/g' project/config.xml
         sed -i 's/<host>db<\/host>/<host>localhost<\/host>/g' project/config.xml
         cat project/config.xml
+
+    - name: Set up MySQL
+      run: |
+        sudo /etc/init.d/mysql start
+        mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -uroot -proot
+        mysql -e "CREATE USER '${{env.DB_USER}}'@'localhost' IDENTIFIED BY '${{env.DB_PASSWORD}}'" -uroot -proot
+        mysql -e "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON ${{env.DB_DATABASE}}.* TO '${{env.DB_USER}}'@'localhost'" -uroot -proot
 
     - name: Source default schema and Raisinbread
       run: |
@@ -70,38 +186,6 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: zip, php-ast
-
-    - name: Validate composer.json and composer.lock
-      run: composer validate
-
-    - name: Cache Composer packages
-      id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - name: Composer cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-
-    - name: Install package dependencies
-      # We only need to install protobuf-compiler
-      # Other deps were added to fix an apt dependency issue introduced by a new github Ubuntu image
-      # (see https://github.com/actions/runner-images/blob/releases/ubuntu22/20230305/images/linux/Ubuntu2204-Readme.md)
-      # that updated the list of installed apt packages/apt repositories. That issue may disappear in future Ubuntu images.
-      run: |
-        sudo apt install -y imagemagick-6-common libmagickcore-6.q16-6 libmagickwand-6.q16-6 \
-                            libprotobuf-dev libprotobuf23 libprotoc23 protobuf-compiler
-        cd modules/electrophysiology_browser/jsx/react-series-data-viewer/
-        protoc protocol-buffers/chunk.proto --js_out=import_style=commonjs,binary:./src/
-
-    - name: Install composer dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
-
-    - name: Build LORIS
-      run: make dev
 
     - name: Start PHP Web Server
       run: php -S localhost:8000 -t htdocs/ htdocs/router.php 2>error_log &

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean dev all check checkstatic unittests phpdev jslatest testdata
+.PHONY: clean dev all check checkstatic unittests phpdev jslatest testdata fastdev jsdev
 
 all: VERSION
 	composer install --no-dev
@@ -12,8 +12,12 @@ VERSION: .
 phpdev:
 	composer install
 
-dev: VERSION phpdev
+dev: phpdev jsdev fastdev 
+
+jsdev:
 	npm ci
+
+fastdev: VERSION
 	npm run compile
 
 jslatest: clean


### PR DESCRIPTION
This increases the speed of our tests by using separate jobs on GitHub Actions for building and testing. Currently every job in our test matrix does a complete build of all javascript, PHP, and sourcing of the database (often twice inside of the docker compose image.) About 2 minutes of each test job is building LORIS and another 3-4 sourcing raisinbread while < 1 minute of each job is spent actually running the tests (except for the integration tests, which are slow.)

This fixes that for the API tests so that there is 1 job to build the javascript (one time, instead of once per test job), 1 job to build the PHP (once for each version of PHP, instead of once for each version of PHP times the number of tests in the test matrix) and has the test jobs depend on those building jobs and use their output instead of duplicating the work 16 times.

Mostly, this will be noticable in combination with #8816 (which does a similar optimization for the Raisinbread database) when building javascript (slow) and raisinbread (also slow) will happen in parallel.

This is only done for the API tests (which don't depend on docker compose, where much of the work is duplicated yet again) but after #8816 should be fairly easy to extend to the unit tests and static tests (which don't depend on Selenium.)