### PR TITLE
[DQT] MRI importer incorrect parameters?

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -438,7 +438,7 @@ class CouchDBMRIImporter
                 $row['PSCID'],
                 $row['Visit_label'],
             ];
-            $docid      = 'MRI_Files:' . join($identifier, '_');
+            $docid      = 'MRI_Files:' . implode('_',$identifier);
             unset($doc['PSCID']);
             unset($doc['Visit_label']);
             unset($doc['SessionID']);

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -438,7 +438,7 @@ class CouchDBMRIImporter
                 $row['PSCID'],
                 $row['Visit_label'],
             ];
-            $docid      = 'MRI_Files:' . implode('_',$identifier);
+            $docid      = 'MRI_Files:' . implode('_', $identifier);
             unset($doc['PSCID']);
             unset($doc['Visit_label']);
             unset($doc['SessionID']);


### PR DESCRIPTION
## Brief summary of changes

Trying to run the mri importer for couchdb gives me this error on demo.loris.ca

```
PHP Fatal error:  Uncaught TypeError: join(): Argument #2 ($array) must be of type ?array, string given in /var/www/loris/tools/CouchDB_MRI_Importer.php:443
Stack trace:
#0 /var/www/loris/tools/CouchDB_MRI_Importer.php(443): join()
#1 /var/www/loris/tools/CouchDB_MRI_Importer.php(73): CouchDBMRIImporter->updateCandidateDocs()
#2 /var/www/loris/tools/CouchDB_MRI_Importer.php(778): CouchDBMRIImporter->run()
```


Not sure I understand how it suddently stopped working