### PR TITLE
[issue_tracker] Do not display inactive users in issue form

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -66,7 +66,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         $inactive_users = [];
         if ($user->hasPermission('access_all_profiles')) {
             $assignee_expanded = $db->pselect(
-                "SELECT Real_name, UserID FROM users",
+                "SELECT Real_name, UserID FROM users WHERE Active='Y'",
                 []
             );
 
@@ -84,7 +84,8 @@ class Edit extends \NDB_Page implements ETagCalculator
             $assignee_expanded = $db->pselect(
                 "SELECT DISTINCT u.Real_name, u.UserID FROM users u
                  LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
-                 WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
+                 WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
+                 AND Active='Y'",
                 [
                     'CenterID' => $CenterID,
                     'DCC'      => $DCCID,
@@ -113,7 +114,7 @@ class Edit extends \NDB_Page implements ETagCalculator
 
         $otherWatchers = [];
         $potential_watchers_expanded = $db->pselect(
-            "SELECT Real_name, UserID FROM users",
+            "SELECT Real_name, UserID FROM users WHERE Active='Y'",
             []
         );
         foreach ($potential_watchers_expanded as $w_row) {

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -192,7 +192,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 ->withDataFrom($provisioner)
                 ->toArray($user);
 
-            $isWatching            = $db->pselectOne(
+            $isWatching = $db->pselectOne(
                 "SELECT userID, issueID FROM issues_watching
                 WHERE issueID=:issueID AND userID=:userID",
                 [
@@ -201,23 +201,23 @@ class Edit extends \NDB_Page implements ETagCalculator
                 ]
             );
 
-            // Add current assignee in assignees dropdown even if not active 
+            // Add current assignee in assignees dropdown even if not active
             if (!isset($assignees[$issueData['assignee']])) {
                 $assignees[$issueData['assignee']] = $db->pselectOne(
                     "SELECT Real_name FROM users
-                    WHERE UserID=:userID", 
+                    WHERE UserID=:userID",
                     [
-                        'userID'  => $issueData['assignee']
+                        'userID' => $issueData['assignee']
                     ]
                 );
             }
-            
+
             $othersWatching = $this->getWatching($issueID);
             // add current watchers to others watching, even if not active
             $otherWatchers = array_merge($otherWatchers, $othersWatching);
             unset($otherWatchers[$user->getUserName()]);
 
-            $issueData['watching'] = $isWatching === null ? 'No' : 'Yes';
+            $issueData['watching']       = $isWatching === null ? 'No' : 'Yes';
             $issueData['commentHistory'] = $this->getComments($issueID);
             $issueData['attachments']    = $attachments;
             $issueData['whoami']         = $user->getUsername();
@@ -360,7 +360,7 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @param int $issueID the relevant issue
      *
-     * @return array [Real_name => userID] of 
+     * @return array [Real_name => userID] of
      *               those who are watching
      */
     function getWatching(int $issueID): array
@@ -847,8 +847,8 @@ class Edit extends \NDB_Page implements ETagCalculator
      * Puts updated fields into the issues_comments table.
      *
      * @param ?string $comment new issue comment
-     * @param int    $issueID the issue ID
-     * @param \User  $user    the user
+     * @param int     $issueID the issue ID
+     * @param \User   $user    the user
      *
      * @return void
      */

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -66,7 +66,8 @@ class Edit extends \NDB_Page implements ETagCalculator
         $inactive_users = [];
         if ($user->hasPermission('access_all_profiles')) {
             $assignee_expanded = $db->pselect(
-                "SELECT Real_name, UserID FROM users WHERE Active='Y'",
+                "SELECT Real_name, UserID FROM users 
+                    WHERE Active='Y' AND Pending_approval='N'",
                 []
             );
 
@@ -85,7 +86,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 "SELECT DISTINCT u.Real_name, u.UserID FROM users u
                  LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
                  WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
-                 AND Active='Y'",
+                 AND Active='Y' AND Pending_approval='N'",
                 [
                     'CenterID' => $CenterID,
                     'DCC'      => $DCCID,
@@ -114,7 +115,8 @@ class Edit extends \NDB_Page implements ETagCalculator
 
         $otherWatchers = [];
         $potential_watchers_expanded = $db->pselect(
-            "SELECT Real_name, UserID FROM users WHERE Active='Y'",
+            "SELECT Real_name, UserID FROM users 
+                WHERE Active='Y' AND Pending_approval='N'",
             []
         );
         foreach ($potential_watchers_expanded as $w_row) {

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -200,11 +200,28 @@ class Edit extends \NDB_Page implements ETagCalculator
                     'userID'  => $user->getUsername(),
                 ]
             );
+
+            // Add current assignee in assignees dropdown even if not active 
+            if (!isset($assignees[$issueData['assignee']])) {
+                $assignees[$issueData['assignee']] = $db->pselectOne(
+                    "SELECT Real_name FROM users
+                    WHERE UserID=:userID", 
+                    [
+                        'userID'  => $issueData['assignee']
+                    ]
+                );
+            }
+            
+            $othersWatching = $this->getWatching($issueID);
+            // add current watchers to others watching, even if not active
+            $otherWatchers = array_merge($otherWatchers, $othersWatching);
+            unset($otherWatchers[$user->getUserName()]);
+
             $issueData['watching'] = $isWatching === null ? 'No' : 'Yes';
             $issueData['commentHistory'] = $this->getComments($issueID);
             $issueData['attachments']    = $attachments;
             $issueData['whoami']         = $user->getUsername();
-            $issueData['othersWatching'] = $this->getWatching($issueID);
+            $issueData['othersWatching'] = array_keys($othersWatching);
 
             // We need to unescape the string here:
             // React is escaping the string in the template
@@ -343,20 +360,23 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @param int $issueID the relevant issue
      *
-     * @return array those who are watching
+     * @return array [Real_name => userID] of 
+     *               those who are watching
      */
     function getWatching(int $issueID): array
     {
         $db = $this->loris->getDatabaseConnection();
 
         $watching = $db->pselect(
-            "SELECT userID from issues_watching WHERE issueID=:issueID",
+            "SELECT Real_name, UserID from users
+            WHERE UserID IN 
+            (SELECT UserID FROM issues_watching WHERE issueID=:issueID)",
             ['issueID' => $issueID]
         );
 
         $whoIsWatching = [];
         foreach ($watching as $watcher) {
-            $whoIsWatching[] = $watcher['userID'];
+            $whoIsWatching[$watcher['UserID']] = $watcher['Real_name'];
         }
         return $whoIsWatching;
     }
@@ -826,13 +846,13 @@ class Edit extends \NDB_Page implements ETagCalculator
     /**
      * Puts updated fields into the issues_comments table.
      *
-     * @param string $comment new issue comment
+     * @param ?string $comment new issue comment
      * @param int    $issueID the issue ID
      * @param \User  $user    the user
      *
      * @return void
      */
-    function updateComments(string $comment, int $issueID, \User $user)
+    function updateComments(?string $comment, int $issueID, \User $user)
     {
         $db = $this->loris->getDatabaseConnection();
         if (isset($comment) && $comment != "null") {

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -159,4 +159,21 @@ class Issue extends \NDB_Form
         // the ajax/EditIssue.php hack.
         return parent::handle($request);
     }
+    
+    /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        $label = ucwords(str_replace('_', ' ', $this->name));
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb($label, "/$this->name"),
+            new \LORIS\Breadcrumb(
+                'Issue',
+                "/issue_tracker/issue/$this->issueID"
+            )
+        );
+    }
 }

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -159,7 +159,7 @@ class Issue extends \NDB_Form
         // the ajax/EditIssue.php hack.
         return parent::handle($request);
     }
-    
+
     /**
      * Generate a breadcrumb trail for this page.
      *

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -115,7 +115,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         //reporters
         $reporters         = [];
         $reporter_expanded = $db->pselect(
-            "SELECT u.UserID,
+            "SELECT DISTINCT u.UserID,
                     u.Real_name
              FROM issues i
              INNER JOIN users u
@@ -129,7 +129,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         //assignees
         $assignees         = [];
         $assignee_expanded = $db->pselect(
-            "SELECT u.UserID,
+            "SELECT DISTINCT u.UserID,
                     u.Real_name
              FROM issues i
              INNER JOIN users u


### PR DESCRIPTION
## Brief summary of changes
Inactive users are not displayed in dropdowns to assign / watch an issue

#### Testing instructions (if applicable)
1. Go to Tools -> Issue Tracker
2. Make a new issue / edit an existing one -> ensure you don't see any inactive user in the "Assignee" nor "Add others to watching" dropdowns

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/4100
