### PR TITLE
[datadict] Add subprojects/cohorts filter options 

### DIFF
--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -31,7 +31,7 @@ class DataDictIndex extends Component {
       error: false,
       isLoaded: false,
       isLoading: false,
-      fieldOptions: {'sourceFrom': {}, 'subprojects': {}},
+      fieldOptions: {'sourceFrom': {}, 'cohorts': {}},
     };
 
     this.fetchData = this.fetchData.bind(this);
@@ -200,12 +200,12 @@ class DataDictIndex extends Component {
             },
         },
         {
-          label: 'Subprojects',
+          label: 'Cohorts',
           show: false,
           filter: {
-              name: 'Subprojects',
+              name: 'Cohorts',
               type: 'multiselect',
-              options: options.subprojects,
+              options: options.cohorts,
           },
       },
     ];

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -31,7 +31,7 @@ class DataDictIndex extends Component {
       error: false,
       isLoaded: false,
       isLoading: false,
-      fieldOptions: {'sourceFrom': {}},
+      fieldOptions: {'sourceFrom': {}, 'subprojects': {}},
     };
 
     this.fetchData = this.fetchData.bind(this);
@@ -199,6 +199,15 @@ class DataDictIndex extends Component {
                 },
             },
         },
+        {
+          label: 'Subprojects',
+          show: false,
+          filter: {
+              name: 'Subprojects',
+              type: 'multiselect',
+              options: options.subprojects,
+          },
+      },
     ];
     return (
         <FilterableDataTable

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -52,7 +52,7 @@ class Datadict extends \DataFrameworkMenu
 
     /**
      * Returns a list of instruments to use as the "Source From"
-     * filter options
+     * filter options and a list of the subprojects for the current user
      *
      * @return array Dynamic field options
      */
@@ -97,8 +97,17 @@ class Datadict extends \DataFrameworkMenu
             }
             $dictInstruments[$key] = $otherNames . $name;
         }
+        // get subprojects
+        $user        = \NDB_Factory::singleton()->user();
+        $projects    = $user->getProjectIDs();
+        $subprojects = [];
+        foreach ($projects AS $projectID) {
+            $subprojects = $subprojects + \Utility::getSubprojectList($projectID);
+        }
+
         return [
-            'sourceFrom' => $dictInstruments,
+            'sourceFrom'  => $dictInstruments,
+            'subprojects' => $subprojects,
         ];
     }
 

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -52,7 +52,7 @@ class Datadict extends \DataFrameworkMenu
 
     /**
      * Returns a list of instruments to use as the "Source From"
-     * filter options and a list of the subprojects for the current user
+     * filter options and a list of the cohorts for the current user
      *
      * @return array Dynamic field options
      */
@@ -97,17 +97,17 @@ class Datadict extends \DataFrameworkMenu
             }
             $dictInstruments[$key] = $otherNames . $name;
         }
-        // get subprojects
-        $user        = \NDB_Factory::singleton()->user();
-        $projects    = $user->getProjectIDs();
-        $subprojects = [];
+        // get cohorts
+        $user     = \NDB_Factory::singleton()->user();
+        $projects = $user->getProjectIDs();
+        $cohorts  = [];
         foreach ($projects AS $projectID) {
-            $subprojects = $subprojects + \Utility::getSubprojectList($projectID);
+            $cohorts = $cohorts + \Utility::getSubprojectList($projectID);
         }
 
         return [
-            'sourceFrom'  => $dictInstruments,
-            'subprojects' => $subprojects,
+            'sourceFrom' => $dictInstruments,
+            'cohorts'    => $cohorts,
         ];
     }
 

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -102,7 +102,7 @@ class Datadict extends \DataFrameworkMenu
         $projects = $user->getProjectIDs();
         $cohorts  = [];
         foreach ($projects AS $projectID) {
-            $cohorts = $cohorts + \Utility::getSubprojectList($projectID);
+            $cohorts = $cohorts + \Utility::getCohortList($projectID);
         }
 
         return [

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -47,12 +47,13 @@ class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     WHEN pto.name IS NOT NULL THEN 'Modified'
                     WHEN pto.name IS NULL THEN 'Unchanged'
                 END as description_status,
-                GROUP_CONCAT(DISTINCT tb.SubprojectID) AS subprojects
+                GROUP_CONCAT(DISTINCT tb.CohortID) AS cohorts
             FROM parameter_type pt
             LEFT JOIN parameter_type_override pto USING (Name)
             LEFT JOIN test_battery tb ON pt.sourceFrom=tb.Test_name
             WHERE pt.Queryable=1
-            GROUP BY pt.sourceFrom, pt.name, pt.sourceField, description, description_status
+            GROUP BY pt.sourceFrom, pt.name, pt.sourceField, 
+                description, description_status
             ",
             []
         );

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -46,10 +46,13 @@ class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     WHEN COALESCE(pto.description,pt.description) = '' THEN 'Empty'
                     WHEN pto.name IS NOT NULL THEN 'Modified'
                     WHEN pto.name IS NULL THEN 'Unchanged'
-                END as description_status
+                END as description_status,
+                GROUP_CONCAT(DISTINCT tb.SubprojectID) AS subprojects
             FROM parameter_type pt
             LEFT JOIN parameter_type_override pto USING (Name)
+            LEFT JOIN test_battery tb ON pt.sourceFrom=tb.Test_name
             WHERE pt.Queryable=1
+            GROUP BY pt.sourceFrom, pt.name, pt.sourceField, description, description_status
             ",
             []
         );

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -14,7 +14,8 @@ class Fields extends \NDB_Page
 {
     /**
      * Returns a list of instruments to use as the "Source From"
-     * filter options as JSON.
+     * filter options and the list of subprojects for the current
+     * user as JSON.
      *
      * @param ServerRequestInterface $request The incoming request
      *
@@ -22,8 +23,18 @@ class Fields extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
+        // get subprojects
+        $user        = \NDB_Factory::singleton()->user();
+        $projects    = $user->getProjectIDs();
+        $subprojects = [];
+        foreach ($projects AS $projectID) {
+            $subprojects = $subprojects + \Utility::getSubprojectList($projectID);
+        }
         return new \LORIS\Http\Response\JSON\OK(
-            ['sourceFrom' => \Utility::getAllInstruments()]
+            [
+                'sourceFrom'  => \Utility::getAllInstruments(),
+                'subprojects' => $subprojects
+            ]
         );
     }
 }

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -14,7 +14,7 @@ class Fields extends \NDB_Page
 {
     /**
      * Returns a list of instruments to use as the "Source From"
-     * filter options and the list of subprojects for the current
+     * filter options and the list of cohorts for the current
      * user as JSON.
      *
      * @param ServerRequestInterface $request The incoming request
@@ -23,17 +23,17 @@ class Fields extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        // get subprojects
-        $user        = \NDB_Factory::singleton()->user();
-        $projects    = $user->getProjectIDs();
-        $subprojects = [];
+        // get cohorts
+        $user     = \NDB_Factory::singleton()->user();
+        $projects = $user->getProjectIDs();
+        $cohorts  = [];
         foreach ($projects AS $projectID) {
-            $subprojects = $subprojects + \Utility::getSubprojectList($projectID);
+            $cohorts = $cohorts + \Utility::getCohortList($projectID);
         }
         return new \LORIS\Http\Response\JSON\OK(
             [
-                'sourceFrom'  => \Utility::getAllInstruments(),
-                'subprojects' => $subprojects
+                'sourceFrom' => \Utility::getAllInstruments(),
+                'cohorts'    => $cohorts
             ]
         );
     }


### PR DESCRIPTION
## Brief summary of changes

This PR adds subprojects as filter options in the data dictionary. 
A user should only see subprojects from the project(s) that they have permission to.

#### Testing instructions (if applicable)

1. Go to Tools -> Data Dictionary
2. Make sure you can see a subproject selection box, with only subprojects from projects your user has permission to as options
3. Make sure that the subprojectIDs link properly onto the subproject titles in the inspect element. 
4. Test that subprojects generally link to the correct instruments.

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/6332
