### PR TITLE
[conflict_resolver]  Add description field

### DIFF
--- a/SQL/New_patches/2023-07-19_add_index_parameter_type.sql
+++ b/SQL/New_patches/2023-07-19_add_index_parameter_type.sql
@@ -1,0 +1,2 @@
+-- Index on parameter_type table to speed up the "Description" field on conflict_resolver.
+CREATE INDEX idx_conflictResolverDesc ON parameter_type(SourceFrom(255),SourceField(255));

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -50,10 +50,10 @@ class ResolvedFilterableDataTable extends Component {
   }
 
   /**
-  * Retrieve all the field metadata
-  *
-  * @return {object}
-  */
+   * Retrieve all the field metadata
+   *
+   * @return {object}
+   */
   fetchFieldsMeta() {
     const url = loris.BaseURL.concat('/dictionary/module/instruments');
     return fetch(url, {credentials: 'same-origin'})
@@ -86,13 +86,13 @@ class ResolvedFilterableDataTable extends Component {
         const data = {
           fieldOptions: json.fieldOptions,
           data: json.data.map((e) => {
-            var fieldInfo = this.state.fieldsMeta[e['Instrument']][
+            const fieldInfo = this.state.fieldsMeta[e['Instrument']][
               e['Instrument']
-              + "_"
+              + '_'
               + e['Question']
             ];
-            e['Description'] = fieldInfo ? fieldInfo['description'] : "";
-            return Object.values(e)
+            e['Description'] = fieldInfo ? fieldInfo['description'] : '';
+            return Object.values(e);
           }),
         };
         this.setState({data});

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -129,6 +129,10 @@ class ResolvedFilterableDataTable extends Component {
         name: 'Question',
         type: 'text',
       }},
+      {label: 'Description', show: true, filter: {
+        name: 'Description',
+        type: 'text',
+      }},
       {label: 'Value 1', show: true, filter: {
         name: 'Value1',
         type: 'text',

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -64,10 +64,10 @@ class UnresolvedFilterableDataTable extends Component {
   }
 
   /**
-  * Retrieve all the field metadata
-  *
-  * @return {object}
-  */
+   * Retrieve all the field metadata
+   *
+   * @return {object}
+   */
   fetchFieldsMeta() {
     const url = loris.BaseURL.concat('/dictionary/module/instruments');
     return fetch(url, {credentials: 'same-origin'})
@@ -100,11 +100,11 @@ class UnresolvedFilterableDataTable extends Component {
           data: json.data.map((e) => {
             var fieldInfo = this.state.fieldsMeta[e['Instrument']][
               e['Instrument']
-              + "_"
+              + '_'
               + e['Question']
             ];
-            e['Description'] = fieldInfo ? fieldInfo['description'] : "";
-            return Object.values(e)
+            e['Description'] = fieldInfo ? fieldInfo['description'] : '';
+            return Object.values(e);
           }),
         };
         this.setState({data});

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -98,7 +98,7 @@ class UnresolvedFilterableDataTable extends Component {
         const data = {
           fieldOptions: json.fieldOptions,
           data: json.data.map((e) => {
-            var fieldInfo = this.state.fieldsMeta[e['Instrument']][
+            const fieldInfo = this.state.fieldsMeta[e['Instrument']][
               e['Instrument']
               + '_'
               + e['Question']

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -141,6 +141,10 @@ class UnresolvedFilterableDataTable extends Component {
         name: 'Question',
         type: 'text',
       }},
+      {label: 'Description', show: true, filter: {
+        name: 'Description',
+        type: 'text',
+      }},
       {label: 'Value 1', show: false},
       {label: 'Value 2', show: false},
       {label: 'Correct Answer', show: true},

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -67,6 +67,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
             'Visit Label'         => $this->visitlabel,
             'Instrument'          => $this->instrument,
             'Question'            => $this->question,
+            'Description'         => $this->description,
             'Value 1'             => $this->value1,
             'Value 2'             => $this->value2,
             'Correct Answer'      => $this->correctanswer,

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -68,7 +68,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
             'Visit Label'         => $this->visitlabel,
             'Instrument'          => $this->instrument,
             'Question'            => $this->question,
-            'Description'         => $this->description,
+            'Description'         => "",
             'Value 1'             => $this->value1,
             'Value 2'             => $this->value2,
             'Correct Answer'      => $this->correctanswer,

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -43,6 +43,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
     protected $visitlabel;
     protected $instrument;
     protected $question;
+    protected $description;
     protected $value1;
     protected $value2;
     protected $correctanswer;

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -62,6 +62,7 @@ class UnresolvedDTO implements DataInstance, SiteHaver
             'Visit Label' => $this->visitlabel,
             'Instrument'  => $this->instrument,
             'Question'    => $this->question,
+            'Description' => $this->description,
             'Value 1'     => $this->value1,
             'Value 2'     => $this->value2,
         ];

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -43,6 +43,7 @@ class UnresolvedDTO implements DataInstance, SiteHaver
     protected $visitlabel;
     protected $instrument;
     protected $question;
+    protected $description;
     protected $value1;
     protected $value2;
 

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -63,7 +63,7 @@ class UnresolvedDTO implements DataInstance, SiteHaver
             'Visit Label' => $this->visitlabel,
             'Instrument'  => $this->instrument,
             'Question'    => $this->question,
-            'Description' => $this->description,
+            'Description' => "",
             'Value 1'     => $this->value1,
             'Value 2'     => $this->value2,
         ];

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -39,6 +39,7 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.Visit_label as visitlabel,
               Project.Name as project,
               conflicts_resolved.FieldName as question,
+              parameter_type.Description as description,
               conflicts_resolved.OldValue1 as value1,
               conflicts_resolved.OldValue2 as value2,
               CASE
@@ -55,6 +56,9 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.ProjectID as projectid
              FROM
               conflicts_resolved
+             LEFT JOIN parameter_type
+                ON (parameter_type.SourceField = conflicts_resolved.FieldName
+                AND parameter_type.SourceFrom = conflicts_resolved.TableName)
              LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)
              LEFT JOIN session ON (flag.SessionID=session.ID)
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -39,7 +39,6 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.Visit_label as visitlabel,
               Project.Name as project,
               conflicts_resolved.FieldName as question,
-              parameter_type.Description as description,
               conflicts_resolved.OldValue1 as value1,
               conflicts_resolved.OldValue2 as value2,
               CASE
@@ -56,9 +55,6 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.ProjectID as projectid
              FROM
               conflicts_resolved
-             LEFT JOIN parameter_type
-                ON (parameter_type.SourceField = conflicts_resolved.FieldName
-                AND parameter_type.SourceFrom = conflicts_resolved.TableName)
              LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)
              LEFT JOIN session ON (flag.SessionID=session.ID)
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)

--- a/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
@@ -39,6 +39,7 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.Visit_label as visitlabel,
               Project.Name as project,
               conflicts_unresolved.FieldName as question,
+              parameter_type.Description as description,
               conflicts_unresolved.Value1 as value1,
               conflicts_unresolved.Value2 as value2,
               psc.name as site,
@@ -46,6 +47,9 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.ProjectID as projectid
              FROM
               conflicts_unresolved 
+             LEFT JOIN parameter_type
+                ON (parameter_type.SourceField = conflicts_unresolved.FieldName
+                AND parameter_type.SourceFrom = conflicts_unresolved.TableName)
              LEFT JOIN flag ON (conflicts_unresolved.CommentId1=flag.CommentID)
              LEFT JOIN session ON (flag.SessionID=session.ID)
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)

--- a/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
@@ -39,17 +39,13 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.Visit_label as visitlabel,
               Project.Name as project,
               conflicts_unresolved.FieldName as question,
-              parameter_type.Description as description,
               conflicts_unresolved.Value1 as value1,
               conflicts_unresolved.Value2 as value2,
               psc.name as site,
               session.CenterID as centerid,
               Project.ProjectID as projectid
              FROM
-              conflicts_unresolved 
-             LEFT JOIN parameter_type
-                ON (parameter_type.SourceField = conflicts_unresolved.FieldName
-                AND parameter_type.SourceFrom = conflicts_unresolved.TableName)
+              conflicts_unresolved
              LEFT JOIN flag ON (conflicts_unresolved.CommentId1=flag.CommentID)
              LEFT JOIN session ON (flag.SessionID=session.ID)
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)


### PR DESCRIPTION
## Brief summary of changes

This adds a 'Description' field to the Conflict Resolver module (both Resolved and Unresolved tabs), which corresponds to the description of the 'Question' with the conflict. Instead of using parameter_type like in the CCNA code, it uses /dictionary/module/instruments to get the description of the fields. Since some fields don't have descriptions (e.g. some _status variables), the empty string is used as default. 

Changes have been made to the Instrument_LINST file such that numeric and date elements are added to the dictionary, even if they are not in the top page (inspired by the change in https://github.com/aces/Loris/pull/8869). 

#### Testing instructions (if applicable)

1. Go to Clinical -> Conflict Resolver 
2. Ensure both tabs 'Unresolved' and 'Resolved' load correctly, and in both, ensure that:
a. You can see a 'Description' selection filter and the field in the table with conflicts 
b. You can input some value in the 'Description' selection filter (e.g. 'date') and that conflicts are filtered appropriately
3. Make sure the rest of the module works as expected according to the test plan 

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/6138
