### PR TITLE
[candidate_list][CouchDB_demographics] Add date of registration

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -268,6 +268,14 @@ class CandidateListIndex extends Component {
         },
       },
       {
+        'label': 'Date of registration',
+        'show': true,
+        'filter': {
+          name: 'Date_registered',
+          type: 'date',
+        },
+      },
+      {
         label: 'Sex',
         show: true,
         filter: {

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -54,6 +54,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 MAX(s.Scan_done) AS scanDone,
                 COALESCE(pso.Description,'Active') AS ParticipantStatus,
                 DATE_FORMAT(c.DoB,'%Y-%m-%d') AS DoB,
+                DATE_FORMAT(c.Date_registered,'%Y-%m-%d') AS Date_registered,
                 c.Sex,
                 COUNT(DISTINCT s.Visit_label) AS VisitCount,
                 IFNULL(MIN(feedback_bvl_thread.Status+0),0) AS Feedback,

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -18,6 +18,10 @@ class CouchDBDemographicsImporter
     // this is just in an instance variable to make
     // the code a little more readable.
     var $Dictionary = [
+        'Date_registered'  => [
+            'Description' => 'Date of Registration',
+            'Type'        => 'date'
+        ],
         'DoB'              => [
             'Description' => 'Date of Birth',
             'Type'        => 'date'
@@ -165,7 +169,8 @@ class CouchDBDemographicsImporter
     {
         $config = \NDB_Config::singleton();
 
-        $fieldsInQuery = "SELECT c.DoB,
+        $fieldsInQuery = "SELECT c.Date_registered,
+                                c.DoB,
                                 c.DoD,
                                 c.CandID,
                                 c.PSCID,


### PR DESCRIPTION
## Brief summary of changes

This PR adds the date of registration of the candidate as a field in the candidate list table and adds it to CouchDB demographic import script.

#### Testing instructions (if applicable)

1. Go to Candidate -> Access Profile
a. See 'Date of registration' as a Selection Filter & as a column in the candidate list table 
b. Check that the Date of Registration displayed is correct for the candidate 
c. Filter for the Date of Registration and check that the appropriate candidates are displayed => then click 'Clear Filters' and see the date blank
2. (After the CouchDB_Import_Demographics script is run) Go to Reports -> Data Query Tool
a. In Define Fields, select 'demographics'
b. Find the field 'Date_registered' with description 'Date of Registration' (might not be on first page) -> select that field and all visits
c. Run query -> ensure you get some results and that the dates are generally correct 

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/6340