### PR TITLE
[Libraries] Feedback panel - fix fieldnames setting

### DIFF
--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -101,8 +101,13 @@ class BVL_Feedback_Panel
         $summary = $this->feedbackThread->getSummaryOfThreads();
         $this->tpl_data['thread_summary_headers'] = json_encode($summary);
 
-        // Get test name from lorispath
-        $test_name = preg_split("#/#", $_REQUEST['lorispath'])[1] ?? '';
+        $test_name = '';
+        if (array_key_exists('test_name', $_REQUEST)) {
+            $test_name = $_REQUEST['test_name'];
+        } else if (array_key_exists('lorispath', $_REQUEST)) {
+            $test_name = preg_split("#/#", $_REQUEST['lorispath'])[1] ?? '';
+        }
+
         // Get field names
         $field_names = Utility::getSourcefields($test_name);
         $fields      = [];

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -101,7 +101,10 @@ class BVL_Feedback_Panel
         $summary = $this->feedbackThread->getSummaryOfThreads();
         $this->tpl_data['thread_summary_headers'] = json_encode($summary);
 
-        $field_names = Utility::getSourcefields($_REQUEST['test_name'] ?? '');
+        // Get test name from lorispath
+        $test_name = preg_split("#/#", $_REQUEST['lorispath'])[1] ?? '';
+        // Get field names
+        $field_names = Utility::getSourcefields($test_name);
         $fields      = [];
         $fields['Across All Fields'] = 'Across All Fields';
         foreach ($field_names as $field_name) {


### PR DESCRIPTION
## Brief summary of changes

In the feedback panel for an instrument, the only option in 'Field Name' was 'Across all fields'. This PR changes how the field names for an instrument are fetched so that all of them appear as an option too. 

#### Testing instructions (if applicable)

1. Go to Candidate -> Access Profile -> choose a participant -> choose a timepoint -> choose an instrument
2. Open the feedback panel
3. In Field Name, ensure you can see all the fields of that instrument, and not just 'Across all fields'
4. Repeat for a different instrument to make sure the appropriate field names appear for different instruments 

#### Note

This is a CCNA override - https://github.com/aces/CCNA/pull/5444
