### PR TITLE
[tools][CouchDB_MRI_Importer] Fix date in MRI data

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -250,7 +250,7 @@ class CouchDBMRIImporter
             'acquisition_date'
         );
         $header['FileInsertDate_'.$type]      = date(
-            'Y-m-d', 
+            'Y-m-d',
             $FileObj->getParameter('InsertTime')
         );
         $header['SeriesDescription_'.$type]   = $FileObj->getParameter($ser_desc);


### PR DESCRIPTION
## Brief summary of changes

The first change in this PR is changing the order of arguments in the function call to join(), as I got the following error while running the script initially:
<img width="722" alt="Screenshot 2023-08-01 135343" src="https://github.com/aces/Loris/assets/75381352/d39f24c1-dcd9-421b-bf32-df18b2b6ae9a">

Then, it fixes the date format {total number of seconds} to a proper YYYY-mm-dd format, for "FileInsert{date}" variables from 
<img width="600" alt="Screenshot 2023-08-01 135127" src="https://github.com/aces/Loris/assets/75381352/302b006f-148d-4119-bfe2-479e9d386c1a">
to: 
<img width="600" alt="Screenshot 2023-08-01 134933" src="https://github.com/aces/Loris/assets/75381352/a7b82814-91f3-44e4-83b3-7335e03af3e5">


#### Testing instructions (if applicable)

1. Run the CouchDB_Import_MRI.php script 
2. Make sure the variables starting with FileInsert{date}  e.g. for mri_data, have a correct date format

#### Note

* This is a CCNA override - https://github.com/aces/CCNA/pull/6371
