### PR TITLE
[LorisForm] Read attribute

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -622,7 +622,7 @@ class LorisForm
         }
 
         // check if a 'value' attribute is set for this element
-        if (!empty($this->form[$name]['value'])) {
+        if (isset($this->form[$name]['value']) && !empty($this->form[$name]['value'])) {
             return $this->_getFilteredValue(
                 $name,
                 $this->form[$name]['value']

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -622,7 +622,9 @@ class LorisForm
         }
 
         // check if a 'value' attribute is set for this element
-        if (isset($this->form[$name]['value']) && !empty($this->form[$name]['value'])) {
+        if (isset($this->form[$name]['value'])
+            && !empty($this->form[$name]['value'])
+        ) {
             return $this->_getFilteredValue(
                 $name,
                 $this->form[$name]['value']

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -622,7 +622,7 @@ class LorisForm
         }
 
         // check if a 'value' attribute is set for this element
-        if (isset($this->form[$name]['value'])) {
+        if (!empty($this->form[$name]['value'])) {
             return $this->_getFilteredValue(
                 $name,
                 $this->form[$name]['value']

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -621,6 +621,15 @@ class LorisForm
             }
         }
 
+        // check if a 'value' attribute is set for this element
+        if (isset($this->form[$name]['value'])) {
+            return $this->_getFilteredValue(
+                $name,
+                $this->form[$name]['value']
+            );
+        }
+
+        // search default values
         if (isset($this->defaultValues[$name])) {
             return $this->_getFilteredValue(
                 $name,

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -165,14 +165,14 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
     function testCheckBoxElement()
     {
         $this->_landing();
-        $this->safeFindElement(
-            WebDriverBy::Name("testCheckbox")
-        )->click();
         $checkbox = $this->safeFindElement(
-            WebDriverBy::Name("fire_away")
+            WebDriverBy::Name("testCheckbox")
         );
         $checkbox->click();
         $this->assertTrue($checkbox->isSelected());
+        $this->safeFindElement(
+            WebDriverBy::Name("fire_away")
+        )->click();
         $data =  $this->DB->pselectOne(
             'SELECT Data FROM flag where SessionID = 999999',
             []

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -168,9 +168,11 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("testCheckbox")
         )->click();
-        $this->safeFindElement(
+        $checkbox = $this->safeFindElement(
             WebDriverBy::Name("fire_away")
-        )->click();
+        );
+        $checkbox->click();
+        $this->assertTrue($checkbox->isSelected());
         $data =  $this->DB->pselectOne(
             'SELECT Data FROM flag where SessionID = 999999',
             []

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -165,14 +165,9 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
     function testCheckBoxElement()
     {
         $this->_landing();
-        $checkbox = $this->safeFindElement(
+        $this->safeFindElement(
             WebDriverBy::Name("testCheckbox")
-        );
-        $checkbox->click();
-        $checkbox = $this->safeFindElement(
-            WebDriverBy::Name("testCheckbox")
-        );
-        $this->assertTrue($checkbox->isSelected());
+        )->click();
         $this->safeFindElement(
             WebDriverBy::Name("fire_away")
         )->click();

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -169,6 +169,9 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::Name("testCheckbox")
         );
         $checkbox->click();
+        $checkbox = $this->safeFindElement(
+            WebDriverBy::Name("testCheckbox")
+        );
         $this->assertTrue($checkbox->isSelected());
         $this->safeFindElement(
             WebDriverBy::Name("fire_away")


### PR DESCRIPTION
## Brief summary of changes

Currently, trying to put a `value` attribute in a form is not possible through the `attribs` parameter.

E.g. `$this->addBasicText('test_text', 'My test text', [], ['value' => 'test']);`  will not create the expected 

![image](https://github.com/aces/Loris/assets/25327259/abe31af7-7cc2-497f-9e4a-fe7551e91135)
field but an empty field.

This is due to the value being filtered by `getValue` function https://github.com/aces/Loris/blob/f8f123db63f07f69ac36c1aacd431fbb04201a3f/php/libraries/LorisForm.class.inc#L570
The `value` attribute will not be read.

This PR adds the `attribute->value` case inside the `getValue` function so it can be executed during the form rendering process.

#### Testing instructions (if applicable)

1. Create a form with a `value` attribute. (e.g. `$this->addBasicText('test_text', 'My test text', [], ['value' => 'test']);`).
2. Render the form and see the error (the field is not populated with the string `test`).
3. Switch to this PR branch and re-render the page.
