### PR TITLE
[Instruments] Handle empty bulkLoadInstanceData

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2205,6 +2205,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $prepBindings[]      = ":cid$i";
             $prepValues["cid$i"] = $commentID;
         }
+        if ($i === 0) {
+            return [];
+        }
 
         if ($this->jsonData) {
             $jsondata = $db->pselect(


### PR DESCRIPTION
The logic of bulkLoadInstanceData constructs an SQL statement with the parameters bound to it by looping over the iterable passed to it. If the iterable is empty, the result will be SQL with the string `.. IN ()` which is not valid SQL. This returns an empty array in that case before attempting to run the generated SQL, since the result of bulk loading nothing should be nothing.