### PR TITLE
[LINST] fix survey and date issues

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -98,7 +98,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             ]
         );
 
-        if (strrpos($this->testName ?? '', '_proband') === false) {
+        if (strrpos($this->testName ?? '', '_proband') === false
+            && !$this->DataEntryType == 'DirectEntry'
+        ) {
             if (!$this->postMortem) {
                 $this->addScoreColumn(
                     'Candidate_Age',
@@ -675,7 +677,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // The question should be added to the LinstQuestions in this
                         // order, before the _date is stripped below for standard
                         // dates to allow XINValidation to recognize the field name
-                        $this->LinstQuestions[$pieces[1]] = ['type' => 'date'];
+                        $this->LinstQuestions[$pieces[1]] = [
+                            'type'       => 'date',
+                            'dateFormat' => $dateFormat,
+                        ];
 
                         if ($dateFormat === 'MonthYear') {
                             // Shows date without day of month
@@ -978,15 +983,27 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $q['UserRules'] = true;
 
                     switch ($q['type']) {
+                    // Selects (including multiselects), Basic Dates and MonthYears
+                    // are the only type of rules that aren't part of a group
+                    // the rest include a _status element
                     case 'select':
-                        // Selects are the only type of rules that aren't part
-                        // of a group, the rest include a _status element
                         $this->XINRegisterRule($question, $rules, $message);
                         break;
+                    case 'date':
+                        if ($q['dateFormat'] === 'BasicDate'
+                            || $q['dateFormat'] === 'MonthYear'
+                        ) {
+                            $this->XINRegisterRule($question, $rules, $message);
+                            break;
+                        }
                     default:
+                        $rules_array = array_merge(
+                            $rules,
+                            [$question.'_status{@}=={@}']
+                        );
                         $this->XINRegisterRule(
                             $question,
-                            $rules,
+                            $rules_array,
                             $message,
                             $question . "_group"
                         );
@@ -1015,7 +1032,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 "InstrumentFormatVersion" => "v0.0.1a-dev",
                 "ShortName"               => "",
                 "LongName"                => "",
-                "IncludeMetaDataFields"   => "true",
+                "IncludeMetaDataFields"   => "false",
             ],
             'Elements' => [],
         ];

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -1032,7 +1032,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 "InstrumentFormatVersion" => "v0.0.1a-dev",
                 "ShortName"               => "",
                 "LongName"                => "",
-                "IncludeMetaDataFields"   => "false",
+                "IncludeMetaDataFields"   => "true",
             ],
             'Elements' => [],
         ];

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -98,9 +98,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             ]
         );
 
-        if (strrpos($this->testName ?? '', '_proband') === false
-            && !$this->DataEntryType == 'DirectEntry'
-        ) {
+        if (strrpos($this->testName ?? '', '_proband') === false) {
             if (!$this->postMortem) {
                 $this->addScoreColumn(
                     'Candidate_Age',


### PR DESCRIPTION
@zaliqarosli some changes derived from the QPN overrides that I believe apply to LORIS

- add fields to XIN validation which are not parts of groups