### PR TITLE
[LorisForm] add required to checkboxes

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1592,6 +1592,7 @@ class LorisForm
         $checked  = '';
         $value    = '';
         $disabled = '';
+        $required = '';
         if (!empty($val)) {
             $checked = 'checked="checked"';
         }
@@ -1601,6 +1602,9 @@ class LorisForm
         if (isset($el['disabled']) || $this->frozen) {
             $disabled = 'disabled';
         }
+        if (isset($el['required'])) {
+            $required = 'required';
+        }
         /// XXX: There seems to be a problem when using &nbsp; to separate the
         //  checkbox from the label. Both Firefox and Chrome will still put a
         //  linebreak between the space and the checkbox. Instead, we wrap use
@@ -1609,7 +1613,7 @@ class LorisForm
         //  label it's still allowed to have linebreaks.
         return "<span style=\"white-space: nowrap\"><input name=\"$el[name]\""
             . " type=\"checkbox\" $checked $value "
-            . "$disabled/>"
+            . "$disabled $required/>"
             . " </span>$el[label]";
     }
 

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1336,7 +1336,7 @@ class LorisForms_Test extends TestCase
         $this->form->addCheckbox("abc", "Hello", []);
         $this->assertEquals(
             "<span style=\"white-space: nowrap\"><input name=\"abc\" " .
-            "type=\"checkbox\"   /> </span>Hello",
+            "type=\"checkbox\"    /> </span>Hello",
             $this->form->checkboxHTML($this->form->form['abc'])
         );
     }
@@ -1358,7 +1358,7 @@ class LorisForms_Test extends TestCase
         $this->assertEquals(
             "<span style=\"white-space: nowrap\"><input name=\"abc\" " .
             "type=\"checkbox\" checked=\"checked\"" .
-            " value=\"value1\" disabled/> </span>Hello",
+            " value=\"value1\" disabled /> </span>Hello",
             $this->form->checkboxHTML($this->form->form['abc'])
         );
     }


### PR DESCRIPTION
This PR was made to remove overrides on COPN and CBIGR

Checkbox elements can not be defined as required like the rest of the elements. This add support for required