### PR TITLE
[LINST] skip metadatafields for surveys

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -779,7 +779,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _saveValues(array $values): void
     {
-        if (strrpos($this->testName, "_proband") === false) {
+        // Surveys do not ask for the metadata informatio nand thus date_taken is
+        // always null so there is no use in going into the savecandidateage function
+        if (strrpos($this->testName, "_proband") === false
+            && $this->DataEntryType === 'normal'
+        ) {
             $this->_saveCandidateAge($values);
         }
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -556,7 +556,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             'instrument_title',
                             $pieces[1]
                         );
-                        $this->_addMetadataFields();
+                        if ($this->DataEntryType!=="DirectEntry") {
+                            $this->_addMetadataFields();
+                        }
                     }
                     break;
                 case 'begingroup':

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1335,10 +1335,11 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_setUpMockDB();
         $this->_setTableData();
-        $this->_instrument->commentID = 'commentID1';
-        $this->_instrument->table     = 'medical_history';
-        $this->_instrument->testName  = 'Test';
-        $this->_instrument->formType  = "XIN";
+        $this->_instrument->commentID     = 'commentID1';
+        $this->_instrument->table         = 'medical_history';
+        $this->_instrument->testName      = 'Test';
+        $this->_instrument->formType      = "XIN";
+        $this->_instrument->DataEntryType = "normal";
         $values = ['Date_taken' => '2005-06-06',
             'arthritis_age'        => 2,
             'arthritis_age_status' => 'status'


### PR DESCRIPTION
Skip over metadatafields and calculate ages in surveys

This is not a big change, one way or another the fields were either being skipped with an empty check, through a project override or through code in the module itself handling the submission. this is just an explicit check to make everything clearer