### PR TITLE
[instrument_list] Fix deprecation warning

### DIFF
--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -471,11 +471,8 @@ class Instrument_List_ControlPanel extends \TimePoint
         $qcStatus = $this->getBVLQCStatus();
 
         foreach ($this->bvlQcTypes as $type) {
-            $isSelected =$type == $this->getBVLQCType();
-            $type       =strtolower($type);
-            if ($type==null) {
-                $type ="none";
-            }
+            $isSelected = $type == $this->getBVLQCType();
+            $type       = strtolower($type ?? 'none');
             if ($isSelected) {
                 $this->tpl_data['bvl_qc_type_'.$type]['icon']
                     = 'far fa-check-square';
@@ -510,11 +507,8 @@ class Instrument_List_ControlPanel extends \TimePoint
         $qcType = $this->getBVLQCType();
 
         foreach ($this->bvlQcStatuses as $status) {
-            $isSelected =$status == $this->getBVLQCStatus();
-            $status     =strtolower($status);
-            if ($status==null) {
-                $status ="none";
-            }
+            $isSelected = $status == $this->getBVLQCStatus();
+            $status     = strtolower($status ?? 'none');
             if ($isSelected) {
                 $this->tpl_data['bvl_qc_status_'.$status]['icon']
                     = 'far fa-check-square';


### PR DESCRIPTION
Fix the warnings:

```
<b>Deprecated</b>:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in <b>modules/instrument_list/php/instrument_list_controlpanel.class.inc</b> on line <b>475</b><br />
<br />
<b>Deprecated</b>:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in <b>modules/instrument_list/php/instrument_list_controlpanel.class.inc</b> on line <b>514</b><br />
```

in PHP 8.2 and above (and maybe below, I didn't check.)