### PR TITLE
[LINST/Dictionary] Add Numeric elements to dictionary

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -734,14 +734,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 case 'numeric':
                     if ($addElements) {
                         $this->addNumericElement($pieces[1], $pieces[2]);
-                        $this->dictionary[] = new DictionaryItem(
-                            $this->testName."_".$pieces[1],
-                            $pieces[2],
-                            $scope,
-                            new IntegerType(),
-                            new Cardinality(Cardinality::SINGLE),
-                        );
                     }
+                    $this->dictionary[] = new DictionaryItem(
+                        $this->testName."_".$pieces[1],
+                        $pieces[2],
+                        $scope,
+                        new IntegerType(),
+                        new Cardinality(Cardinality::SINGLE),
+                    );
                     if ($firstFieldOfPage) {
                         $this->_requiredElements[] = $fieldname;
                         $firstFieldOfPage          = false;


### PR DESCRIPTION
Currently the numeric element type is only being added to the instrument data dictionary if it's on the top page.

This fixes it so that the elements are always added to the dictionary regardless of the page.