### PR TITLE
[Core] Enable use of project modules for ajax requests

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -94,7 +94,7 @@ try {
     $loris = new \LORIS\LorisInstance(
         new \Database(),
         new \NDB_Config(),
-        [__DIR__ . "/../modules", __DIR__ . "/../project/modules"]
+        [__DIR__ . "/../project/modules", __DIR__ . "/../modules"]
     );
     $m     = $loris->getModule($Module);
 


### PR DESCRIPTION
This change enables the use of project modules for requests that use `AjaxHelper`.

The order in which the directories are defined, when the `LorisInstance` is instantiated, determines the order of locations where modules are searched for and registered.