### PR TITLE
[Core] Allow module entrypoint to be written in typescript

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,7 +151,7 @@ function lorisModule(mname, entries) {
 
   for (let i = 0; i < entries.length; i++) {
     entObj[entries[i]] =
-      base + '/' + mname + '/jsx/' + entries[i] + '.js';
+      base + '/' + mname + '/jsx/' + entries[i];
   }
   return {
     entry: entObj,


### PR DESCRIPTION
There is an unnecessary ".js" added to the name resolution in webpack.config.js which forces the entrypoint of modules referred to by the config to be javascript. This removes it so that .ts/.tsx files can serve as the entrypoint to a module.