### PR TITLE
[JS] Add username/id to Loris helper object

### DIFF
--- a/htdocs/js/loris.js
+++ b/htdocs/js/loris.js
@@ -1,6 +1,6 @@
 /* exported LorisHelper */
 
-let LorisHelper = function(configParams, userPerms, studyParams) {
+let LorisHelper = function(user, configParams, userPerms, studyParams) {
   'use strict';
   let lorisObj = configParams;
 
@@ -72,6 +72,8 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
     'use strict';
     return studyParams[param];
   };
+
+  lorisObj.user = user;
 
   return lorisObj;
 };

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -13,7 +13,7 @@
            and can access them through the loris global (ie. loris.BaseURL) *}
         <script src="{$baseurl}/js/loris.js" type="text/javascript"></script>
         <script language="javascript" type="text/javascript">
-        let loris = new LorisHelper({$jsonParams}, {$userPerms|json_encode}, {$studyParams|json_encode});
+        let loris = new LorisHelper({$userjson}, {$jsonParams}, {$userPerms|json_encode}, {$studyParams|json_encode});
         </script>
         {section name=jsfile loop=$jsfiles}
             <script src="{$jsfiles[jsfile]}" type="text/javascript"></script>

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -221,7 +221,12 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         // Do not show menu item if module not active
         $tpl_data['my_preferences'] = $loris->hasModule('my_preferences');
-
+        $tpl_data['userjson']       = json_encode(
+            [
+             'username' => $user->getUsername(),
+             'id'       => $user->getId(),
+            ]
+        );
         // Display the footer links, as specified in the config file
         $links = $this->Config->getExternalLinks('FooterLink');
 


### PR DESCRIPTION
Currently, you can access the PHP user object from smarty templates, but if you need access the username/userid from javascript you need to jump through hoops (like putting them in a smarty template or an endpoint that returns them.)

This adds a `user` object of the form `{username: string, id: number}` to the loris helper object so that you can access the basics from javascript as `loris.user.username` or `loris.user.id` when needed.