### PR TITLE
[TypeScript] Require strict null checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "lib": [
       "es6", "dom", "es2017"
     ],
+    "strictNullChecks" : true
   }
 }


### PR DESCRIPTION
If we're going to catch type errors it seems like a better idea to ensure null checks are done at compile time rather than being surprised at runtime.