### PR TITLE
[TypeScript] Add StaticDataTable type definition

### DIFF
--- a/jsx/StaticDataTable.d.ts
+++ b/jsx/StaticDataTable.d.ts
@@ -1,0 +1,60 @@
+import {ReactNode} from 'react';
+/**
+ * This file contains a sufficient typescript definition of the StaticDataTable
+ * to allow it to be imported into TypeScript with "strict" mode and not trigger
+ * errors.
+ */
+
+type TableRow = (string|null)[];
+
+type StaticDataTableProps = {
+    Headers: string[],
+    Data: TableRow[],
+    RowNumLabel: string?,
+    getFormattedCell: (
+        columnname: string,
+        celldata: string,
+        row: string[],
+        headers: string[],
+        fieldNo: number
+    ) => ReactNode,
+    onSort?: () => void
+};
+
+/**
+ * StaticDataTable class. See StaticDataTable.js
+ */
+class StaticDataTable {
+    props: StaticDataTableProps
+    state: any
+    context: object
+    refs: {[key: string]: ReactInstance}
+
+    /**
+     * Create a StaticDataTable
+     *
+     * @param {StaticDataTableProps} props - React props
+     */
+    constructor(props: StaticDataTableProps)
+
+    /**
+     * React Lifecycle Method
+     *
+     * @returns {ReactNode} - the StaticDataTable
+     */
+    render(): ReactNode
+
+    /**
+     * React Lifecycle Method
+     *
+     * @param {object} newstate - the state to overwrite
+     */
+    setState(newstate: object): void
+
+    /**
+     * React Lifecycle Method
+     */
+    forceUpdate(): void
+}
+
+export default StaticDataTable;

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -527,7 +527,8 @@ class StaticDataTable extends Component {
             this.props.Headers[j],
             data,
             this.props.Data[index[i].RowIdx],
-            this.props.Headers
+            this.props.Headers,
+            j
           );
           if (data !== null) {
             // Note: Can't currently pass a key, need to update columnFormatter


### PR DESCRIPTION
This adds a typescript module definition for StaticDataTable, so that it can be imported from typescript in strict mode without triggering errors.

It also adds a new parameter to the "getFormattedColumn" callback to indicate the current index of the column. (This should technically be a different PR, but it's easier to do it at the same time rather than need to modify the definition after.)