### PR TITLE
[Core] Named form exports for Form.js

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import PaginationLinks from 'jsx/PaginationLinks';
 import createFragment from 'react-addons-create-fragment';
+import {CTA} from 'jsx/Form';
 
 /**
  * Data Table component

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -1,5 +1,13 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
+import {
+    SelectElement,
+    DateElement,
+    TextboxElement,
+    FormElement,
+    FieldsetElement,
+    CheckboxElement,
+} from 'jsx/Form';
 
 /**
  * Filter component

--- a/jsx/FilterForm.js
+++ b/jsx/FilterForm.js
@@ -7,6 +7,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
+import {FormElement} from 'jsx/Form';
 
 /**
  * FilterForm component.

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1,8 +1,3 @@
-/* exported FormElement, FieldsetElement, SelectElement, TagsElement, SearchableDropdown, TextareaElement,
-TextboxElement, PasswordElement, DateElement, DateTimeElement, NumericElement, FileElement, StaticElement, HeaderElement, LinkElement,
-CheckboxElement, ButtonElement, LorisElement
-*/
-
 /**
  * This file contains React components for Loris form elements.
  *
@@ -24,7 +19,7 @@ import PropTypes from 'prop-types';
  * Note that if both are passed `this.props.formElements` is displayed first.
  *
  */
-class FormElement extends Component {
+export class FormElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -174,7 +169,7 @@ FormElement.defaultProps = {
  * The form elements can be passed by nesting Form components directly inside <FieldsetElement></FieldsetElement>.
  *
  */
-class FieldsetElement extends Component {
+export class FieldsetElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -251,7 +246,7 @@ FieldsetElement.defaultProps = {
  * Search Component
  * React wrapper for a searchable dropdown
  */
-class SearchableDropdown extends Component {
+export class SearchableDropdown extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -464,7 +459,7 @@ SearchableDropdown.defaultProps = {
  * Select Component
  * React wrapper for a simple or 'multiple' <select> element.
  */
-class SelectElement extends Component {
+export class SelectElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -702,7 +697,7 @@ SelectElement.defaultProps = {
  *    a normal dropdown select
  * 3: Without options, input is a normal, free text input
  */
-class TagsElement extends Component {
+export class TagsElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1002,7 +997,7 @@ TagsElement.defaultProps = {
  * Textarea Component
  * React wrapper for a <textarea> element.
  */
-class TextareaElement extends Component {
+export class TextareaElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1094,7 +1089,7 @@ TextareaElement.defaultProps = {
  * Textbox Component
  * React wrapper for a <input type="text"> element.
  */
-class TextboxElement extends Component {
+export class TextboxElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1227,7 +1222,7 @@ TextboxElement.defaultProps = {
  * EmailElement Component
  * React wrapper for a <input type="email"> element.
  */
-class EmailElement extends Component {
+export class EmailElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1359,7 +1354,7 @@ EmailElement.defaultProps = {
  * Password Component
  * React wrapper for a <input type="password"> element.
  */
-class PasswordElement extends Component {
+export class PasswordElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1520,7 +1515,7 @@ PasswordElement.defaultProps = {
  * Date Component
  * React wrapper for a <input type="date"> element.
  */
-class DateElement extends Component {
+export class DateElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1683,7 +1678,7 @@ DateElement.defaultProps = {
  * Time Component
  * React wrapper for a <input type="time"> element.
  */
-class TimeElement extends Component {
+export class TimeElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1779,7 +1774,7 @@ TimeElement.defaultProps = {
  * DateTime Component
  * React wrapper for a <input type="datetime-local"> element.
  */
-class DateTimeElement extends Component {
+export class DateTimeElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1875,7 +1870,7 @@ DateTimeElement.defaultProps = {
  * Numeric Component
  * React wrapper for a <input type="number"> element.
  */
-class NumericElement extends Component {
+export class NumericElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1980,7 +1975,7 @@ NumericElement.defaultProps = {
  * File Component
  * React wrapper for a simple or 'multiple' <input type="file"> element.
  */
-class FileElement extends Component {
+export class FileElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2177,7 +2172,7 @@ FileElement.defaultProps = {
  * />
  * ```
  */
-class StaticElement extends Component {
+export class StaticElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2236,7 +2231,7 @@ StaticElement.defaultProps = {
  * Used to display a header element with specific level (1-6) as part of a form
  *
  */
-class HeaderElement extends Component {
+export class HeaderElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2277,7 +2272,7 @@ HeaderElement.defaultProps = {
  * Link element component.
  * Used to link plain/formated text to an href destination as part of a form
  */
-class LinkElement extends Component {
+export class LinkElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2326,7 +2321,7 @@ LinkElement.defaultProps = {
  * Checkbox Component
  * React wrapper for a <input type="checkbox"> element.
  */
-class CheckboxElement extends React.Component {
+export class CheckboxElement extends React.Component {
   /**
    * @constructor
    */
@@ -2426,7 +2421,7 @@ CheckboxElement.defaultProps = {
  * Button component
  * React wrapper for <button> element, typically used to submit forms
  */
-class ButtonElement extends Component {
+export class ButtonElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2499,7 +2494,7 @@ ButtonElement.defaultProps = {
  * React wrapper for <button> element that is used for Call to Actions, usually
  * outside the context of forms.
  */
- class CTA extends Component {
+export class CTA extends Component {
   /**
    * Renders the React component.
    *
@@ -2533,7 +2528,7 @@ ButtonElement.defaultProps = {
 /**
  * Generic form element.
  */
-class LorisElement extends Component {
+export class LorisElement extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2627,7 +2622,7 @@ LorisElement.propTypes = {
  *     male: 'Male',
  *   }
  */
-class RadioElement extends React.Component {
+export class RadioElement extends React.Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2788,7 +2783,7 @@ RadioElement.defaultProps = {
  * Slider Component
  * React wrapper for a <input type='range'> element.
  */
-class SliderElement extends React.Component {
+export class SliderElement extends React.Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2928,30 +2923,6 @@ SliderElement.defaultProps = {
     console.warn('onUserInput() callback is not set');
   },
 };
-
-window.FormElement = FormElement;
-window.FieldsetElement = FieldsetElement;
-window.SelectElement = SelectElement;
-window.TagsElement = TagsElement;
-window.SearchableDropdown = SearchableDropdown;
-window.TextareaElement = TextareaElement;
-window.TextboxElement = TextboxElement;
-window.EmailElement = EmailElement;
-window.PasswordElement = PasswordElement;
-window.DateElement = DateElement;
-window.TimeElement = TimeElement;
-window.DateTimeElement = DateTimeElement;
-window.NumericElement = NumericElement;
-window.FileElement = FileElement;
-window.StaticElement = StaticElement;
-window.HeaderElement = HeaderElement;
-window.LinkElement = LinkElement;
-window.SliderElement = SliderElement;
-window.CheckboxElement = CheckboxElement;
-window.RadioElement = RadioElement;
-window.ButtonElement = ButtonElement;
-window.CTA = CTA;
-window.LorisElement = LorisElement;
 
 export default {
   FormElement,

--- a/jsx/TriggerableModal.js
+++ b/jsx/TriggerableModal.js
@@ -8,6 +8,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 import Modal from 'Modal';
+import {CTA} from 'jsx/Form';
 
 /**
  * Triggerable Modal Component.

--- a/modules/acknowledgements/jsx/acknowledgementsIndex.js
+++ b/modules/acknowledgements/jsx/acknowledgementsIndex.js
@@ -7,6 +7,13 @@ import Modal from 'Modal';
 import Panel from 'Panel';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
+import {
+    SelectElement,
+    FormElement,
+    TextboxElement,
+    DateElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Acknowledgements Module page.

--- a/modules/candidate_list/jsx/openProfileForm.js
+++ b/modules/candidate_list/jsx/openProfileForm.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {TextboxElement, ButtonElement, FormElement} from 'jsx/Form';
 
 /**
  * Open Profile Form

--- a/modules/conflict_resolver/jsx/fix_conflict_form.js
+++ b/modules/conflict_resolver/jsx/fix_conflict_form.js
@@ -4,6 +4,7 @@
  */
 import {Component} from 'react';
 import PropTypes from 'prop-types';
+import {SelectElement} from 'jsx/Form';
 
 /**
  * The fix FixConflictForm renders a <form> within a <td>. The form as a select

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import Panel from 'Panel';
 import Loader from 'Loader';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    SelectElement,
+    StaticElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Create Timepoint.

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    TextboxElement,
+    TextareaElement,
+    SelectElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Document Upload Form

--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -10,6 +10,7 @@ import swal from 'sweetalert2';
 import {createRoot} from 'react-dom/client';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {CheckboxElement} from 'jsx/Form';
 
 /**
  * Doc index component

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types';
 
 import swal from 'sweetalert2';
 import Loader from 'Loader';
+import {
+    SearchableDropdown,
+    SelectElement,
+    FormElement,
+    TextboxElement,
+    TextareaElement,
+    FileElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Media Upload Form

--- a/modules/electrophysiology_uploader/jsx/UploadForm.js
+++ b/modules/electrophysiology_uploader/jsx/UploadForm.js
@@ -2,6 +2,13 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import ProgressBar from 'ProgressBar';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    FileElement,
+    TextboxElement,
+    StaticElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * UploadForm

--- a/modules/examiner/jsx/examinerIndex.js
+++ b/modules/examiner/jsx/examinerIndex.js
@@ -6,6 +6,13 @@ import swal from 'sweetalert2';
 import Modal from 'Modal';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
+import {
+    ButtonElement,
+    CheckboxElement,
+    SelectElement,
+    FormElement,
+    TextboxElement,
+} from 'jsx/Form';
 
 /**
  * Examiner Module Page.

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -2,6 +2,14 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import ProgressBar from 'ProgressBar';
 import Loader from 'jsx/Loader';
+import {
+    FormElement,
+    CheckboxElement,
+    FileElement,
+    TextareaElement,
+    SelectElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Genomic Upload Form

--- a/modules/help_editor/jsx/helpEditorForm.js
+++ b/modules/help_editor/jsx/helpEditorForm.js
@@ -4,6 +4,7 @@ import {createPortal} from 'react-dom';
 import Markdown from 'jsx/Markdown';
 import Help from 'jsx/Help';
 import swal from 'sweetalert2';
+import {TextboxElement, TextareaElement} from 'jsx/Form';
 
 /**
  * Help Editor Form Page.

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -6,6 +6,7 @@ import Loader from 'Loader';
 
 import LogPanel from './LogPanel';
 import UploadForm from './UploadForm';
+import {TextboxElement, SelectElement, ButtonElement} from 'jsx/Form';
 
 /**
  * Imaging uploader component

--- a/modules/imaging_uploader/jsx/LogPanel.js
+++ b/modules/imaging_uploader/jsx/LogPanel.js
@@ -1,6 +1,11 @@
 /* global UploadProgress */
 import React, {Component} from 'react';
 import Panel from 'Panel';
+import {
+    FormElement,
+    SelectElement,
+    TextareaElement,
+} from 'jsx/Form';
 
 /**
  * Log Panel Component

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -2,6 +2,14 @@ import ProgressBar from 'ProgressBar';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    SelectElement,
+    TextboxElement,
+    StaticElement,
+    FileElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Imaging Upload Form

--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -7,6 +7,12 @@ import PropTypes from 'prop-types';
 import Loader from 'Loader';
 import Panel from 'Panel';
 import DOMPurify from 'dompurify';
+import {
+    FormElement,
+    TextboxElement,
+    PasswordElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Login form.

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -2,6 +2,15 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    StaticElement,
+    SelectElement,
+    TextboxElement,
+    EmailElement,
+    CheckboxElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Request account form.

--- a/modules/login/jsx/resetPassword.js
+++ b/modules/login/jsx/resetPassword.js
@@ -1,6 +1,12 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
+import {
+    FormElement,
+    StaticElement,
+    TextboxElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Reset password form.

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -3,6 +3,16 @@ import PropTypes from 'prop-types';
 import ProgressBar from 'ProgressBar';
 import Loader from 'jsx/Loader';
 import swal from 'sweetalert2';
+import {
+    FormElement,
+    HeaderElement,
+    StaticElement,
+    SelectElement,
+    DateElement,
+    TextareaElement,
+    FileElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Media Upload Form

--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -3,6 +3,14 @@ import swal from 'sweetalert2';
 import {createRoot} from 'react-dom/client';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+    SelectElement,
+    DateElement,
+    TextboxElement,
+    FormElement,
+    ButtonElement,
+    FieldsetElement,
+} from 'jsx/Form';
 
 /**
  * New Profile Form

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -856,7 +856,6 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
             $baseurl . '/bootstrap/js/bootstrap.min.js',
             $baseurl . '/js/components/Breadcrumbs.js',
             $baseurl . "/js/util/queryString.js",
-            $baseurl . '/js/components/Form.js',
             $baseurl . '/js/components/Help.js',
         ];
         return $files;

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -806,7 +806,6 @@ class NDB_PageTest extends TestCase
                 '/bootstrap/js/bootstrap.min.js',
                 '/js/components/Breadcrumbs.js',
                 '/js/util/queryString.js',
-                '/js/components/Form.js',
                 '/js/components/Help.js',
             ],
             $this->_page->getJSDependencies()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -219,7 +219,6 @@ let config = [
       StaticDataTable: './jsx/StaticDataTable.js',
       MultiSelectDropdown: './jsx/MultiSelectDropdown.js',
       Breadcrumbs: './jsx/Breadcrumbs.js',
-      Form: './jsx/Form.js',
       CSSGrid: './jsx/CSSGrid.js',
       Help: './jsx/Help.js',
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,6 @@ const resolve = {
     Filter: path.resolve(__dirname, './jsx/Filter'),
     FilterableDataTable: path.resolve(__dirname, './jsx/FilterableDataTable'),
     FilterForm: path.resolve(__dirname, './jsx/FilterForm'),
-    Form: path.resolve(__dirname, './jsx/Form'),
     Loader: path.resolve(__dirname, './jsx/Loader'),
     Modal: path.resolve(__dirname, './jsx/Modal'),
     MultiSelectDropdown: path.resolve(__dirname, './jsx/MultiSelectDropdown'),


### PR DESCRIPTION
This adds the `export` keyword for the classes defined in jsx/Form.js so that they can be imported with a more standard (ie) `import {SelectElement, StaticElement} from 'jsx/Form';`. It removes the globals on `window` and replaces all references in the code with an explicit import.

This allows the element types to be imported from TypeScript strict mode without complaining about them not being defined.