### PR TITLE
[imaging_uploader] Fix auto-populating VisitLabel

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -66,7 +66,7 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        // visitLabel can contain underscores, filename can have suffix appended to patientName
+        // visitLabel can contain underscores, filename can have suffix appended to PSCID_CandID_VisitLabel
         // join the remaining elements of patientName and pattern match
         // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -66,7 +66,7 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        // visitLabel can contain underscores
+        // visitLabel can contain underscores, filename can have suffix appended to patientName
         // join the remaining elements of patientName and pattern match
         // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -93,7 +93,7 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        // visitLabel can contain underscores
+        // visitLabel can contain underscores,  filename can have suffix appended to patientName
         // join the remaining elements of patientName and pattern match
         // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -70,9 +70,9 @@ class UploadForm extends Component {
         // join the remaining elements of patientName and pattern match
         // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);
-        suffix = ids.join('_');
-        visitLabels = form.visitLabel.options.keys;
-        bestMatch = '';
+        const suffix = ids.join('_');
+        const visitLabels = Object.keys(form.visitLabel.options);
+        let bestMatch = '';
         visitLabels.map((visitLabel) => {
           if (suffix.match(visitLabel) !== null) {
             // consider the first match only
@@ -94,9 +94,21 @@ class UploadForm extends Component {
         formData.candID = ids[1];
         formData.pSCID = ids[0];
         // visitLabel can contain underscores
-        // join the remaining elements of patientName and use as visitLabel
+        // join the remaining elements of patientName and pattern match
+        // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);
-        formData.visitLabel = ids.join('_');
+        const suffix = ids.join('_');
+        const visitLabels = Object.keys(form.visitLabel.options);
+        let bestMatch = '';
+        visitLabels.map((visitLabel) => {
+          if (suffix.match(visitLabel) !== null) {
+            // consider the first match only
+            if (suffix.match(visitLabel)[0].length > bestMatch.length) {
+              bestMatch = suffix.match(visitLabel)[0];
+            }
+          }
+        });
+        formData.visitLabel = bestMatch;
       }
     }
 

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -67,9 +67,21 @@ class UploadForm extends Component {
         formData.candID = ids[1];
         formData.pSCID = ids[0];
         // visitLabel can contain underscores
-        // join the remaining elements of patientName and use as visitLabel
+        // join the remaining elements of patientName and pattern match
+        // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);
-        formData.visitLabel = ids.join('_');
+        suffix = ids.join('_');
+        visitLabels = form.visitLabel.options.keys;
+        bestMatch = '';
+        visitLabels.map((visitLabel) => {
+          if (suffix.match(visitLabel) !== null) {
+            // consider the first match only
+            if (suffix.match(visitLabel)[0].length > bestMatch.length) {
+              bestMatch = suffix.match(visitLabel)[0];
+            }
+          }
+        });
+        formData.visitLabel = bestMatch;
       }
     }
 

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -93,7 +93,7 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        // visitLabel can contain underscores,  filename can have suffix appended to patientName
+        // visitLabel can contain underscores,  filename can have suffix appended to PSCID_CandID_VisitLabel
         // join the remaining elements of patientName and pattern match
         // against each visit label. Use as visitLabel the best (longest) match
         ids.splice(0, 2);


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

Fixes https://github.com/aces/Loris/issues/8803

#### Testing instructions (if applicable)

1. In Imaging uploader Upload Form, choose Phantom 'No' and select a file with the proper naming convention, suffixed by any random string.
2. Make sure that only the visit label is populated in the Visit Label field, and not the entire end of the string

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
