### PR TITLE
[Dict] hotfix add hidden fields to dictionary implementation

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -131,6 +131,7 @@ trait LorisFormDictionaryImpl
                 $t = new \LORIS\Data\Types\StringType(255);
                 break;
             case 'header':
+            case 'hidden':
                 continue 2;
             default:
                 throw new \LorisException(


### PR DESCRIPTION
## Brief summary of changes
Some instruments use hidden fields which were not taken into consideration in this class. This should simply skip over the fields in the dictionary building