### PR TITLE
[dataquery api] Clarify schema

### DIFF
--- a/modules/dataquery/static/schema.yml
+++ b/modules/dataquery/static/schema.yml
@@ -288,6 +288,11 @@ components:
         field:
           type: string
           example: "CandID"
+        visits:
+          description: The visit labels for this field for session-level data
+          type: array
+          items:
+            type: string
       required:
         - module
         - category
@@ -368,9 +373,9 @@ components:
       description: |- 
         The result of running a query.
         
-        The result is a stream of data for each CandID that matched by the query. Candidates are separated by an ASCII record separator (0x??). Each cell within the candidate is separated by an ASCII ?? separateor (0x??). Each row should have the exact number of fields that were in the query fields attribute.
+        The result is a stream of data for each CandID that matched by the query. Candidates are separated by an ASCII unit separator (0x1f). Each cell within the candidate is separated by an ASCII record separator (0x1e). Each row should have the exact number of fields that were in the query fields attribute.
         
-        Within each cell, the format of the data varies based on the dictionary of the field type. If the data is candidate scoped, a value is directly returned. If it is session scoped variable or has cardinality of many:one, a JSON object is returned.
+        Within each cell, the data is returned as a JSON value, the exact format varies based on the cell's dictionary type. If the data is candidate scoped, a value is directly returned as a JSON primitive. If it is session scoped variable or has cardinality many:one, a JSON object is returned. Session scoped variables contain a JSON object with the key being the SessionID for each session where this row's candidate has data and the value of which is an object of the format `{ SessionID: number, VisitLabel: string, value: value }`
   
   securitySchemes:
     ApiKeyAuth:


### PR DESCRIPTION
This makes a couple updates to the schema defined for the dataquery API.

Visits may be defined for session scoped fields. A description is added, but the field is not marked as required because it is not used for candidate fields.

QueryResults is better defined. The separators are explicitly defined to be those currently used by `src/Http/DataIteratorBinaryStream` and the cells are now always defined to be JSON values. The format of session scoped data is more explicitly defined to be in line with the expectations of the new data query frontend.