### PR TITLE
[Feedback] Fix typo in getSummaryOfThreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ the `Data` key instead of `$InstrumentName` (PR #7857)
 - Fixed broken DB calls in `assign_missing_instruments` and `instruments` (PR #8162)
 - Add support for PHP 8.1 (PR #7989)
 - Fix Project tab of Configuration module to give correct errors, and prevent saving without Alias (PR #8349)
+- Fix BVL feedback summary in instruments (PR #8889)
 ### Modules
 #### API
 - Ability to use PSCID instead of the CandID in the candidates API (PR #8138)

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -499,7 +499,7 @@ class NDB_BVL_Feedback
         }
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query           .= " AND ft.CommentID = :ComID";
-            $qparams['ComID'] = $this->_feedbackCandidateProfileInfo['CommentID'];
+            $qparams['ComID'] = $this->_feedbackObjectInfo['CommentID'];
         }
 
         if (!$hasReadPermission) {


### PR DESCRIPTION
## Brief summary of changes
I had looked into the suspected bug and confirmed that it is indeed a bug. 

This PR fixes the BVL Feedback summary in instruments by taking the commentID for query params from the array _feedbackObjectInfo instead of _feedbackCandidateProfileInfo, which only included candidate specific data instead of instrument specific data.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Outside of this PR, navigate to an instrument that has at least one feedback comment. 
2. Look at the feedback for that instrument, and check the feedback summary at the top of the window. Notice that it is indicated that there is no feedback
<img width="1440" alt="image" src="https://github.com/aces/Loris/assets/51176779/78e938cf-c656-4b9f-8cac-0aec31eafe6f">
3. Load this PR and refresh the page. 
4. Notice that the summary exists and holds accurate information

![image](https://github.com/aces/Loris/assets/51176779/f810da7d-8672-4a30-afab-cf43e9a73e28)

