### PR TITLE
[behavioural_qc] fixes visitLevel feedback not showing up.

### DIFF
--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -109,23 +109,32 @@ class BehaviouralFeedback extends Component {
         );
         break;
       case 'Feedback Level':
-        rowData['Instrument'] ? reactElement = (
+        let bvlLink = '';
+        let bvlLevel = '';
+        if (rowData['Instrument']) {
+          bvlLink = this.props.baseURL +
+                     '/instruments/' +
+                     rowData['Test Name'] +
+                     '/?candID=' +
+                     rowData['DCCID'] +
+                     '&sessionID=' +
+                     rowData['sessionID'] +
+                     '&commentID=' +
+                     rowData['commentID'];
+          bvlLevel ='Instrument : ' + rowData['Instrument'];
+        } else if (rowData['Visit']) {
+          bvlLink = this.props.baseURL +
+                     '/instrument_list/' +
+                     '?candID=' +
+                     rowData['DCCID'] +
+                     '&sessionID=' +
+                     rowData['sessionID'];
+          bvlLevel ='Visit : ' + rowData['Visit'];
+        }
+        reactElement = (
           <td>
-            <a href={this.props.baseURL +
-              '/instruments/' +
-              rowData['Test Name'] +
-              '/?candID=' +
-              rowData['DCCID'] +
-              '&sessionID=' +
-              rowData['sessionID'] +
-              '&commentID=' +
-              rowData['commentID']
-              }>
-                {'Instrument : ' + rowData['Instrument']}
-            </a>
+            <a href={bvlLink}>{bvlLevel}</a>
           </td>
-        ) : reactElement = (
-          <td>{''}</td>
         );
         break;
       default:


### PR DESCRIPTION
## Brief summary of changes
The visit Level feedback was included as part of the `formatColumn()` function in the `BehaviouralFeedback` class file `/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js`

#### Testing instructions (if applicable)

1. Go to `MainMenu-> Clinical -> Behavioural Quality Control`.
2. Then go to the `Behavioural Feedback` tab.
3. All the columns should show properly now.
4. The links should be also properly working.

![image](https://github.com/aces/Loris/assets/37309344/d85d1afa-78a0-4db2-8324-3e9214ca8094)


#### Link(s) to related issue(s)

* Resolves #8037

