### PR TITLE
[configuration] Escape values in config module

### DIFF
--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -49,11 +49,11 @@
 {/function}
 
 {function name=createTextArea}
-    <textarea class="form-control" rows="4" name="{$k}" {if $d eq "Yes"}disabled{/if}>{$v}</textarea>
+    <textarea class="form-control" rows="4" name="{$k}" {if $d eq "Yes"}disabled{/if}>{$v|escape:html}</textarea>
 {/function}
 
 {function name=createText}
-     <input type="text" class="form-control" name="{$k}" value="{$v}" {if $d eq "Yes"}disabled{/if}>
+     <input type="text" class="form-control" name="{$k}" value="{$v|escape:html}" {if $d eq "Yes"}disabled{/if}>
 {/function}
 
 {function name=createLogDropdown}


### PR DESCRIPTION
PR#8759 converted the escape module to use unsafeInsert/update to save data and prevent double escaping issues. The usages of the textarea were audited to make sure they were properly escaped, however the value is also displayed in the configuration module itself. Until the module is updated from smarty to react (PR#8471), they need to be escaped in the config module itself.

This adds escaping to the config module smarty template.