### PR TITLE
[media] fixes issue when media module try to instantiate a non existing instrument.

### DIFF
--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -91,10 +91,19 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 
         // make sure not to call the factory when $testname is null or ''
         if (!empty($testname) && !isset($this->_instrumentnames[$testname])) {
-            $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
-                $this->lorisinstance,
-                $testname,
-            )->getFullname();
+            try {
+                $this->_instrumentnames[$testname] = \NDB_BVL_Instrument::factory(
+                    $this->lorisinstance,
+                    $testname,
+                )->getFullname();
+            } catch (\Exception $e) {
+                error_log(
+                    "There was a problem instantiating the instrument ".
+                    "'$testname'. Make sure the instrument is valid and ".
+                    "functional in order for it to be displayed in the media ".
+                    "module."
+                );
+            }
         }
         $row['fullName'] = $this->_instrumentnames[$testname] ?? null;
 


### PR DESCRIPTION
## Brief summary of changes
A try catch block was added to prevent the module to break if for any reason one of the instruments could not be instantiated. Pleas refer to issue https://github.com/aces/Loris/issues/8902

#### Testing instructions (if applicable)

1. Having the pre-requisites described in #8902
2. Go to `MainMenu->Clinical->Media`
3. The module should load now
4. The failing to instantiate instruments should be logged in the error-log

#### Link(s) to related issue(s)

* Resolves #8902 
