### PR TITLE
[issue_tracker] Fix inactive user query

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -94,7 +94,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             $inactive_users_expanded = $db->pselect(
                 "SELECT DISTINCT u.Real_name, u.UserID FROM users u
                  LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
-                 WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
+                 WHERE (FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC))
                  AND Active='N'",
                 [
                     'CenterID' => $CenterID,


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the logic in the inactive users query for the assignee drop down of the issue tracker. 

Previously, the query was missing brackets in the logic and was querying active users in the inactive users array. This resulted in all users being unset from the assignees object for users who do not have the "access_all_profiles" permission. With this PR, users without the "access_all_profiles" permission should be able to see the appropriate users in the assignee drop down of a new issue. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. In the 24.1-release branch, navigate to the issue tracker module with a user who does not have the "access_all_profiles" permission. Make sure you are on a database with several active and inactive users, especially at the same site(s) as the user you are using. Click on "New issue"
2. Notice that the "assignee" drop down is blank
3. Checkout this PR and refresh
4. The "assignee" drop down should no longer be blank
5. Check that only users who are active and at the same site as the user or DCC site are displayed in the assignee drop down. 

