### PR TITLE
[media] Fix SQL injection 

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -349,7 +349,7 @@ function getUploadFields()
         $mediaData   = $db->pselectRow(
             "SELECT " .
             "m.session_id as sessionID, " .
-            "(SELECT PSCID from candidate WHERE CandID=s.CandID) as pscid, " .
+            "c.PSCID as pscid, " .
             "Visit_label as visitLabel, " .
             "instrument, " .
             "CenterID as forSite, " .
@@ -358,9 +358,10 @@ function getUploadFields()
             "file_name as fileName, " .
             "hide_file as hideFile, " .
             "language_id as language," .
-            "m.id FROM media m LEFT JOIN session s ON m.session_id = s.ID " .
-            "WHERE m.id = $idMediaFile",
-            []
+            "m.id FROM media m LEFT JOIN session s ON m.session_id = s.ID 
+                LEFT JOIN candidate c ON (c.CandID=s.CandID) " .
+            "WHERE m.id = :mediaId",
+            ['mediaId' => $idMediaFile]
         );
     }
 


### PR DESCRIPTION
This fixes 2 problems with the SQL in the media FileUpload?action=getData endpoint
1. There is an obvious SQL injection attack where user input from the request is directly concatenated into a string that's passed to the database.
2. There was an unnecessary sub-select that could have been a join

This whole section of the code is a mess that should to be re-written, but this PR just tackles the urgent string concatenation.