### PR TITLE
[dictionary] Remove beta tag from dictionary module

### DIFF
--- a/modules/datadict/php/module.class.inc
+++ b/modules/datadict/php/module.class.inc
@@ -55,6 +55,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Dictionary";
+        return "Data Dictionary (Legacy)";
     }
 }

--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -55,7 +55,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Dictionary (Beta)";
+        return "Data Dictionary";
     }
 
     /**


### PR DESCRIPTION
The "beta" dictionary module was added in LORIS 24, and tested in both 24.1, and 25. When 26 is released, it will be the 4th release including it. Its API is also used by the conflict resolver to get field descriptions.

It should no longer be considered beta.

This removes the "beta" tag from the description in the menu, and adds a "legacy" to the old datadict, which needs to be maintained until the new DQT is released (based on the new dictionary.)