### PR TITLE
[YAML schema] Fix candidate key to meta

### DIFF
--- a/modules/api/static/schema-v0.0.4-dev.yml
+++ b/modules/api/static/schema-v0.0.4-dev.yml
@@ -2199,7 +2199,7 @@ components:
     inline_response_200_2:
       type: object
       properties:
-        Candidate:
+        Meta:
           $ref: '#/components/schemas/Candidate'
         Visits:
           type: array

--- a/modules/api/static/schema.yml
+++ b/modules/api/static/schema.yml
@@ -2142,7 +2142,7 @@ components:
     inline_response_200_2:
       type: object
       properties:
-        Candidate:
+        Meta:
           $ref: '#/components/schemas/Candidate'
         Visits:
           type: array


### PR DESCRIPTION
## Brief summary of changes

When querying a specific candidate with `api/v0.0.4-dev/candidates/$id/` endpoint, the returned object looks like this:

```
{"Meta":{"CandID":"000001","Project":"COPN","PSCID":"CA0003","Site":"University of Calgary","EDC":null,"DoB":"1956-01-01","Sex":"Male"},"Visits":{"InitialVisit":"99999","SampleCollection01":"99991"}}
```

The inline_response_200_2 object should have the 'Meta' property instead of 'Candidate' as key to the Candidate object

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
