### PR TITLE
[SQL] Require test_names.Sub_group to not be null

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -252,7 +252,7 @@ CREATE TABLE `test_names` (
   `ID` int(10) unsigned NOT NULL auto_increment,
   `Test_name` varchar(255) default NULL,
   `Full_name` varchar(255) default NULL,
-  `Sub_group` int(11) unsigned default NULL,
+  `Sub_group` int(11) unsigned NOT NULL,
   `IsDirectEntry` boolean default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Test_name` (`Test_name`),

--- a/SQL/New_patches/2023-11-07-No-Null-Subgroup.sql
+++ b/SQL/New_patches/2023-11-07-No-Null-Subgroup.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test_names CHANGE Sub_group Sub_group int(11) unsigned not null;

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -121,6 +121,7 @@ class DashboardTest extends LorisIntegrationTest
             [
                 'ID'        => '111',
                 'Test_name' => 'TestName11111111111',
+                'Sub_group' => 1,
             ]
         );
         $this->DB->insert(


### PR DESCRIPTION
Changes constraints on test_names.Sub_group so that it can not be
null.

Resolves #4268