### PR TITLE
[TypeScript] Convert InfoPanel.js to TypeScript

### DIFF
--- a/jsx/InfoPanel.tsx
+++ b/jsx/InfoPanel.tsx
@@ -1,12 +1,13 @@
-import PropTypes from 'prop-types';
+import {ReactNode} from 'react';
 
 /**
  * Display a message in an information panel.
  *
  * @param {object} props - React props
- * @return {JSX}
+
+ * @returns {ReactNode} - the InfoPanel
  */
-function InfoPanel(props) {
+function InfoPanel(props: {children: ReactNode}): ReactNode {
     return (
         <div className="alert alert-info"
            style={{
@@ -30,8 +31,5 @@ function InfoPanel(props) {
          </div>
    );
 }
-InfoPanel.propTypes = {
-    children: PropTypes.node,
-};
 
 export default InfoPanel;


### PR DESCRIPTION
This converts the InfoPanel component from JavaScript to TypeScript in order to make it easier to import/type check in TS (without affecting the ability to load it in JS.)

(The component is small enough that this is easier than writing a .d.ts file and keeping it in sync.)