### PR TITLE
[CouchDB_MRI_Importer] Remove extra argument in _getQueryForSelectedFiles

### DIFF
--- a/tools/importers/CouchDB_MRI_Importer.php
+++ b/tools/importers/CouchDB_MRI_Importer.php
@@ -158,8 +158,7 @@ class CouchDBMRIImporter
                     . '    THEN ('
                     .        $this->_getQueryForSelectedFiles(
                         'COALESCE(fqs.QCStatus, "No QC on selected file")',
-                        $scantype,
-                        's.ID'
+                        $scantype
                     )
                     .     ') '
                     . '  WHEN 0 '


### PR DESCRIPTION
## Brief summary of changes
's.ID' was being passed as a third argument to the function _getQueryForSelectedFiles, but this function only takes 2 arguments.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Run the CouchDB_MRI_Importer script and ensure that the QC on selected files is correctly selected.

#### Link(s) to related issue(s)

* Resolves #8470
