### PR TITLE
Typescript strict mode

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesCursor.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesCursor.tsx
@@ -220,7 +220,7 @@ const SeriesCursor = (
 };
 
 const createIndices = R.memoizeWith(
-  R.identity,
+  (s: string) => s,
   (array) => array.map((_, i) => i)
 );
 

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -17,7 +17,6 @@ import {
   DEFAULT_MAX_CHANNELS,
   CHANNEL_DISPLAY_OPTIONS,
   SIGNAL_UNIT,
-  Vector2,
   DEFAULT_TIME_INTERVAL,
   STATIC_SERIES_RANGE,
   DEFAULT_VIEWER_HEIGHT,
@@ -814,7 +813,7 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
    *
    * @param v
    */
-  const updateTimeSelectionCallback = useCallback((v: Vector2) => {
+  const updateTimeSelectionCallback = useCallback((v: vec2) => {
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
     R.compose(dragStart, R.nth(0))(v);

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/dragBounds.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/dragBounds.tsx
@@ -29,7 +29,7 @@ export type Action = BoundsAction | { type: 'UPDATE_VIEWED_CHUNKS' };
 export const createDragBoundsEpic = () => (
   action$: Observable<any>,
   state$: Observable<any>,
-): Observable<Action> => {
+): Observable<any> => {
   const startDrag$ = action$.pipe(
     ofType(START_DRAG_INTERVAL),
     Rx.map(R.prop('payload'))

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
@@ -89,7 +89,7 @@ type State = {bounds: BoundsState, dataset: DatasetState, channels: Channel[]};
 type chunkIntervals = {
   interval: [ number, number ],
   numChunks: number,
-  downsampling:  number,
+  downsampling: number,
 };
 
 const UPDATE_DEBOUNCE_TIME = 100;

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/timeSelection.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/timeSelection.tsx
@@ -38,7 +38,7 @@ export const roundTime = (value, decimals = 3) => {
 export const createTimeSelectionEpic = (fromState: (_: any) => any) => (
   action$: Observable<any>,
   state$: Observable<any>
-): Observable<Action> => {
+): Observable<any> => {
   const startDrag$ = action$.pipe(
     ofType(START_DRAG_SELECTION),
     Rx.map(R.prop('payload')),

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/dataset.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/dataset.tsx
@@ -90,7 +90,7 @@ export const datasetReducer = (
       return R.assoc('physioFileID', action.payload, state);
     }
     case SET_DATASET_METADATA: {
-      return R.merge(state, action.payload);
+      return R.mergeAll([state, action.payload]);
     }
     default: {
       return state;

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/vector/index.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/vector/index.tsx
@@ -1,18 +1,16 @@
 import {vec2, glMatrix} from 'gl-matrix';
 
-export type Vector2 = typeof glMatrix.ARRAY_TYPE;
-
 /**
  * Apply transformation f on point p
  *
  * @param {Function[]} f - an array of functions
- * @param {Vector2} p - a point
- * @returns {Vector2} - a vector
+ * @param {vec2} p - a point
+ * @returns {vec2} - a vector
  */
 export const ap = (
-  f: [(_: any) => any, (_: any) => any],
-  p: Vector2
-): Vector2 => vec2.fromValues(f[0](p[0]), f[1](p[1]));
+  f: [(_: number) => number, (_: number) => number],
+  p: vec2
+): vec2 => vec2.fromValues(f[0](p[0]), f[1](p[1]));
 
 export const MIN_INTERVAL = 0.001;
 

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/tsconfig.json
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../../../tsconfig",
+    "compilerOptions": {
+        "strict": false
+    }
+}

--- a/modules/electrophysiology_browser/tsconfig.json
+++ b/modules/electrophysiology_browser/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "strict": false
+}

--- a/modules/electrophysiology_browser/tsconfig.json
+++ b/modules/electrophysiology_browser/tsconfig.json
@@ -1,4 +1,0 @@
-{
-    "strict": false,
-    "jsx": "preserve"
-}

--- a/modules/electrophysiology_browser/tsconfig.json
+++ b/modules/electrophysiology_browser/tsconfig.json
@@ -1,3 +1,4 @@
 {
-    "strict": false
+    "strict": false,
+    "jsx": "preserve"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "lib": [
       "es6", "dom", "es2017"
     ],
+    "strict" : true
   }
 }


### PR DESCRIPTION
This enable strict mode in our TypeScript config so that we will catch as many errors as possible. The config is overloaded for the EEG Browser to disable it because the EEG browser doesn't currently passed, but this should be a short term solution.