### PR TITLE
Remove 'Scan done' field from 'Start visit' menu

### DIFF
--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -91,15 +91,6 @@ class Next_Stage extends \NDB_Form
             );
         }
 
-        // set scan done if applicable
-        if (isset($values['scan_done'])) {
-            $timePoint->setData(
-                [
-                    'Scan_done' => $values['scan_done'],
-                ]
-            );
-        }
-
         // create a new battery object && new battery
         $battery   = new \NDB_BVL_Battery;
         $candidate =& \Candidate::singleton($timePoint->getCandID());
@@ -162,20 +153,6 @@ class Next_Stage extends \NDB_Form
 
         $stage = $timePoint->getNextStage();
         $this->tpl_data['stage'] = $stage;
-
-        // add form elements
-        if ($stage == 'Visit' && $config->getSetting('useScanDone')!='false') {
-            $this->addSelect(
-                'scan_done',
-                'Scan Done',
-                [
-                    ''  => null,
-                    'Y' => 'Yes',
-                    'N' => 'No',
-                ]
-            );
-            $this->addRule('scan_done', 'Scan done is required', 'required');
-        }
 
         $dateAttributes = ['class' => 'form-control input-sm input-date'];
 
@@ -253,11 +230,6 @@ class Next_Stage extends \NDB_Form
             // must be > DOB - ONLY WHEN starting Visit stage
             $date = $values['date1'] ?? '';
 
-            if (empty($values['scan_done'])
-                && $config->getSetting('useScanDone')!='false'
-            ) {
-                $errors['scan_done'] = 'Scan done is required';
-            }
             if ($config->getSetting('useScreening')=="true"
                 && $config->getSetting('screeningAfterVisit')!="true"
                 && strcmp($date, $timePoint->getData('Date_screening')) < 0

--- a/modules/next_stage/templates/form_next_stage.tpl
+++ b/modules/next_stage/templates/form_next_stage.tpl
@@ -26,12 +26,6 @@
     </div>
     {/if}
 
-    {if $form.scan_done.html != ""}
-    <div class="form-group row">
-        <label class="col-sm-2">Scan Done:</label>
-        <div class="col-sm-4 col-md-3">{$form.scan_done.html}</div>
-    </div>
-    {/if}
     <div class="form-group row">
         <div class="col-sm-offset-2 col-sm-4 col-md-3"><input class="btn btn-primary col-xs-12" type="submit" name="fire_away" value="Start {$stage}" onClick="this.form.submit(); this.disabled=true;"/></div>
     </div>

--- a/modules/next_stage/test/next_stageTest.php
+++ b/modules/next_stage/test/next_stageTest.php
@@ -158,10 +158,6 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->webDriver->executescript(
             "document.getElementsByClassName('input-date')[1].value='2015-01-02'"
         );
-        $scanDone = $this->safeFindElement(
-            WebDriverBy::Name("scan_done")
-        );
-        $scanDone->sendKeys("No");
 
         $Cohort = $this->safeFindElement(
             WebDriverBy::Name("CohortID")
@@ -196,10 +192,6 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->webDriver->executescript(
             "document.getElementsByClassName('input-date')[1].value='2015-01-01'"
         );
-        $scanDone = $this->safeFindElement(
-            WebDriverBy::Name("scan_done")
-        );
-        $scanDone->sendKeys("No");
 
         $Cohort = $this->safeFindElement(
             WebDriverBy::Name("CohortID")


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. click on `Create time point` under any candidate profile. And create a time point for a new visit.
2. Open the visit you created and click on the button `Start Visit Stage` on the top left.
3. You shouldn't see the scan done dropdown menu under the `/next_stage` module

#### Link(s) to related issue(s)
- Related to: https://github.com/aces/Loris/issues/8348

