### PR TITLE
add greater than project's recruitmentTarget message for cohort

### DIFF
--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -33,9 +33,9 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
 
 // check if the user's input is greater than the associated Project's recruitmentTarget
     $userCohortID = $_POST['cohortID'] ?? null;   // Get user input for CohortID
-    $userTitle = $_POST['title'] ?? null;  // Get user input for title
+    $userTitle    = $_POST['title'] ?? null;  // Get user input for title
     $userRecruitmentTarget = $_POST['RecruitmentTarget'] ?? null;
-    
+
     $result = $db->pselect(
         "
         SELECT p.recruitmentTarget
@@ -45,68 +45,68 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
         WHERE c.CohortID =:userCohortID or c.title =:userTitle
         ",
         [
-                "userCohortID" => $userCohortID,
-                'userTitle'     => $userTitle,
+            "userCohortID" => $userCohortID,
+            'userTitle'    => $userTitle,
         ]
     );
-if ($result !== null && !empty($result)) {    
-    foreach ($result as $row) {
-    $projectRecruitmentTarget = $row["recruitmentTarget"];
+    if ($result !== null && !empty($result)) {
+        foreach ($result as $row) {
+            $projectRecruitmentTarget = $row["recruitmentTarget"];
 
-    // Check if the user's input is greater than any associated Project's recruitmentTarget
-    if ($userRecruitmentTarget !== null && $userRecruitmentTarget > $projectRecruitmentTarget) {
-	printAndExit(
-        400,
-        ['error' => 'Recruitment Target is greater than the associated Project\'s recruitmentTarget']
-          );    
-	   break; // Stop checking further projects
+            // Check if the user's input is greater than any associated Project's recruitmentTarget
+            if ($userRecruitmentTarget !== null && $userRecruitmentTarget > $projectRecruitmentTarget) {
+                printAndExit(
+                    400,
+                    ['error' => 'Recruitment Target is greater than the associated Project\'s recruitmentTarget']
+                );
+                break; // Stop checking further projects
+            }
         }
-    }   
-}
+    }
 
-// Ends-check if the user's input is greater than the associated Project's recruitmentTarget
+    // Ends-check if the user's input is greater than the associated Project's recruitmentTarget
 
-if ($_POST['cohortID'] === 'new') {
-    if (!in_array($_POST['title'], $CohortList) && !empty($_POST['title'])) {
-        $db->insert(
+    if ($_POST['cohortID'] === 'new') {
+        if (!in_array($_POST['title'], $CohortList) && !empty($_POST['title'])) {
+            $db->insert(
+                "cohort",
+                [
+                    "title"             => $_POST['title'],
+                    "useEDC"            => $_POST['useEDC'],
+                    "WindowDifference"  => $_POST['WindowDifference'],
+                    "RecruitmentTarget" => $recTarget,
+                ]
+            );
+        } else {
+            printAndExit(409, ['error' => 'Conflict']);
+        }
+    } else {
+        $db->update(
             "cohort",
             [
                 "title"             => $_POST['title'],
                 "useEDC"            => $_POST['useEDC'],
                 "WindowDifference"  => $_POST['WindowDifference'],
                 "RecruitmentTarget" => $recTarget,
-            ]
+            ],
+            ["CohortID" => $_POST['cohortID']]
         );
-    } else {
-        printAndExit(409, ['error' => 'Conflict']);
     }
-} else {
-    $db->update(
-        "cohort",
-        [
-            "title"             => $_POST['title'],
-            "useEDC"            => $_POST['useEDC'],
-            "WindowDifference"  => $_POST['WindowDifference'],
-            "RecruitmentTarget" => $recTarget,
-        ],
-        ["CohortID" => $_POST['cohortID']]
-    );
-}
-// FIXME: This should probably be a 201 Created instead.
-printAndExit(200, ["ok" => "Cohort updated successfully"]);
+    // FIXME: This should probably be a 201 Created instead.
+    printAndExit(200, ["ok" => "Cohort updated successfully"]);
 
-/**
- * Prints a parameter converted to JSON-encoded string.
- *
- * @param int                  $code The HTTP Response Code.
- * @param array<string,string> $msg  A key-value pair representing the JSON to
- *                                   be returned from this file.
- *
- * @return void
- */
-function printAndExit(int $code, array $msg): void
-{
-    http_response_code($code);
-    print json_encode($msg);
-    exit;
-}
+    /**
+     * Prints a parameter converted to JSON-encoded string.
+     *
+     * @param int                  $code The HTTP Response Code.
+     * @param array<string,string> $msg  A key-value pair representing the JSON to
+     *                                   be returned from this file.
+     *
+     * @return void
+     */
+    function printAndExit(int $code, array $msg): void
+    {
+        http_response_code($code);
+        print json_encode($msg);
+        exit;
+    }

--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -97,7 +97,7 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
             200,
             ["ok" => "Cohort updated successfully,
 		    but the Recruitment Target of Cohort is greater than
-                     the associated Recruitment Target of Project!"
+                     the Recruitment Target of the associated Project!"
             ]
         );
     }

--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -31,6 +31,41 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
     );
 }
 
+// check if the user's input is greater than the associated Project's recruitmentTarget
+    $userCohortID = $_POST['cohortID'] ?? null;   // Get user input for CohortID
+    $userTitle = $_POST['title'] ?? null;  // Get user input for title
+    $userRecruitmentTarget = $_POST['RecruitmentTarget'] ?? null;
+    
+    $result = $db->pselect(
+        "
+        SELECT p.recruitmentTarget
+        FROM Project p
+        JOIN project_cohort_rel rel ON p.ProjectID = rel.ProjectID
+        JOIN cohort c ON c.CohortID = rel.CohortID
+        WHERE c.CohortID =:userCohortID or c.title =:userTitle
+        ",
+        [
+                "userCohortID" => $userCohortID,
+                'userTitle'     => $userTitle,
+        ]
+    );
+if ($result !== null && !empty($result)) {    
+    foreach ($result as $row) {
+    $projectRecruitmentTarget = $row["recruitmentTarget"];
+
+    // Check if the user's input is greater than any associated Project's recruitmentTarget
+    if ($userRecruitmentTarget !== null && $userRecruitmentTarget > $projectRecruitmentTarget) {
+	printAndExit(
+        400,
+        ['error' => 'Recruitment Target is greater than the associated Project\'s recruitmentTarget']
+          );    
+	   break; // Stop checking further projects
+        }
+    }   
+}
+
+// Ends-check if the user's input is greater than the associated Project's recruitmentTarget
+
 if ($_POST['cohortID'] === 'new') {
     if (!in_array($_POST['title'], $CohortList) && !empty($_POST['title'])) {
         $db->insert(

--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -31,12 +31,12 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
     );
 }
 
-// check if the user's input is greater than the associated Project's recruitmentTarget
+// check if recruitmentTarget is greater than the associated Project's
 // recruitmentTarget warning
     $recruitmentTargetWarning = false;
-    $userCohortID = $_POST['cohortID'] ?? null;   // Get user input for CohortID
-    $userTitle    = $_POST['title'] ?? null;  // Get user input for title
-    $userRecruitmentTarget = $_POST['RecruitmentTarget'] ?? null;
+    $userCohortID    = $_POST['cohortID'] ?? null;
+    $userTitle       = $_POST['title'] ?? null;
+    $userRecruTarget = $_POST['RecruitmentTarget'] ?? null;
 
     $result = $db->pselect(
         "
@@ -53,17 +53,19 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
     );
     if ($result !== null && !empty($result)) {
         foreach ($result as $row) {
-            $projectRecruitmentTarget = $row["recruitmentTarget"];
+            $projectRecruTarget = $row["recruitmentTarget"];
 
-            // Check if the user's input is greater than any associated Project's recruitmentTarget
-            if ($userRecruitmentTarget !== null && $userRecruitmentTarget > $projectRecruitmentTarget) {
+            // Check if the input is greater than any Project's recruitmentTarget
+            if ($userRecruTarget !== null
+                && $userRecruTarget > $projectRecruTarget
+            ) {
                 $recruitmentTargetWarning = true;
                 break; // Stop checking further projects
             }
         }
     }
 
-    // Ends-check if the user's input is greater than the associated Project's recruitmentTarget
+    // Ends-check greater than the associated Project's recruitmentTarget
 
     if ($_POST['cohortID'] === 'new') {
         if (!in_array($_POST['title'], $CohortList) && !empty($_POST['title'])) {

--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -32,6 +32,8 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
 }
 
 // check if the user's input is greater than the associated Project's recruitmentTarget
+// recruitmentTarget warning
+    $recruitmentTargetWarning = false;
     $userCohortID = $_POST['cohortID'] ?? null;   // Get user input for CohortID
     $userTitle    = $_POST['title'] ?? null;  // Get user input for title
     $userRecruitmentTarget = $_POST['RecruitmentTarget'] ?? null;
@@ -55,10 +57,7 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
 
             // Check if the user's input is greater than any associated Project's recruitmentTarget
             if ($userRecruitmentTarget !== null && $userRecruitmentTarget > $projectRecruitmentTarget) {
-                printAndExit(
-                    400,
-                    ['error' => 'Recruitment Target is greater than the associated Project\'s recruitmentTarget']
-                );
+                $recruitmentTargetWarning = true;
                 break; // Stop checking further projects
             }
         }
@@ -93,6 +92,15 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
         );
     }
     // FIXME: This should probably be a 201 Created instead.
+    if ($recruitmentTargetWarning) {
+        printAndExit(
+            200,
+            ["ok" => "Cohort updated successfully,
+		    but the Recruitment Target of Cohort is greater than
+                     the associated Recruitment Target of Project!"
+            ]
+        );
+    }
     printAndExit(200, ["ok" => "Cohort updated successfully"]);
 
     /**


### PR DESCRIPTION
[Config] Subproject recruitment target can be larger than its Project target #5832
The Config module should probably pop up a warning, e.g. Your Subproject recruitment target is greater than the Project recruitment target -- if not enforce a relationship.

(See Staler (SubprojectID 1) on test-loris-dev today, tho not RB -- has Recruitment target 1000000000)

test 
1. goto configration module then click "To configure study cohorts [click here]"
2. input a number of recruitment target, try larger than project's  and  smaller than project's

![截屏2023-11-15 下午1 45 48](https://github.com/aces/Loris/assets/9876007/2684df80-4b43-422b-a65b-63f93bcc5c38)

![截屏2023-11-15 下午2 23 47](https://github.com/aces/Loris/assets/9876007/bb773b6e-09f9-42d0-8c80-21d68f4ff975)
