### PR TITLE
[TS] Use ReactElement instead of ReactNode for InfoPanel

### DIFF
--- a/jsx/InfoPanel.tsx
+++ b/jsx/InfoPanel.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import {ReactElement, ReactNode} from 'react';
 
 /**
  * Display a message in an information panel.
@@ -7,7 +7,7 @@ import {ReactNode} from 'react';
 
  * @returns {ReactNode} - the InfoPanel
  */
-function InfoPanel(props: {children: ReactNode}): ReactNode {
+function InfoPanel(props: {children: ReactNode}): ReactElement {
     return (
         <div className="alert alert-info"
            style={{


### PR DESCRIPTION
This prevents errors about "ReactNode is not a valid JSX element" similar to https://stackoverflow.com/questions/72392225/reactnode-is-not-a-valid-jsx-element

The component always returns a single element, so changing the return from ReactNode to ReactElement is more descriptive at any rate.