### PR TITLE
[Modal] Add missing import statement

### DIFF
--- a/jsx/Modal.js
+++ b/jsx/Modal.js
@@ -7,6 +7,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import swal from 'sweetalert2';
+import {ButtonElement} from 'jsx/Form';
 
 /**
  * Modal Component.


### PR DESCRIPTION
The Modal class uses the ButtonElement which needs to be imported to avoid runtime errors.