### PR TITLE
[LINST] skip metadatafields for surveys

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -298,6 +298,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $base . "project/instruments/$instrument.meta"
             );
         }
+        // Set DataEntryType to normal or DirectEntry
+        if (isset($_REQUEST['key'])) {
+            $obj->DataEntryType = 'DirectEntry';
+        } else {
+            $obj->DataEntryType = 'normal';
+        }
         // Adds all of the form element and form rules to the page after
         // having instantiated the form above
         $obj->loadInstrumentFile(
@@ -477,10 +483,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     {
         // ALWAYS INCLUDE THESE!
 
-        if (isset($_REQUEST['key'])) {
-            $this->DataEntryType = 'DirectEntry';
-        } else {
-            $this->DataEntryType = 'normal';
+        if ($this->DataEntryType === 'normal') {
             // These are required for Save Data to work properly, but not when it's
             // a direct data entry page
             $this->addHidden(
@@ -779,11 +782,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _saveValues(array $values): void
     {
-        // Surveys do not ask for the metadata informatio nand thus date_taken is
-        // always null so there is no use in going into the savecandidateage function
-        if (strrpos($this->testName, "_proband") === false
-            && $this->DataEntryType === 'normal'
-        ) {
+        if (strrpos($this->testName, "_proband") === false) {
             $this->_saveCandidateAge($values);
         }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -779,7 +779,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _saveValues(array $values): void
     {
-        if (strrpos($this->testName, "_proband") === false) {
+        // Surveys do not ask for the metadata informatio nand thus date_taken is
+        // always null so there is no use in going into the savecandidateage function
+        if (strrpos($this->testName, "_proband") === false
+            && $this->DataEntryType === 'normal'
+        ) {
             $this->_saveCandidateAge($values);
         }
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -556,7 +556,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             'instrument_title',
                             $pieces[1]
                         );
-                        $this->_addMetadataFields();
+                        if ($this->DataEntryType!=="DirectEntry") {
+                            $this->_addMetadataFields();
+                        }
                     }
                     break;
                 case 'begingroup':

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1792,7 +1792,8 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setUpMockDB();
         $this->_setTableData();
         $this->_instrument->setup("commentID1", "page");
-        $this->_instrument->table = 'medical_history';
+        $this->_instrument->table         = 'medical_history';
+        $this->_instrument->DataEntryType = "normal";
         $this->assertStringContainsString(
             "<input  name=\"candID\" value=\"\" type=\"hidden\">\n",
             $this->_instrument->display()

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1335,10 +1335,11 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_setUpMockDB();
         $this->_setTableData();
-        $this->_instrument->commentID = 'commentID1';
-        $this->_instrument->table     = 'medical_history';
-        $this->_instrument->testName  = 'Test';
-        $this->_instrument->formType  = "XIN";
+        $this->_instrument->commentID     = 'commentID1';
+        $this->_instrument->table         = 'medical_history';
+        $this->_instrument->testName      = 'Test';
+        $this->_instrument->formType      = "XIN";
+        $this->_instrument->DataEntryType = "normal";
         $values = ['Date_taken' => '2005-06-06',
             'arthritis_age'        => 2,
             'arthritis_age_status' => 'status'


### PR DESCRIPTION
## Brief summary of changes

replacing https://github.com/aces/Loris/pull/8863

Skip over metadatafields and calculate ages in surveys

This is not a big change, one way or another the fields were either being skipped with an empty check, through a project override or through code in the module itself handling the submission. this is just an explicit check to make everything clearer

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
