### PR TITLE
[bvl_feedback] Update summary in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ changes in the following format: PR #1234***
 #### Features
 - Add OpenID Connect authorization support to LORIS (PR #8255)
 
+#### Bug Fixes
+- bvl_feedback updates in real-time (PR #8966)
+
 ## LORIS 25.0 (Release Date: ????-??-??)
 ### Core
 #### Features

--- a/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
@@ -38,6 +38,9 @@ if ($openedthreadcount === 0) {
     exit;
 }
 
-header("HTTP/1.1 204 No Content");
+header("Content-Type: application/json");
+print json_encode(
+    ['status' => 'success']
+);
 exit;
 

--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -900,11 +900,9 @@ class FeedbackPanel extends Component {
         console.error(response.status + ': ' + response.statusText);
         return;
       }
-
-      response.json().then(() => {
-        this.setState({threads: threads});
-        this.loadSummaryServerData();
-      });
+      this.setState({threads: threads});
+      this.loadSummaryServerData();
+      this.loadThreadServerState();
     }).catch((error) => {
       console.error(error);
     });
@@ -936,11 +934,9 @@ class FeedbackPanel extends Component {
         console.error(response.status + ': ' + response.statusText);
         return;
       }
-
-      response.json().then(() => {
-        this.setState({threads: threads});
-        this.loadSummaryServerData();
-      });
+      this.setState({threads: threads});
+      this.loadSummaryServerData();
+      this.loadThreadServerState();
     }).catch((error) => {
       console.error(error);
     });


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the bvl_feedback module to update the summary in real time after opening or closing feedbacks. The PR also fixes a `Unexpected end to json input ` react error when opening and closing feedbacks by changing the success response to a json response.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Off of the main branch, load the bvl_feedback module by clicking the edit icon in the top right of a candidate, visit, or instrument page.
2. Save a few new feedbacks, and notice that the number of open feedbacks in the summary at the top increases every time you save a feedback.
3. Open and close a few feedbacks, and notice that if you open a closed feedback, it still shows as closed until you refresh the page. The summary at the top also does not change until you refresh the page.
4. Load this PR and repeat the previous steps. 
5. Make sure that from this PR, the summary at the top is updated in real time.
6. Also make sure that if you open or close a feedback, they are immediately shown as open or closed instead of having to refresh.

#### Link(s) to related issue(s)

* Resolves #4984