### PR TITLE
[examiner] Only show active examiner sites

### DIFF
--- a/modules/examiner/php/examinerprovisioner.class.inc
+++ b/modules/examiner/php/examinerprovisioner.class.inc
@@ -41,7 +41,7 @@ class ExaminerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
   select
  e.full_name as Examiner,
              u.Email,
- GROUP_CONCAT(DISTINCT psc.CenterID) as centerIds,
+ GROUP_CONCAT(DISTINCT epr.CenterID) as centerIds,
              e.examinerID as ID,
 
  e.radiologist as Radiologist,
@@ -56,6 +56,7 @@ class ExaminerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                                 (c.examinerID=e.examinerID and c.pass = 'certified')
                             LEFT JOIN test_names tn ON (tn.ID = c.testID)
                             LEFT JOIN users u ON u.ID=e.userID
+                            WHERE epr.active='Y'
                             group by e.examinerID
 ",
             [],


### PR DESCRIPTION
## Brief summary of changes
In this PR, only active examiner sites are shown for an examiner in the examiner module. Previously, the module was showing any site that the examiner had once been an examiner at, whether it was active or not.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Add a user as an examiner setting several examiner sites
2. Remove some sites from the examiner
3. Load the examiner module and search for the user
4. Make sure that only sites that are still active are shown in the examiner module

#### Link(s) to related issue(s)

* Resolves #5768
