### PR TITLE
Replace DoB/EDC with 'Derived Age'/'EDC Age' in FrontEnd

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -259,7 +259,7 @@ class CandidateListIndex extends Component {
         },
       },
       {
-        'label': 'DoB',
+        'label': 'Derived Age',
         'show': true,
         'filter': {
           name: 'DoB',

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -53,7 +53,15 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 c.Entity_type AS EntityType,
                 MAX(s.Scan_done) AS scanDone,
                 COALESCE(pso.Description,'Active') AS ParticipantStatus,
-                DATE_FORMAT(c.DoB,'%Y-%m-%d') AS DoB,
+                CONCAT(
+                       (CASE
+			    WHEN YEAR(CURDATE()) < YEAR(c.DoB) THEN 0#or some such validation
+			    ELSE  YEAR(CURDATE()) - YEAR(c.DoB) 
+			    END),' y / ',
+                        (CASE
+			    WHEN MONTH(CURDATE()) < MONTH(c.DoB) THEN MONTH(c.DoB) - MONTH(CURDATE())
+			    ELSE MONTH(CURDATE()) - MONTH(c.DoB)
+			    END),' m') as Age,
                 DATE_FORMAT(c.Date_registered,'%Y-%m-%d') AS Date_registered,
                 c.Sex,
                 COUNT(DISTINCT s.Visit_label) AS VisitCount,

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -294,8 +294,20 @@ class Instrument_List extends \NDB_Menu_Filter
             }
         }
 
-        $this->tpl_data['display']
-            = array_merge($this->candidate->getData(), $this->timePoint->getData());
+        // convert DoB And EDC date to years and months
+        $this->tpl_data['display'] = array_merge($this->candidate->getData(), $this->timePoint->getData());
+	    // DoB to Derived Age
+        $dob=$this->candidate->getData()['DoB'];
+        $dob_year  = abs((date('Y', strtotime($dob)) - date('Y')));
+        $dob_month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // EDC to EDC Age
+        $edc=$this->candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
     }
 
     /**

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -4,13 +4,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+      Derived Age
     </th>
-    {if $display.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+      EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -57,13 +55,11 @@
   <tbody>
   <tr>
     <td>
-      {$display.DoB}
+      {$dob_age}
     </td>
-    {if $display.EDC!=""}
-      <td>
-        {$display.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$display.Sex}
     </td>

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -80,6 +80,18 @@ class Timepoint_List extends \NDB_Menu
         $this->tpl_data['candID']    = $this->candID;
         $this->tpl_data['PSCID']     = $candidate->getPSCID();
         $this->tpl_data['candidate'] = $candidate->getData();
+        // convert DoB date to age and months and rename it to Derived Age
+        $dob=$candidate->getData()['DoB'];
+        $dob_year  = abs((date('Y', strtotime($dob)) - date('Y')));
+        $dob_month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // convert EDC date to age and months and rename it to EDC Age
+        $edc=$candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
 
         $listOfSessionIDs = $candidate->getListOfTimePoints();
 

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -4,13 +4,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+      Derived Age
     </th>
-    {if $candidate.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+      EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -28,13 +26,11 @@
   <tbody>
   <tr>
     <td>
-      {$candidate.DoB}
+      {$dob_age}
     </td>
-    {if $candidate.EDC!=""}
-      <td>
-        {$candidate.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$candidate.Sex}
     </td>

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -384,6 +384,20 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $this->tpl_data['candidate'] = $candidate->getData();
         $this->tpl_data['timePoint'] = $timePoint->getData();
+
+        // convert DoB And EDC date to years and months
+        // DoB to Derived Age
+        $dob=  $candidate->getData()['DoB'];
+        $year  = abs((date('Y', strtotime($dob)) - date('Y')));
+        $month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob_age = $year . " y / " . $month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // EDC to EDC Age
+        $edc=  $candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
     }
 
     /**

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -14,13 +14,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+      Derived Age
     </th>
-    {if $candidate.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+      EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -65,13 +63,11 @@
   <tbody>
   <tr>
     <td>
-      {$candidate.DoB}
+      {$dob_age}
     </td>
-    {if $candidate.EDC!=""}
-      <td>
-        {$candidate.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$candidate.Sex}
     </td>


### PR DESCRIPTION
## Brief summary of changes

Derived age should be expressed in years and months, with the months rounded up/down, and replace the DoB in the FrontEnd everywhere except for the 'Date of Birth' tab in the 'Candidate Information' menu. Likewise, for the EDC with the derived 'EDC age' in years and months (rounded).

#### Testing instructions (if applicable)

1. Under Candidate Access Profile, Replace `DoB` with `Derived Age`.
2. Under (Timepoint_list) Access Profile > Candidate Profile: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`
3. Under (Timepoint_list) Access Profile > Candidate Profile > Timepoint Visit Details: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`
4. Under (Timepoint_list) Access Profile > Candidate Profile > Timepoint Visit Details > Instrument: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/8357
