### PR TITLE
[login] Fix blank page after incorrect password

### DIFF
--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -9,6 +9,7 @@ import Panel from 'Panel';
 import DOMPurify from 'dompurify';
 import {
     FormElement,
+    StaticElement,
     TextboxElement,
     PasswordElement,
     ButtonElement,


### PR DESCRIPTION
The loginIndex was missing an import of StaticElement. This adds it so that the page isn't blank after entering an incorrect password.

Resolves #8965
