### PR TITLE
[candidate_parameters] Fix loading of candidate_parameters page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ mri_violations:
 issue_tracker:
 	target=issue_tracker npm run compile
 
+candidate_parameters:
+	target=candidate_parameters npm run compile
+
 dashboard:
 	target=dashboard npm run compile
 

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -2,6 +2,12 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
 import swal from 'sweetalert2';
+import {
+  FormElement,
+  StaticElement,
+  ButtonElement,
+  DateElement,
+} from 'jsx/Form';
 
 /**
  * Candidate date of birth component

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -2,6 +2,12 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
 import swal from 'sweetalert2';
+import {
+  FormElement,
+  StaticElement,
+  DateElement,
+  ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Candidate date of death component

--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -1,5 +1,13 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {
+  FormElement,
+  StaticElement,
+  SelectElement,
+  DateElement,
+  ButtonElement,
+  TextareaElement,
+} from 'jsx/Form';
 
 /**
  * Candiate info component

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -4,6 +4,14 @@ import swal from 'sweetalert2';
 
 import {VerticalTabs, TabPane} from 'Tabs';
 import Loader from 'Loader';
+import {
+  FormElement,
+  StaticElement,
+  ButtonElement,
+  HeaderElement,
+  SelectElement,
+  DateElement,
+} from 'jsx/Form';
 
 /**
  * Consent Status Component.

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -1,5 +1,12 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {
+  FormElement,
+  StaticElement,
+  SelectElement,
+  TextareaElement,
+  ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Participant status component


### PR DESCRIPTION
The candidate_parameters pages were missing a number of import statements for elements from Form.js, making the page not load. This adds the missing imports.

Resolves #8968