### PR TITLE
[publication] Fix publication loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ mri_violations:
 
 dashboard:
 	target=dashboard npm run compile
+
+publication:
+	target=publication npm run compile
+

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -188,7 +188,10 @@ function getProjectData($db, $user, $id) : array
         $datePublication = htmlspecialchars_decode($result['datePublication'] ?? '');
         $journal         = htmlspecialchars_decode($result['journal'] ?? '');
         $link            = htmlspecialchars_decode($result['link'] ?? '');
-        $publishingStatus = htmlspecialchars_decode($result['publishingStatus'] ?? '');
+        $publishingStatus = htmlspecialchars_decode(
+            $result['publishingStatus']
+            ?? ''
+        );
         $rejectedReason   = htmlspecialchars_decode($result['RejectedReason'] ?? '');
 
         $pubData = [

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -183,13 +183,13 @@ function getProjectData($db, $user, $id) : array
 
         $usersWithEditPerm = $userIDs;
 
-        $title           = htmlspecialchars_decode($result['Title']);
-        $description     = htmlspecialchars_decode($result['Description']);
-        $datePublication = htmlspecialchars_decode($result['datePublication']);
-        $journal         = htmlspecialchars_decode($result['journal']);
-        $link            = htmlspecialchars_decode($result['link']);
-        $publishingStatus = htmlspecialchars_decode($result['publishingStatus']);
-        $rejectedReason   = htmlspecialchars_decode($result['RejectedReason']);
+        $title           = htmlspecialchars_decode($result['Title'] ?? '');
+        $description     = htmlspecialchars_decode($result['Description'] ?? '');
+        $datePublication = htmlspecialchars_decode($result['datePublication'] ?? '');
+        $journal         = htmlspecialchars_decode($result['journal'] ?? '');
+        $link            = htmlspecialchars_decode($result['link'] ?? '');
+        $publishingStatus = htmlspecialchars_decode($result['publishingStatus'] ?? '');
+        $rejectedReason   = htmlspecialchars_decode($result['RejectedReason'] ?? '');
 
         $pubData = [
             'title'                 => $title,

--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -1,6 +1,16 @@
 import React from 'react';
 import swal from 'sweetalert2';
 import PropTypes from 'prop-types';
+import {
+  StaticElement,
+  TagsElement,
+  FileElement,
+  ButtonElement,
+  TextareaElement,
+  TextboxElement,
+  SelectElement,
+  DateElement,
+} from 'jsx/Form';
 
 /**
  * Email element component

--- a/modules/publication/jsx/publicationIndex.js
+++ b/modules/publication/jsx/publicationIndex.js
@@ -4,6 +4,7 @@ import PublicationUploadForm from './uploadForm.js';
 import {createRoot} from 'react-dom/client';
 import React from 'react';
 import PropTypes from 'prop-types';
+import {ButtonElement} from 'jsx/Form';
 
 /**
  * Publication index component

--- a/modules/publication/jsx/uploadForm.js
+++ b/modules/publication/jsx/uploadForm.js
@@ -2,6 +2,10 @@ import React from 'react';
 import ProjectFormFields from './projectFields';
 import swal from 'sweetalert2';
 import PropTypes from 'prop-types';
+import {
+  FormElement,
+  TextboxElement,
+} from 'jsx/Form';
 
 /**
  * Publication upload form component

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -1,6 +1,13 @@
 import ProjectFormFields from './projectFields';
 import swal from 'sweetalert2';
 import PropTypes from 'prop-types';
+import {
+  FormElement,
+  SelectElement,
+  StaticElement,
+  TextboxElement,
+  ButtonElement,
+} from 'jsx/Form';
 
 /**
  * View project component

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -301,7 +301,7 @@ class Publication extends \NDB_Menu_Filter_Form
         array_walk_recursive(
             $result,
             function (&$r) {
-                $r = htmlspecialchars_decode($r);
+                $r = htmlspecialchars_decode($r ?? '');
             }
         );
         $result['form'] = $this->form->form;


### PR DESCRIPTION
This fixes 2 problems with loading the publication module on Raisinbread:

1. When trying to load the page, I get the error:

```
<b>Deprecated</b>:  htmlspecialchars_decode(): Passing null to parameter https://github.com/aces/Loris/pull/1 ($string) of type string is deprecated in <b>/home/driusan/Code/Loris/modules/publication/php/publication.class.inc</b> on line <b>304</b><br />
```

with PHP 8.2.

2. The Form.js imports were missing.

