### PR TITLE
[dictionary] Fixes for correct displaying "Data Type" column for the enumeration type in the "Data Dictionary (Beta)" table 

### DIFF
--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -64,7 +64,6 @@ class DataDictRow implements \LORIS\Data\DataInstance,
             'datascope'          => $scope,
             'type'               => $this->getDataType(),
             'cardinality'        => $this->getCardinality(),
-            'visits'             => $this->visits,
         ];
 
         $itype = $this->item->getDataType();


### PR DESCRIPTION
## Brief summary of changes

The "visits" attribute has been removed from array initialization as it affects the response for the UI. UI waits for JSON where in the list of column for the table row,  "visits"  goes after "otions" by the order.
