### PR TITLE
Replace DoB/EDC with 'Derived Age'/'EDC Age' in FrontEnd

### DIFF
--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -123,7 +123,9 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->safeGet($this->url . "/candidate_profile/900000/");
         $this->safeFindElement(
             WebDriverBy::cssSelector(
-                "#card2 > div > div > div > div:nth-child(1) > div > div:nth-child(2) > h4 > a"
+                "#card0 > div:nth-child(1) >".
+                "div:nth-child(1)>div:nth-child(1)>dl:nth-child(1)>div:nth-".
+                "child(9)>dd:nth-child(2) > div:nth-child(1) > a:nth-child(1)"
             )
         )->click();
         $bodyText

--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -123,9 +123,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->safeGet($this->url . "/candidate_profile/900000/");
         $this->safeFindElement(
             WebDriverBy::cssSelector(
-                "#card0 > div:nth-child(1) >".
-                "div:nth-child(1)>div:nth-child(1)>dl:nth-child(1)>div:nth-".
-                "child(9)>dd:nth-child(2) > div:nth-child(1) > a:nth-child(1)"
+                "#card2 > div > div > div > div:nth-child(1) > div > div:nth-child(2) > h4 > a"
             )
         )->click();
         $bodyText

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -297,16 +297,16 @@ class Instrument_List extends \NDB_Menu_Filter
         $this->tpl_data['display']
             = array_merge($this->candidate->getData(), $this->timePoint->getData());
         // DoB to Derived Age
-        $dob = $this->tpl_data['display'];
-        $dob_year = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
+        $dob       = $this->candidate->getData();
+        $dob_year  = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
         $dob_month = abs((date('m', strtotime($dob['DoB'])) - date('m')));
-        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $dob_age   = $dob_year . " y / " . $dob_month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // EDC to EDC Age
-        $edc = $this->candidate->getData()['EDC'];
-        $edc_year = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc       = $this->candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
         $edc_month = abs((date('m', strtotime($edc)) - date('m')));
-        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
     }
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -296,6 +296,18 @@ class Instrument_List extends \NDB_Menu_Filter
 
         $this->tpl_data['display']
             = array_merge($this->candidate->getData(), $this->timePoint->getData());
+        // DoB to Derived Age
+        $dob = $this->tpl_data['display'];
+        $dob_year = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
+        $dob_month = abs((date('m', strtotime($dob['DoB'])) - date('m')));
+        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // EDC to EDC Age
+        $edc = $this->candidate->getData()['EDC'];
+        $edc_year = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
     }
 
     /**

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -303,9 +303,9 @@ class Instrument_List extends \NDB_Menu_Filter
         $dob_age   = $dob_year . " y / " . $dob_month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // EDC to EDC Age
-        $edc       = $this->candidate->getData()['EDC'];
-        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
-        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc       = $this->candidate->getData();
+        $edc_year  = abs((date('Y', strtotime($edc['EDC'])) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc['EDC'])) - date('m')));
         $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
     }

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -4,13 +4,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+      Derived Age
     </th>
-    {if $display.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+        EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -57,13 +55,11 @@
   <tbody>
   <tr>
     <td>
-      {$display.DoB}
+      {$dob_age}
     </td>
-    {if $display.EDC!=""}
-      <td>
-        {$display.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$display.Sex}
     </td>

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -81,16 +81,16 @@ class Timepoint_List extends \NDB_Menu
         $this->tpl_data['PSCID']     = $candidate->getPSCID();
         $this->tpl_data['candidate'] = $candidate->getData();
         // convert DoB date to age and months and rename it to Derived Age
-        $dob = $candidate->getData()['DoB'];
+        $dob       = $candidate->getData()['DoB'];
         $dob_year  = abs((date('Y', strtotime($dob)) - date('Y')));
         $dob_month = abs((date('m', strtotime($dob)) - date('m')));
-        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $dob_age   = $dob_year . " y / " . $dob_month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // convert EDC date to age and months and rename it to EDC Age
-        $edc=$candidate->getData()['EDC'];
+        $edc       =$candidate->getData()['EDC'];
         $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
         $edc_month = abs((date('m', strtotime($edc)) - date('m')));
-        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
 
         $listOfSessionIDs = $candidate->getListOfTimePoints();

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -81,13 +81,13 @@ class Timepoint_List extends \NDB_Menu
         $this->tpl_data['PSCID']     = $candidate->getPSCID();
         $this->tpl_data['candidate'] = $candidate->getData();
         // convert DoB date to age and months and rename it to Derived Age
-        $dob       = $this->candidate->getData();
+        $dob       = $candidate->getData();
         $dob_year  = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
         $dob_month = abs((date('m', strtotime($dob['DoB'])) - date('m')));
         $dob_age   = $dob_year . " y / " . $dob_month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // convert EDC date to age and months and rename it to EDC Age
-        $edc       = $this->candidate->getData();
+        $edc       = $candidate->getData();
         $edc_year  = abs((date('Y', strtotime($edc['EDC'])) - date('Y')));
         $edc_month = abs((date('m', strtotime($edc['EDC'])) - date('m')));
         $edc_age   = $edc_year . " y / " . $edc_month . " m";

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -80,6 +80,18 @@ class Timepoint_List extends \NDB_Menu
         $this->tpl_data['candID']    = $this->candID;
         $this->tpl_data['PSCID']     = $candidate->getPSCID();
         $this->tpl_data['candidate'] = $candidate->getData();
+        // convert DoB date to age and months and rename it to Derived Age
+        $dob = $candidate->getData()['DoB'];
+        $dob_year  = abs((date('Y', strtotime($dob)) - date('Y')));
+        $dob_month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob_age = $dob_year . " y / " . $dob_month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // convert EDC date to age and months and rename it to EDC Age
+        $edc=$candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
 
         $listOfSessionIDs = $candidate->getListOfTimePoints();
 

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -81,15 +81,15 @@ class Timepoint_List extends \NDB_Menu
         $this->tpl_data['PSCID']     = $candidate->getPSCID();
         $this->tpl_data['candidate'] = $candidate->getData();
         // convert DoB date to age and months and rename it to Derived Age
-        $dob       = $candidate->getData()['DoB'];
-        $dob_year  = abs((date('Y', strtotime($dob)) - date('Y')));
-        $dob_month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob       = $this->candidate->getData();
+        $dob_year  = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
+        $dob_month = abs((date('m', strtotime($dob['DoB'])) - date('m')));
         $dob_age   = $dob_year . " y / " . $dob_month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // convert EDC date to age and months and rename it to EDC Age
-        $edc       =$candidate->getData()['EDC'];
-        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
-        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc       = $this->candidate->getData();
+        $edc_year  = abs((date('Y', strtotime($edc['EDC'])) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc['EDC'])) - date('m')));
         $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
 

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -4,13 +4,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+      Derived Age
     </th>
-    {if $candidate.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+      EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -28,13 +26,11 @@
   <tbody>
   <tr>
     <td>
-      {$candidate.DoB}
+      {$dob_age}
     </td>
-    {if $candidate.EDC!=""}
-      <td>
-        {$candidate.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$candidate.Sex}
     </td>

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -384,6 +384,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $this->tpl_data['candidate'] = $candidate->getData();
         $this->tpl_data['timePoint'] = $timePoint->getData();
+        // convert DoB And EDC date to years and months
+        // DoB to Derived Age
+        $dob=  $candidate->getData()['DoB'];
+        $year  = abs((date('Y', strtotime($dob)) - date('Y')));
+        $month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob_age = $year . " y / " . $month . " m";
+        $this->tpl_data['dob_age'] = $dob_age;
+        // EDC to EDC Age
+        $edc=  $candidate->getData()['EDC'];
+        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $this->tpl_data['edc_age'] = $edc_age;
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -386,13 +386,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $this->tpl_data['timePoint'] = $timePoint->getData();
         // convert DoB And EDC date to years and months
         // DoB to Derived Age
-        $dob     = $this->candidate->getData();
+        $dob     = $candidate->getData();
         $year    = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
         $month   = abs((date('m', strtotime($dob['DoB'])) - date('m')));
         $dob_age = $year . " y / " . $month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // EDC to EDC Age
-        $edc       = $this->candidate->getData();
+        $edc       = $candidate->getData();
         $edc_year  = abs((date('Y', strtotime($edc['EDC'])) - date('Y')));
         $edc_month = abs((date('m', strtotime($edc['EDC'])) - date('m')));
         $edc_age   = $edc_year . " y / " . $edc_month . " m";

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -386,16 +386,16 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $this->tpl_data['timePoint'] = $timePoint->getData();
         // convert DoB And EDC date to years and months
         // DoB to Derived Age
-        $dob=  $candidate->getData()['DoB'];
-        $year  = abs((date('Y', strtotime($dob)) - date('Y')));
-        $month = abs((date('m', strtotime($dob)) - date('m')));
+        $dob     =  $candidate->getData()['DoB'];
+        $year    = abs((date('Y', strtotime($dob)) - date('Y')));
+        $month   = abs((date('m', strtotime($dob)) - date('m')));
         $dob_age = $year . " y / " . $month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // EDC to EDC Age
-        $edc=  $candidate->getData()['EDC'];
+        $edc       =  $candidate->getData()['EDC'];
         $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
         $edc_month = abs((date('m', strtotime($edc)) - date('m')));
-        $edc_age = $edc_year . " y / " . $edc_month . " m";
+        $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -386,15 +386,15 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $this->tpl_data['timePoint'] = $timePoint->getData();
         // convert DoB And EDC date to years and months
         // DoB to Derived Age
-        $dob     =  $candidate->getData()['DoB'];
-        $year    = abs((date('Y', strtotime($dob)) - date('Y')));
-        $month   = abs((date('m', strtotime($dob)) - date('m')));
+        $dob     = $this->candidate->getData();
+        $year    = abs((date('Y', strtotime($dob['DoB'])) - date('Y')));
+        $month   = abs((date('m', strtotime($dob['DoB'])) - date('m')));
         $dob_age = $year . " y / " . $month . " m";
         $this->tpl_data['dob_age'] = $dob_age;
         // EDC to EDC Age
-        $edc       =  $candidate->getData()['EDC'];
-        $edc_year  = abs((date('Y', strtotime($edc)) - date('Y')));
-        $edc_month = abs((date('m', strtotime($edc)) - date('m')));
+        $edc       = $this->candidate->getData();
+        $edc_year  = abs((date('Y', strtotime($edc['EDC'])) - date('Y')));
+        $edc_month = abs((date('m', strtotime($edc['EDC'])) - date('m')));
         $edc_age   = $edc_year . " y / " . $edc_month . " m";
         $this->tpl_data['edc_age'] = $edc_age;
     }

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -14,13 +14,11 @@
   <thead>
   <tr class="info">
     <th>
-      DOB
+       Derived Age
     </th>
-    {if $candidate.EDC!=""}
-      <th>
-        EDC
-      </th>
-    {/if}
+    <th>
+       EDC Age
+    </th>
     <th>
       Biological Sex
     </th>
@@ -65,13 +63,11 @@
   <tbody>
   <tr>
     <td>
-      {$candidate.DoB}
+      {$dob_age}
     </td>
-    {if $candidate.EDC!=""}
-      <td>
-        {$candidate.EDC}
-      </td>
-    {/if}
+    <td>
+      {$edc_age}
+    </td>
     <td>
       {$candidate.Sex}
     </td>


### PR DESCRIPTION
## Brief summary of changes

Derived age should be expressed in years and months, with the months rounded up/down, and replace the DoB in the FrontEnd everywhere except for the 'Date of Birth' tab in the 'Candidate Information' menu. Likewise, for the EDC with the derived 'EDC age' in years and months (rounded).

#### Testing instructions (if applicable)


1. Under (Timepoint_list) Access Profile > Candidate Profile: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`
2. Under (Timepoint_list) Access Profile > Candidate Profile > Timepoint Visit Details: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`
3. Under (Timepoint_list) Access Profile > Candidate Profile > Timepoint Visit Details > Instrument: Replace `DoB` with `Derived Age` And `EDC` with `EDC Age`

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/8357
