### PR TITLE
[tools] Fix efficiency of fix_candidate_age script

### DIFF
--- a/tools/data_integrity/fix_candidate_age.php
+++ b/tools/data_integrity/fix_candidate_age.php
@@ -87,33 +87,11 @@ foreach ($instruments as $testName=>$instrument) {
         ['tn' => $testName]
     );
 
-    foreach ($CommentIDs as $commentID) {
-        // Get Instrument Instance with commentID
-        try {
-            $instrument = NDB_BVL_Instrument::factory(
-                $lorisInstance,
-                $testName,
-                $commentID,
-                '',
-                false
-            );
-        } catch (Exception $e) {
-            echo "\t$testName instrument row with CommentID: ".$commentID.
-                " was ignored for one of the following reasons:\n".
-                "  - The candidate is inactive.\n".
-                "  - The session is inactive.\n\n";
-            continue;
-        }
+    $instrumentInstances = $instrument->bulkLoadInstanceData($CommentIDs);
 
-        if (!$instrument) {
-            // instrument does not exist
-            echo "\t"
-            . "$testName for CommentID:$commentID could not be instantiated."
-            . "\n";
-            continue;
-        }
-
-        $data      = $instrument->getInstanceData();
+    foreach ($instrumentInstances as $instrumentInstance) {
+        $data      = $instrumentInstance->getInstanceData();
+        $commentID = $instrumentInstance->getCommentID();
         $dateTaken = $data['Date_taken'] ?? null;
 
         // Flag for problem with date
@@ -126,8 +104,8 @@ foreach ($instruments as $testName=>$instrument) {
                 $trouble =true;
             } else {
                 // get Age from instrument class
-                $calculatedAge       = $instrument->getCandidateAge();
-                $calculatedAgeMonths = $instrument->calculateAgeMonths(
+                $calculatedAge       = $instrumentInstance->getCandidateAge();
+                $calculatedAgeMonths = $instrumentInstance->calculateAgeMonths(
                     $calculatedAge
                 );
                 //Compare age to value saved in the instrument table
@@ -145,7 +123,7 @@ foreach ($instruments as $testName=>$instrument) {
             //Fix the saved values if confirm and trouble flags enabled
             if ($trouble && $confirm) {
                 echo "\tFixing age for CommentID: ".$commentID."\n";
-                $instrument->_saveValues(['Date_taken' => $dateTaken]);
+                $instrumentInstance->_saveValues(['Date_taken' => $dateTaken]);
             }
         }
     }


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a bug in the fix_candidate_age.php script where it is getting CommentIDs from every instrument _for_ each instrument, instead of just getting commentIDs for that instrument. This is making the script take n times as long where n = the number of instruments on the project. 

#### Testing instructions (if applicable)

1. Run the script
2. Make sure that it runs successfully and in a reasonable time scale.