### PR TITLE
[libraries] Get examiner sites by UserID

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -122,12 +122,12 @@ class User extends UserPermissions implements
                     epr.pending_approval
                   FROM examiners e
                   JOIN examiners_psc_rel epr ON (e.examinerID=epr.examinerID)
-                  WHERE e.full_name=:fn
+                  WHERE e.userID=:uid
                     AND (epr.active='Y'
                           OR (epr.active='N' AND epr.pending_approval='Y')
                         )",
             [
-                "fn" => $row['Real_name'],
+                "uid" => $row['ID'],
             ]
         );
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -105,7 +105,7 @@ class UserTest extends TestCase
      * @var array
      */
     private $_examinerInfo = [0 => ['full_name' => 'John Doe',
-        'userID' => '1',
+        'userID'      => '1',
         'examinerID'  => 1,
         'radiologist' => 1
     ]

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -105,6 +105,7 @@ class UserTest extends TestCase
      * @var array
      */
     private $_examinerInfo = [0 => ['full_name' => 'John Doe',
+        'userID' => '1',
         'examinerID'  => 1,
         'radiologist' => 1
     ]


### PR DESCRIPTION
## Brief summary of changes
We found this bug on CCNA where if a user has the same full name as another user, the examiner sites from the other user will show up in the edit user page. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Outside of this PR, Create 2 users with the same name
2. Set one user as examiner at multiple sites
3. Go to the other user, and see that the same sites show up as examiner
4. Try to remove the examiner sites and notice that you cannot
5. Checkout this PR and refresh the second user (without the examiner sites)
6. Now you should not see examiner sites where they are not meant to be
