### PR TITLE
[DataTable] Fix hide downloadCSV option

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -568,12 +568,14 @@ class DataTable extends Component {
               marginLeft: 'auto',
             }}>
               {this.renderActions()}
-              <button
-                className="btn btn-primary"
-                onClick={this.downloadCSV.bind(null, filteredRowIndexes)}
-              >
+              {this.props.hide.downloadCSV === true ? '' : (
+                  <button
+                    className="btn btn-primary"
+                    onClick={this.downloadCSV.bind(null, filteredRowIndexes)}
+                  >
                 Download Table as CSV
-              </button>
+              </button>)
+              }
               <PaginationLinks
                 Total={filteredCount}
                 onChangePage={this.changePage}


### PR DESCRIPTION
When hide downloadCSV is set to true the Download CSV option is still shown in the table header, but hidden from the table footer. This fixes it so that it is hidden from both.