### PR TITLE
[DataTable] Fix hide defaultColumn

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -517,7 +517,9 @@ class DataTable extends Component {
         const rowIndexDisplay = index[i].Content;
         rows.push(
             <tr key={'tr_' + rowIndex} colSpan={headers.length}>
+              {this.props.hide.defaultColumn === true ? null : (
               <td key={'td_' + rowIndex}>{rowIndexDisplay}</td>
+              )}
               {curRow}
             </tr>
         );


### PR DESCRIPTION
When hide defaultColumn is set to true the DataTable hides the table header but doesn't hide the column in the datatable. This fixes the bug so that the column is hidden and not just the column header.