### PR TITLE
[electrophysiology_browser] Fix EEG data shift

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -100,7 +100,7 @@ class EEGLabSeriesProvider extends Component<CProps> {
             shapes,
             timeInterval,
             seriesRange,
-            validSamples
+            validSamples,
           } = json;
           this.store.dispatch(
             setDatasetMetadata({

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -95,12 +95,13 @@ class EEGLabSeriesProvider extends Component<CProps> {
     Promise.race(racers(fetchJSON, chunksURL, '/index.json')).then(
       ({json, url}) => {
         if (json) {
-          const {channelMetadata, shapes, timeInterval, seriesRange} = json;
+          const {channelMetadata, shapes, timeInterval, seriesRange, validSamples} = json;
           this.store.dispatch(
             setDatasetMetadata({
               chunksURL: url,
               channelMetadata,
               shapes,
+              validSamples,
               timeInterval,
               seriesRange,
               limit,

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -95,7 +95,13 @@ class EEGLabSeriesProvider extends Component<CProps> {
     Promise.race(racers(fetchJSON, chunksURL, '/index.json')).then(
       ({json, url}) => {
         if (json) {
-          const {channelMetadata, shapes, timeInterval, seriesRange, validSamples} = json;
+          const {
+            channelMetadata,
+            shapes,
+            timeInterval,
+            seriesRange,
+            validSamples
+          } = json;
           this.store.dispatch(
             setDatasetMetadata({
               chunksURL: url,

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/LineChunk.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/LineChunk.tsx
@@ -39,17 +39,18 @@ const LineMemo = R.memoizeWith(
         .range([-0.5, 0.5]),
     ];
 
-    const points = [
-      ... previousPoint === null
-        ? []
-        : [
-          vec2.fromValues(
-            scales[0](
-              interval[0] - (1 / values.length) * (interval[1] - interval[0])
-            ),
-            -(scales[1](previousPoint) - DCOffset)
-          )
-      ],
+    const points = previousPoint === null
+      ? []
+      : [
+        vec2.fromValues(
+          scales[0](
+            interval[0] - (1 / values.length) * (interval[1] - interval[0])
+          ),
+          -(scales[1](previousPoint) - DCOffset)
+        )
+    ];
+
+    points.push(
       ...values.map((value, i) =>
         vec2.fromValues(
           scales[0](
@@ -58,7 +59,7 @@ const LineMemo = R.memoizeWith(
           -(scales[1](value) - DCOffset)
         )
       )
-    ];
+    );
 
     return (
       <LinePath

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/LineChunk.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/LineChunk.tsx
@@ -7,10 +7,12 @@ import {Group} from '@visx/group';
 import {colorOrder} from '../../color';
 
 const LineMemo = R.memoizeWith(
-  ({amplitudeScale, filters, channelIndex, traceIndex,
-     chunkIndex, isStacked, DCOffset, numChannels,
-     numChunks, previousPoint}) =>
-    `${amplitudeScale},${filters.join('-')},`
+  ({amplitudeScale, interval, filters,
+     channelIndex, traceIndex, chunkIndex,
+     isStacked, DCOffset, numChannels,
+     numChunks, previousPoint,
+  }) =>
+    `${amplitudeScale},${interval.join('-')},${filters.join('-')},`
     + `${channelIndex}-${traceIndex}-${chunkIndex},`
     + `${isStacked},${DCOffset},${numChannels},`
     + `${numChunks},${previousPoint}`,
@@ -152,7 +154,7 @@ const LineChunk = ({
       top={-p0[1]}
     >
       <Group
-        transform={'translate(' + p0[0] + ' 0)' +
+        transform={'translate(' + p0[0] + ' 0) ' +
           'scale(' + chunkLength + ' ' + chunkHeight + ')'
         }
       >

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -623,7 +623,8 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
           />
         </clipPath>
 
-        {channelList.map((channel, i) => {
+        {
+          channelList.map((channel, i) => {
           if (!channelMetadata[channel.index]) {
             return null;
           }
@@ -733,12 +734,12 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                 : 0;
 
               return (
-                trace.chunks.map((chunk, k) => (
+                trace.chunks.map((chunk, k, chunks) => (
                     <LineChunk
                       channelIndex={channel.index}
                       traceIndex={j}
                       chunkIndex={k}
-                      key={`${k}-${trace.chunks.length}`}
+                      key={`${channel.index}-${k}-${trace.chunks.length}`}
                       chunk={chunk}
                       seriesRange={seriesRange}
                       amplitudeScale={amplitudeScale}
@@ -749,6 +750,11 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                       withDCOffset={DCOffset}
                       numChannels={numDisplayedChannels}
                       numChunks={numChunks}
+                      previousPoint={
+                        k === 0
+                          ? null
+                          : chunks[k - 1].values.slice(-1)[0]
+                      }
                     />
                 ))
               );

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
@@ -110,7 +110,7 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
     Rx.map(([, state]) => fromState(state)),
     Rx.debounceTime(UPDATE_DEBOUNCE_TIME),
     Rx.concatMap(({bounds, dataset, channels}) => {
-      const {chunksURL, shapes, timeInterval} = dataset;
+      const {chunksURL, shapes, validSamples, timeInterval} = dataset;
       if (!chunksURL) {
         return of();
       }
@@ -123,19 +123,25 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
               const shapeChunks =
                 shapes.map((shape) => shape[shape.length - 2]);
 
-              const chunkIntervals : chunkIntervals[] = shapeChunks
+              const valuesPerChunk =
+                shapes.map((shape) => shape[shape.length - 1]);
+
+              const chunkIntervals = shapeChunks
                 .map((numChunks, downsampling) => {
                   const recordingDuration = Math.abs(
                     timeInterval[1] - timeInterval[0]
                   );
 
+                  const filledChunks = (numChunks - 1) +
+                    (validSamples[downsampling] / valuesPerChunk[downsampling]);
+
                   const i0 =
-                    (numChunks *
+                    (filledChunks *
                       Math.floor(bounds.interval[0] - bounds.domain[0])
                     ) / recordingDuration;
 
                   const i1 =
-                    (numChunks *
+                    (filledChunks *
                       Math.ceil(bounds.interval[1] - bounds.domain[0])
                     ) / recordingDuration;
 
@@ -145,7 +151,11 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
                   ];
 
                   return {
-                    interval: interval,
+                    interval:
+                      [
+                        Math.floor(i0),
+                        Math.min(Math.ceil(i1), filledChunks),
+                      ],
                     numChunks: numChunks,
                     downsampling,
                   };
@@ -164,12 +174,16 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
               const chunkPromises = R.range(...finestChunks.interval).flatMap(
                 (chunkIndex) => {
                   const numChunks = finestChunks.numChunks;
+
+                  const filledChunks = (numChunks - 1) +
+                    (validSamples[finestChunks.downsampling] /  valuesPerChunk[finestChunks.downsampling]);
+
                   const chunkInterval = [
                     timeInterval[0] +
-                    (chunkIndex / numChunks) *
+                    (chunkIndex / filledChunks) *
                     (timeInterval[1] - timeInterval[0]),
                     timeInterval[0] +
-                    ((chunkIndex + 1) / numChunks) *
+                    ((chunkIndex + 1) / filledChunks) *
                     (timeInterval[1] - timeInterval[0]),
                   ];
                   if (chunkInterval[0] <= bounds.interval[1]) {

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
@@ -175,8 +175,10 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
                 (chunkIndex) => {
                   const numChunks = finestChunks.numChunks;
 
-                  const filledChunks = (numChunks - 1) +
-                    (validSamples[finestChunks.downsampling] /  valuesPerChunk[finestChunks.downsampling]);
+                  const filledChunks = (numChunks - 1) + (
+                    validSamples[finestChunks.downsampling] /
+                    valuesPerChunk[finestChunks.downsampling]
+                  );
 
                   const chunkInterval = [
                     timeInterval[0] +

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/dataset.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/state/dataset.tsx
@@ -29,6 +29,7 @@ export type Action =
         chunksURL: string,
         channelNames: string[],
         shapes: number[][],
+        validSamples: number[],
         timeInterval: [number, number],
         seriesRange: [number, number],
         limit: number,
@@ -46,6 +47,7 @@ export type State = {
   activeEpoch: number | null,
   physioFileID: number | null,
   shapes: number[][],
+  validSamples: number[],
   timeInterval: [number, number],
   seriesRange: [number, number],
 };
@@ -68,6 +70,7 @@ export const datasetReducer = (
     offsetIndex: 1,
     limit: DEFAULT_MAX_CHANNELS,
     shapes: [],
+    validSamples: [],
     timeInterval: [0, 1],
     seriesRange: [-1, 2],
   },


### PR DESCRIPTION
Closes #8992. Has a Loris-MRI counterpart: aces/Loris-MRI#1030

Loosely dependant on #8998 (file modifications in common and done at a later time).

This PR resolves the data shift issue by adding the number of valid samples in the last chunk to the index.json, and using it for the calculations which previously assumed all chunks were filled.

Testing: Zoom in so that the last chunk of the recording is in frame and ensure that the signal does not flatline at the end. You can also compare the values in the chunk payload with the value obtained by hovering the signal at a given time.