### PR TITLE
[candidate_parameters] use DoB and DoD format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes in the following format: PR #1234***
 
 #### Bug Fixes
 - bvl_feedback updates in real-time (PR #8966)
+- DoB and DoD format respected in candidate parameters (PR #9001)
 
 ## LORIS 25.0 (Release Date: ????-??-??)
 ### Core

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -521,10 +521,22 @@ function getDOBFields(): array
     );
     $pscid         = $candidateData['PSCID'] ?? null;
     $dob           = $candidateData['DoB'] ?? null;
-    $result        = [
-        'pscid'  => $pscid,
-        'candID' => $candID->__toString(),
-        'dob'    => $dob,
+
+    // Get DoB format
+    $factory = \NDB_Factory::singleton();
+    $config  = $factory->config();
+
+    $dobFormat = $config->getSetting('dobFormat');
+
+    $dobProcessedFormat = implode("-", str_split($dobFormat, 1));
+    $dobDate            = DateTime::createFromFormat('Y-m-d', $dob);
+    $formattedDate      = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
+
+    $result = [
+        'pscid'     => $pscid,
+        'candID'    => $candID->__toString(),
+        'dob'       => $formattedDate,
+        'dobFormat' => $dobFormat,
     ];
     return $result;
 }
@@ -546,11 +558,30 @@ function getDODFields(): array
     if ($candidateData === null) {
         throw new \LorisException("Invalid candidate");
     }
+
+    $factory = \NDB_Factory::singleton();
+    $config  = $factory->config();
+
+    // Get formatted dod
+    $dodFormat = $config->getSetting('dodFormat');
+
+    $dodProcessedFormat = implode("-", str_split($dodFormat, 1));
+    $dodDate            = DateTime::createFromFormat('Y-m-d', $candidateData['DoD']);
+    $dod = $dodDate ? $dodDate->format($dodProcessedFormat) : null;
+
+    // Get formatted dob
+    $dobFormat = $config->getSetting('dobFormat');
+
+    $dobProcessedFormat = implode("-", str_split($dobFormat, 1));
+    $dobDate            = DateTime::createFromFormat('Y-m-d', $candidateData['DoB']);
+    $dob = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
+
     $result = [
-        'pscid'  => $candidateData['PSCID'],
-        'candID' => $candID->__toString(),
-        'dod'    => $candidateData['DoD'],
-        'dob'    => $candidateData['DoB'],
+        'pscid'     => $candidateData['PSCID'],
+        'candID'    => $candID->__toString(),
+        'dod'       => $dod,
+        'dob'       => $dob,
+        'dodFormat' => $config->getSetting('dodFormat'),
     ];
     return $result;
 }

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -85,6 +85,7 @@ class CandidateDOB extends Component {
         return <Loader/>;
     }
 
+    let dateFormat = this.state.data.dobFormat;
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dob_edit')) {
@@ -116,6 +117,7 @@ class CandidateDOB extends Component {
           <DateElement
             label='Date Of Birth:'
             name='dob'
+            dateFormat={dateFormat}
             value={this.state.formData.dob}
             onUserInput={this.setFormData}
             disabled={disabled}

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -83,6 +83,7 @@ class CandidateDOD extends Component {
       return <Loader/>;
     }
 
+    let dateFormat = this.state.data.dodFormat;
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dod_edit')) {
@@ -114,6 +115,7 @@ class CandidateDOD extends Component {
           <DateElement
             label='Date Of Death:'
             name='dod'
+            dateFormat={dateFormat}
             value={this.state.formData.dod}
             onUserInput={this.setFormData}
             disabled={disabled}


### PR DESCRIPTION
## Brief summary of changes

This PR uses the DoB and DoD format from configuration in the DoB and DoD tabs respectively.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Modify the DoB and DoD format in the configuration module
2. Make sure that these formats are respected in their respective tabs in the candidate parameters module
3. Try saving the DoB and DoD in each new format, make sure it saves properly and loads properly
4. Make sure to test on candidates _with_ and _without_ DoB and DoD

#### Link(s) to related issue(s)

* Resolves #6994
