### PR TITLE
[tools] Fix SQL error for duplicate rows

### DIFF
--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -102,7 +102,7 @@ foreach ($instruments as $instrument => $full_name) {
             $candid = $candidate['CandID'];
             $pscid  = $candidate['PSCID'];
             foreach ($subprojectids as $subprojectid) {
-                $session_info = $DB->pselectRow(
+                $session_info = $DB->pselect(
                     "SELECT DISTINCT s.Visit_label,s.ID from session s
                     JOIN candidate c on (c.candid=s.candid)
                     JOIN flag f on (f.sessionid=s.id)
@@ -115,8 +115,8 @@ foreach ($instruments as $instrument => $full_name) {
                     ]
                 );
                 if (($session_info!=null) && (!empty($session_info))) {
-                    $sessionid   = $session_info['ID'];
-                    $visit_label = $session_info['Visit_label'];
+                    $sessionid   = $session_info[0]['ID'];
+                    $visit_label = $session_info[0]['Visit_label'];
                     if ($sessionid !=null) {
                         $commentid = getCommentIDs(
                             $instrument,


### PR DESCRIPTION
Update the select query from `pselectRow` to `pselect` on line 105 under [tools] detect_duplicated_commentids.php file
 Have you updated related documentation?yes, [tools] detect_duplicated_commentids.php file
Issue: https://github.com/aces/Loris/issues/8060
rebase: https://github.com/aces/Loris/pull/8305
