### PR TITLE
Mri violations fix

### DIFF
--- a/modules/mri_violations/php/usercentermatchornulloranypermission.class.inc
+++ b/modules/mri_violations/php/usercentermatchornulloranypermission.class.inc
@@ -12,12 +12,20 @@ namespace LORIS\mri_violations;
 class UserCenterMatchOrNullOrAnyPermission implements \LORIS\Data\Filter
 {
     /**
+     * User permissions
+     *
+     * @var string[]
+     */
+    private $permissions;
+
+    /**
      * {@constructor}
      *
      * @param string[] $permissions - List of possible permissions
      */
-    public function __construct(protected array $permissions)
+    public function __construct(array $permissions)
     {
+        $this->permissions = $permissions;
     }
 
     /**


### PR DESCRIPTION
Fix module errors:
```
[CRITICAL] /var/www/loris/php/libraries/UserPermissions.class.inc:160: Uncaught TypeError: UserPermissions::hasAnyPermission(): Argument #1 ($permissions) must be of type array, null given
```
```
PHP Parse error:  syntax error, unexpected 'protected' (T_PROTECTED), expecting variable (T_VARIABLE) in /var/www/loris/project/modules/mri_violations/php/usercentermatchornulloranypermission.class.inc on line 19
```