### PR TITLE
[Installer] Fix MariaDB database installation

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -424,18 +424,18 @@ class Installer
         // new user, since the new user is also going to be used from
         // the same web server so should have the same address.
         $connectHost = $DB->PDO->query(
-            "SELECT host FROM `mysql`.`user`
-		WHERE CONCAT(user, '@', host)=CURRENT_USER"
+            "SELECT Host FROM `mysql`.`user`
+		WHERE CONCAT(user, '@', Host)=CURRENT_USER"
         )->fetch(\PDO::FETCH_ASSOC);
 
-        if (!is_array($connectHost) || empty($connectHost['host'])) {
+        if (!is_array($connectHost) || empty($connectHost['Host'])) {
             // This should never happen. It would mean that the user
             // that we ran the query from isn't connected..
             $this->_lastErr = "Could not retrieve hostname for MySQL user";
             return false;
         }
 
-        $connectHost = $connectHost['host'];
+        $connectHost = $connectHost['Host'];
 
         $userExistsQ = $DB->prepare(
             "SELECT 'x' FROM mysql.user

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -423,6 +423,9 @@ class Installer
         // that the current user is connect from to be the host of the
         // new user, since the new user is also going to be used from
         // the same web server so should have the same address.
+        // The 'Host' field name returned by the PDO seems to be capitalized
+        // in the response sent by MariaDB, so we always capitaliaze it to
+        // be compatible with both MySQL and MariaDB.
         $connectHost = $DB->PDO->query(
             "SELECT Host FROM `mysql`.`user`
 		WHERE CONCAT(user, '@', Host)=CURRENT_USER"


### PR DESCRIPTION
## Brief summary of changes

The database installer did not work on my machine with MariaDB. I updated it so that it works with both MySQL and MariaDB.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

I tested the change with both MariaDB 10.11.4 and MySQL 8.0.36 on fresh Debian 12 machines.

#### Link(s) to related issue(s)

* Resolves #7438

Please not that I am not an expert on databases so I don't know the exact specifications of case sensivity in MySQL and MariaDB, I just wrote a change that "seems to work".