### PR TITLE
[candidate] Create Sex table and remove Sex enum

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,7 +38,8 @@ return [
         "php",
         "htdocs",
         "modules",
-        "src",
+	"src",
+        "vendor",
         "test"
     ],
     'exclude_file_list' => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -39,7 +39,6 @@ return [
         "htdocs",
         "modules",
         "src",
-        "vendor",
         "test"
     ],
     'exclude_file_list' => [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ changes in the following format: PR #1234***
 - Add OpenID Connect authorization support to LORIS (PR #8255)
 
 #### Updates and Improvements
-- Create new `sex` table to hold candidate sex options, and change Sex and ProbandSex columns of `candidate` table to a varchar(255) datatype that is restricted by this table (PR #9025)
+- Create new `sex` table to hold candidate sex options, and change Sex and ProbandSex columns of `candidate` table to a varchar(255) datatype that is restricted by the `sex` table (PR #9025)
 
 #### Bug Fixes
 - Fix examiner site display (PR #8967)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ changes in the following format: PR #1234***
 #### Features
 - Add OpenID Connect authorization support to LORIS (PR #8255)
 
+#### Updates and Improvements
+- Create new `sex` table to hold candidate sex options, and change Sex and ProbandSex columns of `candidate` table to a varchar(255) datatype that is restricted by this table (PR #9025)
+
 #### Bug Fixes
 - Fix examiner site display (PR #8967)
 - bvl_feedback updates in real-time (PR #8966)

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -72,6 +72,15 @@ CREATE TABLE `language` (
 INSERT INTO language (language_code, language_label) VALUES
     ('en-CA', 'English');
 
+CREATE TABLE `sex` (
+  `SexID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `SexValue` varchar(255) NOT NULL,
+  PRIMARY KEY (`SexID`),
+  UNIQUE KEY `SexValue` (`SexValue`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COMMENT='Stores sex options available for candidates in LORIS';
+
+INSERT INTO sex (SexValue) VALUES ('Male'), ('Female'), ('Other');
+
 CREATE TABLE `users` (
   `ID` int(10) unsigned NOT NULL auto_increment,
   `UserID` varchar(255) NOT NULL default '',
@@ -151,7 +160,7 @@ CREATE TABLE `candidate` (
   `DoB` date DEFAULT NULL,
   `DoD` date DEFAULT NULL,
   `EDC` date DEFAULT NULL,
-  `Sex` enum('Male','Female','Other') DEFAULT NULL,
+  `Sex` varchar(255) DEFAULT NULL,
   `RegistrationCenterID` integer unsigned NOT NULL DEFAULT '0',
   `RegistrationProjectID` int(10) unsigned NOT NULL,
   `Ethnicity` varchar(255) DEFAULT NULL,
@@ -166,7 +175,7 @@ CREATE TABLE `candidate` (
   `flagged_other_status` enum('not_answered') DEFAULT NULL,
   `Testdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `Entity_type` enum('Human','Scanner') NOT NULL DEFAULT 'Human',
-  `ProbandSex` enum('Male','Female','Other') DEFAULT NULL,
+  `ProbandSex` varchar(255) DEFAULT NULL,
   `ProbandDoB` date DEFAULT NULL,
   PRIMARY KEY (`CandID`),
   UNIQUE KEY `ID` (`ID`),
@@ -175,9 +184,13 @@ CREATE TABLE `candidate` (
   KEY `CandidateActive` (`Active`),
   KEY `FK_candidate_2_idx` (`flagged_reason`),
   KEY `PSCID` (`PSCID`),
+  KEY `FK_candidate_sex_1` (`Sex`),
+  KEY `FK_candidate_sex_2` (`ProbandSex`),
   CONSTRAINT `FK_candidate_1` FOREIGN KEY (`RegistrationCenterID`) REFERENCES `psc` (`CenterID`),
   CONSTRAINT `FK_candidate_2` FOREIGN KEY (`flagged_reason`) REFERENCES `caveat_options` (`ID`) ON DELETE RESTRICT ON UPDATE CASCADE,
-  CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE
+  CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE,
+  CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`SexValue`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`SexValue`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `session` (

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -73,13 +73,11 @@ INSERT INTO language (language_code, language_label) VALUES
     ('en-CA', 'English');
 
 CREATE TABLE `sex` (
-  `SexID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `Sex` varchar(255) NOT NULL,
-  PRIMARY KEY (`SexID`),
-  UNIQUE KEY `Sex` (`Sex`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='Stores sex options available for candidates in LORIS';
+  `Name` varchar(255) NOT NULL,
+  PRIMARY KEY `Name` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Stores sex options available for candidates in LORIS';
 
-INSERT INTO sex (Sex) VALUES ('Male'), ('Female'), ('Other');
+INSERT INTO sex (Name) VALUES ('Male'), ('Female'), ('Other');
 
 CREATE TABLE `users` (
   `ID` int(10) unsigned NOT NULL auto_increment,
@@ -189,8 +187,8 @@ CREATE TABLE `candidate` (
   CONSTRAINT `FK_candidate_1` FOREIGN KEY (`RegistrationCenterID`) REFERENCES `psc` (`CenterID`),
   CONSTRAINT `FK_candidate_2` FOREIGN KEY (`flagged_reason`) REFERENCES `caveat_options` (`ID`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE,
-  CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE,
-  CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE
+  CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Name`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Name`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `session` (

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -74,12 +74,12 @@ INSERT INTO language (language_code, language_label) VALUES
 
 CREATE TABLE `sex` (
   `SexID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `SexValue` varchar(255) NOT NULL,
+  `Sex` varchar(255) NOT NULL,
   PRIMARY KEY (`SexID`),
-  UNIQUE KEY `SexValue` (`SexValue`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COMMENT='Stores sex options available for candidates in LORIS';
+  UNIQUE KEY `Sex` (`Sex`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='Stores sex options available for candidates in LORIS';
 
-INSERT INTO sex (SexValue) VALUES ('Male'), ('Female'), ('Other');
+INSERT INTO sex (Sex) VALUES ('Male'), ('Female'), ('Other');
 
 CREATE TABLE `users` (
   `ID` int(10) unsigned NOT NULL auto_increment,
@@ -189,8 +189,8 @@ CREATE TABLE `candidate` (
   CONSTRAINT `FK_candidate_1` FOREIGN KEY (`RegistrationCenterID`) REFERENCES `psc` (`CenterID`),
   CONSTRAINT `FK_candidate_2` FOREIGN KEY (`flagged_reason`) REFERENCES `caveat_options` (`ID`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `FK_candidate_RegistrationProjectID` FOREIGN KEY (`RegistrationProjectID`) REFERENCES `Project` (`ProjectID`) ON UPDATE CASCADE,
-  CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`SexValue`) ON DELETE RESTRICT ON UPDATE CASCADE,
-  CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`SexValue`) ON DELETE RESTRICT ON UPDATE CASCADE
+  CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `session` (

--- a/SQL/New_patches/2024-01-29-create-sex-table.sql
+++ b/SQL/New_patches/2024-01-29-create-sex-table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `sex` (
+  `SexID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `Sex` varchar(255) NOT NULL,
+  PRIMARY KEY (`SexID`),
+  UNIQUE KEY `Sex` (`Sex`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='Stores sex options available for candidates in LORIS';
+
+INSERT INTO sex (Sex) VALUES ('Male'), ('Female'), ('Other');
+
+ALTER TABLE candidate
+  MODIFY COLUMN sex varchar(255) DEFAULT NULL,
+  MODIFY COLUMN ProbandSex varchar(255) DEFAULT NULL,
+  ADD KEY `FK_candidate_sex_1` (`Sex`),
+  ADD KEY `FK_candidate_sex_2` (`ProbandSex`),
+  ADD CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/SQL/New_patches/2024-01-29-create-sex-table.sql
+++ b/SQL/New_patches/2024-01-29-create-sex-table.sql
@@ -1,9 +1,7 @@
 CREATE TABLE `sex` (
-  `SexID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `Sex` varchar(255) NOT NULL,
-  PRIMARY KEY (`SexID`),
-  UNIQUE KEY `Sex` (`Sex`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='Stores sex options available for candidates in LORIS';
+  `Name` varchar(255) NOT NULL,
+  PRIMARY KEY `Name` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Stores sex options available for candidates in LORIS';
 
 INSERT INTO sex (Sex) VALUES ('Male'), ('Female'), ('Other');
 
@@ -12,5 +10,5 @@ ALTER TABLE candidate
   MODIFY COLUMN ProbandSex varchar(255) DEFAULT NULL,
   ADD KEY `FK_candidate_sex_1` (`Sex`),
   ADD KEY `FK_candidate_sex_2` (`ProbandSex`),
-  ADD CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE,
-  ADD CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Sex`) ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT `FK_candidate_sex_1` FOREIGN KEY (`Sex`) REFERENCES `sex` (`Name`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `FK_candidate_sex_2` FOREIGN KEY (`ProbandSex`) REFERENCES `sex` (`Name`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -282,11 +282,7 @@ class CandidateListIndex extends Component {
           name: 'sex',
           type: 'select',
           hide: this.state.hideFilter,
-          options: {
-            'Male': 'Male',
-            'Female': 'Female',
-            'Other': 'Other',
-          },
+          options: options.Sex,
         },
       },
       {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -119,6 +119,7 @@ class Candidate_List extends \DataFrameworkMenu
             'cohort'            => $cohort_options,
             'participantstatus' => $participant_status_options,
             'useedc'            => $config->getSetting("useEDC"),
+            'Sex'               => \Utility::getSexList(),
         ];
     }
 

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -220,6 +220,7 @@ function getProbandInfoFields()
         'ageDifference'    => $ageDifference,
         'extra_parameters' => $extra_parameters,
         'parameter_values' => $parameter_values,
+        'sexOptions'       => \Utility::getSexList(),
     ];
 
     return $result;

--- a/modules/candidate_parameters/jsx/ProbandInfo.js
+++ b/modules/candidate_parameters/jsx/ProbandInfo.js
@@ -1,6 +1,14 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
+import {
+  FormElement,
+  StaticElement,
+  SelectElement,
+  ButtonElement,
+  DateElement,
+  TextareaElement,
+} from 'jsx/Form';
 
 /**
  * Proband Info Component.
@@ -16,11 +24,7 @@ class ProbandInfo extends Component {
     super(props);
 
     this.state = {
-      sexOptions: {
-        Male: 'Male',
-        Female: 'Female',
-        Other: 'Other',
-      },
+      sexOptions: {},
       Data: [],
       formData: {},
       updateResult: null,
@@ -66,6 +70,7 @@ class ProbandInfo extends Component {
           formData: formData,
           Data: data,
           isLoaded: true,
+          sexOptions: data.sexOptions,
         });
       },
       error: (error) => {

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -74,7 +74,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                     "Sex",
                     "Candidate's biological sex",
                     $candscope,
-                    new \LORIS\Data\Types\Enumeration('Male', 'Female', 'Other'),
+                    new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -54,6 +54,8 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             "Demographics",
             "Candidate Demographics",
         );
+        $sexList      = \Utility::getSexList();
+        $t            = new Enumeration(...$sexList);
         $demographics = $demographics->withItems(
             [
                 new DictionaryItem(
@@ -74,7 +76,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                     "Sex",
                     "Candidate's biological sex",
                     $candscope,
-                    new \LORIS\Data\Types\StringType(255),
+                    $t,
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -4,6 +4,7 @@ namespace LORIS\candidate_parameters;
 use LORIS\Data\Scope;
 use LORIS\Data\Cardinality;
 use LORIS\Data\Dictionary\DictionaryItem;
+use LORIS\Data\Types\Enumeration;
 
 /**
  * A CandidateQueryEngine providers a QueryEngine interface to query

--- a/modules/genomic_browser/jsx/tabs_content/cnv.js
+++ b/modules/genomic_browser/jsx/tabs_content/cnv.js
@@ -137,10 +137,7 @@ class CNV extends Component {
         filter: {
           name: 'Sex',
           type: 'select',
-          options: {
-            Male: 'Male',
-            Female: 'Female',
-          },
+          options: options.Sex,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -138,10 +138,7 @@ class Methylation extends Component {
         filter: {
           name: 'Sex',
           type: 'select',
-          options: {
-            Male: 'Male',
-            Female: 'Female',
-          },
+          options: options.Sex,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/profiles.js
+++ b/modules/genomic_browser/jsx/tabs_content/profiles.js
@@ -168,10 +168,7 @@ class Profiles extends Component {
         filter: {
           name: 'Sex',
           type: 'select',
-          options: {
-            Male: 'Male',
-            Female: 'Female',
-          },
+          options: options.Sex,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/snp.js
+++ b/modules/genomic_browser/jsx/tabs_content/snp.js
@@ -138,10 +138,7 @@ class SNP extends Component {
         filter: {
           name: 'Sex',
           type: 'select',
-          options: {
-            Male: 'Male',
-            Female: 'Female',
-          },
+          options: options.Sex,
         },
       },
       {

--- a/modules/genomic_browser/php/views/cnv.class.inc
+++ b/modules/genomic_browser/php/views/cnv.class.inc
@@ -43,6 +43,7 @@ class CNV
             'Sites'    => $sites,
             'Cohorts'  => $cohorts,
             'Platform' => $platform_options,
+            'Sex'      => \Utility::getSexList(),
         ];
     }
 

--- a/modules/genomic_browser/php/views/methylation.class.inc
+++ b/modules/genomic_browser/php/views/methylation.class.inc
@@ -57,6 +57,7 @@ class Methylation
                 'genotyping_platform',
                 'Name'
             ),
+            'Sex'             => \Utility::getSexList(),
         ];
     }
 

--- a/modules/genomic_browser/php/views/profiles.class.inc
+++ b/modules/genomic_browser/php/views/profiles.class.inc
@@ -41,6 +41,7 @@ class Profiles
         $this->_formElement = [
             'Sites'   => $sites,
             'Cohorts' => $cohorts,
+            'Sex'     => \Utility::getSexList(),
         ];
     }
 

--- a/modules/genomic_browser/php/views/snp.class.inc
+++ b/modules/genomic_browser/php/views/snp.class.inc
@@ -43,6 +43,7 @@ class SNP
             'Sites'    => $sites,
             'Cohorts'  => $cohorts,
             'Platform' => $platform_options,
+            'Sex'      => \Utility::getSexList(),
         ];
     }
 

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -46,14 +46,11 @@ class New_Profile extends \NDB_Form
         $ageMin    = $config->getSetting('ageMin');
         $dobFormat = $config->getSetting('dobFormat');
         $edc       = $config->getSetting('useEDC');
-        $sex       = [
-            'Male'   => 'Male',
-            'Female' => 'Female',
-            'Other'  => 'Other',
-        ];
-        $pscidSet  = "false";
-        $minYear   = (isset($startYear, $ageMax)) ? $startYear - $ageMax : null;
-        $maxYear   = (isset($endYear, $ageMin)) ? $endYear - $ageMin : null;
+        $sex       = \Utility::getSexList();
+
+        $pscidSet = "false";
+        $minYear  = (isset($startYear, $ageMax)) ? $startYear - $ageMax : null;
+        $maxYear  = (isset($endYear, $ageMin)) ? $endYear - $ageMin : null;
 
         // Get sites for the select dropdown
         $user_list_of_sites = $user->getCenterIDs();

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -135,7 +135,7 @@ class Utility
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $query = "SELECT SexValue FROM sex";
+        $query = "SELECT Sex FROM sex";
 
         $result = $DB->pselectCol($query, []);
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -126,6 +126,23 @@ class Utility
     }
 
     /**
+     * Returns list of sex options in the database
+     *
+     * @return array An associative array of sex values.
+     */
+    static function getSexList(): array
+    {
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
+
+        $query = "SELECT SexValue FROM sex";
+
+        $result = $DB->pselectCol($query, []);
+
+        return array_combine($result, $result);
+    }
+
+    /**
      * Returns a list of sites in the database
      *
      * @param boolean $study_site if true only return study sites from psc

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -135,7 +135,7 @@ class Utility
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $query = "SELECT Sex FROM sex";
+        $query = "SELECT Name FROM sex";
 
         $result = $DB->pselectCol($query, []);
 

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -60,7 +60,7 @@ class Sex implements \JsonSerializable
      */
     public static function validate(string $value, array $validValues): bool
     {
-        return in_array($value, $validValues, true);
+        return in_array($value, array_values($validValues), true);
     }
 
     /**

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -44,7 +44,7 @@ class Sex implements \JsonSerializable
         if (!self::validate($value, $this->validValues)) {
             throw new \DomainException(
                 'The value is not valid. Must be one of: '
-                . implode(', ', $this->validValues)
+                . implode(', ', array_values($this->validValues))
             );
         }
         $this->value = $value;

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -28,11 +28,7 @@ class Sex implements \JsonSerializable
     /* @var string */
     public $value;
 
-    private const VALID_VALUES = array(
-                                  'Male',
-                                  'Female',
-                                  'Other',
-                                 );
+    private $validValues = [];
 
     /**
      * Calls validate() immediately.
@@ -43,10 +39,12 @@ class Sex implements \JsonSerializable
      */
     public function __construct(string $value)
     {
-        if (!self::validate($value)) {
+        $this->validValues = \Utility::getSexList();
+
+        if (!self::validate($value, $this->validValues)) {
             throw new \DomainException(
                 'The value is not valid. Must be one of: '
-                . implode(', ', self::VALID_VALUES)
+                . implode(', ', $this->validValues)
             );
         }
         $this->value = $value;
@@ -55,13 +53,14 @@ class Sex implements \JsonSerializable
     /**
      * Ensures that the value is well-formed.
      *
-     * @param string $value The value to be validated
+     * @param string $value      The value to be validated
+     * @param array  $laidValues The restricted optional values of $value
      *
      * @return bool True if the value format is valid
      */
-    public static function validate(string $value): bool
+    public static function validate(string $value, array $validValues): bool
     {
-        return in_array($value, self::VALID_VALUES, true);
+        return in_array($value, $validValues, true);
     }
 
     /**

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -143,8 +143,6 @@ class CandidateTest extends TestCase
         $this->_factory->setDatabase($this->_dbMock);
         /**
          * To solve the phan issue
-         *
-         * @phan-suppress PhanUndeclaredMethod
          * @phan-methods  class \Database
          */
 
@@ -163,7 +161,8 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-        // Set the expected behavior for the getSexList method
+	// Set the expected behavior for the getSexList method
+        /* @phan-suppress-next-line PhanUndeclaredMethod */
         $this->_dbMock->expects($this->any())
             ->method('pselectCol')
             ->willReturn(['Male','Female','Other']);

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -156,8 +156,8 @@ class CandidateTest extends TestCase
             'UserID'                => 'admin',
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
-	];
-	'@phanvar \PHPUnit\Framework\MockObject\MockObject $this->_dbMock';
+        ];
+        '@phanvar \PHPUnit\Framework\MockObject\MockObject $this->_dbMock';
         $this->_dbMock->method('pselectCol')
             ->willReturn(['Male','Female','Other']);
         $this->_candidate = new Candidate();

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -130,7 +130,7 @@ class CandidateTest extends TestCase
         ];
 
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $dbMock     = $this->getMockBuilder('Database')->getMock();
+        $dbMock     = $this->getMockBuilder(Database::class)->getMock();
 
         '@phan-var \NDB_Config $configMock';
         '@phan-var \Database $dbMock';
@@ -141,11 +141,6 @@ class CandidateTest extends TestCase
         $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);
         $this->_factory->setDatabase($this->_dbMock);
-        /**
-         * To solve the phan issue
-         *
-         * @phan-methods class \Database
-         */
 
         $this->_candidateInfo = [
             'RegistrationCenterID'  => '2',
@@ -162,8 +157,6 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-        // Set the expected behavior for the getSexList method
-        /* @phan-suppress-next-line PhanUndeclaredMethod */
         $this->_dbMock->expects($this->any())
             ->method('pselectCol')
             ->willReturn(['Male','Female','Other']);

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -182,7 +182,7 @@ class CandidateTest extends TestCase
      */
     public function testSelectRetrievesCandidateInfo()
     {
-        //$this->_setUpTestDoublesForSelectCandidate();
+        $this->_setUpTestDoublesForSelectCandidate();
         $this->_dbMock
             ->method('pselect')
             ->willReturn(
@@ -561,7 +561,7 @@ class CandidateTest extends TestCase
             ['CohortID' => 1],
             ['CohortID' => 2]
         ];
-        //$this->_setUpTestDoublesForSelectCandidate();
+        $this->_setUpTestDoublesForSelectCandidate();
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
@@ -621,6 +621,7 @@ class CandidateTest extends TestCase
      */
     public function testGetCohortForMostRecentVisitReturnsMostRecentVisitLabel()
     {
+        $this->_setUpTestDoublesForSelectCandidate();
         $cohort = [
             [
                 'CohortID' => 1,
@@ -664,6 +665,8 @@ class CandidateTest extends TestCase
      */
     public function testGetCohortForMostRecentVisitReturnsNull()
     {
+        $this->_setUpTestDoublesForSelectCandidate();
+
         $cohort = [];
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
@@ -833,6 +836,8 @@ class CandidateTest extends TestCase
      */
     public function testGetSessionIDForExistingVisit()
     {
+        $this->_setUpTestDoublesForSelectCandidate();
+
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -21,6 +21,11 @@ use LORIS\StudyEntities\Candidate\CandID;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
+/**
+ * @phan-methods class \Database
+ * @method \PHPUnit\Framework\MockObject\MockObject|static pselectCol(mixed $query, array $params)
+ * @method \PHPUnit\Framework\MockObject\MockObject|static expects($thisArg)
+ */
 class CandidateTest extends TestCase
 {
     /**

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -157,10 +157,7 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-        '@phanvar \PHPUnit\Framework\MockObject\MockObject $this->_dbMock';
-        $this->_dbMock->method('pselectCol')
-            ->willReturn(['Male','Female','Other']);
-        $this->_candidate = new Candidate();
+        $this->_candidate     = new Candidate();
     }
 
     /**
@@ -1367,6 +1364,9 @@ class CandidateTest extends TestCase
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
+
+        $this->_dbMock->method('pselectCol')
+            ->willReturn(['Male','Female','Other']);
 
         $this->_configMock->method('getSetting')
             ->will($this->returnValueMap($this->_configMap));

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -130,10 +130,7 @@ class CandidateTest extends TestCase
         ];
 
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $dbMock     = $this->getMockBuilder(Database::class)->getMock();
-
-        '@phan-var \NDB_Config $configMock';
-        '@phan-var \Database $dbMock';
+        $dbMock     = $this->getMockBuilder('\Database')->getMock();
 
         $this->_configMock = $configMock;
         $this->_dbMock     = $dbMock;
@@ -157,8 +154,7 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-        $this->_dbMock->expects($this->any())
-            ->method('pselectCol')
+        $this->_dbMock->method('pselectCol')
             ->willReturn(['Male','Female','Other']);
         $this->_candidate = new Candidate();
     }

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -144,9 +144,8 @@ class CandidateTest extends TestCase
         /**
          * To solve the phan issue
          *
-         * @phan-methods class \Database
-         * @method       MockObject|static pselectCol(mixed $query, array $params)
-         * @method       MockObject|static expects($thisArg)
+         * @phan-suppress PhanUndeclaredMethod
+         * @phan-methods  class \Database
          */
 
         $this->_candidateInfo = [

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -557,11 +557,12 @@ class CandidateTest extends TestCase
      */
     public function testGetValidCohortsReturnsAListOfCohorts()
     {
+        $this->_dbMock->method('pselectCol')
+            ->willReturn(['Male','Female','Other']);
         $cohorts = [
             ['CohortID' => 1],
             ['CohortID' => 2]
         ];
-        $this->_setUpTestDoublesForSelectCandidate();
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
@@ -621,7 +622,8 @@ class CandidateTest extends TestCase
      */
     public function testGetCohortForMostRecentVisitReturnsMostRecentVisitLabel()
     {
-        $this->_setUpTestDoublesForSelectCandidate();
+        $this->_dbMock->method('pselectCol')
+            ->willReturn(['Male','Female','Other']);
         $cohort = [
             [
                 'CohortID' => 1,
@@ -665,8 +667,8 @@ class CandidateTest extends TestCase
      */
     public function testGetCohortForMostRecentVisitReturnsNull()
     {
-        $this->_setUpTestDoublesForSelectCandidate();
-
+        $this->_dbMock->method('pselectCol')
+            ->willReturn(['Male','Female','Other']);
         $cohort = [];
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -132,6 +132,9 @@ class CandidateTest extends TestCase
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
         $dbMock     = $this->getMockBuilder('\Database')->getMock();
 
+        '@phan-var \NDB_Config $configMock';
+        '@phan-var \Database $dbMock';
+
         $this->_configMock = $configMock;
         $this->_dbMock     = $dbMock;
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -157,7 +157,10 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-
+        // Set the expected behavior for the getSexList method
+        $this->_dbMock->expects($this->any())
+             ->method('pselectCol')
+             ->willReturn(['Male','Female','Other']);
         $this->_candidate = new Candidate();
     }
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -159,8 +159,8 @@ class CandidateTest extends TestCase
         ];
         // Set the expected behavior for the getSexList method
         $this->_dbMock->expects($this->any())
-             ->method('pselectCol')
-             ->willReturn(['Male','Female','Other']);
+            ->method('pselectCol')
+            ->willReturn(['Male','Female','Other']);
         $this->_candidate = new Candidate();
     }
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -21,11 +21,6 @@ use LORIS\StudyEntities\Candidate\CandID;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-/**
- * @phan-methods class \Database
- * @method \PHPUnit\Framework\MockObject\MockObject|static pselectCol(mixed $query, array $params)
- * @method \PHPUnit\Framework\MockObject\MockObject|static expects($thisArg)
- */
 class CandidateTest extends TestCase
 {
     /**
@@ -146,6 +141,13 @@ class CandidateTest extends TestCase
         $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);
         $this->_factory->setDatabase($this->_dbMock);
+        /**
+         * To solve the phan issue
+         *
+         * @phan-methods class \Database
+         * @method       MockObject|static pselectCol(mixed $query, array $params)
+         * @method       MockObject|static expects($thisArg)
+         */
 
         $this->_candidateInfo = [
             'RegistrationCenterID'  => '2',

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -143,7 +143,8 @@ class CandidateTest extends TestCase
         $this->_factory->setDatabase($this->_dbMock);
         /**
          * To solve the phan issue
-         * @phan-methods  class \Database
+         *
+         * @phan-methods class \Database
          */
 
         $this->_candidateInfo = [
@@ -161,7 +162,7 @@ class CandidateTest extends TestCase
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
-	// Set the expected behavior for the getSexList method
+        // Set the expected behavior for the getSexList method
         /* @phan-suppress-next-line PhanUndeclaredMethod */
         $this->_dbMock->expects($this->any())
             ->method('pselectCol')

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -86,7 +86,7 @@ class CandidateTest extends TestCase
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit\Framework\MockObject\MockObject
+     * @phan-var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 
@@ -156,7 +156,8 @@ class CandidateTest extends TestCase
             'UserID'                => 'admin',
             'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
-        ];
+	];
+	'@phanvar \PHPUnit\Framework\MockObject\MockObject $this->_dbMock';
         $this->_dbMock->method('pselectCol')
             ->willReturn(['Male','Female','Other']);
         $this->_candidate = new Candidate();

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -48,7 +48,7 @@ class CouchDBDemographicsImporter
         ],
         'Sex'              => [
             'Description' => 'Candidate\'s biological sex',
-            'Type'        => "enum('Male', 'Female', 'Other')"
+            'Type'        => "varchar(255)"
         ],
         'Site'             => [
             'Description' => 'Site that this visit took place at',
@@ -324,7 +324,7 @@ class CouchDBDemographicsImporter
         if ($config->getSetting("useProband") === "true") {
             $this->Dictionary["Sex_proband"]    = [
                 'Description' => 'Proband\'s biological sex',
-                'Type'        => "enum('Male','Female', 'Other')"
+                'Type'        => "varchar(255)"
             ];
             $this->Dictionary["Age_difference"] = [
                 'Description' => 'Age difference between the candidate and ' .


### PR DESCRIPTION
## Brief summary of changes
This PR changed the datatype of the candidate table columns "Sex" and ProbandSex" from enum to varchar(255), instead creating a constraint on the columns determined by a new "sex" table. 

The "sex" table contains optional values for candidate sex and candidate proband sex. Projects can add or remove Sex options by simply inserting into or dropping from this table. 

I also modified anywhere that I could find that was hardcoding Sex options to instead get the sex options from the database through a Utility class function.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Test creating a new candidate. Make sure that the sex is inserted into the candidate table properly. 
2. Set "use proband" config setting to true in the config module, and then test the proband tab of candidate parameters
3. Go to the candidate list module and select "Show Advanced Filters". Make sure that the Sex filter contains the right values  and works properly. 
4. Check the cnv, methylation, profiles, and snp tabs all filter for Sex properly, and that the sex dropdown contains the correct values. 
5. Add or drop a value from the Sex table, and repeat steps 1 through 5 making sure that the drop-downs are populated with the updated sex options. 
6. Attempt update a candidate to have a Sex and ProbandSex that do not exist in the sex table. Make sure you get an error.
7. Attempt to delete  a value from the sex table that is used in the candidate table. Make sure you get an error.
8. Test the CouchDB_Import_Demographics.php script

#### Link(s) to related issue(s)

* Resolves #8936
