### PR TITLE
[Instrument List] Show Timepoint Project

### DIFF
--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -22,7 +22,7 @@
     {else}
       {if $display.ProjectTitle != ""}
         <th>
-          Candidate Project
+          Candidate Registration Project
         </th>
       {/if}
       {if $display.ProjectName != ""}
@@ -110,7 +110,7 @@
         {$display.PSC}
       </td>
       <td>
-        {$display.SubprojectTitle}
+        {$display.CohortTitle}
       </td>
       <td>
         {$display.Scan_done|default:"<img alt=\"Data Missing\" src=\"{$baseurl|default}/images/help2.gif\" width=\"12\" height=\"12\" />"}

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -15,10 +15,21 @@
     <th>
       Biological Sex
     </th>
-    {if $display.ProjectTitle != ""}
+    {if $display.ProjectTitle == $display.ProjectName && $display.ProjectName != ""}
       <th>
         Project
       </th>
+    {else}
+      {if $display.ProjectTitle != ""}
+        <th>
+          Candidate Project
+        </th>
+      {/if}
+      {if $display.ProjectName != ""}
+        <th>
+          Timepoint Project
+        </th>
+      {/if}
     {/if}
     {foreach from=$display.DisplayParameters item=value key=name}
       <th>
@@ -68,10 +79,21 @@
     <td>
       {$display.Sex}
     </td>
-    {if $display.ProjectTitle != ""}
+    {if $display.ProjectName != "" && $display.ProjectName == $display.ProjectTitle}  
       <td>
-        {$display.ProjectTitle}
+        {$display.ProjectName}
       </td>
+    {else}
+      {if $display.ProjectTitle != ""}  
+        <td>
+          {$display.ProjectTitle}
+        </td>
+      {/if}
+      {if $display.ProjectName != ""}  
+        <td>
+          {$display.ProjectName}
+        </td>
+      {/if}
     {/if}
     {foreach from=$display.DisplayParameters item=value key=name}
       <td>
@@ -88,7 +110,7 @@
         {$display.PSC}
       </td>
       <td>
-        {$display.CohortTitle}
+        {$display.SubprojectTitle}
       </td>
       <td>
         {$display.Scan_done|default:"<img alt=\"Data Missing\" src=\"{$baseurl|default}/images/help2.gif\" width=\"12\" height=\"12\" />"}


### PR DESCRIPTION
## Brief summary of changes
- Changed the behaviour of showcasing the Candidate Registration Project on a visit's page. If the Timepoint Project differs from the Candidate Registration Project then it displays them separately, if they are the same then it shows the project under "Project"

Timepoint with a different project than the Candidate:
<kbd>
<img width="395" alt="image" src="https://github.com/aces/Loris/assets/51128536/2d1e3839-c624-4bc0-bc12-2f9263661c6c">
</kbd>
Timepoint with the same project as the Candidate:
<kbd>
<img width="337" alt="image" src="https://github.com/aces/Loris/assets/51128536/0bfad82b-64bc-4300-9363-4f3c949a4bc0">
</kbd>

#### Testing instructions (if applicable)

1. Try adding a timepoint to a candidate with a different project
2. See that it shows the correct Timepoint Project and Candidate Project
3. Try different combinations including same timepoint and candidate project

#### Link(s) to related issue(s)

* Resolves #8784  (Reference the issue this fixes, if any.)
