### PR TITLE
[Login] Add login suggestion and redirection for error 403

### DIFF
--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -136,9 +136,11 @@ class Login extends Component {
       })
       .then((response) => {
         if (response.ok) {
-          response.json().then((data) => {
-            // success - refresh page and user is logged in.
-            window.location.href = window.location.origin;
+          response.json().then(() => {
+            // Redirect if there is a "redirect" param, refresh the page otherwise
+            window.location.href = this.props.redirect !== null
+              ? this.props.redirect
+              : window.location.origin;
           });
         } else {
           response.json().then((data) => {
@@ -337,6 +339,7 @@ Login.propTypes = {
   defaultRequestFirstName: PropTypes.string,
   defaultRequestLastName: PropTypes.string,
   defaultRequestEmail: PropTypes.string,
+  redirect: PropTypes.string,
 };
 
 window.addEventListener('load', () => {
@@ -353,6 +356,7 @@ window.addEventListener('load', () => {
       defaultRequestFirstName={getParam('firstname', '')}
       defaultRequestLastName={getParam('lastname', '')}
       defaultRequestEmail={getParam('email', '')}
+      redirect={getParam('redirect', null)}
       module={'login'}
     />
   );

--- a/modules/login/test/Login_Redirect_Test_Plan.md
+++ b/modules/login/test/Login_Redirect_Test_Plan.md
@@ -1,0 +1,6 @@
+# Login Redirect Test Plan
+
+1. As an anonymous user, go to a page that requires to be logged in (this requires to use the URL of the page).
+2. When met with a 403 error, choose the option "Try logging in" and enter your user credentials.
+3. You should be redirected to the previous page and have access to it if you have the permissions to do so.
+4. The option "Try logging in" should not appeared for logged in users that access pages they do not have the permissions for.

--- a/smarty/templates/403.tpl
+++ b/smarty/templates/403.tpl
@@ -1,4 +1,11 @@
 <div class="container">
+    <h2>403: Forbidden</h2>
     <h3>{$message}</h3>
-    <div><a href="{$baseurl}">Go to main page</a> | <a onclick="window.history.back();" href="#">Go back one page</a></div>
+    <div>
+        <a href="{$baseurl}">Go to main page</a>
+        | <a onclick="window.history.back();" href="#">Go back one page</a>
+        {if $anonymous}
+            | <a href="/login?redirect={$url}">Try logging in</a>
+        {/if}
+    </div>
 </div>

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -58,7 +58,7 @@ class Error extends HtmlResponse
         // Variables used to suggest the user to login and later redirect them if they
         // are not authenticated in a 403.
         $tpl_data['anonymous'] = $user instanceof \LORIS\AnonymousUser;
-        $tpl_data['url']       = urlencode($_SERVER['REQUEST_URI']);
+        $tpl_data['url']       = urlencode($uri->__toString());
 
         // Add a link to the issue tracker as long as a LORIS Instance object
         // is present in the request.

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -55,6 +55,11 @@ class Error extends HtmlResponse
         $lorisInstance = $request->getAttribute('loris');
         $user          = $request->getAttribute('user') ?? new \LORIS\AnonymousUser();
 
+        // Variables used to suggest the user to login and later redirect them if they
+        // are not authenticated in a 403.
+        $tpl_data['anonymous'] = $user instanceof \LORIS\AnonymousUser;
+        $tpl_data['url']       = urlencode($_SERVER['REQUEST_URI']);
+
         // Add a link to the issue tracker as long as a LORIS Instance object
         // is present in the request.
         if (! $user instanceof \LORIS\AnonymousUser


### PR DESCRIPTION
## Brief summary of changes

Whenever an unauthenticated gets a 403 error, they can try logging in and be redirected to the page they got the 403 on.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to a page that exists and require authentication while not being authenticated.
2. Click "Try logging in"
3. Log in (after one or several tries)
4. You are redirected to the previous page

I implemented this using an URL query parameter, but I guess using `window.history` could also have worked. If anyone has an opinion on this please tell me.