### PR TITLE
[instrument_builder] - fix blank page

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -11,6 +11,14 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {
+    SelectElement,
+    DateElement,
+    TextareaElement,
+    TextElement,
+    NumericElement,
+    ButtonElement,
+} from 'jsx/Form';
 
 /**
  * Note: This is a wrapper for Form.js (Only used in instrument builder)


### PR DESCRIPTION
https://github.com/aces/Loris/issues/9037
#### Testing instructions (if applicable)
Go to 'instrument_builder'
Click on 'Data entry'
create any data entry will cause the error
textbox
textarea
....
