### PR TITLE
[Cleanup] Remove console.log

### DIFF
--- a/modules/configuration/jsx/DiagnosisEvolution.js
+++ b/modules/configuration/jsx/DiagnosisEvolution.js
@@ -406,7 +406,7 @@ class DiagnosisEvolution extends Component {
                 });
             }
         }).catch((error) => {
-            console.log(error);
+            console.warn(error);
         });
     }
 
@@ -501,7 +501,7 @@ class DiagnosisEvolution extends Component {
                 });
             }
         }).catch((error) => {
-            console.log(error);
+            console.warn(error);
         });
     }
 

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -93,7 +93,6 @@ class ImagingQCIndex extends Component {
       })
       .catch((error) => {
           this.setState({error: error});
-          console.log(error);
       });
   }
 


### PR DESCRIPTION
Fix eslint warnings about console.log that slipped through the code review of the PRs where they were merged.

One was a debug statement left behind, and 2 were the incorrect log level.