### PR TITLE
Remove lorispath from PSR7 request

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -41,6 +41,24 @@ $middlewarechain = (new \LORIS\Middleware\ContentLength())
 
 $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();
 
+// Remove the lorispath from the URI query parameters.
+// Both the request query parameters and the URI query string must be updated.
+$params        = $serverrequest->getQueryParams();
+$params        = array_diff_key($params, ["lorispath" => null]);
+$serverrequest = $serverrequest->withQueryParams($params);
+
+$query = implode(
+    "&",
+    array_map(
+        fn ($key, $value) => $key . "=" . $value,
+        array_keys($params),
+        $params
+    )
+);
+
+$uri           = $serverrequest->getUri();
+$serverrequest = $serverrequest->withUri($uri->withQuery($query));
+
 // Now that we've created the ServerRequest, handle it.
 $factory = \NDB_Factory::singleton();
 $user    = $factory->user();

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -43,8 +43,8 @@ $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();
 
 // Remove the lorispath from the URI query parameters.
 // Both the request query parameters and the URI query string must be updated.
-$params        = $serverrequest->getQueryParams();
-$params        = array_diff_key($params, ["lorispath" => null]);
+$params = $serverrequest->getQueryParams();
+unset($params['lorispath']);
 $serverrequest = $serverrequest->withQueryParams($params);
 
 $query = implode(


### PR DESCRIPTION
## Brief summary of changes

Removes `lorispath` from the PSR7 request's query parameters and uri query string (both must be updated separately).
Manipulating arrays in PHP is so verbose 😴.

#### Testing instructions

var dump `$serverrequest`

#### Links to related issues

* Resolves #9049
* Enables #9041
