### PR TITLE
[MRI Violations] Fix violated_scans_view_allsites permission

### DIFF
--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -144,7 +144,11 @@ class Mri_Violations extends \DataFrameworkMenu
             );
         default:
             return (new Provisioner())
-                ->filter(new UserCenterMatchOrNull())
+                ->filter(
+                    new UserCenterMatchOrNullOrAnyPermission(
+                        $this->allSitePermissionNames(),
+                    )
+                )
                 ->filter(new UserProjectMatchOrNull());
         }
     }


### PR DESCRIPTION
The permission violated_scans_view_allsites does not work anymore for the module. This fixes the issue.