### PR TITLE
fix missing imports

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -1,12 +1,13 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {
-    SelectElement,
-    DateElement,
-    TextboxElement,
-    FormElement,
-    FieldsetElement,
     CheckboxElement,
+    DateElement,
+    FieldsetElement,
+    FormElement,
+    NumericElement,
+    SelectElement,
+    TextboxElement,
 } from 'jsx/Form';
 
 /**

--- a/modules/battery_manager/jsx/batteryManagerForm.js
+++ b/modules/battery_manager/jsx/batteryManagerForm.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {NumericElement} from 'jsx/Form';
 
 /**
  * Battery Manager Form

--- a/modules/battery_manager/jsx/batteryManagerIndex.js
+++ b/modules/battery_manager/jsx/batteryManagerIndex.js
@@ -6,6 +6,7 @@ import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import Modal from 'Modal';
 import swal from 'sweetalert2';
+import {CTA} from 'jsx/Form';
 
 import BatteryManagerForm from './batteryManagerForm';
 


### PR DESCRIPTION
## Brief summary of changes

Fix missing imports in the battery manager and its dependencies (`jsx/Filter.jsx`), which prevented the main page of the battery manager from loading.

## Links to related issues

- Resolves #9062