### PR TITLE
Refactor `NDB_Page::getCSS/JSDependencies()`

### DIFF
--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -212,24 +212,14 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Add dependency on default acknowledgements.js
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be included
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-
-        $baseDeps = parent::getJSDependencies();
-
-        return array_merge(
-            $baseDeps,
-            [
-                $baseurl . '/acknowledgements/js/acknowledgementsIndex.js',
-            ]
-        );
-
+        return [
+            '/acknowledgements/js/acknowledgementsIndex.js',
+        ];
     }
-
 }

--- a/modules/api_docs/php/api_docs.class.inc
+++ b/modules/api_docs/php/api_docs.class.inc
@@ -84,23 +84,14 @@ class API_Docs extends \NDB_Page
     }
 
     /**
-     * Add JS dependency
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be included
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-
-        $baseDeps = parent::getJSDependencies();
-
-        return array_merge(
-            $baseDeps,
-            [
-                $baseurl . '/api_docs/js/swagger-ui_custom.js',
-            ]
-        );
-
+        return [
+            '/api_docs/js/swagger-ui_custom.js',
+        ];
     }
 }

--- a/modules/battery_manager/php/battery_manager.class.inc
+++ b/modules/battery_manager/php/battery_manager.class.inc
@@ -59,21 +59,14 @@ class Battery_Manager extends \NDB_Page
     }
 
     /**
-     * Include additional JS files.
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    public function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/battery_manager/js/batteryManagerIndex.js",
-            ]
-        );
+        return [
+            '/battery_manager/js/batteryManagerIndex.js',
+        ];
     }
 }
-

--- a/modules/behavioural_qc/php/behavioural_qc.class.inc
+++ b/modules/behavioural_qc/php/behavioural_qc.class.inc
@@ -41,22 +41,15 @@ class Behavioural_QC extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/behavioural_qc/js/behaviouralQCIndex.js',
-            ]
-        );
+        return [
+            '/behavioural_qc/js/behaviouralQCIndex.js',
+        ];
     }
 
     /**

--- a/modules/behavioural_qc/php/behavioural_qc.class.inc
+++ b/modules/behavioural_qc/php/behavioural_qc.class.inc
@@ -53,6 +53,18 @@ class Behavioural_QC extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/behavioural_qc/css/behavioural_qc.css'
+        ];
+    }
+
+    /**
      * Generate a breadcrumb trail for this page.
      *
      * @return \LORIS\BreadcrumbTrail
@@ -64,23 +76,6 @@ class Behavioural_QC extends \NDB_Form
                 'Behavioural Quality Control',
                 '/behavioural_qc'
             )
-        );
-    }
-
-    /**
-     * Include additional CSS files:
-     *  1. behavioural_qc
-     *
-     * @return array of CSS to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/behavioural_qc/css/behavioural_qc.css']
         );
     }
 }

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -67,26 +67,16 @@ class Brainbrowser extends \NDB_Page
     }
 
     /**
-     * Include additional CSS files:
-     *  1. jQuery UI
-     *  2. volume-viewer-demo.css
-     *  3. brainbrowser.css
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
-                $baseURL . "/brainbrowser/css/volume-viewer-demo.css",
-                $baseURL . "/brainbrowser/css/brainbrowser.css",
-            ]
-        );
+        return [
+            '/css/loris-jquery/jquery-ui-1.10.4.custom.min.css',
+            '/brainbrowser/css/volume-viewer-demo.css',
+            '/brainbrowser/css/brainbrowser.css',
+        ];
     }
 }
-

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -50,28 +50,20 @@ class Brainbrowser extends \NDB_Page
     }
 
     /**
-     * Override base function to include brainbrowser javascript files
-     * and dependencies
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be included
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-
-        $deps = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/brainbrowser/js/Brainbrowser.js",
-                $baseURL . "/brainbrowser/js/jquery.mousewheel.min.js",
-                $baseURL . "/brainbrowser/js/three.min.js",
-                $baseURL . "/brainbrowser/js/brainbrowser.volume-viewer.min.js",
-                $baseURL . "/brainbrowser/js/brainbrowser.config.js",
-                $baseURL . "/brainbrowser/js/brainbrowser.loris.js",
-            ]
-        );
+        return [
+            '/brainbrowser/js/Brainbrowser.js',
+            '/brainbrowser/js/jquery.mousewheel.min.js',
+            '/brainbrowser/js/three.min.js',
+            '/brainbrowser/js/brainbrowser.volume-viewer.min.js',
+            '/brainbrowser/js/brainbrowser.config.js',
+            '/brainbrowser/js/brainbrowser.loris.js',
+        ];
     }
 
     /**

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -50,6 +50,20 @@ class Brainbrowser extends \NDB_Page
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/css/loris-jquery/jquery-ui-1.10.4.custom.min.css',
+            '/brainbrowser/css/volume-viewer-demo.css',
+            '/brainbrowser/css/brainbrowser.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -63,20 +77,6 @@ class Brainbrowser extends \NDB_Page
             '/brainbrowser/js/brainbrowser.volume-viewer.min.js',
             '/brainbrowser/js/brainbrowser.config.js',
             '/brainbrowser/js/brainbrowser.loris.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/css/loris-jquery/jquery-ui-1.10.4.custom.min.css',
-            '/brainbrowser/css/volume-viewer-demo.css',
-            '/brainbrowser/css/brainbrowser.css',
         ];
     }
 }

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -124,22 +124,15 @@ class Candidate_List extends \DataFrameworkMenu
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/candidate_list/js/candidateListIndex.js",
-            ]
-        );
+        return [
+            '/candidate_list/js/candidateListIndex.js',
+        ];
     }
 
     /**

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -64,21 +64,15 @@ class Candidate_Parameters extends \NDB_Form
     }
 
     /**
-     * Include the Tabs.js and index.js (entry point of the module)
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/candidate_parameters/js/CandidateParameters.js",
-            ]
-        );
+        return [
+            '/candidate_parameters/js/CandidateParameters.js',
+        ];
     }
 
     /**

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -103,19 +103,15 @@ class Candidate_Profile extends \NDB_Page
     }
 
     /**
-     * Add CSSGrid dependency for the module.
+     * Add Javascript dependencies
      *
-     * @return array
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/js/components/CSSGrid.js']
-        );
+        return [
+            '/js/components/CSSGrid.js',
+        ];
     }
 
     /**

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -184,18 +184,6 @@ class Configuration extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/configuration/js/configuration_helper.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -204,6 +192,18 @@ class Configuration extends \NDB_Form
     {
         return [
             '/configuration/css/configuration.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/configuration/js/configuration_helper.js',
         ];
     }
 }

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -195,20 +195,15 @@ class Configuration extends \NDB_Form
         ];
     }
 
-     /**
-      * Include additional CSS files:
-      *  1. configuration
-      *
-      * @return array of CSS to be inserted
-      */
-    function getCSSDependencies()
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/configuration/css/configuration.css"]
-        );
+        return [
+            '/configuration/css/configuration.css',
+        ];
     }
 }

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -106,8 +106,8 @@ class Configuration extends \NDB_Form
         $DB = $this->loris->getDatabaseConnection();
 
         $parentConfigItems = $DB->pselect(
-            "SELECT Label, Name 
-             FROM ConfigSettings 
+            "SELECT Label, Name
+             FROM ConfigSettings
              WHERE Parent IS NULL AND Visible=1 ORDER BY OrderNumber",
             []
         );
@@ -184,22 +184,15 @@ class Configuration extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/configuration/js/configuration_helper.js",
-            ]
-        );
+        return [
+            '/configuration/js/configuration_helper.js',
+        ];
     }
 
      /**

--- a/modules/configuration/php/diagnosis_evolution.class.inc
+++ b/modules/configuration/php/diagnosis_evolution.class.inc
@@ -42,19 +42,15 @@ class Diagnosis_Evolution extends \NDB_Page
     }
 
     /**
-     * Include additional JS files:
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/configuration/js/DiagnosisEvolution.js"]
-        );
+        return [
+            '/configuration/js/DiagnosisEvolution.js',
+        ];
     }
 
     /**

--- a/modules/configuration/php/diagnosis_evolution.class.inc
+++ b/modules/configuration/php/diagnosis_evolution.class.inc
@@ -42,18 +42,6 @@ class Diagnosis_Evolution extends \NDB_Page
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/configuration/js/DiagnosisEvolution.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -62,6 +50,18 @@ class Diagnosis_Evolution extends \NDB_Page
     {
         return [
             '/configuration/css/configuration.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/configuration/js/DiagnosisEvolution.js',
         ];
     }
 }

--- a/modules/configuration/php/diagnosis_evolution.class.inc
+++ b/modules/configuration/php/diagnosis_evolution.class.inc
@@ -54,19 +54,14 @@ class Diagnosis_Evolution extends \NDB_Page
     }
 
     /**
-     * Include additional CSS files:
-     *  1. configuration
+     * Add CSS dependencies
      *
-     * @return array of CSS to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/configuration/css/configuration.css"]
-        );
+        return [
+            '/configuration/css/configuration.css',
+        ];
     }
 }

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -65,19 +65,14 @@ class Project extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. configuration
+     * Add CSS dependencies
      *
-     * @return array of CSS to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/configuration/css/configuration.css"]
-        );
+        return [
+            '/configuration/css/configuration.css',
+        ];
     }
 }

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -42,20 +42,14 @@ class Conflict_Resolver extends \NDB_Page
     }
 
     /**
-     * {@inheritDoc}
+     * Add Javascript dependencies
      *
-     * @return array A list of javascript files url.
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/conflict_resolver/js/conflict_resolver.js',
-            ]
-        );
+        return [
+            '/conflict_resolver/js/conflict_resolver.js',
+        ];
     }
 }

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -77,22 +77,16 @@ class Create_Timepoint extends \NDB_Form
             )
         );
     }
+
     /**
-     * Get js Dependencies
+     * Add Javascript dependencies
      *
-     * @return array
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $depends = parent::getJSDependencies();
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        $depends = array_merge(
-            $depends,
-            [
-                $baseurl . '/create_timepoint/js/createTimepointIndex.js',
-            ]
-        );
-        return $depends;
+        return [
+            '/create_timepoint/js/createTimepointIndex.js',
+        ];
     }
 }

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -138,19 +138,6 @@ class Dashboard extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return array_merge(
-            ['/dashboard/js/dashboard-helper.js'],
-            $this->widgetjs,
-        );
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -160,6 +147,19 @@ class Dashboard extends \NDB_Form
         return array_merge(
             ['/dashboard/css/dashboard.css'],
             $this->widgetcss,
+        );
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return array_merge(
+            ['/dashboard/js/dashboard-helper.js'],
+            $this->widgetjs,
         );
     }
 

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -156,23 +156,14 @@ class Dashboard extends \NDB_Form
     }
 
     /**
-     * Add dependency on D3 and C3 javascript libraries
-     * for the pretty dashboards in the chart
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be included
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-
-        $baseDeps = parent::getJSDependencies();
-
         return array_merge(
-            $baseDeps,
-            [
-                $baseurl . '/dashboard/js/dashboard-helper.js',
-            ],
+            ['/dashboard/js/dashboard-helper.js'],
             $this->widgetjs,
         );
     }

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -138,24 +138,6 @@ class Dashboard extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. dashboard.css
-     *
-     * @return array of css to be included
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/dashboard/css/dashboard.css"],
-            $this->widgetcss,
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -165,6 +147,19 @@ class Dashboard extends \NDB_Form
         return array_merge(
             ['/dashboard/js/dashboard-helper.js'],
             $this->widgetjs,
+        );
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return array_merge(
+            ['/dashboard/css/dashboard.css'],
+            $this->widgetcss,
         );
     }
 

--- a/modules/dashboard/php/widgetdependencies.class.inc
+++ b/modules/dashboard/php/widgetdependencies.class.inc
@@ -58,17 +58,6 @@ class WidgetDependencies
     }
 
     /**
-     * Return a list of javascript dependencies URLs which are required for the
-     * widget to load.
-     *
-     * @return string[]
-     */
-    public function getJSDependencies() : array
-    {
-        return $this->_js;
-    }
-
-    /**
      * Return a list of CSS dependencies which are required for the
      * widget to display correctly.
      *
@@ -77,5 +66,16 @@ class WidgetDependencies
     public function getCSSDependencies() : array
     {
         return $this->_css;
+    }
+
+    /**
+     * Return a list of javascript dependencies URLs which are required for the
+     * widget to load.
+     *
+     * @return string[]
+     */
+    public function getJSDependencies() : array
+    {
+        return $this->_js;
     }
 }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -68,9 +68,9 @@ class Data_Release extends \NDB_Menu_Filter
         $this->query   = " FROM data_release dr";
 
         if (!$user->hasPermission("superuser")) {
-            $this->query .= " JOIN data_release_permissions drp 
-            ON (dr.id=drp.data_release_id) 
-            JOIN users u ON (u.ID=drp.userid) 
+            $this->query .= " JOIN data_release_permissions drp
+            ON (dr.id=drp.data_release_id)
+            JOIN users u ON (u.ID=drp.userid)
             WHERE u.UserID=".$DB->quote($user->getUsername());
         }
 
@@ -248,19 +248,14 @@ class Data_Release extends \NDB_Menu_Filter
     }
 
     /**
-     * Include the column formatter
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        return array_merge(
-            parent::getJSDependencies(),
-            [
-                $baseurl . "/data_release/js/dataReleaseIndex.js",
-            ]
-        );
+        return [
+            '/data_release/js/dataReleaseIndex.js',
+        ];
     }
 }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -113,22 +113,15 @@ class Datadict extends \DataFrameworkMenu
     }
 
     /**
-     * Include the column formatter required to make the content editable in
-     * the datadict menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
-     **/
-    function getJSDependencies()
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/datadict/js/dataDictIndex.js",
-            ]
-        );
+        return [
+            '/datadict/js/dataDictIndex.js',
+        ];
     }
 
     /**

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -43,21 +43,14 @@ class Dataquery extends \NDB_Page
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/dataquery/js/index.js",
-            ]
-        );
+        return [
+            '/dataquery/js/index.js',
+        ];
     }
 }

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -93,22 +93,14 @@ class Dicom_Archive extends \DataFrameworkMenu
     }
 
     /**
-     * Overrides base getJSDependencies() to add support for dicom specific
-     * React column formatters.
+     * Add Javascript dependencies
      *
-     * @return array of extra JS files that this page depends on
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/dicom_archive/js/dicom_archive.js",
-            ]
-        );
+        return [
+            '/dicom_archive/js/dicom_archive.js',
+        ];
     }
 }
-

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -342,22 +342,6 @@ class ViewDetails extends \NDB_Form
     }
 
     /**
-     * Adds custom CSS for the viewdetails table styling.
-     *
-     * @return array of CSS to include in the page
-     */
-    function getCSSDependencies()
-    {
-        $depends = parent::getCSSDependencies();
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        return array_merge(
-            $depends,
-            [$baseURL . "/dicom_archive/css/dicom_archive.css"]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -366,6 +350,18 @@ class ViewDetails extends \NDB_Form
     {
         return [
             '/dicom_archive/js/view_details_link.js',
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/dicom_archive/css/dicom_archive.css',
         ];
     }
 

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -342,18 +342,6 @@ class ViewDetails extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/dicom_archive/js/view_details_link.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -362,6 +350,18 @@ class ViewDetails extends \NDB_Form
     {
         return [
             '/dicom_archive/css/dicom_archive.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/dicom_archive/js/view_details_link.js',
         ];
     }
 

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -358,21 +358,15 @@ class ViewDetails extends \NDB_Form
     }
 
     /**
-     * Overrides base getJSDependencies() to add additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of extra JS files that this page depends on
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/dicom_archive/js/view_details_link.js",
-            ]
-        );
+        return [
+            '/dicom_archive/js/view_details_link.js',
+        ];
     }
 
     /**

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -73,22 +73,15 @@ class Dictionary extends \DataFrameworkMenu
     }
 
     /**
-     * Include the column formatter required to make the content editable in
-     * the datadict menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
-     **/
-    function getJSDependencies()
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/dictionary/js/dataDictIndex.js",
-            ]
-        );
+        return [
+            '/dictionary/js/dataDictIndex.js',
+        ];
     }
 
     /**

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -191,18 +191,6 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/document_repository/js/docIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -211,6 +199,18 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     {
         return [
             '/document_repository/css/document_repository.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/document_repository/js/docIndex.js',
         ];
     }
 }

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -211,24 +211,14 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/document_repository/js/docIndex.js",
-            ]
-        );
+        return [
+            '/document_repository/js/docIndex.js',
+        ];
     }
-
 }
-
-

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -191,26 +191,6 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. jQuery UI
-     *  2. document_repository.css
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/document_repository/css/document_repository.css",
-            ]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -219,6 +199,18 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     {
         return [
             '/document_repository/js/docIndex.js',
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/document_repository/css/document_repository.css',
         ];
     }
 }

--- a/modules/document_repository/php/edit.class.inc
+++ b/modules/document_repository/php/edit.class.inc
@@ -53,20 +53,14 @@ class Edit extends \NDB_Page
     }
 
     /**
-     * Include additional JS files:
-     *  1. editForm.js - reactified form to update repository
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
     function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/document_repository/js/editFormIndex.js"]
-        );
+        return [
+            '/document_repository/js/editFormIndex.js'
+        ];
     }
-
 }

--- a/modules/dqt/php/dqt.class.inc
+++ b/modules/dqt/php/dqt.class.inc
@@ -43,32 +43,25 @@ class Dqt extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/js/d3.min.js',
-                $baseURL . '/js/c3.min.js',
-                $baseURL . '/dqt/js/react.fieldselector.js',
-                $baseURL . '/dqt/js/react.filterBuilder.js',
-                $baseURL . '/dqt/js/react.tabs.js',
-                $baseURL . '/dqt/js/react.sidebar.js',
-                $baseURL . '/dqt/js/react.app.js',
-                $baseURL . '/js/flot/jquery.flot.min.js',
-                $baseURL . '/js/components/PaginationLinks.js',
-                $baseURL . '/js/jszip/jszip.min.js',
-                $baseURL . '/js/components/MultiSelectDropdown.js',
-            ]
-        );
+        return [
+            '/js/d3.min.js',
+            '/js/c3.min.js',
+            '/dqt/js/react.fieldselector.js',
+            '/dqt/js/react.filterBuilder.js',
+            '/dqt/js/react.tabs.js',
+            '/dqt/js/react.sidebar.js',
+            '/dqt/js/react.app.js',
+            '/js/flot/jquery.flot.min.js',
+            '/js/components/PaginationLinks.js',
+            '/js/jszip/jszip.min.js',
+            '/js/components/MultiSelectDropdown.js',
+        ];
     }
 
     /**

--- a/modules/dqt/php/dqt.class.inc
+++ b/modules/dqt/php/dqt.class.inc
@@ -43,6 +43,19 @@ class Dqt extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/dqt/css/dataquery.css',
+            '/css/c3.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -61,19 +74,6 @@ class Dqt extends \NDB_Form
             '/js/components/PaginationLinks.js',
             '/js/jszip/jszip.min.js',
             '/js/components/MultiSelectDropdown.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/dqt/css/dataquery.css',
-            '/css/c3.css',
         ];
     }
 

--- a/modules/dqt/php/dqt.class.inc
+++ b/modules/dqt/php/dqt.class.inc
@@ -65,6 +65,19 @@ class Dqt extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/dqt/css/dataquery.css',
+            '/css/c3.css',
+        ];
+    }
+
+    /**
      * Generate a breadcrumb trail for this page.
      *
      * @return \LORIS\BreadcrumbTrail
@@ -73,26 +86,6 @@ class Dqt extends \NDB_Form
     {
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb('Data Query Tool', "/$this->name")
-        );
-    }
-
-    /**
-     * Include additional CSS files:
-     *  1. dataquery.css
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/dqt/css/dataquery.css',
-                $baseURL . '/css/c3.css',
-            ]
         );
     }
 }

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -97,24 +97,15 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
         return new ElectrophysiologyBrowserRowProvisioner();
     }
 
-
-
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of extra JS files that this page depends on
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        return array_merge(
-            parent::getJSDependencies(),
-            [
-                $baseURL
-                . '/electrophysiology_browser/js/electrophysiologyBrowserIndex.js',
-            ]
-        );
+        return [
+            '/electrophysiology_browser/js/electrophysiologyBrowserIndex.js',
+        ];
     }
-
 }

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -655,23 +655,15 @@ class Sessions extends \NDB_Page
     }
 
     /**
-     * Get JS Dependencies
+     * Add Javascript dependencies
      *
-     * @return array of extra JS files that this page depends on
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $depends = parent::getJSDependencies();
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        $depends = array_merge(
-            $depends,
-            [
-                $baseurl
-                . '/electrophysiology_browser/js/electrophysiologySessionView.js',
-            ]
-        );
-        return $depends;
+        return [
+            '/electrophysiology_browser/js/electrophysiologySessionView.js',
+        ];
     }
 
     /**

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -667,23 +667,15 @@ class Sessions extends \NDB_Page
     }
 
     /**
-     * Get CSS Dependencies
+     * Add CSS dependencies
      *
-     * @return array
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $depends = parent::getCSSDependencies();
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        $depends = array_merge(
-            $depends,
-            [
-                $baseurl
-                . '/electrophysiology_browser/css/electrophysiology_browser.css',
-            ]
-        );
-        return $depends;
+        return [
+            '/electrophysiology_browser/css/electrophysiology_browser.css',
+        ];
     }
 
     /**

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -655,18 +655,6 @@ class Sessions extends \NDB_Page
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/electrophysiology_browser/js/electrophysiologySessionView.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -675,6 +663,18 @@ class Sessions extends \NDB_Page
     {
         return [
             '/electrophysiology_browser/css/electrophysiology_browser.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/electrophysiology_browser/js/electrophysiologySessionView.js',
         ];
     }
 

--- a/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
@@ -92,21 +92,14 @@ class Electrophysiology_Uploader extends \DataFrameworkMenu
     }
 
     /**
-     * {@inheritDoc}
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL .
-                "/electrophysiology_uploader/js/ElectrophysiologyUploader.js",
-            ]
-        );
+        return [
+            '/electrophysiology_uploader/js/ElectrophysiologyUploader.js',
+        ];
     }
 }

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -100,22 +100,16 @@ class Examiner extends \DataFrameworkMenu
     {
         return new ExaminerProvisioner();
     }
+
     /**
-     * Include the index examiner javascript dependency
+     * Add Javascript dependencies
      *
-     * @return array
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/examiner/js/examinerIndex.js",
-            ]
-        );
+        return [
+            '/examiner/js/examinerIndex.js',
+        ];
     }
 }
-

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -47,20 +47,14 @@ class Genomic_Browser extends \NDB_Page
     }
 
     /**
-     * Loads the compiled react code for the genomic_browser.
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be included
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/genomic_browser/js/genomicBrowserIndex.js',
-            ]
-        );
+        return [
+            '/genomic_browser/js/genomicBrowserIndex.js',
+        ];
     }
 }

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -131,22 +131,14 @@ class Edit_Help_Content extends \NDB_Form
     }
 
     /**
-     * GetJSDependencies
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/help_editor/js/helpEditorForm.js",
-            ]
-        );
+        return [
+            '/help_editor/js/helpEditorForm.js',
+        ];
     }
 }
-
-

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -70,20 +70,14 @@ class Help_Editor extends \NDB_Menu_Filter
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/help_editor/js/help_editor.js"]
-        );
+        return [
+            '/help_editor/js/help_editor.js',
+        ];
     }
 }
-

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -201,22 +201,15 @@ class Imaging_Browser extends \DataFrameworkMenu
         );
     }
 
-
-
     /**
-     * Include the column formatter
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        return array_merge(
-            parent::getJSDependencies(),
-            [
-                $baseurl . "/imaging_browser/js/imagingBrowserIndex.js",
-            ]
-        );
+        return [
+            '/imaging_browser/js/imagingBrowserIndex.js',
+        ];
     }
 }

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -184,18 +184,6 @@ class Imaging_Browser extends \DataFrameworkMenu
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/imaging_browser/js/imagingBrowserIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -204,6 +192,18 @@ class Imaging_Browser extends \DataFrameworkMenu
     {
         return [
             '/imaging_browser/css/imaging_browser.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/imaging_browser/js/imagingBrowserIndex.js',
         ];
     }
 }

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -183,24 +183,6 @@ class Imaging_Browser extends \DataFrameworkMenu
         return $provisioner;
     }
 
-
-    /**
-     * Include additional CSS files:
-     *  1. imaging_browser.css
-     *
-     * @return array of css to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/imaging_browser/css/imaging_browser.css"]
-        );
-    }
-
     /**
      * Add Javascript dependencies
      *
@@ -210,6 +192,18 @@ class Imaging_Browser extends \DataFrameworkMenu
     {
         return [
             '/imaging_browser/js/imagingBrowserIndex.js',
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/imaging_browser/css/imaging_browser.css',
         ];
     }
 }

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -996,6 +996,18 @@ class ViewSession extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/imaging_browser/css/imaging_browser.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -1005,18 +1017,6 @@ class ViewSession extends \NDB_Form
         return [
             '/imaging_browser/js/jiv_and_imaging_browser.js',
             '/imaging_browser/js/ImagePanel.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/imaging_browser/css/imaging_browser.css',
         ];
     }
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -1009,20 +1009,15 @@ class ViewSession extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. imaging_browser.css
+     * Add CSS dependencies
      *
-     * @return array of css to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/imaging_browser/css/imaging_browser.css"]
-        );
+        return [
+            '/imaging_browser/css/imaging_browser.css',
+        ];
     }
 
     /**

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -994,24 +994,18 @@ class ViewSession extends \NDB_Form
         );
         return $controlPanel->display();
     }
+
     /**
-     * Get js Dependencies
+     * Add Javascript dependencies
      *
-     * @return array
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $depends = parent::getJSDependencies();
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        $depends = array_merge(
-            $depends,
-            [
-                $baseurl . "/imaging_browser/js/jiv_and_imaging_browser.js",
-                $baseurl . "/imaging_browser/js/ImagePanel.js",
-            ]
-        );
-        return $depends;
+        return [
+            '/imaging_browser/js/jiv_and_imaging_browser.js',
+            '/imaging_browser/js/ImagePanel.js',
+        ];
     }
 
     /**

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -358,21 +358,15 @@ class Imaging_QC extends \NDB_Menu_Filter
     }
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/imaging_qc/js/imagingQCIndex.js",
-            ]
-        );
+        return [
+            '/imaging_qc/js/imagingQCIndex.js',
+        ];
     }
 
     /**

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -730,21 +730,17 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  imaging_uploader.css
+     * Add CSS dependencies
      *
-     * @return array of css to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/imaging_uploader/css/imaging_uploader.css"]
-        );
+        return [
+            '/imaging_uploader/css/imaging_uploader.css',
+        ];
     }
+
     /**
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -717,6 +717,18 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/imaging_uploader/css/imaging_uploader.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -726,18 +738,6 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         return [
             '/imaging_uploader/js/index.js',
             '/imaging_uploader/js/imaging_uploader_helper.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/imaging_uploader/css/imaging_uploader.css',
         ];
     }
 

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -715,25 +715,20 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         }
         return $files;
     }
+
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/imaging_uploader/js/index.js",
-                $baseURL . "/imaging_uploader/js/imaging_uploader_helper.js",
-            ]
-        );
+        return [
+            '/imaging_uploader/js/index.js',
+            '/imaging_uploader/js/imaging_uploader_helper.js',
+        ];
     }
+
     /**
      * Include additional CSS files:
      *  imaging_uploader.css

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -45,23 +45,6 @@ class Instrument_Builder extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. instrument_builder.css
-     *
-     * @return array of CSS to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/instrument_builder/css/instrument_builder.css"]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -73,6 +56,18 @@ class Instrument_Builder extends \NDB_Form
             '/instrument_builder/js/instrument_builder.rules.js',
             '/instrument_builder/js/react.questions.js',
             '/instrument_builder/js/react.instrument_builder.js',
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/instrument_builder/css/instrument_builder.css',
         ];
     }
 }

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -62,24 +62,17 @@ class Instrument_Builder extends \NDB_Form
     }
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of JS to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        $depends = parent::getJSDependencies();
-        return array_merge(
-            $depends,
-            [
-                $baseurl . "/instrument_builder/js/instrument_builder.instrument.js",
-                $baseurl . "/instrument_builder/js/instrument_builder.rules.js",
-                $baseurl . "/instrument_builder/js/react.questions.js",
-                $baseurl . "/instrument_builder/js/react.instrument_builder.js",
-            ]
-        );
+        return [
+            '/instrument_builder/js/instrument_builder.instrument.js',
+            '/instrument_builder/js/instrument_builder.rules.js',
+            '/instrument_builder/js/react.questions.js',
+            '/instrument_builder/js/react.instrument_builder.js',
+        ];
     }
 }
-

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -45,6 +45,18 @@ class Instrument_Builder extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/instrument_builder/css/instrument_builder.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -56,18 +68,6 @@ class Instrument_Builder extends \NDB_Form
             '/instrument_builder/js/instrument_builder.rules.js',
             '/instrument_builder/js/react.questions.js',
             '/instrument_builder/js/react.instrument_builder.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/instrument_builder/css/instrument_builder.css',
         ];
     }
 }

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -316,22 +316,15 @@ class Instrument_List extends \NDB_Menu_Filter
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/instrument_list/js/instrument_list_helper.js",
-            ]
-        );
+        return [
+            '/instrument_list/js/instrument_list_helper.js',
+        ];
     }
 
     /**

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -315,20 +315,14 @@ class Instrument_Manager extends \DataFrameworkMenu
     }
 
     /**
-     * {@inheritDoc}
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/instrument_manager/js/instrumentManagerIndex.js",
-            ]
-        );
+        return [
+            '/instrument_manager/js/instrumentManagerIndex.js',
+        ];
     }
 }

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -55,18 +55,6 @@ class Issue extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/issue_tracker/js/index.js'
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -75,6 +63,18 @@ class Issue extends \NDB_Form
     {
         return [
             '/issue_tracker/css/issue_tracker.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/issue_tracker/js/index.js'
         ];
     }
 

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -71,19 +71,15 @@ class Issue extends \NDB_Form
     }
 
     /**
-     * Include issueIndex.js
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/issue_tracker/js/index.js"]
-        );
+        return [
+            '/issue_tracker/js/index.js'
+        ];
     }
 
     /**

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -55,22 +55,6 @@ class Issue extends \NDB_Form
     }
 
     /**
-     * Include issue_tracker.css
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/issue_tracker/css/issue_tracker.css"]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -79,6 +63,18 @@ class Issue extends \NDB_Form
     {
         return [
             '/issue_tracker/js/index.js'
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/issue_tracker/css/issue_tracker.css',
         ];
     }
 

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -212,18 +212,14 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Overrides base getJSDependencies() to add support for issue tracker
-     * specific React Index file.
+     * Add Javascript dependencies
      *
-     * @return array of extra JS files that this page depends on
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
-        return array_merge(
-            parent::getJSDependencies(),
-            [$baseurl . "/issue_tracker/js/issueTrackerIndex.js"]
-        );
+        return [
+            '/issue_tracker/js/issueTrackerIndex.js'
+        ];
     }
 }

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -17,22 +17,17 @@ class Login extends \NDB_Page
     public $skipTemplate = true;
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/login/js/loginIndex.js',
-            ]
-        );
+        return [
+            '/login/js/loginIndex.js',
+        ];
     }
+
     /**
      * Include additional CSS files:
      *

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -17,18 +17,6 @@ class Login extends \NDB_Page
     public $skipTemplate = true;
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/login/js/loginIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -37,6 +25,18 @@ class Login extends \NDB_Page
     {
         return [
             '/login/css/login.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/login/js/loginIndex.js',
         ];
     }
 }

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -29,19 +29,14 @@ class Login extends \NDB_Page
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/login/css/login.css']
-        );
+        return [
+            '/login/css/login.css',
+        ];
     }
-
 }

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -73,20 +73,15 @@ class Edit extends \NDB_Form
     }
 
     /**
-     * Include additional JS files:
-     *  1. editForm.js - reactified form to update media
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/media/js/editFormIndex.js"]
-        );
+        return [
+            '/media/js/editFormIndex.js'
+        ];
     }
 
     /**
@@ -100,5 +95,4 @@ class Edit extends \NDB_Form
     {
         return $user->hasPermission('media_write');
     }
-
 }

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -56,18 +56,6 @@ class Edit extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/media/js/editFormIndex.js'
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -76,6 +64,18 @@ class Edit extends \NDB_Form
     {
         return [
             '/media/css/media.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/media/js/editFormIndex.js'
         ];
     }
 

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -56,23 +56,6 @@ class Edit extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. media.js
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies()
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/media/css/media.css"]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -81,6 +64,18 @@ class Edit extends \NDB_Form
     {
         return [
             '/media/js/editFormIndex.js'
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/media/css/media.css',
         ];
     }
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -179,21 +179,14 @@ class Media extends \DataFrameworkMenu
     }
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/media/js/mediaIndex.js",
-            ]
-        );
+        return [
+            '/media/js/mediaIndex.js',
+        ];
     }
 }
-

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -162,18 +162,6 @@ class Media extends \DataFrameworkMenu
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/media/js/mediaIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -182,6 +170,18 @@ class Media extends \DataFrameworkMenu
     {
         return [
             '/media/css/media.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/media/js/mediaIndex.js',
         ];
     }
 }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -162,23 +162,6 @@ class Media extends \DataFrameworkMenu
     }
 
     /**
-     * Include additional CSS files:
-     *  1. media.css
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies() : array
-    {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/media/css/media.css"]
-        );
-    }
-
-    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -187,6 +170,18 @@ class Media extends \DataFrameworkMenu
     {
         return [
             '/media/js/mediaIndex.js',
+        ];
+    }
+
+    /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/media/css/media.css',
         ];
     }
 }

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -68,21 +68,14 @@ class Module_Manager extends \DataFrameworkMenu
     }
 
     /**
-     * {@inheritDoc}
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/module_manager/js/modulemanager.js",
-            ]
-        );
+        return [
+            '/module_manager/js/modulemanager.js',
+        ];
     }
 }
-

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -173,21 +173,14 @@ class Mri_Violations extends \DataFrameworkMenu
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of css to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies() : array
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/mri_violations/css/mri_violations.css",
-            ]
-        );
+        return [
+            '/mri_violations/css/mri_violations.css',
+        ];
     }
 }
-

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -161,21 +161,15 @@ class Mri_Violations extends \DataFrameworkMenu
     }
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/mri_violations/js/mriViolationsIndex.js",
-            ]
-        );
+        return [
+            '/mri_violations/js/mriViolationsIndex.js',
+        ];
     }
 
     /**

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -161,18 +161,6 @@ class Mri_Violations extends \DataFrameworkMenu
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/mri_violations/js/mriViolationsIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -181,6 +169,18 @@ class Mri_Violations extends \DataFrameworkMenu
     {
         return [
             '/mri_violations/css/mri_violations.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/mri_violations/js/mriViolationsIndex.js',
         ];
     }
 }

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -472,6 +472,18 @@ class My_Preferences extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/css/password.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -482,18 +494,6 @@ class My_Preferences extends \NDB_Form
             '/js/passwordVisibility.js',
             '/my_preferences/js/my_preferences_helper.js',
             '/js/components/CSSGrid.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/css/password.css',
         ];
     }
 }

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -486,22 +486,14 @@ class My_Preferences extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. configuration
+     * Add CSS dependencies
      *
-     * @return array of CSS to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/css/password.css",
-            ]
-        );
+        return [
+            '/css/password.css',
+        ];
     }
 }
-

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -472,24 +472,17 @@ class My_Preferences extends \NDB_Form
     }
 
     /**
-     * Add dependency for password visibility
+     * Add Javascript dependencies
      *
-     * @return array of javascript files to be sourced
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory  = \NDB_Factory::singleton();
-        $baseurl  = $factory->settings()->getBaseURL();
-        $baseDeps = parent::getJSDependencies();
-
-        return array_merge(
-            $baseDeps,
-            [
-                $baseurl . '/js/passwordVisibility.js',
-                $baseurl . '/my_preferences/js/my_preferences_helper.js',
-                $baseurl . '/js/components/CSSGrid.js',
-            ]
-        );
+        return [
+            '/js/passwordVisibility.js',
+            '/my_preferences/js/my_preferences_helper.js',
+            '/js/components/CSSGrid.js',
+        ];
     }
 
     /**

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -83,18 +83,14 @@ class New_Profile extends \NDB_Form
     }
 
     /**
-     * Include additional JS files
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
     function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/new_profile/js/NewProfileIndex.js']
-        );
+        return [
+            '/new_profile/js/NewProfileIndex.js'
+        ];
     }
 }

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -253,18 +253,6 @@ class Publication extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/publication/js/publicationIndex.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -273,6 +261,18 @@ class Publication extends \NDB_Menu_Filter_Form
     {
         return [
             '/publication/css/publication.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/publication/js/publicationIndex.js',
         ];
     }
 

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -252,22 +252,16 @@ class Publication extends \NDB_Menu_Filter_Form
         );
     }
 
-
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the candidate_list menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/publication/js/publicationIndex.js']
-        );
+        return [
+            '/publication/js/publicationIndex.js',
+        ];
     }
 
     /**

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -265,20 +265,15 @@ class Publication extends \NDB_Menu_Filter_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  imaging_uploader.css
+     * Add CSS dependencies
      *
-     * @return array of css to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies() : array
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/publication/css/publication.css']
-        );
+        return [
+            '/publication/css/publication.css',
+        ];
     }
 
     /**
@@ -306,4 +301,3 @@ class Publication extends \NDB_Menu_Filter_Form
         return json_encode($result);
     }
 }
-

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -85,21 +85,6 @@ class View_Project extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. media.js
-     *
-     * @return array of javascript to be inserted
-     */
-    function getCSSDependencies() : array
-    {
-        $deps = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            []
-        );
-    }
-
-    /**
      * Generate a breadcrumb trail for this page.
      *
      * @return \LORIS\BreadcrumbTrail

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -117,20 +117,14 @@ class View_Project extends \NDB_Form
     }
 
     /**
-     * Include additional JS files:
-     *  1. editForm.js - reactified form to update media
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies() : array
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/publication/js/viewProjectIndex.js"]
-        );
+        return [
+            '/publication/js/viewProjectIndex.js',
+        ];
     }
-
 }

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -70,7 +70,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
             'userid',
         ];
 
-        $this->query = " FROM server_processes 
+        $this->query = " FROM server_processes
                          WHERE 1=1";
 
         $this->formToFilter = [
@@ -82,22 +82,14 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
     }
 
     /**
-     * Gathers JS dependecies and merge them with the parent
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL .
-             "/server_processes_manager/js/server_processes_managerIndex.js",
-            ]
-        );
+        return [
+            '/server_processes_manager/js/server_processes_managerIndex.js',
+        ];
     }
-
 }

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -91,7 +91,7 @@ class Module extends \Module
                         $baseURL . '/statistics/css/recruitment.css'
                     ],
                     [
-                        $baseURL . '/statistics/js/WidgetIndex.js'
+                        '/statistics/js/WidgetIndex.js'
                     ],
                 )
             );

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -57,23 +57,17 @@ class Statistics extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the statistics menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/statistics/js/statistics.js",
-            ]
-        );
+        return [
+            '/statistics/js/statistics.js',
+        ];
     }
+
     /**
      * Include additional CSS files:
      *

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -53,19 +53,6 @@ class Statistics extends \NDB_Form
                  ORDER BY OrderNo",
             []
         );
-
-    }
-
-    /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/statistics/js/statistics.js',
-        ];
     }
 
     /**
@@ -77,6 +64,18 @@ class Statistics extends \NDB_Form
     {
         return [
             '/statistics/css/statistics.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/statistics/js/statistics.js',
         ];
     }
 }

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -69,19 +69,14 @@ class Statistics extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/statistics/css/statistics.css"]
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
 }
-

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -110,7 +110,7 @@ class Statistics_Mri_Site extends Statistics_Site
         $query = '';
         switch ($issue) {
         case 'Tarchive_Missing':
-            $query = "SELECT DISTINCT f.CommentID as CommentID, 
+            $query = "SELECT DISTINCT f.CommentID as CommentID,
                             c.PSCID, s.ID as SessionID, s.CandID as CandID,
                             s.Visit_label
                     FROM flag f JOIN session s ON (f.SessionID=s.ID)
@@ -167,7 +167,7 @@ class Statistics_Mri_Site extends Statistics_Site
                         LEFT JOIN mri_parameter_form mpf
                        ON (mpf.CommentID=f.CommentID)
                         LEFT JOIN candidate c ON (c.CandID=s.CandID)
-                        WHERE s.Active='Y' 
+                        WHERE s.Active='Y'
                            AND c.Entity_type != 'Scanner'
                            AND (f.ID IS NULL OR
                            f.Data_entry <> 'Complete' OR
@@ -251,19 +251,14 @@ class Statistics_Mri_Site extends Statistics_Site
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/statistics/css/statistics.css"]
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
 }
-

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -317,19 +317,14 @@ class Statistics_Site extends \NDB_Menu
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/statistics/css/statistics.css"]
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
 }
-

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -389,18 +389,14 @@ class Stats_Behavioural extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/statistics/css/statistics.css"]
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
 }

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -377,22 +377,15 @@ class Stats_Behavioural extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the statistics menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/statistics/js/form_stats_behavioural.js",
-            ]
-        );
+        return [
+            '/statistics/js/form_stats_behavioural.js',
+        ];
     }
 
     /**
@@ -411,4 +404,3 @@ class Stats_Behavioural extends \NDB_Form
         );
     }
 }
-

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -377,18 +377,6 @@ class Stats_Behavioural extends \NDB_Form
     }
 
     /**
-     * Add Javascript dependencies
-     *
-     * @return array The list of Javascript files this page depends on
-     */
-    function getJSDependencies(): array
-    {
-        return [
-            '/statistics/js/form_stats_behavioural.js',
-        ];
-    }
-
-    /**
      * Add CSS dependencies
      *
      * @return array The list of CSS files this page depends on
@@ -397,6 +385,18 @@ class Stats_Behavioural extends \NDB_Form
     {
         return [
             '/statistics/css/statistics.css',
+        ];
+    }
+
+    /**
+     * Add Javascript dependencies
+     *
+     * @return array The list of Javascript files this page depends on
+     */
+    function getJSDependencies(): array
+    {
+        return [
+            '/statistics/js/form_stats_behavioural.js',
         ];
     }
 }

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -639,20 +639,14 @@ class Stats_Demographic extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . '/statistics/css/statistics.css']
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
-
 }
-

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -628,21 +628,16 @@ class Stats_Demographic extends \NDB_Form
      * Include the column formatter required to display the feedback link colours
      * in the statistics menu
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/statistics/js/table_statistics.js',
-                $baseURL . '/statistics/js/form_stats_demographic.js',
-            ]
-        );
+        return [
+            '/statistics/js/table_statistics.js',
+            '/statistics/js/form_stats_demographic.js',
+        ];
     }
+
     /**
      * Include additional CSS files:
      *

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -625,6 +625,18 @@ class Stats_Demographic extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/statistics/css/statistics.css',
+        ];
+    }
+
+    /**
      * Include the column formatter required to display the feedback link colours
      * in the statistics menu
      *
@@ -635,18 +647,6 @@ class Stats_Demographic extends \NDB_Form
         return [
             '/statistics/js/table_statistics.js',
             '/statistics/js/form_stats_demographic.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/statistics/css/statistics.css',
         ];
     }
 }

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -605,23 +605,16 @@ class Stats_MRI extends \NDB_Form
     }
 
     /**
-     * Include the column formatter required to display the feedback link colours
-     * in the statistics menu
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/statistics/js/table_statistics.js",
-                $baseURL . "/statistics/js/form_stats_MRI.js",
-            ]
-        );
+        return [
+            '/statistics/js/table_statistics.js',
+            '/statistics/js/form_stats_MRI.js',
+        ];
     }
     /**
      * Include additional CSS files:

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -616,21 +616,16 @@ class Stats_MRI extends \NDB_Form
             '/statistics/js/form_stats_MRI.js',
         ];
     }
+
     /**
-     * Include additional CSS files:
+     * Add CSS dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/statistics/css/statistics.css"]
-        );
+        return [
+            '/statistics/css/statistics.css',
+        ];
     }
-
 }
-

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -605,6 +605,18 @@ class Stats_MRI extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/statistics/css/statistics.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -614,18 +626,6 @@ class Stats_MRI extends \NDB_Form
         return [
             '/statistics/js/table_statistics.js',
             '/statistics/js/form_stats_MRI.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/statistics/css/statistics.css',
         ];
     }
 }

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -302,21 +302,14 @@ class AddSurvey extends \NDB_Form
     }
 
     /**
-     * Gathers JS dependecies and merge them with the parent
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/survey_accounts/js/survey_accounts_helper.js",
-            ]
-        );
+        return [
+            '/survey_accounts/js/survey_accounts_helper.js',
+        ];
     }
 }
-

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -104,20 +104,14 @@ class Survey_Accounts extends \DataFrameworkMenu
     }
 
     /**
-     * {@inheritDoc}
+     * Add Javascript dependencies
      *
-     * @return array
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/survey_accounts/js/surveyAccountsIndex.js",
-            ]
-        );
+        return [
+            '/survey_accounts/js/surveyAccountsIndex.js'
+        ];
     }
 }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1366,6 +1366,18 @@ class Edit_User extends \NDB_Form
     }
 
     /**
+     * Add CSS dependencies
+     *
+     * @return array The list of CSS files this page depends on
+     */
+    function getCSSDependencies(): array
+    {
+        return [
+            '/css/password.css',
+        ];
+    }
+
+    /**
      * Add Javascript dependencies
      *
      * @return array The list of Javascript files this page depends on
@@ -1377,18 +1389,6 @@ class Edit_User extends \NDB_Form
             '/js/passwordVisibility.js',
             '/user_accounts/js/edit_user_helper.js',
             '/js/invalid_form_scroll.js',
-        ];
-    }
-
-    /**
-     * Add CSS dependencies
-     *
-     * @return array The list of CSS files this page depends on
-     */
-    function getCSSDependencies(): array
-    {
-        return [
-            '/css/password.css',
         ];
     }
 }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1366,24 +1366,18 @@ class Edit_User extends \NDB_Form
     }
 
     /**
-     * Gathers JS dependencies and merges them with the parent
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . '/user_accounts/js/rejectUser.js',
-                $baseURL . '/js/passwordVisibility.js',
-                $baseURL . '/user_accounts/js/edit_user_helper.js',
-                $baseURL . '/js/invalid_form_scroll.js',
-            ]
-        );
+        return [
+            '/user_accounts/js/rejectUser.js',
+            '/js/passwordVisibility.js',
+            '/user_accounts/js/edit_user_helper.js',
+            '/js/invalid_form_scroll.js',
+        ];
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1381,21 +1381,14 @@ class Edit_User extends \NDB_Form
     }
 
     /**
-     * Include additional CSS files:
-     *  1. configuration
+     * Add CSS dependencies
      *
-     * @return array of CSS to be inserted
+     * @return array The list of CSS files this page depends on
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getCSSDependencies();
-        return array_merge(
-            $deps,
-            [
-                $baseURL . "/css/password.css",
-            ]
-        );
+        return [
+            '/css/password.css',
+        ];
     }
 }

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -97,19 +97,14 @@ class User_Accounts extends \DataFrameworkMenu
     }
 
     /**
-     * Gathers JS dependecies and merge them with the parent
+     * Add Javascript dependencies
      *
-     * @return array of javascript to be inserted
+     * @return array The list of Javascript files this page depends on
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
-        $factory = \NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return array_merge(
-            $deps,
-            [$baseURL . "/user_accounts/js/userAccountsIndex.js"]
-        );
+        return [
+            '/user_accounts/js/userAccountsIndex.js',
+        ];
     }
 }
-

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -824,25 +824,4 @@ class NDB_Menu_Filter extends NDB_Menu
         }
         return $FilterValues;
     }
-
-    /**
-     * Adds React table related dependencies to menu filters, since forms don't
-     * usually have tables or pagination
-     *
-     * @return array of javascript files to be sourced
-     */
-    function getJSDependencies()
-    {
-        $factory = NDB_Factory::singleton();
-        $depends = parent::getJSDependencies();
-        $baseURL = $factory->settings()->getBaseURL();
-        return array_merge(
-            $depends,
-            [
-                $baseURL . '/js/components/PaginationLinks.js',
-                $baseURL . '/js/components/StaticDataTable.js',
-            ]
-        );
-    }
 }
-

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -817,6 +817,50 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
     }
 
     /**
+     * Returns an ordered list of CSS dependencies that this page depends
+     * on. These will get loaded into the template in order, so that
+     * interdependent files can be included in the correct order.
+     *
+     * @return array of strings with URLs to retrieve CSS resources
+     */
+    function getAllCSSDependencies(): array
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+
+        $files = [
+            '/bootstrap/css/bootstrap.min.css',
+            '/bootstrap/css/custom-css.css',
+            '/js/jquery/datepicker/datepicker.css',
+        ];
+
+        $files = array_merge(
+            $files,
+            $this->getCSSDependencies()
+        );
+
+        $files = array_map(
+            fn($file) => $baseURL . $file,
+            $files
+        );
+
+        return $files;
+    }
+
+    /**
+     * Returns the ordered list of page-specific CSS dependencies that a
+     * specific page depends on. These will get loaded into the template in
+     * order, after the global Loris CSS dependencies.
+     *
+     * @return array The list of CSS dependencies. The Loris base URL
+     * is automatically prepended to each path.
+     */
+    function getCSSDependencies(): array
+    {
+        return [];
+    }
+
+    /**
      * Returns an ordered list of javascript dependencies that this page depends
      * on. These will get loaded into the template in order, so that
      * interdependent files can be included in the correct order.
@@ -880,50 +924,6 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
      * is automatically prepended to each path.
      */
     function getJSDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * Returns an ordered list of CSS dependencies that this page depends
-     * on. These will get loaded into the template in order, so that
-     * interdependent files can be included in the correct order.
-     *
-     * @return array of strings with URLs to retrieve CSS resources
-     */
-    function getAllCSSDependencies(): array
-    {
-        $factory = NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-
-        $files = [
-            '/bootstrap/css/bootstrap.min.css',
-            '/bootstrap/css/custom-css.css',
-            '/js/jquery/datepicker/datepicker.css',
-        ];
-
-        $files = array_merge(
-            $files,
-            $this->getCSSDependencies()
-        );
-
-        $files = array_map(
-            fn($file) => $baseURL . $file,
-            $files
-        );
-
-        return $files;
-    }
-
-    /**
-     * Returns the ordered list of page-specific CSS dependencies that a
-     * specific page depends on. These will get loaded into the template in
-     * order, after the global Loris CSS dependencies.
-     *
-     * @return array The list of CSS dependencies. The Loris base URL
-     * is automatically prepended to each path.
-     */
-    function getCSSDependencies(): array
     {
         return [];
     }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -818,49 +818,71 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
 
     /**
      * Returns an ordered list of javascript dependencies that this page depends
-     * on.  These will get loaded into the template in order, so that
+     * on. These will get loaded into the template in order, so that
      * interdependent files can be included in the correct order.
      *
      * @return array of strings with URLs to retrieve JS resources
      */
-    function getJSDependencies()
+    function getAllJSDependencies()
     {
         $factory = NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
+        $baseURL = $factory->settings()->getBaseURL();
         $config  = $factory->config();
 
-        $min = ($config->getSetting("sandbox") === '1') ? '' : '.min';
+        $min = $config->getSetting("sandbox") === '0';
 
         // Currently jquery-ui is required for dialogs and datepickers to work.
         // In the future release, dialogs should be replaced with bootstrap dialogs
         // and datepickers only created by modernizr
 
         $files = [
-            $baseurl . '/js/jquery/jquery-1.11.0.min.js',
-            $baseurl . '/js/loris-scripts.js',
-            $baseurl . '/js/modernizr/modernizr.min.js',
-                  // Only load minified file on production, not sandboxes
-            $baseurl . '/js/polyfills.js',
-                    // $baseurl . '/js/react/react-with-addons' . $min . '.js',
-                    // $baseurl . '/js/react/react-dom' . $min . '.js',
-            $baseurl . ($min === '' ?
-                      '/vendor/js/react/react.development.js' :
-                      '/vendor/js/react/react.production' . $min . '.js'),
-            $baseurl . ($min === '' ?
-                      '/vendor/js/react/react-dom.development.js' :
-                      '/vendor/js/react/react-dom.production' . $min . '.js'),
-
-            $baseurl . '/js/jquery/jquery-ui-1.10.4.custom.min.js',
-            $baseurl . '/js/jquery.dynamictable.js',
-            $baseurl . '/js/jquery.fileupload.js',
-            $baseurl . '/bootstrap/js/bootstrap.min.js',
-            $baseurl . '/js/components/Breadcrumbs.js',
-            $baseurl . "/js/util/queryString.js",
-            $baseurl . '/js/components/Help.js',
+            '/js/jquery/jquery-1.11.0.min.js',
+            '/js/loris-scripts.js',
+            '/js/modernizr/modernizr.min.js',
+            // Only load minified file on production, not sandboxes
+            '/js/polyfills.js',
+            // $baseurl . '/js/react/react-with-addons' . $min . '.js',
+            // $baseurl . '/js/react/react-dom' . $min . '.js',
+            ($min
+                ? '/vendor/js/react/react.production.min.js'
+                : '/vendor/js/react/react.development.js'),
+            ($min
+                ? '/vendor/js/react/react-dom.production.min.js'
+                : '/vendor/js/react/react-dom.development.js'),
+            '/js/jquery/jquery-ui-1.10.4.custom.min.js',
+            '/js/jquery.dynamictable.js',
+            '/js/jquery.fileupload.js',
+            '/bootstrap/js/bootstrap.min.js',
+            '/js/components/Breadcrumbs.js',
+            '/js/util/queryString.js',
+            '/js/components/Help.js',
         ];
+
+        $files = array_merge(
+            $files,
+            $this->getJSDependencies()
+        );
+
+        $files = array_map(
+            fn($file) => $baseURL . $file,
+            $files
+        );
+
         return $files;
     }
 
+    /**
+     * Returns the ordered list of page-specific Javascript dependencies that a
+     * specific page depends on. These will get loaded into the template in
+     * order, after the global Loris Javascript dependencies.
+     *
+     * @return array The list of Javascript dependencies. The Loris base URL
+     * is automatically prepended to each path.
+     */
+    function getJSDependencies(): array
+    {
+        return [];
+    }
 
     /**
      * Returns an ordered list of CSS dependencies that this page depends

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -867,7 +867,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
      *
      * @return array of strings with URLs to retrieve JS resources
      */
-    function getAllJSDependencies()
+    function getAllJSDependencies(): array
     {
         $factory = NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -873,7 +873,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
         $baseURL = $factory->settings()->getBaseURL();
         $config  = $factory->config();
 
-        $min = $config->getSetting("sandbox") === '0';
+        $min = $config->getSetting("sandbox") !== '1';
 
         // Currently jquery-ui is required for dialogs and datepickers to work.
         // In the future release, dialogs should be replaced with bootstrap dialogs

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -886,22 +886,46 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
 
     /**
      * Returns an ordered list of CSS dependencies that this page depends
-     * on.  These will get loaded into the template in order, so that
+     * on. These will get loaded into the template in order, so that
      * interdependent files can be included in the correct order.
      *
      * @return array of strings with URLs to retrieve CSS resources
      */
-    function getCSSDependencies()
+    function getAllCSSDependencies(): array
     {
         $factory = NDB_Factory::singleton();
-        $baseurl = $factory->settings()->getBaseURL();
+        $baseURL = $factory->settings()->getBaseURL();
 
         $files = [
-            $baseurl . "/bootstrap/css/bootstrap.min.css",
-            $baseurl . "/bootstrap/css/custom-css.css",
-            $baseurl . "/js/jquery/datepicker/datepicker.css"
+            '/bootstrap/css/bootstrap.min.css',
+            '/bootstrap/css/custom-css.css',
+            '/js/jquery/datepicker/datepicker.css',
         ];
+
+        $files = array_merge(
+            $files,
+            $this->getCSSDependencies()
+        );
+
+        $files = array_map(
+            fn($file) => $baseURL . $file,
+            $files
+        );
+
         return $files;
+    }
+
+    /**
+     * Returns the ordered list of page-specific CSS dependencies that a
+     * specific page depends on. These will get loaded into the template in
+     * order, after the global Loris CSS dependencies.
+     *
+     * @return array The list of CSS dependencies. The Loris base URL
+     * is automatically prepended to each path.
+     */
+    function getCSSDependencies(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Middleware/PageDecorationMiddleware.php
+++ b/src/Middleware/PageDecorationMiddleware.php
@@ -38,7 +38,7 @@ class PageDecorationMiddleware implements MiddlewareInterface
             return (new \LORIS\Middleware\AnonymousPageDecorationMiddleware(
                 $baseURL ?? "",
                 $config,
-                $page->getJSDependencies(),
+                $page->getAllJSDependencies(),
                 $page->getCSSDependencies()
             )
             )->process($request, $handler);
@@ -51,7 +51,7 @@ class PageDecorationMiddleware implements MiddlewareInterface
             $baseURL ?? "",
             $page->name ?? "",
             $config,
-            $page->getJSDependencies(),
+            $page->getAllJSDependencies(),
             $page->getCSSDependencies(),
             $DB
         )

--- a/src/Middleware/PageDecorationMiddleware.php
+++ b/src/Middleware/PageDecorationMiddleware.php
@@ -39,7 +39,7 @@ class PageDecorationMiddleware implements MiddlewareInterface
                 $baseURL ?? "",
                 $config,
                 $page->getAllJSDependencies(),
-                $page->getCSSDependencies()
+                $page->getAllCSSDependencies()
             )
             )->process($request, $handler);
         }
@@ -52,7 +52,7 @@ class PageDecorationMiddleware implements MiddlewareInterface
             $page->name ?? "",
             $config,
             $page->getAllJSDependencies(),
-            $page->getCSSDependencies(),
+            $page->getAllCSSDependencies(),
             $DB
         )
         )->process($request, $handler);

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -780,7 +780,7 @@ class NDB_PageTest extends TestCase
     }
 
     /**
-     * Test that getCSSDependencies returns the correct array of dependencies
+     * Test that getAllCSSDependencies returns the correct array of dependencies
      *
      * @covers NDB_Page::getAllCSSDependencies
      * @return void
@@ -803,7 +803,7 @@ class NDB_PageTest extends TestCase
     }
 
     /**
-     * Test that getJSDependencies returns the correct array of dependencies
+     * Test that getAllJSDependencies returns the correct array of dependencies
      *
      * @covers NDB_Page::getAllJSDependencies
      * @return void

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -782,7 +782,7 @@ class NDB_PageTest extends TestCase
     /**
      * Test that getJSDependencies returns the correct array of dependencies
      *
-     * @covers NDB_Page::getJSDependencies
+     * @covers NDB_Page::getAllJSDependencies
      * @return void
      */
     public function testGetJSDependencies()
@@ -815,7 +815,7 @@ class NDB_PageTest extends TestCase
     /**
      * Test that getCSSDependencies returns the correct array of dependencies
      *
-     * @covers NDB_Page::getCSSDependencies
+     * @covers NDB_Page::getAllCSSDependencies
      * @return void
      */
     public function testGetCSSDependencies()
@@ -831,7 +831,7 @@ class NDB_PageTest extends TestCase
                 '/bootstrap/css/custom-css.css',
                 '/js/jquery/datepicker/datepicker.css'
             ],
-            $this->_page->getCSSDependencies()
+            $this->_page->getAllCSSDependencies()
         );
     }
 }

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -780,6 +780,29 @@ class NDB_PageTest extends TestCase
     }
 
     /**
+     * Test that getCSSDependencies returns the correct array of dependencies
+     *
+     * @covers NDB_Page::getAllCSSDependencies
+     * @return void
+     */
+    public function testGetCSSDependencies()
+    {
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        '@phan-var \NDB_Config $configMock';
+
+        $factory = NDB_Factory::singleton();
+        $factory->setConfig($configMock);
+        $this->assertEquals(
+            [
+                '/bootstrap/css/bootstrap.min.css',
+                '/bootstrap/css/custom-css.css',
+                '/js/jquery/datepicker/datepicker.css'
+            ],
+            $this->_page->getAllCSSDependencies()
+        );
+    }
+
+    /**
      * Test that getJSDependencies returns the correct array of dependencies
      *
      * @covers NDB_Page::getAllJSDependencies
@@ -809,29 +832,6 @@ class NDB_PageTest extends TestCase
                 '/js/components/Help.js',
             ],
             $this->_page->getAllJSDependencies()
-        );
-    }
-
-    /**
-     * Test that getCSSDependencies returns the correct array of dependencies
-     *
-     * @covers NDB_Page::getAllCSSDependencies
-     * @return void
-     */
-    public function testGetCSSDependencies()
-    {
-        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        '@phan-var \NDB_Config $configMock';
-
-        $factory = NDB_Factory::singleton();
-        $factory->setConfig($configMock);
-        $this->assertEquals(
-            [
-                '/bootstrap/css/bootstrap.min.css',
-                '/bootstrap/css/custom-css.css',
-                '/js/jquery/datepicker/datepicker.css'
-            ],
-            $this->_page->getAllCSSDependencies()
         );
     }
 }

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -808,7 +808,7 @@ class NDB_PageTest extends TestCase
                 '/js/util/queryString.js',
                 '/js/components/Help.js',
             ],
-            $this->_page->getJSDependencies()
+            $this->_page->getAllJSDependencies()
         );
     }
 


### PR DESCRIPTION
## Brief summary of changes

While browsing the Loris code, I noticed that the methods `NDB_Page::getCSSDependencies()` and `NDB_Page::getJSDependencies()` are defined in a way that forces each redefinition to duplicate (**more than 50 times**) the appending of the dependencies and the prepending of the Loris base URL to each dependency. This is bad for several reasons : duplication (duplicated code), complexity (repeated use of `parent` / `array_merge`), verbosity (because of the duplicated code), fragility (forgetting to duplicate the logic leads to a bug).

I propose this simplified model that divides `getCSS/JSDependencies()` method in two:
1. `NDB_Page::getCSS/JSDependencies()`, redefined in each final class that returns the page-specific dependencies of that class.
2. `NDB_Page::getAllCSS/JSDependencies()`, defined only in `NDB_Page`, that calls the previous method, appends the returned page-specific dependencies to the global ones, and prepends the Loris base URL to each dependency.

If I take a random file, here is the result:

Before
```php
    function getJSDependencies()
    {
        $factory = \NDB_Factory::singleton();
        $baseURL = $factory->settings()->getBaseURL();
        $deps    = parent::getJSDependencies();
        return array_merge(
            $deps,
            [
                $baseURL . "/statistics/js/table_statistics.js",
                $baseURL . "/statistics/js/form_stats_MRI.js",
            ]
        );
    }
```
After
```php
    function getJSDependencies(): array
    {
        return [
            '/statistics/js/table_statistics.js',
            '/statistics/js/form_stats_MRI.js',
        ];
    }
```

#### Further thoughts

- I personally prefer to put the method CSS before the JS one, as it is arguably more simple and generally appears first in a web page.
- **All** the dependencies used `$baseURL`, thus enabling its factoring. If there is ever a need for an external dependency, it is possible to create `getExternalDependencies()` methods. I think segregating internal and external dependencies is a good thing.
- This new model does not support "intermediate" dependencies (defined in neither the base nor the final class). I think this is a good thing, as deep inheritance hierarchies should generally be avoided. The only case it appeared before this PR was in `NDB_Menu_Filter`, which however only includes library React components (tables...) that should already be imported by each module that uses them.
- Having to manually rewrite the PHPDoc for each redefined method seems suboptimal to me. I think it would be better to simmply use  `@inheritDoc`, which the linter does not seem to detect right now. I'll also add that many previous comments were outdated (listing files that were no longer there) or inconsistent with one another (different formats for the same meaning).

#### Testing instructions

1. Browse Loris and verify the CSS/JS files are correctly included.

#### Links to related issues

* PR #9073 fixes some missing imports that were exposed by this PR.
