### PR TITLE
[imaging browser] Remove apparently unused button

### DIFF
--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -119,17 +119,6 @@ class ViewSession extends \NDB_Form
 
             $this->tpl_data['showFloatJIV'] = true;
 
-            $file = $this->_DB->pselectOne(
-                "SELECT File FROM files f
-                JOIN session s
-                ON (s.ID=f.SessionID)
-                WHERE s.ID=:sid AND FileType='obj'",
-                ['sid' => $this->sessionID]
-            );
-            if (!empty($file)) {
-                $this->tpl_data['show3DViewer'] = true;
-            }
-
             $this->tpl_data['status_options']    = [
                 ''     => '&nbsp;',
                 'Pass' => 'Pass',

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -1,9 +1,4 @@
 <!-- Main table -->
-{if $show3DViewer|default}
-{*<td nowrap="nowrap">the first opening td already opened in main.tpl *}<input type="button" name="button" value="3D Viewer" class="button" id = "dccid" name = "dccid" style = "background-color: #816e91" onclick="window.open('BrainBrowser/display.html?sessionID={$subject.sessionID}')" /></td>
-
-</br>
-{/if}
 <div>
 {$headerTable}
 </div>


### PR DESCRIPTION
## Brief summary of changes

While browsing Loris code, I stumbled upon a button in view session that appears to be broken / dead code in the imaging browser:
- The button points to the `BrainBrowser/display.html` URL. However, there seems is no such file in LORIS.
- The button uses a relative link, which is probably wrong.
- The button is only displayed if a session has a corresponding "obj" file in the database. However, there is no such file in Rainsinbread.

Thus, I open this PR to remove this button. But before merging it, I'd like to know if anyone has any information regarding the button or its display condition.

Pinging the imaging squad @ridz1208 @cmadjar @laemtl.