### PR TITLE
[dataquery] Fix bug where field is incorrectly striked-through

### DIFF
--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -289,6 +289,7 @@ function DefineFilters(props: {
                                     0
                                 );
                                 setModalGroup(newquery);
+                                setDeleteItemIndex(null);
                             }}
                             onMouseEnter={() => setDeleteItemIndex(0)}
                             onMouseLeave={() => setDeleteItemIndex(null)}


### PR DESCRIPTION
The strike-through effect on a line is only supposed to happen when hovering over the trashcan icon. After clicking it, "onMouseLeave" event doesn't fire, causing the component's state to remain in a state where the last index is "hovered". As a result, the next time you add a filter upon deleting the last one it has an incorrect strike-through effect.

This resets the hovered index onClick in addition to onMouseLeave to fix the issue.

Resolves #9076.