### PR TITLE
fix db installer host name

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -424,18 +424,18 @@ class Installer
         // new user, since the new user is also going to be used from
         // the same web server so should have the same address.
         $connectHost = $DB->PDO->query(
-            "SELECT host FROM `mysql`.`user`
-		WHERE CONCAT(user, '@', host)=CURRENT_USER"
+            "SELECT Host FROM `mysql`.`user`
+		WHERE CONCAT(User, '@', Host)=CURRENT_USER"
         )->fetch(\PDO::FETCH_ASSOC);
 
-        if (!is_array($connectHost) || empty($connectHost['host'])) {
+        if (!is_array($connectHost) || empty($connectHost['Host'])) {
             // This should never happen. It would mean that the user
             // that we ran the query from isn't connected..
             $this->_lastErr = "Could not retrieve hostname for MySQL user";
             return false;
         }
 
-        $connectHost = $connectHost['host'];
+        $connectHost = $connectHost['Host'];
 
         $userExistsQ = $DB->prepare(
             "SELECT 'x' FROM mysql.user


### PR DESCRIPTION
## Brief summary of changes

Fix the database installer so that the 'Host' field name matches the name found in the database. This difference prevented Loris from being installed on systems in which the database returns tables whose field names are capitalized according to their name in the database, and not in the query (our dev VMs does the latter, hence why we did not have this bug during development).

#### Testing instructions

Run the database installer on a system with a database whose returned field names are not capitalized according to the query.

#### Links to related issues

* Seems to solve #9101. However, there might be more places in which the query capizalization does not match that of the database, so I would advise against closing this issue until a long-term solution has been found.
