### PR TITLE
[dataquery] bottom panel collapse #9067 - fix 

### DIFF
--- a/modules/dataquery/jsx/components/expansionpanels.tsx
+++ b/modules/dataquery/jsx/components/expansionpanels.tsx
@@ -16,6 +16,7 @@ const ExpansionPanels = (props: {
         content: React.ReactElement,
         defaultOpen?: boolean,
         alwaysOpen: boolean,
+        id: string,
     }[]
 }) => {
   return (
@@ -24,6 +25,7 @@ const ExpansionPanels = (props: {
       { props.panels.map((panel, index) => (
         <Panel
           key={index}
+          id= {panel.id}
           title={panel.title}
           collapsed={panel.alwaysOpen}
           initCollapsed={panel.defaultOpen || props.alwaysOpen || true}>

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -57,6 +57,7 @@ function Welcome(props: {
         content: React.ReactElement,
         alwaysOpen: boolean,
         defaultOpen: boolean,
+        id: string,
     }[] = [];
     if (props.topQueries.length > 0) {
         panels.push({
@@ -82,6 +83,7 @@ function Welcome(props: {
                 ),
             alwaysOpen: false,
             defaultOpen: true,
+            id: 'p1',
         });
     }
     panels.push({
@@ -92,6 +94,7 @@ function Welcome(props: {
                      />,
             alwaysOpen: false,
             defaultOpen: true,
+            id: 'p2'   
     });
     panels.push({
             title: 'Recent Queries',
@@ -120,6 +123,7 @@ function Welcome(props: {
               ),
             alwaysOpen: false,
             defaultOpen: true,
+            id: 'p3',
     });
 
     if (props.sharedQueries.length > 0) {
@@ -145,6 +149,7 @@ function Welcome(props: {
               ),
               alwaysOpen: false,
               defaultOpen: true,
+              id: 'p4',
         });
     }
 


### PR DESCRIPTION
Issue https://github.com/aces/Loris/issues/9067
Click the "Recent queries" collapse panel header button.
What did you expect to happen?
The bottom panel should collapse.
