### PR TITLE
[electrophysiology_uploader] Add PSCID and Visit Label filters to data table

### DIFF
--- a/modules/electrophysiology_uploader/jsx/UploadViewer.js
+++ b/modules/electrophysiology_uploader/jsx/UploadViewer.js
@@ -53,10 +53,19 @@ export default function UploadViewer(props) {
     {
       label: 'PSCID',
       show: true,
+      filter: {
+        name: 'pscid',
+        type: 'text',
+      },
     },
     {
       label: 'Visit',
       show: true,
+      filter: {
+        name: 'visitLabel',
+        type: 'select',
+        options: props.fieldOptions.visitLabel,
+      },
     },
     {
       label: 'Upload Location',

--- a/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
@@ -77,7 +77,8 @@ class Electrophysiology_Uploader extends \DataFrameworkMenu
         }
 
         return [
-            'sites' => $site_options
+            'sites'      => $site_options,
+            'visitLabel' => \Utility::getVisitList(),
         ];
     }
 


### PR DESCRIPTION
Closes #9059.

This PR adds `PSCID` and `Visit Label` to the `FilterableDataTable`.

<img width="1397" alt="Screenshot 2024-02-29 at 10 24 42 AM" src="https://github.com/aces/Loris/assets/15801528/5a7fe74b-d0d6-4989-ba38-e065625cc8f6">
