### PR TITLE
[dataquery] shift next step box to the left

### DIFF
--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -145,7 +145,7 @@ function NextSteps(props: {
               display: 'flex',
               alignItems: 'stretch',
               height: 120,
-              paddingRight : '14px',
+              paddingRight: '14px',
             }}>
               <div style={style}>
                 <h3>Next Steps</h3>

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -145,6 +145,7 @@ function NextSteps(props: {
               display: 'flex',
               alignItems: 'stretch',
               height: 120,
+              paddingRight : '14px',
             }}>
               <div style={style}>
                 <h3>Next Steps</h3>


### PR DESCRIPTION
## Brief summary of changes

Shifts the block few px away from the right window side so the right arrow can be accessed anytime.

![Recording 2024-02-29 at 11 30 44](https://github.com/aces/Loris/assets/25327259/3da209dc-0682-42a0-88a1-810b8b18d012)

#### Link(s) to related issue(s)

* Resolves #9065 
