### PR TITLE
Augment LINST instrument read buffer

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -390,7 +390,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 'Delimiter' => $this->_GUIDelimiter,
             ];
 
-            while (($line = fgets($fp, 4096)) !== false) {
+            // Buffer = 128KB
+            while (($line = fgets($fp, 131072)) !== false) {
                 $pieces = preg_split("/{@}/", $line);
                 $this->LinstLines[] = $pieces;
 


### PR DESCRIPTION
## Brief summary of changes

For LINST instruments, some can have very long line (i.e. lots of options for select/dropdown).
These lines are bigger than the currently defined buffer read size i.e. `4K` and triggers visible warnings.

E.g. for HBCD, one instrument generated from REDCap has one line with 15869 characters. 
The line is truncated and some select options cannot be read.

![image](https://github.com/aces/Loris/assets/25327259/ec1c178c-f096-40b9-9cbb-ed7ae712273a)

https://github.com/aces/HBCD/issues/1725

This PR pushes the buffer size to `128K`.

#### Testing instructions (if applicable)

1. Try accessing a LINST instrument with a very long line.

E.g. 
```
# replace `...` with more values 
select{@}very_long_line{@}This line is very long{@}NULL=>''{-}'1'=>'0.1'{-}'2'=>'0.2'{-}'3'=>'0.3'{-}'4'=>'0.4'{-}'5'=>'0.5'{-}'6'=>'0.6'{-}'7'=>'0.7'{-}'8'=>'0.8'{-}'9'=>'0.9'{-}'10'=>'1.0'{-}'11'=>'1.1'{-}'12'=>'1.2'{-}'13'=>'1.3'{-}'14'=>'1.4'{-}'15'=>'1.5'{-}'16'=>'1.6'{-}'17'=>'1.7'{-}'18'=>'1.8'{-}'19'=>'1.9'{-}....
```

