### PR TITLE
[Conflict Resolver] readme + permission edits to reflect the need for datadict permissions

### DIFF
--- a/SQL/New_patches/2024-03-11-changePermissionCodeToDictionary.sql
+++ b/SQL/New_patches/2024-03-11-changePermissionCodeToDictionary.sql
@@ -1,0 +1,3 @@
+UPDATE permissions
+SET moduleID = (select ID FROM modules WHERE Name = 'dictionary')
+WHERE moduleID IN (SELECT ID FROM modules WHERE Name = 'datadict');

--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -34,7 +34,7 @@ will not be enforced by LORIS.
 
 ## Permissions
 
-Accessing the module requires the `conflict_resolver` permission.
+Accessing the module requires the `conflict_resolver` permission, as well as either 'Data Dictionary (Legacy): Edit Parameter Type Descriptions' or 'Data Dictionary (Legacy): Edit Parameter Type Descriptions'.
 
 A user should only see conflicts at the sites at which the user is
 a member.

--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -34,7 +34,7 @@ will not be enforced by LORIS.
 
 ## Permissions
 
-Accessing the module requires the `conflict_resolver` permission, as well as either 'Data Dictionary (Legacy): Edit Parameter Type Descriptions' or 'Data Dictionary (Legacy): Edit Parameter Type Descriptions'.
+Accessing the module requires the `conflict_resolver` permission, as well as either 'Dictionary: Edit Parameter Type Descriptions' or 'Dictionary: Edit Parameter Type Descriptions'.
 
 A user should only see conflicts at the sites at which the user is
 a member.

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -38,7 +38,7 @@ class Conflict_Resolver extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('conflict_resolver') && ($user->hasPermission('data_dict_edit') || $user->hasPermission('data_dict_view'));
+        return $user->hasPermission('conflict_resolver') && ($user->hasAnyPermission('data_dict_edit', 'data_dict_view');
     }
 
     /**

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -38,7 +38,9 @@ class Conflict_Resolver extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('conflict_resolver') && $user->hasAnyPermission(['data_dict_edit', 'data_dict_view']);
+        $hasConflictPerm = $user->hasPermission('conflict_resolver');
+        $hasDictPerms = $user->hasAnyPermission(['data_dict_edit', 'data_dict_view']);
+        return $hasConflictPerm && $hasDictPerms;
     }
 
     /**

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -38,7 +38,7 @@ class Conflict_Resolver extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('conflict_resolver');
+        return $user->hasPermission('conflict_resolver') && ($user->hasPermission('data_dict_edit') || $user->hasPermission('data_dict_view'));
     }
 
     /**

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -38,7 +38,7 @@ class Conflict_Resolver extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('conflict_resolver') && ($user->hasAnyPermission('data_dict_edit', 'data_dict_view');
+        return $user->hasPermission('conflict_resolver') && $user->hasAnyPermission(['data_dict_edit', 'data_dict_view']);
     }
 
     /**

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -39,7 +39,8 @@ class Conflict_Resolver extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         $hasConflictPerm = $user->hasPermission('conflict_resolver');
-        $hasDictPerms = $user->hasAnyPermission(['data_dict_edit', 'data_dict_view']);
+        $dictPerms       = ['data_dict_edit', 'data_dict_view'];
+        $hasDictPerms    = $user->hasAnyPermission($dictPerms);
         return $hasConflictPerm && $hasDictPerms;
     }
 

--- a/modules/conflict_resolver/test/TestPlan.md
+++ b/modules/conflict_resolver/test/TestPlan.md
@@ -5,7 +5,7 @@
     2. Menu item loads the module page
     3. Check for existence of 'Resolving conflicts' permission checkbox on 'User Accounts > Edit User'
        Verify that the permission works as expected (hides menu item and blocks page access)
-    4. Check that access will be blocked for users who dont have either the 'Data Dictionary (Legacy): Edit Parameter Type Descriptions' or 'Data Dictionary (Legacy): View Parameter Type Descriptions'
+    4. Check that access will be blocked for users who dont have either the 'Dictionary: Edit Parameter Type Descriptions' or 'Dictionary: View Parameter Type Descriptions'
 2. Verify the following conditions are required for creation of new unresolved conflict
    to be instantiated in the module table:[Manual Testing]
     1. Double data entry active on instrument

--- a/modules/conflict_resolver/test/TestPlan.md
+++ b/modules/conflict_resolver/test/TestPlan.md
@@ -5,6 +5,7 @@
     2. Menu item loads the module page
     3. Check for existence of 'Resolving conflicts' permission checkbox on 'User Accounts > Edit User'
        Verify that the permission works as expected (hides menu item and blocks page access)
+    4. Check that access will be blocked for users who dont have either the 'Data Dictionary (Legacy): Edit Parameter Type Descriptions' or 'Data Dictionary (Legacy): View Parameter Type Descriptions'
 2. Verify the following conditions are required for creation of new unresolved conflict
    to be instantiated in the module table:[Manual Testing]
     1. Double data entry active on instrument

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -101,7 +101,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $bodyElement->getText();
         $accessError = "You do not have access to this page.";
         $this->assertStringNotContainsString($accessError, $bodyText);
-        $loadingError = "An error occured while loading the page."
+        $loadingError = "An error occured while loading the page.";
         $this->assertStringNotContainsString($loadingError, $bodyText);
         $this->resetPermissions();
     }

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -94,14 +94,14 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       */
     function testConflictResolverPermission()
     {
-        $this->setupPermissions(["conflict_resolver","data_dict_edit","data_dict_view"]);
+        $permissionList = ["conflict_resolver","data_dict_edit","data_dict_view"];
+        $this->setupPermissions($permissionList);
         $this->safeGet($this->url . "/conflict_resolver/");
-        $bodyText = $this->safeFindElement( WebDriverBy::cssSelector("body"))->getText();
-          
-        $this->assertStringNotContainsString( "You do not have access to this page.", $bodyText);
-        $this->assertStringNotContainsString("An error occured while loading the page.", $bodyText );
+        $bodyText = $this->safeFindElement(WebDriverBy::cssSelector("body"))->getText();
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("An error occured while loading the page.", $bodyText);
         $this->resetPermissions();
-} 
+        } 
     /**
      * Tests clear button in the form
      * The form should refreash and the data should be gone.

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -97,9 +97,12 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $permissionList = ["conflict_resolver","data_dict_edit","data_dict_view"];
         $this->setupPermissions($permissionList);
         $this->safeGet($this->url . "/conflict_resolver/");
-        $bodyText = $this->safeFindElement(WebDriverBy::cssSelector("body"))->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
-        $this->assertStringNotContainsString("An error occured while loading the page.", $bodyText);
+        $bodyElement = $this->safeFindElement(WebDriverBy::cssSelector("body"));
+        $bodyText = $bodyElement->getText();
+        $accessError = "You do not have access to this page.";
+        $this->assertStringNotContainsString($accessError, $bodyText);
+        $loadingError = "An error occured while loading the page."
+        $this->assertStringNotContainsString($loadingError, $bodyText);
         $this->resetPermissions();
     }
     /**

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -94,15 +94,14 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       */
     function testConflictResolverPermission()
     {
-        $this->checkPagePermissions(
-            '/conflict_resolver/',
-            [
-                'conflict_resolver',
-                'data_dict_edit'
-            ],
-            "Conflict Resolver"
-        );
-    }
+        $this->setupPermissions(["conflict_resolver","data_dict_edit","data_dict_view"]);
+        $this->safeGet($this->url . "/conflict_resolver/");
+        $bodyText = $this->safeFindElement( WebDriverBy::cssSelector("body"))->getText();
+          
+        $this->assertStringNotContainsString( "You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("An error occured while loading the page.", $bodyText );
+        $this->resetPermissions();
+} 
     /**
      * Tests clear button in the form
      * The form should refreash and the data should be gone.

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -97,7 +97,8 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $this->checkPagePermissions(
             '/conflict_resolver/',
             [
-                'conflict_resolver'
+                'conflict_resolver',
+                'data_dict_edit'
             ],
             "Conflict Resolver"
         );

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -98,7 +98,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $this->setupPermissions($permissionList);
         $this->safeGet($this->url . "/conflict_resolver/");
         $bodyElement = $this->safeFindElement(WebDriverBy::cssSelector("body"));
-        $bodyText = $bodyElement->getText();
+        $bodyText    = $bodyElement->getText();
         $accessError = "You do not have access to this page.";
         $this->assertStringNotContainsString($accessError, $bodyText);
         $loadingError = "An error occured while loading the page.";

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -101,7 +101,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->assertStringNotContainsString("An error occured while loading the page.", $bodyText);
         $this->resetPermissions();
-        } 
+    }
     /**
      * Tests clear button in the form
      * The form should refreash and the data should be gone.

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -429,6 +429,8 @@ class DashboardTest extends LorisIntegrationTest
             [
                 "conflict_resolver",
                 "access_all_profiles",
+                "data_dict_edit",
+                "data_dict_view"
             ]
         );
         $this->safeGet($this->url . '/dashboard/');

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -14,14 +14,14 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (12,'examiner_view','Add and Certify Examiners - Own Sites',17,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (13,'examiner_multisite','Add and Certify Examiners - All Sites',17,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (17,'conflict_resolver','Resolve Conflicts',9,NULL,2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (18,'data_dict_view','Parameter Type Descriptions',13,'View',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (18,'data_dict_view','Parameter Type Descriptions',46,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (19,'violated_scans_view_allsites','Violated Scans - All Sites',30,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (22,'config','Settings',8,'View/Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (23,'imaging_browser_view_site','Imaging Scans - Own Sites',20,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (24,'imaging_browser_view_allsites','Imaging Scans - All Sites',20,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (25,'dicom_archive_view_allsites','DICOMs - All Sites',15,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (28,'instrument_builder','Instrument Forms',23,'Create/Edit',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (29,'data_dict_edit','Parameter Type Descriptions',13,'Edit',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (29,'data_dict_edit','Parameter Type Descriptions',46,'Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (31,'candidate_parameter_view','Candidate Information',7,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (32,'candidate_parameter_edit','Candidate Information',7,'Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (33,'genomic_browser_view_site','Genomic Data - Own Sites',18,'View',2);
@@ -64,7 +64,7 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (70,'api_docs','API Documentation: View LORIS API Manual',NULL,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (71,'electrophysiology_browser_edit_annotations','Annotations',41,'Create/Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (72,'monitor_eeg_uploads','Monitor EEG uploads',47,'Create/Edit',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (73,'conflict_resolver','Parameter Type Descriptions',46,NULL,2);
+
 
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -64,5 +64,7 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (70,'api_docs','API Documentation: View LORIS API Manual',NULL,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (71,'electrophysiology_browser_edit_annotations','Annotations',41,'Create/Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (72,'monitor_eeg_uploads','Monitor EEG uploads',47,'Create/Edit',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (73,'conflict_resolver','Parameter Type Descriptions',46,NULL,2);
+
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
Makes changes to reflect the necessity of dictionary edit and view permissions in order to access the conflict resolver module. This includes:
- the addition of checks for relevant permissions
- an update to the readme and test plan files
- an sql patch which changes the permission code prefixes  from 'Data Dictionary (legacy)...' to 'Dictionary...'

* Resolves #9095 
