### PR TITLE
[help] Remove typo from CSS

### DIFF
--- a/htdocs/main.css
+++ b/htdocs/main.css
@@ -647,7 +647,6 @@ td.MenuWidth2 input[type=text] {
     height: 3em;
     width: 100%;
     font-size: 14px;
-    font-color #000000:
     color: #000;
     text-align: center;
     vertical-align: bottom;


### PR DESCRIPTION
## Brief summary of changes
- There was a line in the css file `font-color #000000:` that has been removed as it looks like a typo
- The line does nothing as font-color is not a css property. The line was problematic since it should have a colon after font-color, and a semi-colon after the line.
