### PR TITLE
StaticDataTable mixed column types sorting

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -303,7 +303,7 @@ class StaticDataTable extends Component {
   hasMixedTypes() {
     // TODO: data column type check should probably be done once at init,
     // meaning when receiving data, to find which columns have mixed types.
-    let typesFound = null;
+    let typeFound = null;
 
     // not the default column
     if (this.state.SortColumn === -1) {
@@ -328,13 +328,13 @@ class StaticDataTable extends Component {
       // check number
       if (!isNaN(val) && typeof val !== 'object') {
         // if string is found, mix of types, break
-        if (typesFound === 'string') {
+        if (typeFound === 'string') {
           isMixedType = true;
           break;
         }
         // register number only if not already in
-        if (typesFound == null) {
-          typesFound = 'number';
+        if (typeFound == null) {
+          typeFound = 'number';
         }
 
         // avoid string section
@@ -344,13 +344,13 @@ class StaticDataTable extends Component {
       // check string
       if (typeof val === 'string' || val instanceof String) {
         // if number is found, mix of types, break
-        if (typesFound === 'number') {
+        if (typeFound === 'number') {
           isMixedType = true;
           break;
         }
         // register string only if not already in
-        if (typesFound == null) {
-          typesFound = 'string';
+        if (typeFound == null) {
+          typeFound = 'string';
         }
       }
     }

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -310,9 +310,6 @@ class StaticDataTable extends Component {
       return false;
     }
 
-    // is the current sorted column with mixed type?
-    let isMixedType = false;
-
     // Only checks string or number types, others are considered undefined.
     // Break out of this loop once we encounter two mixed types:
     // number and string inside the sorted column.
@@ -329,8 +326,7 @@ class StaticDataTable extends Component {
       if (!isNaN(val) && typeof val !== 'object') {
         // if string is found, mix of types, break
         if (typeFound === 'string') {
-          isMixedType = true;
-          break;
+          return true;
         }
         // register number only if not already in
         if (typeFound == null) {
@@ -345,8 +341,7 @@ class StaticDataTable extends Component {
       if (typeof val === 'string' || val instanceof String) {
         // if number is found, mix of types, break
         if (typeFound === 'number') {
-          isMixedType = true;
-          break;
+          return true;
         }
         // register string only if not already in
         if (typeFound == null) {
@@ -354,7 +349,7 @@ class StaticDataTable extends Component {
         }
       }
     }
-    return isMixedType;
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Brief summary of changes

When mixing numbers with strings in an instrument field value (e.g. text field) results in a DQT column that has a sorting issues. This happened for a "summary" instrument in HBCD project that import results from multiple other instruments. This instrument has to clearly display the value of the field (i.e. numeric) or "No data" (i.e. string).

#### Testing instructions (if applicable)

1. Apply numeric values in an instrument field.
2. Run the DQT update (dict build + DQT imports).
3. Make a DQT query that contains the right fields/columns.
4. Try to sort these columns.
5. See error.

#### Link(s) to related issue(s)

Linked to [HBCD#1652](https://github.com/aces/HBCD/issues/1652)
