### PR TITLE
[configuration] Fix option deletion issue.

### DIFF
--- a/modules/configuration/jsx/configuration_helper.js
+++ b/modules/configuration/jsx/configuration_helper.js
@@ -39,14 +39,12 @@ $(function() {
     $('.btn-remove').on('click', function(e) {
         e.preventDefault();
 
-        let options = $(this).parent().parent().children().prop('options');
-        let selectedIndex = $(this)
-                            .parent().parent().children()
-                            .prop('selectedIndex');
-        let selectedOption = options[selectedIndex].text;
-        let fieldName = $(this)
-                        .parent().parent().parent().parent().parent().children()
-                        .attr('data-original-title');
+        let selectedOption = $(this).parent().parent().children()
+                             .prop('value');
+
+        let fieldName      = $(this)
+                             .parent().parent().parent().parent().parent().children()
+                             .attr('data-original-title');
 
         swal.fire({
             text: 'Please confirm you want to delete the option "' +

--- a/modules/configuration/jsx/configuration_helper.js
+++ b/modules/configuration/jsx/configuration_helper.js
@@ -42,9 +42,9 @@ $(function() {
         let selectedOption = $(this).parent().parent().children()
                              .prop('value');
 
-        let fieldName      = $(this)
-                             .parent().parent().parent().parent().parent().children()
-                             .attr('data-original-title');
+        let fieldName = $(this)
+                        .parent().parent().parent().parent().parent().children()
+                        .attr('data-original-title');
 
         swal.fire({
             text: 'Please confirm you want to delete the option "' +


### PR DESCRIPTION
## Brief summary of changes
The handler in `configuration/jsx/configuration_helper.js` was not properly taken the option to be deleted since the fields not always have necessary to be of SELECT type (they could be also text for example).
Now it should take the appropriate option to be deleted.

#### Testing instructions (if applicable)

1. Please go to configuration module `MainMenu->Admin->Configuration`
2. Go to one of the "Tabs" that allow multiselect (for example `MINC to BIDS Converter Tool Options` )
3. Create some options and try to delete they after
![image](https://github.com/aces/Loris/assets/37309344/d9bf1050-0255-49c0-b02d-a702f0049bdd)

5.  Test **Confirming** and **Canceling** 
6.  The field should be deleted under confirmation.
7.  Please test also with "other data type" (for example instruments in Study tab)

#### Link(s) to related issue(s)

* Resolves #9096