### PR TITLE
[candidate_profile] Fixing the display of cohorts in candidate Info card

### DIFF
--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -136,7 +136,7 @@ export class CandidateInfo extends Component {
             },
             {
                 label: subprojlabel,
-                value: cohorts,
+                value: cohorts.join(', '),
             },
             {
                 label: 'Site',


### PR DESCRIPTION
## Brief summary of changes

- [X] Fixing the cohort displayed in the candidate info card

#### Testing instructions (if applicable)

1. Under `Candidate profile` go to any candidate and see the Ccandidate info card you will notice that the cohort info is displaying incorrectly. After fetching the new changes and `npm run compile` you will notice the fields are separated by comma.

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/9090
