### PR TITLE
[new_profile] Test plan update

### DIFF
--- a/modules/new_profile/test/TestPlan.md
+++ b/modules/new_profile/test/TestPlan.md
@@ -6,7 +6,9 @@
    [Manual Testing]
 3. Ensure that you get an error if dates don't match (both DoB and EDC).
    [Automation Testing]
-4. Ensure that you get an error if any field is missing.
+4. Ensure that you get an error if any field is missing and you have config setting
+useEDC turned off. If you have useEDC turned on, ensure all fields are required,
+except the DoB, which is optional in that case.
    [Manual Testing]
 5. Ensure that when the logged-in user has only 1 site affiliation, the site
 dropdown shows only one site and it is already selected.


### PR DESCRIPTION
This PR updates the test plan of the `new_profile` module. The test plan now specifies that all fields on the form should be filled out in order for the form to be valid with one exception: if you have `useEDC` turned on you can get away with not entering the DoB.



Fixes #9141 