### PR TITLE
[instrument_manager] Fixing error in generate_tables_sql_and_testNames tool

### DIFF
--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -29,9 +29,9 @@ $tblCount       = 0;
 $parameterCount = 0;
 $pages          = [];
 foreach ($instruments as $instrument) {
-    $catId = "";
+    $catId  = "";
     $output = "";
-    $items = explode("\n", trim($instrument));
+    $items  = explode("\n", trim($instrument));
     foreach ($items as $item) {
         $paramId = "";
         $bits    = explode("{@}", trim($item));

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -30,7 +30,7 @@ $parameterCount = 0;
 $pages          = [];
 foreach ($instruments as $instrument) {
     $catId = "";
-    $output = "":
+    $output = "";
     $items = explode("\n", trim($instrument));
     foreach ($items as $item) {
         $paramId = "";

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -30,10 +30,10 @@ $parameterCount = 0;
 $pages          = [];
 foreach ($instruments as $instrument) {
     $catId = "";
+    $output = "":
     $items = explode("\n", trim($instrument));
     foreach ($items as $item) {
         $paramId = "";
-        $output  = "";
         $bits    = explode("{@}", trim($item));
         if (preg_match("/Examiner[0-9]*/", $bits[1])) {
             continue;


### PR DESCRIPTION
The `tools/generate_tables_sql_and_testNames.php` script is causing an error when uploading a new instrument using the Instrument Manager module. Since the output string was being reset to empty within the for-loop, the "Create Table" statement was not properly generated. 

#### Testing instructions

1. Go to the instrument manager module and try uploading the `/test/instruments/test_all_fields.linst` file
2. Check that there is a success message and that the project folder and database are correctly updated with the new instrument.

