### PR TITLE
EEGVisEnabled check issue and webpack cache

### DIFF
--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -88,7 +88,7 @@ getConfig.stdout.on('data', (data) => {
     );
   }
 
-  if (EEGVisEnabled === 'true') {
+  if (EEGVisEnabled === 'true' || EEGVisEnabled === '1') {
     console.info('\n ----- \n >> '
       + 'EEG Browser visualization components enabled '
       + '\n -----'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -235,7 +235,7 @@ let config = [
     resolve: resolve,
     module: mod,
     stats: 'errors-warnings',
-    cache: false,
+    cache: {type: 'filesystem'},
   },
 ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ modulePlugins.push(
   })
 );
 
-if (EEGVisEnabled !== 'true') {
+if (EEGVisEnabled !== 'true' && EEGVisEnabled !== '1' ) {
   modulePlugins.push(
     new IgnorePlugin({
       resourceRegExp: /react-series-data-viewer/,
@@ -235,6 +235,7 @@ let config = [
     resolve: resolve,
     module: mod,
     stats: 'errors-warnings',
+    cache: false,
   },
 ];
 


### PR DESCRIPTION
- Fix a WebpackMissingModule error with the EEGBrowser when EEGVisEnabled is set to "1" | "0" instead of "true" | "false".
- Turn the webpack cache to off as it contributes to the heap memory issues for users with less than 2GB Ram. In dev mode, all cache is stored in memory. Alternatively, if build speed is impacted, it can also be set to filesystem.