### PR TITLE
[issue_tracker] null option assignee

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -110,6 +110,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 = $this->formatUserInformation($a_row['UserID']);
         }
 
+
         foreach ($inactive_users_expanded as $u_row) {
             $inactive_users[$u_row['UserID']]
                 = $this->formatUserInformation($u_row['UserID']);
@@ -209,13 +210,30 @@ class Edit extends \NDB_Page implements ETagCalculator
                 ]
             );
 
+            // Extract userID from issue description.
+            // Without doing that, "user fullname (userid)" is used instead.
+            $issueAssigneeUserID = null;
+            if (!is_null($issueData['assignee'])
+                && !empty($issueData['assignee'])
+            ) {
+                $parPos = strpos($issueData['assignee'], '(');
+                if ($parPos !== false) {
+                    $issueAssigneeUserID = substr(
+                        $issueData['assignee'],
+                        $parPos+1,
+                        -1
+                    );
+                }
+            }
             // Add current assignee in assignees dropdown even if not active
-            if (!isset($assignees[$issueData['assignee']])) {
-                $assignees[$issueData['assignee']] = $db->pselectOne(
+            if (isset($issueAssigneeUserID)
+                && !isset($assignees[$issueAssigneeUserID])
+            ) {
+                $assignees[$issueAssigneeUserID] = $db->pselectOne(
                     "SELECT Real_name FROM users
                     WHERE UserID=:userID",
                     [
-                        'userID' => $issueData['assignee']
+                        'userID' => $issueAssigneeUserID
                     ]
                 );
             }

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -110,7 +110,6 @@ class Edit extends \NDB_Page implements ETagCalculator
                 = $this->formatUserInformation($a_row['UserID']);
         }
 
-
         foreach ($inactive_users_expanded as $u_row) {
             $inactive_users[$u_row['UserID']]
                 = $this->formatUserInformation($u_row['UserID']);
@@ -510,7 +509,6 @@ class Edit extends \NDB_Page implements ETagCalculator
                 $validateValues[$vField] = $values[$vField];
             }
         }
-
 
         $issueID = intval($values['issueID']);
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -493,6 +493,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             }
         }
 
+
         $issueID = intval($values['issueID']);
 
         $issueValues['lastUpdatedBy'] = $user->getUserName();
@@ -527,7 +528,11 @@ class Edit extends \NDB_Page implements ETagCalculator
         );
 
         if (!empty($issueID)) {
-            $db->unsafeUpdate('issues', $issueValues, ['issueID' => $issueID]);
+            try {
+                $db->unsafeUpdate('issues', $issueValues, ['issueID' => $issueID]);
+            } catch (\Exception $ex) {
+                return new \LORIS\Http\Response\JSON\InternalServerError();
+            }
         } else {
             $issueValues['reporter']    = $user->getUsername();
             $issueValues['dateCreated'] = date('Y-m-d H:i:s');


### PR DESCRIPTION
## Brief summary of changes

This PR:
- Forces an internal server error JSON response on db update error, which allows to actually see front-end swal error.
- Bug fixes the "null" userID assignee that was the current user (i.e. added based on a composed string "full name (userid)").

#### Testing instructions (if applicable)

1. Go to Report > issue tracker
2. click on "new issue".
3. assert no "null" user is in the "assignee" dropdown
4. create new issue with some basic fileds.
5. click inside the previously created issue inside the main issue tracker table.
6. click on "assignee" dropdown.
7. assert no "null" user is in the "assignee" dropdown.

#### Link(s) to related issue(s)

* Resolves #9128 
