### PR TITLE
[statistics] bug fix - projectID issue

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -99,8 +99,8 @@ class Statistics_Site extends \NDB_Menu
 
         //SITES
         $projectID = new \ProjectID(strval($projectID));
-        $factory = \NDB_Factory::singleton();
-        $user    = $factory->user();
+        $factory   = \NDB_Factory::singleton();
+        $user      = $factory->user();
 
         if (!empty($centerID) && $user->hasCenter($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -98,7 +98,7 @@ class Statistics_Site extends \NDB_Menu
     {
 
         //SITES
-
+        $projectID = new \ProjectID(strval($projectID));
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
 


### PR DESCRIPTION
fix issue 
https://github.com/aces/Loris/issues/9137
[CRITICAL] /var/www/Loris/php/libraries/User.class.inc:476: Uncaught TypeError: User::hasProject(): Argument #1 ($projectID) must be of type ProjectID, string given, called in /var/www/Loris/modules/statistics/php/statistics_site.class.inc on line 134 and defined in /var/www/Loris/php/libraries/User.class.inc:476
Bug 
https://test-dev-260.loris.ca/statistics/statistics_site/?CenterID=2&ProjectID=1
