### PR TITLE
[Login] password reset page-  missing element import

### DIFF
--- a/modules/login/jsx/passwordExpiry.js
+++ b/modules/login/jsx/passwordExpiry.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
 import {
+    StaticElement,	
     FormElement,
     PasswordElement,
     ButtonElement,

--- a/modules/login/jsx/passwordExpiry.js
+++ b/modules/login/jsx/passwordExpiry.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'Panel';
 import {
-    StaticElement,	
+    StaticElement,
     FormElement,
     PasswordElement,
     ButtonElement,


### PR DESCRIPTION
## Brief summary of changes
StaticElement
https://github.com/aces/Loris/issues/9143
[login] Update password page still accessible with expired one-time password #9144


#### Testing instructions (if applicable)
Testing reset password page and submitting two mismatching passwords, it will show the error, not the blank page.