### PR TITLE
updated testplan for new_profile to specify age calculation

### DIFF
--- a/modules/new_profile/test/TestPlan.md
+++ b/modules/new_profile/test/TestPlan.md
@@ -25,7 +25,7 @@ get an error if an invalid PSCID entered (and not if a valid PSCID is entered).
    [Automation Testing]
 9. Go to the Configuration module and change the "Minimum candidate age" value,
 ensure that "Date of Birth" and "Date of Birth Confirm" fields
-properly reflects the changes. If no value is entered, this two fields should
+properly reflects the changes. Note that the minimum and maximum possible birth years are calculated based on 'StartYear' and 'EndYear' rather than the current date, so it is possible to create a candidate with an age which is *currently* outside of the specified range. For context, check the setup() function in the new profile php class. If no value is entered, this two fields should
 have the current day as the maximum possible value to choose.
    [Manual Testing]
 10. Change date format from 'YMd' to 'YM' in the Configuration module


### PR DESCRIPTION
Updated the testplan for new_profile to reflect that min and max ages are calculated based on StartYear and EndYear respectively, which can appear to be a bug. 
