### PR TITLE
Add help text for new data query module

### DIFF
--- a/modules/dataquery/help/dataquery.md
+++ b/modules/dataquery/help/dataquery.md
@@ -1,0 +1,31 @@
+# Data Query
+
+This module allows you to query data within LORIS.
+There are three steps to defining a query:
+
+- First, you must select the fields that you're
+  interested in on the **Define Fields** page.
+- Next, you can optionally define filters on the
+  **Define Filters** page to restrict the population
+  that is returned.
+- Finally, you view your query results on the **View Data** page
+
+The **Next Steps** on the bottom right of your screen always the
+context-sensitive next steps that you can do to build your query.
+
+Your recently run queries will be displayed in the **Recent Queries** panel
+on the first screen of the module (you can return to it at any time by using
+the LORIS breadcrumbs.) Instead of building a new query, you can reload a
+query that you've recently run by clicking on the load icon next to the query.
+
+Queries can be shared with others by clicking the share icon.
+This will cause the query to be shared with all users who
+have access to the fields used by the query. It will display
+in a **Shared Queries** panel below the **Recent Queries**.
+
+You may also give a query a name at any time by clicking the
+pencil icon. This makes it easier to find queries you care
+about by giving them an easier to remember name that can be used
+for filtering. When you share a query, the name will be shared
+along with it.
+


### PR DESCRIPTION
This adds help text for the new dataquery module. The help text is adapted from the "Introduction" panel on the front page and largely says the same thing, but unfortunately can't display the icons that come from React components so instead uses text description of them.

Fixes #9129