### PR TITLE
[help] Add padding to bottom of help content to compensate for offset

### DIFF
--- a/htdocs/main.css
+++ b/htdocs/main.css
@@ -689,6 +689,7 @@ tr.directentry {
     transition: all 0.6s ease 0s;
     width: 320px;
     max-height: 100vh;
+    padding-bottom: calc(1em + 30px);
 }
 
 .help-content h1 {


### PR DESCRIPTION
This adds padding to the bottom of the help text of fontsize + 30px (which should match the size of the loris header) so that the bottom of help text is readable by the user.

This should address the first problem from #9180 but not the second.