### PR TITLE
[Statistics] Fix checkbox places in Imaging Statistics

### DIFF
--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -9,8 +9,8 @@
         </div>
     <br><br>
     <div id="scancheckbox">
-        <input type="checkbox" id="selectall"/> Select All
-        {html_checkboxes id="MRIScans" options=$scan_types name="MRIScans" selected=$Scans_sel_box class="timesheet-daily-checkbox"}
+        <input type="checkbox" id="selectall" style="margin-bottom: 8px;"/> Select All
+        {html_checkboxes id="MRIScans" options=$scan_types name="MRIScans" selected=$Scans_sel_box class="timesheet-daily-checkbox" style="margin: 4px 0 4px;"}
         {*<input type="checkbox" name="all" value="bla" checked><b>All Scan Types</b>
         {foreach item=scan key=scanid from=$scan_types}
             <input type="checkbox" name="{$scan}" value="{$scanid}" class="timesheet-daily-checkbox">{$scan}


### PR DESCRIPTION
## Brief summary of changes
The checkboxes had alignment issues


- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to the statistic module
2. go to Imaging Statistics
3. Check the alignment of the checkboxes

<img width="1553" alt="Screenshot 2024-03-28 at 12 00 55 PM" src="https://github.com/aces/Loris/assets/51356424/49fc4ed1-0c55-4b3c-bc34-ed5a2f936751">

#### Link(s) to related issue(s)

* Resolves #9140
