### PR TITLE
[Publication] Fix baseurl missing from emails

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -426,8 +426,8 @@ function cleanup(int $pubID) : void
 /**
  * Send out email notifications for project submission
  *
- * @param int    $pubID publication ID
- * @param string $type  The notification type i.e., submission|edit|review
+ * @param int    $pubID   publication ID
+ * @param string $type    The notification type i.e., submission|edit|review
  * @param string $baseURL the base URL of the loris site
  *
  * @return void

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -510,7 +510,6 @@ function notify($pubID, $type, $baseURL) : void
  */
 function editProject() : void
 {
-
     $db = \NDB_Factory::singleton()->database();
     $id = isset($_REQUEST['id']) ? intval($_REQUEST['id']) : null;
 

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -428,6 +428,7 @@ function cleanup(int $pubID) : void
  *
  * @param int    $pubID publication ID
  * @param string $type  The notification type i.e., submission|edit|review
+ * @param string $baseURL the base URL of the loris site
  *
  * @return void
  */

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -511,7 +511,6 @@ function notify($pubID, $type, $baseURL) : void
 function editProject() : void
 {
 
-    error_log(print_r($_POST, true));
     $db = \NDB_Factory::singleton()->database();
     $id = isset($_REQUEST['id']) ? intval($_REQUEST['id']) : null;
 

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -138,7 +138,7 @@ function uploadPublication() : void
         showPublicationError($e->getMessage(), 500);
     }
 
-    notify($pubID, 'submission');
+    notify($pubID, 'submission', $_POST['baseURL']);
 }
 
 /**
@@ -431,7 +431,7 @@ function cleanup(int $pubID) : void
  *
  * @return void
  */
-function notify($pubID, $type) : void
+function notify($pubID, $type, $baseURL) : void
 {
     $acceptedTypes = [
         'submission',
@@ -464,12 +464,11 @@ function notify($pubID, $type) : void
         );
         throw new \LorisException('Invalid publication ID specified.');
     }
-    $url = \NDB_Factory::singleton()->settings()->getBaseURL();
 
     $emailData['Title']       = $data['Title'];
     $emailData['Date']        = $data['DateProposed'];
     $emailData['User']        = $user->getFullname();
-    $emailData['URL']         = $url . '/publication/view_project/?id='.$pubID;
+    $emailData['URL']         = $baseURL . '/publication/view_project/?id='.$pubID;
     $emailData['ProjectName'] = $config->getSetting('prefix');
     $Notifier = new \NDB_Notifier(
         "publication",
@@ -511,6 +510,8 @@ function notify($pubID, $type) : void
  */
 function editProject() : void
 {
+
+    error_log(print_r($_POST, true));
     $db = \NDB_Factory::singleton()->database();
     $id = isset($_REQUEST['id']) ? intval($_REQUEST['id']) : null;
 
@@ -618,10 +619,10 @@ function editProject() : void
     processFiles($id);
     // if publication status is changed, send review email
     if (isset($toUpdate['PublicationStatusID'])) {
-        notify($id, 'review');
+        notify($id, 'review', $_POST['baseURL']);
     } else {
         // otherwise send edit email
-        notify($id, 'edit');
+        notify($id, 'edit', $_POST['baseURL']);
     }
     if (!empty($toUpdate)) {
         $db->update(

--- a/modules/publication/jsx/uploadForm.js
+++ b/modules/publication/jsx/uploadForm.js
@@ -158,7 +158,10 @@ class PublicationUploadForm extends React.Component {
       );
       return;
     }
-    let formData = this.state.formData;
+    let formData = {
+      ...this.state.formData,
+      baseURL: loris.BaseURL
+    };
 
     let formObj = new FormData();
     for (let key in formData) {

--- a/modules/publication/jsx/uploadForm.js
+++ b/modules/publication/jsx/uploadForm.js
@@ -160,7 +160,7 @@ class PublicationUploadForm extends React.Component {
     }
     let formData = {
       ...this.state.formData,
-      baseURL: loris.BaseURL
+      baseURL: loris.BaseURL,
     };
 
     let formObj = new FormData();

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -56,7 +56,7 @@ class ViewProject extends React.Component {
     }
     let formData = {
       ...this.state.formData,
-      baseURL: loris.BaseURL
+      baseURL: loris.BaseURL,
     };
 
     let formObj = new FormData();

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -54,7 +54,11 @@ class ViewProject extends React.Component {
       );
       return;
     }
-    let formData = this.state.formData;
+    let formData = {
+      ...this.state.formData,
+      baseURL: loris.BaseURL
+    };
+
     let formObj = new FormData();
     for (let key in formData) {
       if (formData.hasOwnProperty(key) && formData[key] !== '') {


### PR DESCRIPTION
## Brief summary of changes

- The loris baseURL is now sent from the react pages to the ajax scripts on submit for both editing and uploading a new publication, and then is sent in the email.
- I did it this way as `\NDB_Factory::singleton()->settings()->getBaseURL()` does not work in ajax files, and since it is deprecated it made more sense to do a hotfix rather than investigating the issue with ajax.
- This was noticed and fixed for files in php folders in #7807, however that same fix does not work for ajax. Thankfully publication is the only module with ajax still that uses getBaseUrl().
<img width="747" alt="image" src="https://github.com/aces/Loris/assets/51128536/76597790-05af-4bc1-bea1-5c017c144f9f">

#### Testing instructions (if applicable)

1. Open the publication module and propose a project, enter a real email and make sure to press send email to lead investigator. 
2. Check your email and confirm that the link is complete
3. Try editing a publication and make sure that the email is sent as well

#### Link(s) to related issue(s)

* Resolves #9132
