### PR TITLE
[Publication] Fix for auto-selecting Project in edit

### DIFF
--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -145,13 +145,15 @@ function getData($db) : array
  */
 function getProjectData($db, $user, $id) : array
 {
-    $query  = 'SELECT Title, Description, p.project as project, datePublication, '.
+    $query  = 'SELECT Title, Description, p.project as project, pr.Name as projectName, datePublication, '.
         'journal, link, publishingStatus, DateProposed, '.
         'pc.Name as LeadInvestigator, pc.Email as LeadInvestigatorEmail, '.
         'PublicationStatusID, UserID, RejectedReason  '.
         'FROM publication p '.
         'LEFT JOIN publication_collaborator pc '.
         'ON p.LeadInvestigatorID = pc.PublicationCollaboratorID '.
+        'LEFT JOIN Project pr '.
+        'ON p.project = pr.ProjectID '.
         'WHERE p.PublicationID=:pid ';
     $result = $db->pselectRow(
         $query,
@@ -197,6 +199,7 @@ function getProjectData($db, $user, $id) : array
             'title'                 => $title,
             'description'           => $description,
             'project'               => $result['project'],
+            'projectName'           => $result['projectName'],
             'datePublication'       => $datePublication,
             'journal'               => $journal,
             'link'                  => $link,

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -145,7 +145,8 @@ function getData($db) : array
  */
 function getProjectData($db, $user, $id) : array
 {
-    $query  = 'SELECT Title, Description, p.project as project, pr.Name as projectName, datePublication, '.
+    $query  = 'SELECT Title, Description, ' .
+        'p.project as project, pr.Name as projectName, datePublication, '.
         'journal, link, publishingStatus, DateProposed, '.
         'pc.Name as LeadInvestigator, pc.Email as LeadInvestigatorEmail, '.
         'PublicationStatusID, UserID, RejectedReason  '.

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -145,15 +145,13 @@ function getData($db) : array
  */
 function getProjectData($db, $user, $id) : array
 {
-    $query  = 'SELECT Title, Description, pr.Name as project, datePublication, '.
+    $query  = 'SELECT Title, Description, p.project as project, datePublication, '.
         'journal, link, publishingStatus, DateProposed, '.
         'pc.Name as LeadInvestigator, pc.Email as LeadInvestigatorEmail, '.
         'PublicationStatusID, UserID, RejectedReason  '.
         'FROM publication p '.
         'LEFT JOIN publication_collaborator pc '.
         'ON p.LeadInvestigatorID = pc.PublicationCollaboratorID '.
-        'LEFT JOIN Project pr '.
-        'ON p.project = pr.ProjectID '.
         'WHERE p.PublicationID=:pid ';
     $result = $db->pselectRow(
         $query,

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -105,11 +105,13 @@ class ViewProject extends React.Component {
       }
 
       response.json().then(
+        
         (data) => {
           let formData = {
             title: data.title,
             description: data.description,
             project: data.project,
+            projectName: data.projectName,
             publishingStatus: data.publishingStatus,
             datePublication: data.datePublication,
             journal: data.journal,
@@ -304,7 +306,7 @@ class ViewProject extends React.Component {
         <StaticElement
           name="project"
           label="Project"
-          text={this.state.formData.project}
+          text={this.state.formData.projectName}
         />
         <StaticElement
           name="publishingStatus"

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -103,13 +103,16 @@ class ViewProject extends React.Component {
         });
         return;
       }
+      let projectKey = Object.keys(data.projectOptions).find(
+          key => data.projectOptions[key] === data.project
+        );
 
       response.json().then(
         (data) => {
           let formData = {
             title: data.title,
             description: data.description,
-            project: data.project,
+            project: projectKey,
             publishingStatus: data.publishingStatus,
             datePublication: data.datePublication,
             journal: data.journal,

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -103,16 +103,13 @@ class ViewProject extends React.Component {
         });
         return;
       }
-      let projectKey = Object.keys(data.projectOptions).find(
-          key => data.projectOptions[key] === data.project
-        );
 
       response.json().then(
         (data) => {
           let formData = {
             title: data.title,
             description: data.description,
-            project: projectKey,
+            project: data.project,
             publishingStatus: data.publishingStatus,
             datePublication: data.datePublication,
             journal: data.journal,

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -105,7 +105,6 @@ class ViewProject extends React.Component {
       }
 
       response.json().then(
-        
         (data) => {
           let formData = {
             title: data.title,


### PR DESCRIPTION
## Brief summary of changes

- The value expected by the field is the number id, but the fetch statement was returning the name - so I modified the sql statement to fetch the project ID.

#### Testing instructions (if applicable)

1. Propose a new project in the publication module and remember the project name
2. Submit and then go back to the main module and select it and make sure the project is auto selected

#### Link(s) to related issue(s)

* Resolves #9134  (Reference the issue this fixes, if any.)
