### PR TITLE
Add  to configuration server_processes_manager module

### DIFF
--- a/modules/server_processes_manager/README.md
+++ b/modules/server_processes_manager/README.md
@@ -54,7 +54,13 @@ module and the ability to view the information for all processes.
 
 ## Configurations
 
-There are no configuration settings associated to this module.
+The following configurations affect the load of the server_processes_manager module:
+
+ - /opt/Loris-MRI/bin/mri/
+
+    - This setting displays the Page of the `server_processes_manager` module.
+        
+        - To display the module you need to add `/opt/Loris-MRI/bin/mri/` to the LORIS-MRI code path in configuration module.
 
 ## Interactions with LORIS
 

--- a/modules/server_processes_manager/test/TestPlan.md
+++ b/modules/server_processes_manager/test/TestPlan.md
@@ -23,3 +23,4 @@ This test plan should be executed by someone with decent knowledge of the MRI up
    When the process finishes (when the exit code file contains something), verify that all the process files
    have been deleted from `/tmp` if and only if the exit code is zero.
 
+- Note: If the page doesn't load add the following path `/opt/Loris-MRI/bin/mri/` to the LORIS-MRI code path in configuration module.


### PR DESCRIPTION
#### Testing instructions (if applicable)

1. Go to the server processes manager without setting up LORIS-MRI code path `/opt/Loris-MRI/bin/mri/` in the configuration module.
2. See that page doesn't load.
3. See that this is not mentioned in the README or TestPlan.

#### Link(s) to related issue(s):
    - https://github.com/aces/Loris/issues/9153