### PR TITLE
[form + mri_violations] Add DatetimeElement to filter fields by date and time

### DIFF
--- a/jsx/DatetimeElement.tsx
+++ b/jsx/DatetimeElement.tsx
@@ -174,7 +174,8 @@ export default function DatetimeElement(props: DatetimeElementProps) {
    * @param e The React event.
    */
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
-    const newValue = formatDatetime(value, e.target.value.replace(/[- :]/g, ''));
+    const rawValue = e.target.value.replace(/[- :]/g, '');
+    const newValue = formatDatetime(value, rawValue);
     if (newValue === null) {
       return;
     }

--- a/jsx/DatetimeElement.tsx
+++ b/jsx/DatetimeElement.tsx
@@ -1,0 +1,244 @@
+import {ChangeEvent, ReactNode, useState} from 'react';
+
+const format = 'YYYY-MM-DD hh:mm:ss';
+
+/**
+ * Check if a character is a digit.
+ *
+ * @param character The character to check
+ * @returns The result of the check
+ */
+function isDigit(character: string) {
+  return character >= '0' && character <= '9';
+}
+
+/**
+ * Check if a character is a letter.
+ *
+ * @param character A character to check
+ * @returns The result of the check
+ */
+function isLetter(character: string) {
+  return (character >= 'A' && character <= 'Z')
+    || (character >= 'a' && character <= 'z');
+}
+
+/**
+ * Insert a string inside another string at a given index.
+ *
+ * @param string The string in which the substring is to be inserted
+ * @param index The index at which to insert the substring
+ * @param other The substring to insert
+ * @returns The new string
+ */
+function stringInsert(string: string, index: number, other: string) {
+  return string.slice(0, index) + other + string.slice(index);
+}
+
+/**
+ * Pick the elements of a list at the given indexes.
+ *
+ * @param list The list to pick elements from.
+ * @param indexes The indexes of the elements to pick.
+ * @returns A list containing the elements picked.
+ */
+function listPick<T>(list: T[], indexes: number[]) {
+  return indexes.map((index) => list[index]);
+}
+
+/**
+ * Checks if a value matches the datetime format, formatting it if necessary.
+ *
+ * @param oldDatetime The old value of the input (which is valid)
+ * @param newDatetime The new value of the input (which may be invalid)
+ * @returns The formatted new value, or `null` if the new value is invalid
+ */
+function formatDatetime(oldDatetime: string, newDatetime: string) {
+  let i = 0;
+  while (i < newDatetime.length) {
+    // Check that the new value is no longer than the format.
+    // This check is done inside the loop because the value might grow during
+    // formatting.
+    if (i >= format.length) {
+      return null;
+    }
+
+    // Check that each new value character matches that expected from the
+    // format.
+    const valueChar = newDatetime[i];
+    const formatChar = format[i];
+    if (isLetter(formatChar)) {
+      if (!isDigit(valueChar)) {
+        return null;
+      }
+    } else {
+      if (isDigit(valueChar)) {
+        newDatetime = stringInsert(newDatetime, i, formatChar);
+      } else if (valueChar !== formatChar) {
+        return null;
+      }
+    }
+
+    i++;
+  }
+
+  // If a character was added, add a special character if it is expected from
+  // the format.
+  if (newDatetime.length > oldDatetime.length &&
+    newDatetime.length < format.length
+  ) {
+    const nextChar = format[newDatetime.length];
+    if (!isLetter(nextChar)) {
+      newDatetime += nextChar;
+    }
+  }
+
+  // If a character was removed, remove a special character if it is expected
+  // from the format.
+  if (newDatetime.length < oldDatetime.length && newDatetime.length > 0) {
+    const prevChar = format[newDatetime.length - 1];
+    if (!isLetter(prevChar)) {
+      newDatetime = newDatetime.slice(0, -1);
+    }
+  }
+
+  return newDatetime;
+}
+
+interface MaskProps {
+  value: string;
+  children: ReactNode;
+}
+
+/**
+ * React component for an input datetime mask.
+ *
+ * @param props The props of the component
+ * @returns The corresponding React element
+ */
+function Mask(props: MaskProps) {
+  // '\u00A0' is a non-breakable space.
+  return (
+    <div style={{position: 'relative'}}>
+      {props.children}
+      <div className="form-control" style={{
+        position: 'absolute',
+        top: 0, left: 0,
+        backgroundColor: 'transparent',
+        borderColor: 'transparent',
+        boxShadow: 'none',
+        pointerEvents: 'none',
+      }}>
+        <div style={{
+          fontFamily: 'monospace',
+          color: '#777777',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+        }}>
+          {'\u00A0'.repeat(props.value.length)}
+          {format.slice(props.value.length)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface DatetimeElementProps {
+  name: string;
+  label: string;
+  value?: string;
+  id?: string;
+  dateFormat: string;
+  required?: boolean;
+  disabled?: boolean;
+  hasError?: boolean;
+  errorMessage?: string;
+  onUserInput: (name: string, value: string) => void;
+}
+
+/**
+ * Datetime input (down to the second) React component
+ * Compared to the standard HTML input, this input accepts incomplete datetimes
+ * (useful for filtering).
+ *
+ * @param props The props of the component
+ * @returns The corresponding React element
+ */
+export default function DatetimeElement(props: DatetimeElementProps) {
+  const onUserInput = props.onUserInput !== undefined
+    ? props.onUserInput
+    : () => console.warn('onUserInput() callback is not set');
+
+  const [value, setValue] = useState(props.value ?? '');
+
+  /**
+   * Handle a change in the input.
+   *
+   * @param e The React event.
+   */
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    const newValue = formatDatetime(value, e.target.value.replace(/[- :]/g, ''));
+    if (newValue === null) {
+      return;
+    }
+
+    setValue(newValue);
+
+    onUserInput(
+      props.name,
+      newValue,
+    );
+  }
+
+  const required = props.required ?? false;
+  const disabled = props.disabled ?? false;
+  let errorMessage = null;
+  let elementClass = 'row form-group';
+
+  if (props.required && value == '') {
+    errorMessage = <span>This field is required</span>;
+    elementClass += ' has-error';
+  } else if (props.hasError) {
+    errorMessage = <span>{props.errorMessage}</span>;
+    elementClass += ' has-error';
+  }
+
+  let labelHTML;
+  let classSz = 'col-sm-12';
+  if (props.label) {
+    classSz = 'col-sm-9';
+    labelHTML = (
+      <label
+        className="col-sm-3 control-label"
+        htmlFor={props.label}
+      >
+        {props.label}
+        {required
+          ? (<span className="text-danger">*</span>)
+          : null}
+      </label>
+    );
+  }
+
+  return (
+    <div className={elementClass}>
+      {labelHTML}
+      <div className={classSz}>
+        <Mask value={value}>
+          <input
+            className="form-control"
+            name={props.name}
+            placeholder={format}
+            id={props.id}
+            onChange={handleChange}
+            value={value}
+            required={required}
+            disabled={disabled}
+            style={{fontFamily: 'monospace'}}
+          />
+        </Mask>
+        {errorMessage}
+      </div>
+    </div>
+  );
+}

--- a/jsx/DatetimeElement.tsx
+++ b/jsx/DatetimeElement.tsx
@@ -54,8 +54,7 @@ function listPick<T>(list: T[], indexes: number[]) {
  * @returns The formatted new value, or `null` if the new value is invalid
  */
 function formatDatetime(oldDatetime: string, newDatetime: string) {
-  let i = 0;
-  while (i < newDatetime.length) {
+  for (let i = 0; i < newDatetime.length; i++) {
     // Check that the new value is no longer than the format.
     // This check is done inside the loop because the value might grow during
     // formatting.
@@ -78,8 +77,6 @@ function formatDatetime(oldDatetime: string, newDatetime: string) {
         return null;
       }
     }
-
-    i++;
   }
 
   // If a character was added, add a special character if it is expected from

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -10,7 +10,7 @@ import {
     SelectElement,
     TextboxElement,
 } from 'jsx/Form';
-import DatetimeElement from 'jsx/DatetimeElement';
+import DateTimePartialElement from 'jsx/form/DateTimePartialElement';
 
 /**
  * Filter component
@@ -101,7 +101,7 @@ function Filter(props) {
             element = <DateElement/>;
             break;
           case 'datetime':
-            element = <DatetimeElement />;
+            element = <DateTimePartialElement />;
             break;
           case 'checkbox':
             element = <CheckboxElement/>;

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -10,6 +10,7 @@ import {
     SelectElement,
     TextboxElement,
 } from 'jsx/Form';
+import DatetimeElement from 'jsx/DatetimeElement';
 
 /**
  * Filter component
@@ -47,8 +48,8 @@ function Filter(props) {
     const {fields} = JSON.parse(JSON.stringify(props));
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
-    const exactMatch = (!(type === 'text' || type === 'date'));
-
+    const exactMatch = (!(type === 'text' || type === 'date'
+      || type === 'datetime'));
     if (value === null || value === '' ||
       (value.constructor === Array && value.length === 0) ||
       (type === 'checkbox' && value === false)) {
@@ -99,11 +100,14 @@ function Filter(props) {
           case 'date':
             element = <DateElement/>;
             break;
-          case 'time':
-            element = <TimeElement/>;
+          case 'datetime':
+            element = <DatetimeElement />;
             break;
           case 'checkbox':
             element = <CheckboxElement/>;
+            break;
+          case 'time':
+            element = <TimeElement/>;
             break;
           default:
             element = <TextboxElement/>;

--- a/jsx/form/DateTimePartialElement.tsx
+++ b/jsx/form/DateTimePartialElement.tsx
@@ -150,7 +150,7 @@ interface DateTimePartialElementProps {
  * @param props The props of the component
  * @returns The corresponding React element
  */
-export default function DateTimePartialElement(props: DateTimePartialElementProps) {
+function DateTimePartialElement(props: DateTimePartialElementProps) {
   const onUserInput = props.onUserInput !== undefined
     ? props.onUserInput
     : () => console.warn('onUserInput() callback is not set');
@@ -228,3 +228,5 @@ export default function DateTimePartialElement(props: DateTimePartialElementProp
     </div>
   );
 }
+
+export default DateTimePartialElement;

--- a/jsx/form/DateTimePartialElement.tsx
+++ b/jsx/form/DateTimePartialElement.tsx
@@ -36,25 +36,14 @@ function stringInsert(string: string, index: number, other: string) {
 }
 
 /**
- * Pick the elements of a list at the given indexes.
- *
- * @param list The list to pick elements from.
- * @param indexes The indexes of the elements to pick.
- * @returns A list containing the elements picked.
- */
-function listPick<T>(list: T[], indexes: number[]) {
-  return indexes.map((index) => list[index]);
-}
-
-/**
  * Checks if a value matches the datetime format, formatting it if necessary.
  *
- * @param oldDatetime The old value of the input (which is valid)
- * @param newDatetime The new value of the input (which may be invalid)
+ * @param oldDateTime The old value of the input (which is valid)
+ * @param newDateTime The new value of the input (which may be invalid)
  * @returns The formatted new value, or `null` if the new value is invalid
  */
-function formatDatetime(oldDatetime: string, newDatetime: string) {
-  for (let i = 0; i < newDatetime.length; i++) {
+function formatDatetime(oldDateTime: string, newDateTime: string) {
+  for (let i = 0; i < newDateTime.length; i++) {
     // Check that the new value is no longer than the format.
     // This check is done inside the loop because the value might grow during
     // formatting.
@@ -64,7 +53,7 @@ function formatDatetime(oldDatetime: string, newDatetime: string) {
 
     // Check that each new value character matches that expected from the
     // format.
-    const valueChar = newDatetime[i];
+    const valueChar = newDateTime[i];
     const formatChar = format[i];
     if (isLetter(formatChar)) {
       if (!isDigit(valueChar)) {
@@ -72,7 +61,7 @@ function formatDatetime(oldDatetime: string, newDatetime: string) {
       }
     } else {
       if (isDigit(valueChar)) {
-        newDatetime = stringInsert(newDatetime, i, formatChar);
+        newDateTime = stringInsert(newDateTime, i, formatChar);
       } else if (valueChar !== formatChar) {
         return null;
       }
@@ -81,25 +70,25 @@ function formatDatetime(oldDatetime: string, newDatetime: string) {
 
   // If a character was added, add a special character if it is expected from
   // the format.
-  if (newDatetime.length > oldDatetime.length &&
-    newDatetime.length < format.length
+  if (newDateTime.length > oldDateTime.length &&
+    newDateTime.length < format.length
   ) {
-    const nextChar = format[newDatetime.length];
+    const nextChar = format[newDateTime.length];
     if (!isLetter(nextChar)) {
-      newDatetime += nextChar;
+      newDateTime += nextChar;
     }
   }
 
   // If a character was removed, remove a special character if it is expected
   // from the format.
-  if (newDatetime.length < oldDatetime.length && newDatetime.length > 0) {
-    const prevChar = format[newDatetime.length - 1];
+  if (newDateTime.length < oldDateTime.length && newDateTime.length > 0) {
+    const prevChar = format[newDateTime.length - 1];
     if (!isLetter(prevChar)) {
-      newDatetime = newDatetime.slice(0, -1);
+      newDateTime = newDateTime.slice(0, -1);
     }
   }
 
-  return newDatetime;
+  return newDateTime;
 }
 
 interface MaskProps {
@@ -140,7 +129,7 @@ function Mask(props: MaskProps) {
   );
 }
 
-interface DatetimeElementProps {
+interface DateTimePartialElementProps {
   name: string;
   label: string;
   value?: string;
@@ -161,7 +150,7 @@ interface DatetimeElementProps {
  * @param props The props of the component
  * @returns The corresponding React element
  */
-export default function DatetimeElement(props: DatetimeElementProps) {
+export default function DateTimePartialElement(props: DateTimePartialElementProps) {
   const onUserInput = props.onUserInput !== undefined
     ? props.onUserInput
     : () => console.warn('onUserInput() callback is not set');
@@ -226,7 +215,6 @@ export default function DatetimeElement(props: DatetimeElementProps) {
           <input
             className="form-control"
             name={props.name}
-            placeholder={format}
             id={props.id}
             onChange={handleChange}
             value={value}

--- a/modules/mri_violations/jsx/mriViolationsIndex.js
+++ b/modules/mri_violations/jsx/mriViolationsIndex.js
@@ -288,7 +288,7 @@ const filters = (fieldoptions) => {
       {
         label: 'Time Run', show: true, filter: {
           name: 'timeRun',
-          type: 'date',
+          type: 'datetime',
         },
       },
       {


### PR DESCRIPTION
## Brief summary of changes

Add a `DatetimeElement` to input datetime information, which can be used to filter table columns with both dates times.

I originally developed this custom input last thursday, but then learned that this kind of input already exists in HTML `<input type="datetime-local" step="1" />`. However, the HTML input only allows to enter complete datetimes, which is not what we want as a filter should work even with incomplete information.

I wrote my input in a separate file from `jsx/Form` to use a more modern technology stack (Typescript / functional React) from those. However, I still follow their structure somewhat closely.

#### Testing instructions (if applicable)

1. Go to MRI violations,  filter entries by datetime.

#### Links to related issues

* Resolves #9091
