### PR TITLE
[publication] Fix download prevention by adding download notification

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1188,7 +1188,8 @@ INSERT INTO notification_modules (module_name, operation_type, as_admin, templat
   ('document_repository', 'edit', 'N', 'notifier_document_repository_edit.tpl', 'Document Repository: Document Edited'),
   ('publication', 'submission', 'N', 'notifier_publication_submission.tpl', 'Publication: Submission Received'),
   ('publication', 'review', 'N', 'notifier_publication_review.tpl', 'Publication: Proposal has been reviewed'),
-  ('publication', 'edit', 'N', 'notifier_publication_edit.tpl', 'Publication: Proposal has been edited');
+  ('publication', 'edit', 'N', 'notifier_publication_edit.tpl', 'Publication: Proposal has been edited'),
+  ('publication', 'download', 'N', 'notifier_publication_download.tpl', 'Publication: File Downloaded');
 
 INSERT INTO notification_modules_services_rel SELECT nm.id, ns.id FROM notification_modules nm JOIN notification_services ns WHERE nm.module_name='document_repository' AND ns.service='email_text';
 INSERT INTO notification_modules_services_rel SELECT nm.id, ns.id FROM notification_modules nm JOIN notification_services ns WHERE nm.module_name='publication' AND ns.service='email_text';

--- a/SQL/New_patches/2024-04-04-publication_download_notification.sql
+++ b/SQL/New_patches/2024-04-04-publication_download_notification.sql
@@ -1,0 +1,31 @@
+-- Create 'Download' operation notification for 'publication' module
+INSERT INTO notification_modules (module_name, operation_type, as_admin, template_file, description)
+VALUES ('publication', 'download', 'N', 'notifier_publication_download.tpl', 'Publication: File Downloaded');
+
+-- Create permission_rels -- Use same as publication/edit
+INSERT INTO notification_modules_perm_rel (notification_module_id, perm_id)
+    SELECT nm.id, nmpr.perm_id
+    FROM notification_modules AS nm
+    JOIN notification_modules_perm_rel AS nmpr
+    ON notification_module_id = (
+        SELECT id
+        FROM notification_modules
+        WHERE module_name = 'publication'
+        AND operation_type = 'edit'
+    )
+    WHERE module_name = 'publication'
+    AND operation_type = 'download'
+
+-- Create service_rel (email_text) -- Derive from publication/edit
+INSERT INTO notification_modules_services_rel (module_id, service_id)
+SELECT nm.id, nmsr.service_id
+FROM notification_modules AS nm
+    JOIN notification_modules_services_rel AS nmsr
+    ON module_id = (
+      SELECT id
+      FROM notification_modules
+      WHERE module_name = 'publication'
+        AND operation_type = 'edit'
+    )
+WHERE module_name = 'publication'
+AND operation_type = 'download'

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -65,7 +65,7 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
             ["file" => $file]
         );
 
-        $db      =  $this->loris->getDatabaseConnection();
+        $db    =  $this->loris->getDatabaseConnection();
         $title = $db->pselectOne(
             "SELECT Title " .
             "FROM publication " .
@@ -75,12 +75,14 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
             ['file' => $file]
         );
 
-        $config  = \NDB_Factory::singleton()->config();
+        $config      = \NDB_Factory::singleton()->config();
         $projectName = $config->getSetting('prefix') ?? 'LORIS';
 
-        $downloadNotifier->notify([
-            'Title'       => $title,
-            'ProjectName' => $projectName,
-        ]);
+        $downloadNotifier->notify(
+            [
+                'Title'       => $title,
+                'ProjectName' => $projectName,
+            ]
+        );
     }
 }

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -49,4 +49,38 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
     {
         return "/files/";
     }
+
+    /**
+     * Send a notification for the download.
+     *
+     * @param string $file The filename being downloaded
+     *
+     * @return void
+     */
+    protected function doDownloadNotification($file)
+    {
+        $downloadNotifier = new \NDB_Notifier(
+            $this->Module->getName(),
+            "download",
+            ["file" => $file]
+        );
+
+        $db      =  $this->loris->getDatabaseConnection();
+        $title = $db->pselectOne(
+            "SELECT Title " .
+            "FROM publication " .
+            "JOIN publication_upload ".
+            "USING (PublicationID) " .
+            "WHERE Filename=:file",
+            ['file' => $file]
+        );
+
+        $config  = \NDB_Factory::singleton()->config();
+        $projectName = $config->getSetting('prefix') ?? 'LORIS';
+
+        $downloadNotifier->notify([
+            'Title'       => $title,
+            'ProjectName' => $projectName,
+        ]);
+    }
 }

--- a/raisinbread/RB_files/RB_notification_modules.sql
+++ b/raisinbread/RB_files/RB_notification_modules.sql
@@ -10,5 +10,6 @@ INSERT INTO `notification_modules` (`id`, `module_name`, `operation_type`, `as_a
 INSERT INTO `notification_modules` (`id`, `module_name`, `operation_type`, `as_admin`, `template_file`, `description`) VALUES (7,'publication','submission','N','notifier_publication_submission.tpl','Publication: Submission Received');
 INSERT INTO `notification_modules` (`id`, `module_name`, `operation_type`, `as_admin`, `template_file`, `description`) VALUES (8,'publication','review','N','notifier_publication_review.tpl','Publication: Proposal has been reviewed');
 INSERT INTO `notification_modules` (`id`, `module_name`, `operation_type`, `as_admin`, `template_file`, `description`) VALUES (9,'publication','edit','N','notifier_publication_edit.tpl','Publication: Proposal has been edited');
+INSERT INTO `notification_modules` (`id`, `module_name`, `operation_type`, `as_admin`, `template_file`, `description`) VALUES (10, 'publication', 'download', 'N', 'notifier_publication_download.tpl', 'Publication: File Downloaded');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_notification_modules_perm_rel.sql
+++ b/raisinbread/RB_files/RB_notification_modules_perm_rel.sql
@@ -18,5 +18,8 @@ INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (9,53);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (9,54);
 INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (9,55);
+INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (10,53);
+INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (10,54);
+INSERT INTO `notification_modules_perm_rel` (`notification_module_id`, `perm_id`) VALUES (10,55);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_notification_modules_services_rel.sql
+++ b/raisinbread/RB_files/RB_notification_modules_services_rel.sql
@@ -10,5 +10,6 @@ INSERT INTO `notification_modules_services_rel` (`module_id`, `service_id`) VALU
 INSERT INTO `notification_modules_services_rel` (`module_id`, `service_id`) VALUES (7,2);
 INSERT INTO `notification_modules_services_rel` (`module_id`, `service_id`) VALUES (8,2);
 INSERT INTO `notification_modules_services_rel` (`module_id`, `service_id`) VALUES (9,2);
+INSERT INTO `notification_modules_services_rel` (`module_id`, `service_id`) VALUES (10,2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/smarty/templates/email/notifier_publication_download.tpl
+++ b/smarty/templates/email/notifier_publication_download.tpl
@@ -2,7 +2,7 @@ Subject: [LORIS] A project proposal file has been downloaded
 
 Hello,
 
-{$notifier_user} has donloaded the file "{$file}" from the project proposal "{$Title}" in the publication module.
+{$notifier_user} has downloaded the file "{$file}" from the project proposal "{$Title}" in the publication module.
 
 Thank you,
 The {$ProjectName} Team

--- a/smarty/templates/email/notifier_publication_download.tpl
+++ b/smarty/templates/email/notifier_publication_download.tpl
@@ -1,0 +1,8 @@
+Subject: [LORIS] A project proposal file has been downloaded
+
+Hello,
+
+{$notifier_user} has donloaded the file "{$file}" from the project proposal "{$Title}" in the publication module.
+
+Thank you,
+The {$ProjectName} Team


### PR DESCRIPTION
Closes #9133.

An error regarding the non-existence of a `notification_module` with module: `publication` and operation: `download` prevented the downloading of files.

~TODO: Add patch to RB inserts if solution is approved~

## Before testing
- Run the SQL patch
- Check the new checkbox in your preferences to enable receiving the e-mail

## Testing
- Successfully download an uploaded file in the `publication` module
- Confirm the reception of a notification e-mail and that the placeholders are correctly replaced
