### PR TITLE
EEG Browser file_reader 500 error

### DIFF
--- a/modules/electrophysiology_browser/php/file_reader.class.inc
+++ b/modules/electrophysiology_browser/php/file_reader.class.inc
@@ -36,18 +36,18 @@ class File_Reader extends \NDB_Page
         case "GET":
             $file     = $request->getQueryParams()['file'] ?? null;
             $filename = urldecode(basename($file));
-            $path     = dirname($file);
+            $path     = $downloadpath . dirname($file);
+            $fileinfo = new \SPLFileInfo($path);
 
-            try {
-                $downloader = new \LORIS\FilesDownloadHandler(
-                    new \SPLFileInfo($downloadpath . $path)
-                );
-                return $downloader->handle(
-                    $request->withAttribute('filename', $filename)
-                );
-            } catch (\Exception $e) {
+            if (!$fileinfo->isDir()) {
                 return new \LORIS\Http\Response\JSON\NotFound();
             }
+
+            $downloader = new \LORIS\FilesDownloadHandler($fileinfo);
+
+            return $downloader->handle(
+                $request->withAttribute('filename', $filename)
+            );
         default:
             return (new \LORIS\Http\Response\JSON\MethodNotAllowed(
                 ["GET"]

--- a/modules/electrophysiology_browser/php/file_reader.class.inc
+++ b/modules/electrophysiology_browser/php/file_reader.class.inc
@@ -38,12 +38,16 @@ class File_Reader extends \NDB_Page
             $filename = urldecode(basename($file));
             $path     = dirname($file);
 
-            $downloader = new \LORIS\FilesDownloadHandler(
-                new \SPLFileInfo($downloadpath . $path)
-            );
-            return $downloader->handle(
-                $request->withAttribute('filename', $filename)
-            );
+            try {
+                $downloader = new \LORIS\FilesDownloadHandler(
+                    new \SPLFileInfo($downloadpath . $path)
+                );
+                return $downloader->handle(
+                    $request->withAttribute('filename', $filename)
+                );
+            } catch (\Exception $e) {
+                return new \LORIS\Http\Response\JSON\NotFound();
+            }
         default:
             return (new \LORIS\Http\Response\JSON\MethodNotAllowed(
                 ["GET"]


### PR DESCRIPTION
Fix the following error:
```
[Thu Apr 04 11:06:58.004034 2024] [php:notice] [pid 4117] [client 192.168.122.1:59978] [ERROR] Download directory /data-raisinbread/bids_imports/PIDCC0821_V03_BIDSVersion_1.6.0_chunks/sub-PIDCC0821_ses-V03_task-FACE_acq-eeg_eeg.chunks is not a directory#0 /var/www/Loris/modules/electrophysiology_browser/php/file_reader.class.inc(42): LORIS\\FilesDownloadHandler->__construct()\n#1 /var/www/Loris/src/Middleware/UserPageDecorationMiddleware.php(247): LORIS\\electrophysiology_browser\\File_Reader->handle()\n#2 /var/www/Loris/src/Middleware/PageDecorationMiddleware.php(58): LORIS\\Middleware\\UserPageDecorationMiddleware->process()\n#3 /var/www/Loris/php/libraries/NDB_Page.class.inc(725): LORIS\\Middleware\\PageDecorationMiddleware->process()\n#4 /var/www/Loris/php/libraries/Module.class.inc(321): NDB_Page->process()\n#5 /var/www/Loris/src/Middleware/ResponseGenerator.php(50): Module->handle()\n#6 /var/www/Loris/src/Middleware/AuthMiddleware.php(63): LORIS\\Middleware\\ResponseGenerator->process()\n#7 /var/www/Loris/src/Router/ModuleRouter.php(74): LORIS\\Middleware\\AuthMiddleware->process()\n#8 /var/www/Loris/src/Middleware/ExceptionHandlingMiddleware.php(54): LORIS\\Router\\ModuleRouter->handle()\n#9 /var/www/Loris/src/Router/BaseRouter.php(132): LORIS\\Middleware\\ExceptionHandlingMiddleware->process()\n#10 /var/www/Loris/src/Middleware/ResponseGenerator.php(50): LORIS\\Router\\BaseRouter->handle()\n#11 /var/www/Loris/src/Middleware/ContentLength.php(52): LORIS\\Middleware\\ResponseGenerator->process()\n#12 /var/www/Loris/htdocs/index.php(73): LORIS\\Middleware\\ContentLength->process()\n#13 {main}, referer: https://test-dev-260.loris.ca/electrophysiology_browser/sessions/2161?outputType=raw
```

To test:
- visit https://test-dev-260.loris.ca/electrophysiology_browser/sessions/2161?outputType=raw
-  note the 500 errors in the network tab
- checkout this pr
-  500 errors are not converted in 404