### PR TITLE
[statistics] Recruitment graph optimization

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -111,12 +111,16 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
-        $data = $DB->pselectColWithIndexKey("
+        $data = $DB->pselectColWithIndexKey(
+            "
             SELECT COUNT(c.CandID), c.RegistrationCenterID as CenterID
                 FROM candidate c
                 WHERE c.Active='Y' AND c.Entity_type='Human'
                 GROUP BY c.RegistrationCenterID
-        ", [], "CenterID");
+        ",
+            [],
+            "CenterID"
+        );
 
         foreach ($list_of_sites as $siteID => $siteName) {
 
@@ -140,19 +144,21 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
-        $data = $DB->pselect("
+        $data           = $DB->pselect(
+            "
                 SELECT COUNT(c.CandID) as Count,
                     c.RegistrationCenterID as SiteID,
                     c.Sex as Sex
                 FROM candidate c
                 WHERE c.Active='Y' AND c.Entity_type='Human'
                 GROUP BY c.RegistrationCenterID, c.Sex",
-        []);
+            []
+        );
         $processed_data = [];
         foreach ($data as $row) {
             $siteid = $row['SiteID'];
-            $count = intval($row['Count']);
-            $sex = strtolower($row['Sex']);
+            $count  = intval($row['Count']);
+            $sex    = strtolower($row['Sex']);
             if (!isset($processed_data[$siteid])) {
                 $processed_data[$siteid] = [
                     strtolower($sex) => $count
@@ -164,8 +170,12 @@ class Charts extends \NDB_Page
         }
         foreach ($list_of_sites as $siteID => $siteName) {
             $sexData['labels'][] = $siteName;
-            $sexData['datasets']['female'][] = $processed_data[$siteID]['female'] ?? 0;
-            $sexData['datasets']['male'][] = $processed_data[$siteID]['male'] ?? 0;
+
+            $sexData['datasets']['female'][]
+                = $processed_data[$siteID]['female'] ?? 0;
+
+            $sexData['datasets']['male'][]
+                = $processed_data[$siteID]['male'] ?? 0;
         }
         return (new \LORIS\Http\Response\JsonResponse($sexData));
     }
@@ -294,22 +304,25 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
-
-        $recruitment_summary = $DB->pselect("SELECT COUNT(c.CandID) as Count,
+        $recruitment_summary = $DB->pselect(
+            "SELECT COUNT(c.CandID) as Count,
             MONTH(c.Date_registered) as Month,
             YEAR(c.Date_registered) as Year,
             c.RegistrationCenterID as SiteID
                 FROM candidate c
                     WHERE c.Entity_type='Human'
-                GROUP BY MONTH(c.Date_registered), YEAR(c.Date_registered), c.RegistrationCenterID",
-        []);
+                GROUP BY MONTH(c.Date_registered),
+                    YEAR(c.Date_registered),
+                    c.RegistrationCenterID",
+            []
+        );
 
         $recruitmentdata = [];
-        foreach($recruitment_summary as $row) {
+        foreach ($recruitment_summary as $row) {
             $siteId = $row['SiteID'];
-            $year = $row['Year'];
-            $month = $row['Month'];
-            if(!isset($recruitmentdata[$siteId])) {
+            $year   = $row['Year'];
+            $month  = $row['Month'];
+            if (!isset($recruitmentdata[$siteId])) {
                 $recruitmentdata[$siteId] = [
                     $year => [$month => $row['Count']]
                 ];
@@ -368,14 +381,16 @@ class Charts extends \NDB_Page
     /**
      * Helper to generate the data for the site recruitment line for $siteID.
      *
-     * @param int   $siteID The centerID to get data for.
-     * @param array $labels The list of labels on the chart to fill the data for.
+     * @param int   $siteID          The centerID to get data for.
+     * @param array $labels          The list of labels on the chart to fill
+     *                               the data for.
+     * @param array $recruitmentdata The raw recruitment data to split according to
+                                     the labels
      *
      * @return array
      */
     private function _getSiteLineRecruitmentData($siteID, $labels, $recruitmentdata)
     {
-        $DB   = \NDB_Factory::singleton()->database();
         $data = [];
         foreach ($labels as $label) {
             $month  = (strlen($label) == 6)

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -111,20 +111,18 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
-        foreach ($list_of_sites as $siteID => $siteName) {
-            $totalRecruitment = $DB->pselectOne(
-                "SELECT COUNT(c.CandID)
+        $data = $DB->pselectColWithIndexKey("
+            SELECT COUNT(c.CandID), c.RegistrationCenterID as CenterID
                 FROM candidate c
-                WHERE
-                c.RegistrationCenterID=:Site AND
-                c.Active='Y' AND
-                c.Entity_type='Human'",
-                ['Site' => $siteID]
-            );
+                WHERE c.Active='Y' AND c.Entity_type='Human'
+                GROUP BY c.RegistrationCenterID
+        ", [], "CenterID");
+
+        foreach ($list_of_sites as $siteID => $siteName) {
 
             $recruitmentBySiteData[] = [
                 "label" => $siteName,
-                "total" => $totalRecruitment,
+                "total" => intval($data[$siteID]) ?? 0,
             ];
         }
         return new \LORIS\Http\Response\JsonResponse($recruitmentBySiteData);
@@ -142,23 +140,32 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
+        $data = $DB->pselect("
+                SELECT COUNT(c.CandID) as Count,
+                    c.RegistrationCenterID as SiteID,
+                    c.Sex as Sex
+                FROM candidate c
+                WHERE c.Active='Y' AND c.Entity_type='Human'
+                GROUP BY c.RegistrationCenterID, c.Sex",
+        []);
+        $processed_data = [];
+        foreach ($data as $row) {
+            $siteid = $row['SiteID'];
+            $count = intval($row['Count']);
+            $sex = strtolower($row['Sex']);
+            if (!isset($processed_data[$siteid])) {
+                $processed_data[$siteid] = [
+                    strtolower($sex) => $count
+                ];
+            } else {
+                assert(!isset($processed_data[$siteid][$sex]));
+                $processed_data[$siteid][$sex] = $count;
+            }
+        }
         foreach ($list_of_sites as $siteID => $siteName) {
             $sexData['labels'][] = $siteName;
-            $sexData['datasets']['female'][] = $DB->pselectOne(
-                "SELECT COUNT(c.CandID)
-                FROM candidate c
-                WHERE c.RegistrationCenterID=:Site
-                    AND c.Sex='female' AND c.Active='Y'
-                    AND c.Entity_type='Human'",
-                ['Site' => $siteID]
-            );
-            $sexData['datasets']['male'][]   = $DB->pselectOne(
-                "SELECT COUNT(c.CandID)
-                FROM candidate c
-                WHERE c.RegistrationCenterID=:Site AND c.Sex='male' AND c.Active='Y'
-                AND c.Entity_type='Human'",
-                ['Site' => $siteID]
-            );
+            $sexData['datasets']['female'][] = $processed_data[$siteID]['female'] ?? 0;
+            $sexData['datasets']['male'][] = $processed_data[$siteID]['male'] ?? 0;
         }
         return (new \LORIS\Http\Response\JsonResponse($sexData));
     }
@@ -287,6 +294,33 @@ class Charts extends \NDB_Page
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
+
+        $recruitment_summary = $DB->pselect("SELECT COUNT(c.CandID) as Count,
+            MONTH(c.Date_registered) as Month,
+            YEAR(c.Date_registered) as Year,
+            c.RegistrationCenterID as SiteID
+                FROM candidate c
+                    WHERE c.Entity_type='Human'
+                GROUP BY MONTH(c.Date_registered), YEAR(c.Date_registered), c.RegistrationCenterID",
+        []);
+
+        $recruitmentdata = [];
+        foreach($recruitment_summary as $row) {
+            $siteId = $row['SiteID'];
+            $year = $row['Year'];
+            $month = $row['Month'];
+            if(!isset($recruitmentdata[$siteId])) {
+                $recruitmentdata[$siteId] = [
+                    $year => [$month => $row['Count']]
+                ];
+            } else if (!isset($recruitmentdata[$siteId][$year])) {
+                $recruitmentdata[$siteId][$year] = [$month => $row['Count']];
+            } else {
+                assert(!isset($recruitmentdata[$siteId][$year][$month]));
+                $recruitmentdata[$siteId][$year][$month] = $row['Count'];
+            }
+
+        }
         foreach ($list_of_sites as $siteID => $siteName) {
             if (!isset($recruitmentData['labels'])) {
                 continue;
@@ -296,6 +330,7 @@ class Charts extends \NDB_Page
                 "data" => $this->_getSiteLineRecruitmentData(
                     $siteID,
                     $recruitmentData['labels'],
+                    $recruitmentdata,
                 ),
             ];
         }
@@ -338,28 +373,15 @@ class Charts extends \NDB_Page
      *
      * @return array
      */
-    private function _getSiteLineRecruitmentData($siteID, $labels)
+    private function _getSiteLineRecruitmentData($siteID, $labels, $recruitmentdata)
     {
         $DB   = \NDB_Factory::singleton()->database();
         $data = [];
-
         foreach ($labels as $label) {
             $month  = (strlen($label) == 6)
                 ? substr($label, 0, 1) : substr($label, 0, 2);
             $year   = substr($label, -4, 4);
-            $data[] = $DB->pselectOne(
-                "SELECT COUNT(c.CandID)
-                FROM candidate c
-                WHERE c.RegistrationCenterID=:Site
-                AND MONTH(c.Date_registered)=:Month
-                AND YEAR(c.Date_registered)=:Year
-                AND c.Entity_type='Human'",
-                [
-                    'Site'  => $siteID,
-                    'Month' => $month,
-                    'Year'  => $year,
-                ]
-            );
+            $data[] = intval($recruitmentdata[$siteID][$year][$month] ?? "0");
         }
         return $data;
     }

--- a/modules/statistics/php/widgets.class.inc
+++ b/modules/statistics/php/widgets.class.inc
@@ -65,14 +65,23 @@ class Widgets extends \NDB_Page implements ETagCalculator
 
         $recruitmentTarget = $config->getSetting('recruitmentTarget');
 
-        $totalScans  = $this->_getTotalRecruitment($db);
+        $recruitmentRaw = $db->pselect("SELECT
+                COUNT(*) as Count,
+                c.Sex as Sex,
+                c.RegistrationProjectID as ProjectID
+             FROM candidate c
+                 WHERE c.Active='Y' AND c.Entity_type='Human'
+                 AND c.RegistrationCenterID <> 1
+             GROUP BY c.Sex, c.RegistrationProjectID",
+        []);
+        $totalScans  = $this->_getTotalRecruitment($recruitmentRaw);
         $recruitment = [
             'overall' => $this->_createProjectProgressBar(
                 'overall',
                 "Overall Recruitment",
                 $recruitmentTarget,
                 $totalScans,
-                $db,
+                $recruitmentRaw,
             )
         ];
 
@@ -89,8 +98,8 @@ class Widgets extends \NDB_Page implements ETagCalculator
                 $projectID,
                 $projectInfo['Name'],
                 $projectInfo['recruitmentTarget'],
-                $this->getTotalRecruitmentByProject($db, $projectID),
-                $db
+                $this->getTotalRecruitmentByProject($recruitmentRaw, $projectID),
+                $recruitmentRaw
             );
         }
 
@@ -115,14 +124,13 @@ class Widgets extends \NDB_Page implements ETagCalculator
      *
      * @return int
      */
-    private function _getTotalRecruitment(\Database $DB): int
+    private function _getTotalRecruitment(array $rawData): int
     {
-        return $DB->pselectOneInt(
-            "SELECT COUNT(*) FROM candidate c
-             WHERE c.Active='Y' AND c.Entity_type='Human'
-             AND c.RegistrationCenterID <> 1",
-            []
-        ) ?? 0;
+        $sum = 0;
+        foreach ($rawData as $row) {
+            $sum += intval($row['Count']);
+        }
+        return $sum;
     }
 
     /**
@@ -144,7 +152,7 @@ class Widgets extends \NDB_Page implements ETagCalculator
         $title,
         $recruitmentTarget,
         $totalRecruitment,
-        \Database $db
+        $rawData
     ): array {
         $rv = [
             'total_recruitment' => $totalRecruitment,
@@ -156,17 +164,17 @@ class Widgets extends \NDB_Page implements ETagCalculator
 
         $rv['recruitment_target'] = $recruitmentTarget;
         if ($ID == 'overall') {
-            $totalFemales = $this->_getTotalSex($db, "Female");
+            $totalFemales = $this->_getTotalSex($rawData, "Female");
         } else {
-            $totalFemales = $this->getTotalSexByProject($db, "Female", intval($ID));
+            $totalFemales = $this->getTotalSexByProject($rawData, "Female", intval($ID));
         }
         $rv['female_total']   = $totalFemales;
         $rv['female_percent']
             = round($totalFemales / $recruitmentTarget * 100);
         if ($ID == 'overall') {
-            $totalMales = $this->_getTotalSex($db, "Male");
+            $totalMales = $this->_getTotalSex($rawData, "Male");
         } else {
-            $totalMales = $this->getTotalSexByProject($db, "Male", intval($ID));
+            $totalMales = $this->getTotalSexByProject($rawData, "Male", intval($ID));
         }
         $rv['male_total']   = $totalMales;
         $rv['male_percent']
@@ -192,15 +200,15 @@ class Widgets extends \NDB_Page implements ETagCalculator
      *
      * @return int
      */
-    private function _getTotalSex(\Database $db, string $sex) : int
+    private function _getTotalSex(array $rawdata, string $sex) : int
     {
-        return $db->pselectOneInt(
-            "SELECT COUNT(c.CandID)
-            FROM candidate c
-            WHERE c.Sex=:sex AND c.Active='Y' AND c.Entity_type='Human'
-            AND c.RegistrationCenterID <> 1",
-            ['sex' => $sex]
-        ) ?? 0;
+        $sum = 0;
+        foreach($rawdata as $row) {
+            if ($row['Sex'] == $sex) {
+                $sum += intval($row['Count']);
+            }
+        }
+        return $sum;
     }
 
     /**
@@ -214,18 +222,15 @@ class Widgets extends \NDB_Page implements ETagCalculator
      *
      * @return int
      */
-    function getTotalSexByProject(\Database $DB, string $sex, int $projectID) : int
+    function getTotalSexByProject(array $raw, string $sex, int $projectID) : int
     {
-        return $DB->pselectOneInt(
-            "SELECT COUNT(c.CandID)
-            FROM candidate c
-            WHERE c.Sex=:sex AND c.Active='Y' AND c.RegistrationProjectID=:PID
-            AND c.Entity_type='Human' AND c.RegistrationCenterID <> 1",
-            [
-                'sex' => $sex,
-                'PID' => "$projectID",
-            ]
-        ) ?? 0;
+        $sum = 0;
+        foreach($raw as $row) {
+            if ($row['Sex'] == $sex && $row['ProjectID'] == $projectID) {
+                $sum += intval($row['Count']);
+            }
+        }
+        return $sum;
     }
 
     /**
@@ -237,17 +242,15 @@ class Widgets extends \NDB_Page implements ETagCalculator
      *
      * @return int
      */
-    function getTotalRecruitmentByProject(\Database $db, int $projectID): int
+    function getTotalRecruitmentByProject(array $data, int $projectID): int
     {
-        return $db->pselectOneInt(
-            "SELECT COUNT(*)
-             FROM candidate c
-             WHERE c.Active='Y'
-              AND c.RegistrationProjectID=:PID
-              AND c.Entity_type='Human'
-              AND c.RegistrationCenterID <> 1",
-            ['PID' => "$projectID"]
-        ) ?? 0;
+        $sum = 0;
+        foreach($data as $row) {
+            if (intval($row['ProjectID']) == $projectID) {
+                $sum += intval($row['Count']);
+            }
+        }
+        return $sum;
     }
 
     /**

--- a/modules/statistics/php/widgets.class.inc
+++ b/modules/statistics/php/widgets.class.inc
@@ -76,7 +76,7 @@ class Widgets extends \NDB_Page implements ETagCalculator
              GROUP BY c.Sex, c.RegistrationProjectID",
             []
         );
-        $totalScans     = $this->_getTotalRecruitment($recruitmentRaw);
+        $totalScans     = array_sum(array_column($recruitmentRaw, 'Count'));
         $recruitment    = [
             'overall' => $this->_createProjectProgressBar(
                 'overall',
@@ -117,22 +117,6 @@ class Widgets extends \NDB_Page implements ETagCalculator
         $this->_cache = new \LORIS\Http\Response\JsonResponse($values);
 
         return $this->_cache;
-    }
-
-    /**
-     * Gets the total count of candidates associated with a specific project
-     *
-     * @param array $rawData The raw, grouped data from the database
-     *
-     * @return int
-     */
-    private function _getTotalRecruitment(array $rawData): int
-    {
-        $sum = 0;
-        foreach ($rawData as $row) {
-            $sum += intval($row['Count']);
-        }
-        return $sum;
     }
 
     /**

--- a/modules/statistics/php/widgets.class.inc
+++ b/modules/statistics/php/widgets.class.inc
@@ -65,7 +65,8 @@ class Widgets extends \NDB_Page implements ETagCalculator
 
         $recruitmentTarget = $config->getSetting('recruitmentTarget');
 
-        $recruitmentRaw = $db->pselect("SELECT
+        $recruitmentRaw = $db->pselect(
+            "SELECT
                 COUNT(*) as Count,
                 c.Sex as Sex,
                 c.RegistrationProjectID as ProjectID
@@ -73,9 +74,10 @@ class Widgets extends \NDB_Page implements ETagCalculator
                  WHERE c.Active='Y' AND c.Entity_type='Human'
                  AND c.RegistrationCenterID <> 1
              GROUP BY c.Sex, c.RegistrationProjectID",
-        []);
-        $totalScans  = $this->_getTotalRecruitment($recruitmentRaw);
-        $recruitment = [
+            []
+        );
+        $totalScans     = $this->_getTotalRecruitment($recruitmentRaw);
+        $recruitment    = [
             'overall' => $this->_createProjectProgressBar(
                 'overall',
                 "Overall Recruitment",
@@ -120,7 +122,7 @@ class Widgets extends \NDB_Page implements ETagCalculator
     /**
      * Gets the total count of candidates associated with a specific project
      *
-     * @param \Database $DB The database connection to get the count from.
+     * @param array $rawData The raw, grouped data from the database
      *
      * @return int
      */
@@ -136,14 +138,14 @@ class Widgets extends \NDB_Page implements ETagCalculator
     /**
      * Generates the template data for a progress bar.
      *
-     * @param string    $ID                The name of the progress bar being
-     *                                     created.
-     * @param string    $title             The title to add to the template
-     *                                     variables.
-     * @param int       $recruitmentTarget The target for this recruitment type.
-     * @param int       $totalRecruitment  The total number of candidates of all
-     *                                     types.
-     * @param \Database $db                The database connection to get data from.
+     * @param string $ID                The name of the progress bar being
+     *                                  created.
+     * @param string $title             The title to add to the template
+     *                                  variables.
+     * @param int    $recruitmentTarget The target for this recruitment type.
+     * @param int    $totalRecruitment  The total number of candidates of all
+     *                                  types.
+     * @param array  $rawData           The raw data from the database
      *
      * @return array Smarty template data
      */
@@ -166,7 +168,11 @@ class Widgets extends \NDB_Page implements ETagCalculator
         if ($ID == 'overall') {
             $totalFemales = $this->_getTotalSex($rawData, "Female");
         } else {
-            $totalFemales = $this->getTotalSexByProject($rawData, "Female", intval($ID));
+            $totalFemales = $this->getTotalSexByProject(
+                $rawData,
+                "Female",
+                intval($ID)
+            );
         }
         $rv['female_total']   = $totalFemales;
         $rv['female_percent']
@@ -194,16 +200,15 @@ class Widgets extends \NDB_Page implements ETagCalculator
     /**
      * Gets the total count of candidates of a specific sex
      *
-     * @param \Database $db  A database connection to retrieve information
-     *                       from.
-     * @param string    $sex Biological sex (male or female)
+     * @param array  $raw The raw data returned from the SQL query.
+     * @param string $sex Biological sex (male or female)
      *
      * @return int
      */
-    private function _getTotalSex(array $rawdata, string $sex) : int
+    private function _getTotalSex(array $raw, string $sex) : int
     {
         $sum = 0;
-        foreach($rawdata as $row) {
+        foreach ($raw as $row) {
             if ($row['Sex'] == $sex) {
                 $sum += intval($row['Count']);
             }
@@ -215,17 +220,16 @@ class Widgets extends \NDB_Page implements ETagCalculator
      * Gets the total count of candidates of a specific sex,
      * associated with a specific project
      *
-     * @param \Database $DB        A database connection to retrieve information
-     *                             from.
-     * @param string    $sex       A biological sex (male or female)
-     * @param int       $projectID Project ID
+     * @param array  $raw       The raw data returned from the SQL query.
+     * @param string $sex       A biological sex (male or female)
+     * @param int    $projectID Project ID
      *
      * @return int
      */
     function getTotalSexByProject(array $raw, string $sex, int $projectID) : int
     {
         $sum = 0;
-        foreach($raw as $row) {
+        foreach ($raw as $row) {
             if ($row['Sex'] == $sex && $row['ProjectID'] == $projectID) {
                 $sum += intval($row['Count']);
             }
@@ -236,16 +240,15 @@ class Widgets extends \NDB_Page implements ETagCalculator
     /**
      * Gets the total count of candidates associated with a specific project.
      *
-     * @param \Database $db        A database connection to retrieve information
-     *                             from.
-     * @param int       $projectID The Project ID to get recruitment for.
+     * @param array $data      The raw data returned from the SQL query.
+     * @param int   $projectID The Project ID to get recruitment for.
      *
      * @return int
      */
     function getTotalRecruitmentByProject(array $data, int $projectID): int
     {
         $sum = 0;
-        foreach($data as $row) {
+        foreach ($data as $row) {
             if (intval($row['ProjectID']) == $projectID) {
                 $sum += intval($row['Count']);
             }


### PR DESCRIPTION
The recruitment graphs on the dashboard provided by the statistics module are not efficient. They run one SQL query per month per year per site for each graph that is displayed. This is highly inefficient for large projects.

This replaces the single queries in the inner loops with a single group-by query which it processes into the same format.

The result should be significantly faster load times on the dashboard when the statistics module is loaded.

#### Testing instructions (if applicable)

1. Load the LORIS dashboard with and without this change. The load time should be significantly faster for on-going projects with a lot of sites or spread over a long amount of time. The results returned should be identical.
