### PR TITLE
[new_profile] Site not selected when recruiting another candidate

### DIFF
--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -140,14 +140,12 @@ class NewProfileIndex extends React.Component {
             cancelButtonColor: '#3085d6',
             cancelButtonText: 'Recruit another candidate',
           }).then((result) => {
-            if (result.value === true) {
-              window.location.href = '/' + data.CandID;
-            } else {
-              this.setState({
-                formData: {},
-                submitDisabled: false,
-              });
-            }
+            // Go to the candidate profile or reload the page, depending
+            // on whether the user clicked on 'Access Profile' or
+            // 'Recruit another candidate' respectively
+            window.location.href = result.value === true
+                ? window.location.href = '/' + data.CandID
+                : window.location.href;
           });
         } )
         .catch((error) => {

--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -144,7 +144,7 @@ class NewProfileIndex extends React.Component {
             // on whether the user clicked on 'Access Profile' or
             // 'Recruit another candidate' respectively
             window.location.href = result.value === true
-                ? window.location.href = '/' + data.CandID
+                ? '/' + data.CandID
                 : window.location.href;
           });
         } )

--- a/modules/new_profile/test/TestPlan.md
+++ b/modules/new_profile/test/TestPlan.md
@@ -31,4 +31,5 @@ have the current day as the maximum possible value to choose.
 10. Change date format from 'YMd' to 'YM' in the Configuration module
 and repeat steps 4 to 6 while asserting that database values being
 saved are correct.
+11. As a user with only one site affiliation, fill the form with valid values and create a new user. When the popup indicating that the creation succeeded is displayed, click on 'Recruit another candidate'. Ensure that when the page reloads, the user's (unique) site is selected.
    [Manual Testing]


### PR DESCRIPTION
This PR ensures that if a user is associated to only one site and creates two candidates in a row, his/her site will be automatically selected on the new profile form when the form is first displayed and when he/she clicks on 'Recruit another candidate'. It also updates the module's test plan to cover this scenario.

Fixes #9146 
 