### PR TITLE
data_dictionary_builder.php unique constraint fix

### DIFF
--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -52,12 +52,13 @@ $instrumentParameterTypeCategoryIDs = [];
 $instrumentParameterTypeIDs         = [];
 
 $parameter_types = $DB->pselectColWithIndexKey(
-    "SELECT
-        CONCAT(`Name`, '-', `SourceFrom`) AS paramkey,
-        ParameterTypeID
-    FROM parameter_type",
+    "SELECT pt.Name, pt.ParameterTypeID
+    FROM parameter_type pt
+        JOIN parameter_type_category_rel ptcr USING (ParameterTypeID)
+        JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
+    WHERE ptc.Type = 'Instrument'",
     [],
-    "paramkey"
+    "Name"
 );
 
 // 2 query to clear all old parameter_type data associated to instruments.
@@ -207,12 +208,11 @@ foreach ($instruments AS $instrument) {
                 "Queryable"   => "1",
             ];
 
-            $key = "$Name-$testname";
             // Check if the same element existed in the parameter_type table
             // before deleting the data.
-            if (array_key_exists($key, $parameter_types)) {
+            if (array_key_exists($Name, $parameter_types)) {
                 //If element existed, reuse the same id
-                $ParameterTypeID = $parameter_types[$key];
+                $ParameterTypeID = $parameter_types[$Name];
                 $query_params["ParameterTypeID"] = $ParameterTypeID;
             } else {
                 //If it's new set it to empty string
@@ -268,9 +268,8 @@ foreach ($instruments AS $instrument) {
         "Queryable"   => "1",
     ];
 
-    $key = "$Name-$testname";
-    if (array_key_exists($key, $parameter_types)) {
-        $ParameterTypeID = $parameter_types[$key];
+    if (array_key_exists($Name, $parameter_types)) {
+        $ParameterTypeID = $parameter_types[$Name];
         $query_params["ParameterTypeID"] = $ParameterTypeID;
     } else {
         $ParameterTypeID = "";
@@ -313,9 +312,8 @@ foreach ($instruments AS $instrument) {
         "Queryable"   => "1",
     ];
 
-    $key = "$Name-$testname";
-    if (array_key_exists($key, $parameter_types)) {
-        $ParameterTypeID = $parameter_types[$key];
+    if (array_key_exists($Name, $parameter_types)) {
+        $ParameterTypeID = $parameter_types[$Name];
         $query_params["ParameterTypeID"] = $ParameterTypeID;
     } else {
         $ParameterTypeID = "";

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -51,11 +51,13 @@ $parameter_types = [];
 $instrumentParameterTypeCategoryIDs = [];
 $instrumentParameterTypeIDs         = [];
 
-
 $parameter_types = $DB->pselectColWithIndexKey(
-    "Select Name, ParameterTypeID from parameter_type",
+    "SELECT
+        CONCAT(`Name`, '-', `SourceFrom`) AS paramkey,
+        ParameterTypeID
+    FROM parameter_type",
     [],
-    "Name"
+    "paramkey"
 );
 
 // 2 query to clear all old parameter_type data associated to instruments.
@@ -205,11 +207,12 @@ foreach ($instruments AS $instrument) {
                 "Queryable"   => "1",
             ];
 
+            $key = "$Name-$testname";
             // Check if the same element existed in the parameter_type table
             // before deleting the data.
-            if (array_key_exists($Name, $parameter_types)) {
+            if (array_key_exists($key, $parameter_types)) {
                 //If element existed, reuse the same id
-                $ParameterTypeID = $parameter_types[$Name];
+                $ParameterTypeID = $parameter_types[$key];
                 $query_params["ParameterTypeID"] = $ParameterTypeID;
             } else {
                 //If it's new set it to empty string
@@ -265,8 +268,9 @@ foreach ($instruments AS $instrument) {
         "Queryable"   => "1",
     ];
 
-    if (array_key_exists($Name, $parameter_types)) {
-        $ParameterTypeID = $parameter_types[$Name];
+    $key = "$Name-$testname";
+    if (array_key_exists($key, $parameter_types)) {
+        $ParameterTypeID = $parameter_types[$key];
         $query_params["ParameterTypeID"] = $ParameterTypeID;
     } else {
         $ParameterTypeID = "";
@@ -309,8 +313,9 @@ foreach ($instruments AS $instrument) {
         "Queryable"   => "1",
     ];
 
-    if (array_key_exists($Name, $parameter_types)) {
-        $ParameterTypeID = $parameter_types[$Name];
+    $key = "$Name-$testname";
+    if (array_key_exists($key, $parameter_types)) {
+        $ParameterTypeID = $parameter_types[$key];
         $query_params["ParameterTypeID"] = $ParameterTypeID;
     } else {
         $ParameterTypeID = "";


### PR DESCRIPTION
Fix the data_dictionary_builder.php script 
~~by enforcing the unique key constraint Name + SourceFrom.~~
by reducing the scope of the main query to instruments. Instruments have unique parameter names, and the script is intended to  build a dictionary for instruments. 

Error below was encountered with EEG/MRI parameter_file fields.

Error seen when 2 parameter_type entries share the same Name:
```
lorisadmin@smathew-dev:/var/www/loris/project/tools/exporters$ php data_dictionary_builder.php
Could not execute Select Name, ParameterTypeID from parameter_type. Stack trace#0 /var/www/loris/project/tools/exporters/data_dictionary_builder.php(60): Database->pselectColWithIndexKey()
#1 {main}
PHP Fatal error:  Uncaught DatabaseException: The uniqueKey supplied to pselectColWithIndexKey() does not 
                    appear to be unique or is nullable. This function expects the 
                    key to be both UNIQUE and NOT NULL. in /var/www/loris/php/libraries/Database.class.inc:971
Stack trace:
#0 /var/www/loris/project/tools/exporters/data_dictionary_builder.php(60): Database->pselectColWithIndexKey()
```