### PR TITLE
[notification] Fix sender name in email

### DIFF
--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -86,7 +86,7 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
             $notifierID  = $this->notifier->getId();
-            $senderName  = $this->notifier->getUsername();
+            $senderName  = $this->notifier->getFullname();
             $senderEmail = $this->notifier->getEmail();
             $this->tpl_data['notified_user'] = $name;
             $this->tpl_data['notifier_user'] = "$senderName <$senderEmail>";

--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -86,9 +86,10 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
             $notifierID  = $this->notifier->getId();
+            $senderName  = $this->notifier->getUsername();
             $senderEmail = $this->notifier->getEmail();
             $this->tpl_data['notified_user'] = $name;
-            $this->tpl_data['notifier_user'] = "$notifierID <$senderEmail>";
+            $this->tpl_data['notifier_user'] = "$senderName <$senderEmail>";
             $recipientEmail = $this->getEmail((int)$uid);
 
             if ($notifierID === $uid) {
@@ -99,7 +100,8 @@ class NDB_Notifier extends NDB_Notifier_Abstract
                     $this->template,
                     $this->tpl_data
                 );
-                $this->log((int)$notifierID, (int)$uid, 'email_text');
+
+                $this->log($notifierID, (int)$uid, 'email_text');
             }
         }
     }


### PR DESCRIPTION
## Brief summary of changes

Display the name of the user instead of their ID in the notification emails.

#### Testing instructions

1. Trigger an email notification which displays the sender name in the email (such as media file upload).

#### Link(s) to related issue(s)

* Resolves #9202
