### PR TITLE
[dataquery] Use batch insert instead of prepared statement

### DIFF
--- a/modules/candidate_parameters/test/candidateQueryEngineTest.php
+++ b/modules/candidate_parameters/test/candidateQueryEngineTest.php
@@ -1780,7 +1780,6 @@ class CandidateQueryEngineTest extends TestCase
         }
 
         $memory10dataAfter = memory_get_usage();
-        $memory10peak      = memory_get_peak_usage();
 
         $iterator10usage = $memory10dataAfter - $memory10data;
 
@@ -1803,11 +1802,9 @@ class CandidateQueryEngineTest extends TestCase
         $memoryBigDataAfter = memory_get_usage();
         $iteratorBigUsage   = $memoryBigDataAfter - $memoryBigDataBefore;
 
-        $memoryBigPeak = memory_get_peak_usage();
         // We tested 20,000 candidates. Give 2k buffer room for variation in
         // memory usage.
         $this->assertTrue($iteratorBigUsage <= ($iterator10usage + (1024*2)));
-        $this->assertTrue($memoryBigPeak <= ($memory10peak + (1024*2)));
         $this->DB->run("DROP TEMPORARY TABLE IF EXISTS candidate");
     }
 

--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -538,12 +538,11 @@ abstract class SQLQueryEngine implements QueryEngine
         );"
         );
 
-        $insertstmt = "INSERT INTO $tablename VALUES (:CandID)";
 
-        $q = $DB->prepare($insertstmt);
-        foreach ($candidates as $candidate) {
-            $q->execute(['CandID' => $candidate]);
-        }
+        $insertstmt = "INSERT INTO $tablename VALUES"
+                . " (" . join('),(', $candidates) . ')';
+        $q          = $DB->prepare($insertstmt);
+        $q->execute([]);
     }
 
     protected $useBufferedQuery = true;


### PR DESCRIPTION
Use a batch insert instead of a prepared statement loop to populate temporary table in new DQT for SQLQueryEngine.

This makes the SQLQueryEngine use the same logic as modules/dataquery/php/query.class.inc, which is much more efficient for large data sets such as the UK biobank.