### PR TITLE
[publication] Fix download prevention by overriding download notification function

### DIFF
--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -52,11 +52,11 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
 
     /**
      * Send a notification for the download.
-     * 
+     *
      * @param string $file The filename being downloaded
      *
      * @return void
-     * 
+     *
      * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
      * Next line suppressed due to false-positive
      * Unused parameter $file required to match parent signature

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -52,10 +52,14 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
 
     /**
      * Send a notification for the download.
-     *
+     * 
      * @param string $file The filename being downloaded
      *
      * @return void
+     * 
+     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
+     * Next line suppressed due to false-positive
+     * Unused parameter $file required to match parent signature
      */
     protected function doDownloadNotification($file)
     {

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -59,6 +59,7 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
      * @param string $file The filename being downloaded
      *
      * @return void
+     *
      * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
      */
     protected function doDownloadNotification($file)

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -1,4 +1,9 @@
 <?php
+
+// @phan-file-suppress PhanUnusedProtectedMethodParameter
+// Suppressed due to false-positive for doDownloadNotification function
+// Unused parameter $file required to match parent signature
+
 namespace LORIS\publication;
 
 /**
@@ -53,14 +58,10 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
     /**
      * Send a notification for the download.
      *
-     * Next line suppressed due to false-positive
-     * Unused parameter $file required to match parent signature
-     *
      * @param string $file The filename being downloaded
      *
      * @return void
-     *
-     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter */
+     */
     protected function doDownloadNotification($file)
     {
         // Not implemented for this module

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -60,8 +60,7 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
      *
      * @return void
      *
-     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
-     */
+     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter */
     protected function doDownloadNotification($file)
     {
         // Not implemented for this module

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -53,15 +53,14 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
     /**
      * Send a notification for the download.
      *
+     * Next line suppressed due to false-positive
+     * Unused parameter $file required to match parent signature
+     *
      * @param string $file The filename being downloaded
      *
      * @return void
-     *
-     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
-     * Next line suppressed due to false-positive
-     * Unused parameter $file required to match parent signature
      */
-    protected function doDownloadNotification($file)
+    protected function doDownloadNotification($file) // @phan-suppress-current-line PhanUnusedProtectedMethodParameter
     {
         // Not implemented for this module
     }

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -60,7 +60,7 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
      *
      * @return void
      */
-    // @phan-suppress-next-line PhanUnusedProtectedMethodParameter
+    /** @phan-suppress-next-line PhanUnusedProtectedMethodParameter */
     protected function doDownloadNotification($file)
     {
         // Not implemented for this module

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -59,8 +59,8 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
      * @param string $file The filename being downloaded
      *
      * @return void
+     * @phan-suppress-next-line PhanUnusedProtectedMethodParameter
      */
-    /** @phan-suppress-next-line PhanUnusedProtectedMethodParameter */
     protected function doDownloadNotification($file)
     {
         // Not implemented for this module

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -49,4 +49,16 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
     {
         return "/files/";
     }
+
+    /**
+     * Send a notification for the download.
+     *
+     * @param string $file The filename being downloaded
+     *
+     * @return void
+     */
+    protected function doDownloadNotification($file)
+    {
+        // Not implemented for this module
+    }
 }

--- a/modules/publication/php/files.class.inc
+++ b/modules/publication/php/files.class.inc
@@ -60,7 +60,8 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
      *
      * @return void
      */
-    protected function doDownloadNotification($file) // @phan-suppress-current-line PhanUnusedProtectedMethodParameter
+    // @phan-suppress-next-line PhanUnusedProtectedMethodParameter
+    protected function doDownloadNotification($file)
     {
         // Not implemented for this module
     }


### PR DESCRIPTION
Closes #9133.

An error regarding the non-existence of a `notification_module` with module: `publication` and operation: `download` prevented the downloading of files.

The notification function was overridden for this module to bypass the `LorisException` thrown by the non-existence of entries. It appeared by far to be a simpler solution than checking for and adding extra logic when the entries do not exist.