### PR TITLE
[isntrument_builder] blank page when trying to add a score 

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -19,6 +19,7 @@ import {
     TextElement,
     NumericElement,
     ButtonElement,
+    StaticElement,
 } from 'jsx/Form';
 
 /**


### PR DESCRIPTION
## Brief summary of changes

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. go to instrument builder
2. create a score element
3. make sure it is added correctly

#### Link(s) to related issue(s)
#9152

* Resolves #  (Reference the issue this fixes, if any.)
