### PR TITLE
[dicom archive] Remove superfluous newline in dicom archive view details

### DIFF
--- a/modules/dicom_archive/templates/form_viewDetails.tpl
+++ b/modules/dicom_archive/templates/form_viewDetails.tpl
@@ -80,14 +80,14 @@
   <tr>
     <th>md5sum of Archive</th>
     <td>
-      <pre><br><b>{$archive.md5sumArchive}</pre>
-      </b></td>
+      <pre><b>{$archive.md5sumArchive}</b></pre>
+    </td>
   </tr>
   <tr>
     <th>md5sum of Dicom unzipped</th>
-    <td><br><b>
-        <pre>{$archive.md5sumDicomOnly}</pre>
-      </b></td>
+    <td>
+      <pre><b>{$archive.md5sumDicomOnly}</b></pre>
+    </td>
   </tr>
   <tr>
     <th class="valign-top">Series</th>


### PR DESCRIPTION
Very small PR (free review !), it basically removes a superfluous newline that has been bugging me for a while in the DICOM archive.

Before :
![image](https://github.com/aces/Loris/assets/23308005/20358a32-ebf1-4dfe-bd4b-1440cdbc1043)

After :
![image](https://github.com/aces/Loris/assets/23308005/1d3cc156-635b-4c15-a6c9-6e233b1a7a15)
