### PR TITLE
[Settings] Cache settings after first retrieval

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -387,6 +387,7 @@ class NDB_Config
         throw new ConfigurationException("No setting $name in config.xml");
     }
 
+    protected $settingCache = [];
     /**
      * Gets a setting by name
      *
@@ -396,10 +397,14 @@ class NDB_Config
      */
     function getSetting(string $name)
     {
+        if (isset($this->settingCache[$name])) {
+            return $this->settingCache[$name];
+        }
         try {
             $XMLValue = $this->getSettingFromXML($name);
 
             if ($XMLValue !== null) {
+                $this->settingCache[$name] = $XMLValue;
                 return $XMLValue;
             }
         } catch (ConfigurationException $e) {
@@ -411,7 +416,10 @@ class NDB_Config
         // nothing in the config file, so get the value from the DB
         // This will throw a ConfigurationException if it does not
         // exist.
-        return $this->getSettingFromDB($name);
+        $DBVal = $this->getSettingFromDB($name);
+        $this->settingCache[$name] = $DBVal;
+        return $DBVal;
+
     }
 
     /**


### PR DESCRIPTION
There are a number of settings that we use frequently in LORIS such as "base" to get the base path. When accessed multiple times in a request at different places in LORIS, each one currently requires a query against the database.

This caches any settings that are used in NDB_Config so that future calls to `getSetting()` can return the cached value and not make another round trip to the DB.