### PR TITLE
[dashboard] Add project filter for tasks widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes in the following format: PR #1234***
 
 #### Updates and Improvements
 - Create new `sex` table to hold candidate sex options, and change Sex and ProbandSex columns of `candidate` table to a varchar(255) datatype that is restricted by the `sex` table (PR #9025)
+- Add Project filter for "My tasks" counts in dashboard (PR #9220)
 
 #### Bug Fixes
 - Fix examiner site display (PR #8967)

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -122,6 +122,7 @@ class Module extends \Module
                          s.CenterID <> 1",
                     'access_all_profiles',
                     's.CenterID',
+                    's.ProjectID',
                     $baseURL . '/' . $this->getName(),
                     'conflict_resolver'
                 )

--- a/modules/dashboard/php/taskquerywidget.class.inc
+++ b/modules/dashboard/php/taskquerywidget.class.inc
@@ -33,21 +33,23 @@ class TaskQueryWidget extends TaskWidget
     /**
      * Construct a TaskQueryWidget
      *
-     * @param \User     $user      The user whose tasks are being displayed
-     * @param string    $label     The label for the task widget. It should be
-     *                             singular and phrased in a way that adding
-     *                             an "s" pluralizes.
-     * @param \Database $db        The database connection for the query.
-     * @param string    $dbquery   The query to run to get a count.
-     * @param string    $allperm   The permission to use to determine if the user
-     *                             has access to all sites, or only user sites.
-     *                             If the empty string, center permissions will
-     *                             not be used.
-     * @param string    $sitefield The field to use in the query to site-restrict
-     *                             the results.
-     * @param string    $link      The link for the widget to go to when clicked.
-     * @param string    $cssclass  An optional css class to add to the task for
-     *                             testing.
+     * @param \User     $user         The user whose tasks are being displayed
+     * @param string    $label        The label for the task widget. It should be
+     *                                singular and phrased in a way that adding
+     *                                an "s" pluralizes.
+     * @param \Database $db           The database connection for the query.
+     * @param string    $dbquery      The query to run to get a count.
+     * @param string    $allperm      The permission to use to determine if the user
+     *                                has access to all sites, or only user sites.
+     *                                If the empty string, center permissions will
+     *                                not be used.
+     * @param string    $sitefield    The field to use in the query to site-restrict
+     *                                the results.
+     * @param string    $projectfield The field to use in the query to restrict the
+     *                                project in results.
+     * @param string    $link         The link for the widget to go to when clicked.
+     * @param string    $cssclass     An optional css class to add to the task for
+     *                                testing.
      */
     public function __construct(
         \User $user,
@@ -56,6 +58,7 @@ class TaskQueryWidget extends TaskWidget
         string $dbquery,
         string $allperm,
         string $sitefield,
+        string $projectfield,
         string $link,
         string $cssclass
     ) {
@@ -68,6 +71,10 @@ class TaskQueryWidget extends TaskWidget
                 $dbquery  .= " AND FIND_IN_SET($sitefield, :SiteID)";
                 $siteLabel = 'Site: All User Sites';
             }
+        }
+        if ($projectfield) {
+            $queryparams['ProjectID'] = implode(',', $user->getProjectIDs());
+            $dbquery .= " AND FIND_IN_SET($projectfield, :ProjectID)";
         }
 
         $number = (int )$db->pselectOne($dbquery, $queryparams);

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -83,6 +83,13 @@ class DashboardTest extends LorisIntegrationTest
             ]
         );
         $this->DB->insert(
+            "user_project_rel",
+            [
+                'UserID'    => $user_id,
+                'ProjectID' => '7777',
+            ]
+        );
+        $this->DB->insert(
             "candidate",
             [
                 'CandID'                => '999888',

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -86,7 +86,7 @@ class DashboardTest extends LorisIntegrationTest
             "user_project_rel",
             [
                 'UserID'    => $user_id,
-                'ProjectID' => '7777',
+                'ProjectID' => '1',
             ]
         );
         $this->DB->insert(
@@ -323,6 +323,17 @@ class DashboardTest extends LorisIntegrationTest
             ["Value" => null],
             ["ConfigID" => 48]
         );
+        $user_id = $this->DB->pselectOne(
+            "SELECT ID FROM users WHERE UserID=:test_user_id",
+            ["test_user_id" => 'testUser1']
+        );
+        $this->DB->delete(
+            "user_project_rel",
+            [
+                'UserID'    => $user_id,
+                'ProjectID' => '1',
+            ]
+        );
         $this->DB->run('SET foreign_key_checks =1');
         parent::tearDown();
     }
@@ -413,7 +424,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
             ".new-scans",
-            "10",
+            "4",
             "- Imaging Browser"
         );
         $this->resetPermissions();
@@ -443,7 +454,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
             ".conflict_resolver",
-            "574",
+            "570",
             "- Conflict Resolver"
         );
         $this->resetPermissions();
@@ -520,7 +531,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
             ".pending-accounts",
-            "2",
+            "1",
             "- User Accounts"
         );
         $this->resetPermissions();

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -80,6 +80,7 @@ class Module extends \Module
                          AND s.CenterID <> 1",
                     'imaging_browser_view_allsites',
                     's.CenterID',
+                    's.ProjectID',
                     $baseURL . "/imaging_browser/?pendingNew=N&pendingNew=P",
                     "new-scans"
                 )

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -135,6 +135,7 @@ class Module extends \Module
                         AND s.Active='Y' AND c.Active='Y'",
                     'access_all_profiles',
                     's.CenterID',
+                    's.ProjectID',
                     $baseURL . "/statistics/statistics_site/",
                     ""
                 ),

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -96,6 +96,7 @@ class Module extends \Module
                      . $DB->quote($user->getUsername()),
                     '',
                     '',
+                    '',
                     $baseURL . "/issue_tracker/?$url",
                     "issue_tracker"
                 )

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -86,9 +86,11 @@ class Module extends \Module
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
+                        LEFT JOIN user_project_rel upr2 ON (upr2.UserID=users.ID)
                     WHERE users.Pending_approval='Y'",
                     'user_accounts_multisite',
                     'upr.CenterID',
+                    'upr2.ProjectID',
                     $baseURL . "/user_accounts/?pendingApproval=Y",
                     "pending-accounts"
                 )


### PR DESCRIPTION
## Brief summary of changes
This PR adds a project filter for TaskQueryWidget so that a user will only see the relevant tasks to their own project assignments.
- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Login with a user that has only one project
2. Check that all of the task counts are relevant for only that project
3. Take note that the Imaging tasks may not reflect what is shown in the table results that it links to, I have created a separate issue [here](https://github.com/aces/Loris/issues/9219) for that.

#### Link(s) to related issue(s)

* Resolves #9130