### PR TITLE
[dataquery/dictionary] Add option to display enums as either value or field in dataquery module

### DIFF
--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -414,7 +414,11 @@ function valueInput(fielddict: FieldDictionary,
               i++
           ) {
              const opt = fielddict.options[i];
-             opts[opt] = opt;
+             if (fielddict.labels) {
+                 opts[opt] = fielddict.labels[i];
+             } else {
+                 opts[opt] = opt;
+             }
           }
           if (op == 'in') {
            return <SelectElement

--- a/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
+++ b/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
@@ -19,7 +19,7 @@ function useBreadcrumbs(
     useEffect(() => {
         const breadcrumbs = [
             {
-                text: 'Data Query Tool (Alpha)',
+                text: 'Data Query Tool (Beta)',
                 /**
                  * OnClick handler for the main breadcrumb
                  *
@@ -77,7 +77,7 @@ function useBreadcrumbs(
                  */
                 onClick: (e) => {
                     e.preventDefault();
-                    setActiveTab('View Data');
+                    setActiveTab('ViewData');
                 },
             });
         }

--- a/modules/dataquery/jsx/types.tsx
+++ b/modules/dataquery/jsx/types.tsx
@@ -111,6 +111,7 @@ export type FieldDictionary = {
     cardinality: 'unique' | 'single' | 'optional' | 'many',
     visits?: string[], // session only
     options?: string[], // enum only
+    labels?: string[], // enum only, and only if provided
 }
 
 export interface DictionaryCategory {

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -60,12 +60,25 @@ enum EnumDisplayTypes {
     EnumValue
 }
 
-function DisplayValue(props: {value: any, dictionary: FieldDictionary, enumDisplay: EnumDisplayTypes}) {
+/**
+ * Returns the value to display for a field.
+ *
+ * @param {object} props - React props
+ * @param {any} props.value - the value to be formatted
+ * @param {FieldDictionary} props.dictionary - The field's dictionary
+ * @param {EnumDisplayTypes} props.enumDisplay - The format to display enums
+ * @returns {React.ReactElement} - the mapped value
+ */
+function DisplayValue(props: {
+    value: any,
+    dictionary: FieldDictionary,
+    enumDisplay: EnumDisplayTypes}
+) {
     let display = props.value;
-    switch(props.enumDisplay) {
+    switch (props.enumDisplay) {
     case EnumDisplayTypes.EnumLabel:
         if (props.dictionary.labels && props.dictionary.options) {
-                for(let i = 0; i < props.dictionary.options.length; i++) {
+                for (let i = 0; i < props.dictionary.options.length; i++) {
                     if (props.dictionary.options[i] == props.value) {
                         display= props.dictionary.labels[i];
                         break;
@@ -303,7 +316,8 @@ function ViewData(props: {
         = useState<VisitOrgType>('inline');
     const [headerDisplay, setHeaderDisplay]
         = useState<HeaderDisplayType>('fieldnamedesc');
-    const [enumDisplay, setEnumDisplay] = useState<EnumDisplayTypes>(EnumDisplayTypes.EnumLabel);
+    const [enumDisplay, setEnumDisplay]
+        = useState<EnumDisplayTypes>(EnumDisplayTypes.EnumLabel);
     const queryData = useRunQuery(props.fields, props.filters, props.onRun);
     const organizedData = useDataOrganization(
         queryData,
@@ -436,7 +450,9 @@ function ViewData(props: {
                 'values': 'Values',
             }}
             label='Display options as'
-            value={enumDisplay == EnumDisplayTypes.EnumLabel ? 'labels' : 'values'}
+            value={enumDisplay == EnumDisplayTypes.EnumLabel
+                ? 'labels'
+                : 'values'}
             multiple={false}
             emptyOption={false}
             onUserInput={
@@ -763,6 +779,8 @@ function expandLongitudinalCells(
  * @param {array} dict - The full dictionary
  * @param {boolean} displayEmptyVisits - Whether visits with
                                  no data should be displayed
+ * @param {EnumDisplayTypes} enumDisplay - The format to display
+                                           enum values
  * @returns {function} - the appropriate column formatter for
                          this data organization
  */
@@ -876,17 +894,28 @@ function organizedFormatter(
                                             Object.keys(values).map(
                                                 (keyid: string):
                                                   React.ReactNode => {
-                                                    let val = values[keyid];
+                                                    const val = values[keyid];
                                                     if (val === null) {
                                                         return;
                                                     }
                                                     hasdata = true;
+                                                    // Workarounds for line length
+                                                    const f = fielddict;
+                                                    const e = enumDisplay;
+                                                    const dval = (
+                                                        <DisplayValue
+                                                           value={val}
+                                                           dictionary={f}
+                                                           enumDisplay={e}
+                                                         />
+                                                    );
+
                                                     return (
                                                         <div style={{
                                                             margin: '1ex',
                                                           }}>
                                                             <dt>{keyid}</dt>
-                                                            <dd><DisplayValue value={val} dictionary={fielddict} enumDisplay={enumDisplay} /></dd>
+                                                            <dd>{dval}</dd>
                                                         </div>
                                                     );
                                                 })

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -13,8 +13,6 @@ import getDictionaryDescription from './getdictionarydescription';
 
 type TableRow = (string|null)[];
 
-type JSONString = string;
-
 type SessionRowCell = {
     VisitLabel: string;
     value?: string
@@ -762,7 +760,10 @@ function expandLongitudinalCells(
                            .join(';'), dictionary: fielddict};
                     default:
                        if (thissession.value !== undefined) {
-                           return {value: thissession.value, dictionary: fielddict};
+                           return {
+                             value: thissession.value,
+                             dictionary: fielddict,
+                           };
                        }
                        throw new Error('Value was undefined');
                     }
@@ -1073,7 +1074,12 @@ function organizedFormatter(
                     return <td><i>(No data)</i></td>;
                 }
 
-                return <td><DisplayValue value={cellValue(cell.value)} dictionary={cell.dictionary} enumDisplay={enumDisplay} /></td>;
+                return (<td>
+                            <DisplayValue
+                                value={cellValue(cell.value)}
+                                dictionary={cell.dictionary}
+                                enumDisplay={enumDisplay} />
+                    </td>);
             })}</>;
         };
         return callback;
@@ -1081,8 +1087,11 @@ function organizedFormatter(
         /**
          * Callback that organizes data cross-sectionally
          *
-         * @param {string} label - The label for the column
-         * @param {string} cell - The raw cell value returned by the API.
+         * @param {string} label - The header label
+         * @param {string} cell - the JSON value of the cell
+         * @param {string[]} row - the entire row
+         * @param {string[]} headers - the headers for the table
+         * @param {number} fieldNo - The field number of this cell
          * @returns {React.ReactElement} - The table cell for this cell.
          */
         callback = (
@@ -1102,11 +1111,16 @@ function organizedFormatter(
 
             const fieldobj = fields[fieldNo-1];
             const fielddict = getDictionary(fieldobj, dict);
-            console.log(fielddict, fieldobj, cell);
 
             return fielddict === null
                 ? <TableCell data={cell} />
-                : <td><DisplayValue value={cellValue(cell)} dictionary={fielddict} enumDisplay={enumDisplay} /></td>;
+                : (<td>
+                    <DisplayValue
+                        value={cellValue(cell)}
+                        dictionary={fielddict}
+                        enumDisplay={enumDisplay}
+                    />
+                  </td>);
         };
         return callback;
     }

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -645,6 +645,7 @@ function organizedMapper(
             if (value === null) {
                 return '';
             }
+
             return cellValue(value);
         };
     case 'longitudinal':
@@ -1079,11 +1080,28 @@ function organizedFormatter(
          * @param {string} cell - The raw cell value returned by the API.
          * @returns {React.ReactElement} - The table cell for this cell.
          */
-        callback = (label: string, cell: JSONString): ReactNode => {
+        callback = (
+            label: string,
+            cell: string,
+            row: TableRow,
+            headers: string[],
+            fieldNo: number
+        ): ReactNode => {
             if (cell === null) {
                 return <td><i>No data for visit</i></td>;
             }
-            return <TableCell data={cell} />;
+            if (fieldNo == 0) {
+                // automatically added Visit column
+                return <TableCell data={cell} />;
+            }
+
+            const fieldobj = fields[fieldNo-1];
+            const fielddict = getDictionary(fieldobj, dict);
+            console.log(fielddict, fieldobj, cell);
+
+            return fielddict === null
+                ? <TableCell data={cell} />
+                : <td><DisplayValue value={cellValue(cell)} dictionary={fielddict} enumDisplay={enumDisplay} /></td>;
         };
         return callback;
     }

--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -37,7 +37,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Query Tool (Alpha)";
+        return "Data Query Tool (Beta)";
     }
 
     /**

--- a/modules/dictionary/php/moduledict.class.inc
+++ b/modules/dictionary/php/moduledict.class.inc
@@ -99,6 +99,10 @@ class ModuleDict extends \NDB_Page
             ];
             if ($datatype instanceof \LORIS\Data\Types\Enumeration) {
                 $organized[$cat][$fieldname]['options'] = $datatype->getOptions();
+                $labels = $datatype->getLabels();
+                if (!empty($labels)) {
+                    $organized[$cat][$fieldname]['labels'] = $datatype->getLabels();
+                }
             }
             if ($scope->__toString() == "session") {
                 $organized[$cat][$fieldname]['visits'] = $row->getVisits();

--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -94,20 +94,23 @@ trait LorisFormDictionaryImpl
                 // "1" array_keys turns it into an int and we want to
                 // ignore null/empty, so instead we just walk through
                 // the array and coerce things to a string.
-                $keys = [];
-                foreach (array_keys($element['options']) as $key) {
+                $keys   = [];
+                $labels = [];
+                foreach ($element['options'] as $key => $label) {
                     if ($key === '' || $key === null) {
                         continue;
                     }
 
                     // Coerce it to a string
-                    $keys[] = "$key";
+                    $keys[]   = "$key";
+                    $labels[] = "$label";
                 }
                 if (array_key_exists('multiple', $element)) {
                     $card = new Cardinality(Cardinality::MANY);
                 }
 
                 $t = new \LORIS\Data\Types\Enumeration(...$keys);
+                $t = $t->withLabels(...$labels);
                 break;
             case 'text':
                 $t = new \LORIS\Data\Types\StringType(255);

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -732,9 +732,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->selectMultipleElements[] = $pieces[1];
                     // fall through and also execute select code below
                 case 'select':
-                    $options  = preg_split("/{-}/", trim($pieces[3]));
-                    $opt      = [];
-                    $dictopts = [];
+                    $options    = preg_split("/{-}/", trim($pieces[3]));
+                    $opt        = [];
+                    $dictopts   = [];
+                    $dictlabels = [];
 
                     foreach ($options as $o) {
                         $arr = explode("=>", $o);
@@ -750,7 +751,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
 
                         if ($key !== '') {
-                            $dictopts[] = $key;
+                            $dictopts[]   = $key;
+                            $dictlabels[] = $val;
                         }
                         $opt[$key] = $val;
                     }
@@ -807,6 +809,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     }
 
                     $t  = new Enumeration(...$dictopts);
+                    $t  = $t->withLabels(...$dictlabels);
                     $it = new DictionaryItem(
                         $this->testName."_".$pieces[1],
                         $pieces[2],

--- a/src/Data/Types/Enumeration.php
+++ b/src/Data/Types/Enumeration.php
@@ -9,7 +9,16 @@ namespace LORIS\Data\Types;
  */
 class Enumeration implements \LORIS\Data\Type
 {
+    /**
+     * Valid options for this Enumeration
+     */
     protected $options = [];
+
+    /**
+     * Optional labels for the Enumeration value. This must either be
+     * null or an array of equal length to options.
+     */
+    protected $labels = null;
 
     /**
      * Construct an Enumeration type
@@ -61,5 +70,30 @@ class Enumeration implements \LORIS\Data\Type
     public function asSQLType() : string
     {
         return "enum(" . join(",", $this->options) . ")";
+    }
+
+    /**
+     * Returns a new Enumeration which is identical to this one
+     * except with the options being accompanied by a label.
+     */
+    public function withLabels(string ...$labels)
+    {
+        if (count($labels) != count($this->options)) {
+            throw new \LengthException("Number of labels does not match number of options");
+        }
+        $new         = clone $this;
+        $new->labels = $labels;
+        return $new;
+    }
+
+    /**
+     * Return the labels for the values of this enum, or null
+     * if no labels have been provided.
+     *
+     * @return ?string[]
+     */
+    public function getLabels() : ?array
+    {
+        return $this->labels;
     }
 }


### PR DESCRIPTION
The dataquery module was showing the backend enum value, rather than the frontend label, which isn't very useful to most users.

This adds an option for the user to select how they want to display enums.

It also updates the menu label from "alpha" to "beta" since the module has now been tested with large data sets.