### PR TITLE
Fix unused vars eslint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,7 @@
         "ignoreComments": true
     }],
     "no-unexpected-multiline": "off",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "error",
     "no-useless-escape": "off",
     "no-dupe-keys": "off",
     "react/no-direct-mutation-state": "off",

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1529,21 +1529,6 @@ export class DateElement extends Component {
   }
 
   /**
-   * Called by React when the component has been rendered on the page.
-   */
-  componentDidMount() {
-    // Check if props minYear and maxYear are valid values if supplied
-    let minYear = this.props.minYear;
-    let maxYear = this.props.maxYear;
-    if (this.props.minYear === '' || this.props.minYear === null) {
-      minYear = '1000';
-    }
-    if (this.props.maxYear === '' || this.props.maxYear === null) {
-      maxYear = '9999';
-    }
-  }
-
-  /**
    * Handle change
    *
    * @param {object} e - Event

--- a/modules/document_repository/jsx/editForm.js
+++ b/modules/document_repository/jsx/editForm.js
@@ -8,7 +8,6 @@ import {
     TextareaElement,
     SelectElement,
     ButtonElement,
-    FileElement,
 } from 'jsx/Form';
 /**
  * Document Edit Form

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/fetchChunks.tsx
@@ -147,11 +147,6 @@ export const createFetchChunksEpic = (fromState: (any) => State) => (
                       Math.ceil(bounds.interval[1] - bounds.domain[0])
                     ) / recordingDuration;
 
-                  const interval : [number, number] = [
-                    Math.floor(i0),
-                    Math.min(Math.ceil(i1), numChunks),
-                  ];
-
                   return {
                     interval:
                       [

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -16,9 +16,7 @@ import {
     DateElement,
     TextboxElement,
     TextareaElement,
-    TextElement,
     NumericElement,
-    ButtonElement,
     StaticElement,
 } from 'jsx/Form';
 

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -14,7 +14,6 @@ import PropTypes from 'prop-types';
 import swal from 'sweetalert2';
 import {
     FormElement,
-    TextboxElement,
     TextareaElement,
     SelectElement,
     DateElement,


### PR DESCRIPTION
Fix errors unused-vars warnings that are easily fixed errors. I'm not sure of the impact of changing the remaining two since they're used in a destructuring context. Someone familiar with the EEG browser should fix (and test) them.

Upgrade rule from "warning" to "error" for javascript, while leaving it for typescript since there are two that are still unresolved.