### PR TITLE
[dictionary] Fix loading of dictionary module

### DIFF
--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -55,7 +55,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             "Demographics",
             "Candidate Demographics",
         );
-        $sexList      = \Utility::getSexList();
+        $sexList      = array_keys(\Utility::getSexList());
         $t            = new Enumeration(...$sexList);
         $demographics = $demographics->withItems(
             [


### PR DESCRIPTION
The "Sex" data type is incorrectly returning an object instead of an array for the field options of the dictionary because \Utility::getSexList returns an associative array, not an array.

This fixes it so that the dictionary module loads.