### PR TITLE
Fix webpack compilation of JS modules

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,8 @@ module.exports = function(api) {
       {
         "regenerator": true
       }
-    ]
+    ],
+    "@babel/plugin-transform-modules-commonjs"
   ];
   return {
     presets,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "@babel/cli": "^7.6.4",
                 "@babel/core": "^7.11.0",
                 "@babel/eslint-parser": "^7.19.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.1",
                 "@babel/preset-env": "^7.9.6",
                 "@babel/preset-react": "^7.6.3",
                 "@types/c3": "^0.7.8",
@@ -339,30 +340,32 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.18.6",
-            "license": "MIT",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.19.0",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+            "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.18.6",
-                "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
-                "@babel/types": "^7.19.0"
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.24.3",
+                "@babel/helper-simple-access": "^7.24.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
@@ -377,8 +380,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -416,10 +420,11 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.18.6",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+            "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
             "dependencies": {
-                "@babel/types": "^7.18.6"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -437,25 +442,28 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "license": "MIT",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1197,14 +1205,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.18.6",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
+            "integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.18.6",
-                "@babel/helper-plugin-utils": "^7.18.6",
-                "@babel/helper-simple-access": "^7.18.6",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
+                "@babel/helper-module-transforms": "^7.23.3",
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-simple-access": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1690,11 +1698,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.0",
-            "license": "MIT",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@babel/cli": "^7.6.4",
         "@babel/core": "^7.11.0",
         "@babel/eslint-parser": "^7.19.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.1",
         "@babel/preset-env": "^7.9.6",
         "@babel/preset-react": "^7.6.3",
         "@types/c3": "^0.7.8",


### PR DESCRIPTION
This seems to fix the issue found during the testing meeting, where there was a problem in the compilation of JS modules (found in the dataquery but probably in other places too).

For me, it looks like a clean solution, as we probably want to "unmodule" our code as late as possible, and thus in Babel, but I am not sure what caused the problem in the first place sooo.