### PR TITLE
[new_profile] Make list of available projects user dependent

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -231,15 +231,17 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             },
             $user->getProjects()
         );
-        if (!in_array($projectname, $userprojects, true)) {
-            return new \LORIS\Http\Response\JSON\Forbidden(
-                "You are not affiliated with the candidate's project"
-            );
-        }
+
         try {
             $project = \NDB_Factory::singleton()->project($projectname);
         } catch (\NotFound $e) {
             return new \LORIS\Http\Response\JSON\BadRequest($e->getMessage());
+        }
+
+        if (!in_array($projectname, $userprojects, true)) {
+            return new \LORIS\Http\Response\JSON\Forbidden(
+                "You are not affiliated with the candidate's project"
+            );
         }
 
         $centerid = array_search(

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -224,7 +224,18 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-        $projectname = $data['Candidate']['Project'] ?? '';
+        $projectname  = $data['Candidate']['Project'] ?? '';
+        $userprojects = array_map(
+            function ($project) {
+                return $project->getName();
+            },
+            $user->getProjects()
+        );
+        if (!in_array($projectname, $userprojects, true)) {
+            return new \LORIS\Http\Response\JSON\Forbidden(
+                "You are not affiliated with the candidate's project"
+            );
+        }
         try {
             $project = \NDB_Factory::singleton()->project($projectname);
         } catch (\NotFound $e) {

--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -99,7 +99,7 @@ class NewProfileIndex extends React.Component {
 
     let candidateObject = {
       'Candidate': {
-        'Project': configData.project[formData.project],
+        'Project': formData.project,
         // 'PSCID' : conditionally included below
         // 'EDC' : conditionally included below
         'DoB': formData.dobDate,

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -58,11 +58,9 @@ class New_Profile extends \NDB_Form
 
         // Get projects for the select dropdown
         $projList = [];
-        $projects = \Utility::getProjectList();
-        foreach ($projects as $projectID => $projectName) {
-            $projList[$projectID] = $projectName;
+        foreach ($user->getProjects() as $project) {
+            $projList[$project->getName()] = $project->getName();
         }
-        $project = $projList ?? null;
 
         // Get setting through pscid
         $PSCIDsettings = $config->getSetting('PSCID');
@@ -78,7 +76,7 @@ class New_Profile extends \NDB_Form
             'sex'       => $sex,
             'pscidSet'  => $pscidSet,
             'site'      => $site,
-            'project'   => $project,
+            'project'   => $projList,
         ];
     }
 

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -91,7 +91,7 @@ class NewProfileTestIntegrationTest extends LorisIntegrationTest
         $sexOption->selectByValue("1");
         $sexElement = $this->safeFindElement(WebDriverBy::Name('project'));
         $sexOption  = new WebDriverSelect($sexElement);
-        $sexOption->selectByValue("1");
+        $sexOption->selectByValue("Pumpernickel");
 
         $this->safeFindElement(
             WebDriverBy::cssSelector($this->dateTaken)


### PR DESCRIPTION
## Brief summary of changes
It seems like until this PR any user, regardless of their projects, could create participants for any other project. This is very problematic on the institutional LORIS instances like CBIG and BHI.

Currently submitted to CBIG as an override