### PR TITLE
[statistics] Do not depend on instrument table for queries

### DIFF
--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -68,14 +68,17 @@ class Statistics_DD_Site extends statistics_site
     /**
      * CompleteCount function
      *
-     * @param \CenterID  $centerID   the value of centerID
-     * @param \ProjectID $projectID  the value of projectID
-     * @param string     $instrument the value of instrument
+     * @param ?\CenterID  $centerID   the value of centerID
+     * @param ?\ProjectID $projectID  the value of projectID
+     * @param string      $instrument the value of instrument
      *
      * @return ?string
      */
-    function _completeCount($centerID, $projectID, $instrument): ?string
-    {
+    function _completeCount(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $instrument
+    ): ?string {
         $this->_checkCriteria($centerID, $projectID);
         $DB = $this->loris->getDatabaseConnection();
 
@@ -99,14 +102,17 @@ class Statistics_DD_Site extends statistics_site
     /**
      * GetResults function
      *
-     * @param \CenterID  $centerID   the value of centerID
-     * @param \ProjectID $projectID  the value of projectID
-     * @param string     $instrument the value of instrument
+     * @param ?\CenterID  $centerID   the value of centerID
+     * @param ?\ProjectID $projectID  the value of projectID
+     * @param string      $instrument the value of instrument
      *
      * @return array
      */
-    function _getResults($centerID, $projectID, $instrument)
-    {
+    function _getResults(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $instrument
+    ) {
         $this->_checkCriteria($centerID, $projectID);
         $DB = $this->loris->getDatabaseConnection();
         $safe_instrument = $DB->escape($instrument);

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -31,12 +31,12 @@ class Statistics_Mri_Site extends Statistics_Site
     /**
      * CheckCriteria function
      *
-     * @param \CenterID  $centerID  the value of centerID
-     * @param \ProjectID $projectID the value of projectID
+     * @param ?\CenterID  $centerID  the value of centerID
+     * @param ?\ProjectID $projectID the value of projectID
      *
      * @return void
      */
-    function _checkCriteria($centerID, $projectID)
+    function _checkCriteria(?\CenterID $centerID, ?\ProjectID $projectID)
     {
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
@@ -69,28 +69,34 @@ class Statistics_Mri_Site extends Statistics_Site
     /**
      * CompleteCount function
      *
-     * @param \CenterID  $centerID  the value of centerID
-     * @param \ProjectID $projectID the value of projectID
-     * @param string     $issue     the value of issue
+     * @param ?\CenterID  $centerID  the value of centerID
+     * @param ?\ProjectID $projectID the value of projectID
+     * @param string      $issue     the value of issue
      *
      * @return ?string
      */
-    function _completeCount($centerID, $projectID, $issue): ?string
-    {
+    function _completeCount(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $issue
+    ): ?string {
         return null;
     }
 
     /**
      * GetResults function
      *
-     * @param \CenterID  $centerID  the value of centerID
-     * @param \ProjectID $projectID the value of projectID
-     * @param string     $issue     the value of issue
+     * @param ?\CenterID  $centerID  the value of centerID
+     * @param ?\ProjectID $projectID the value of projectID
+     * @param string      $issue     the value of issue
      *
      * @return array
      */
-    function _getResults($centerID, $projectID, $issue)
-    {
+    function _getResults(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $issue
+    ) {
         $this->_checkCriteria($centerID, $projectID);
         $DB = $this->loris->getDatabaseConnection();
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -94,11 +94,10 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return void
      */
-    function _checkCriteria($centerID, $projectID)
+    function _checkCriteria(?\CenterID $centerID, ?\ProjectID $projectID)
     {
 
         //SITES
-        $projectID = new \ProjectID(strval($projectID));
         $factory   = \NDB_Factory::singleton();
         $user      = $factory->user();
 
@@ -178,30 +177,32 @@ class Statistics_Site extends \NDB_Menu
     /**
      * CompleteCount function
      *
-     * @param \CenterID  $centerID   the value of centerID
-     * @param \ProjectID $projectID  the value of projectID
-     * @param string     $instrument the value of instrument
+     * @param ?\CenterID  $centerID   the value of centerID
+     * @param ?\ProjectID $projectID  the value of projectID
+     * @param string      $instrument the value of instrument
      *
      * @return ?string
      */
-    function _completeCount($centerID, $projectID, $instrument): ?string
+    function _completeCount(?\CenterID $centerID, ?\ProjectID $projectID, string $instrument): ?string
     {
 
         $this->_checkCriteria($centerID, $projectID);
         $DB    = $this->loris->getDatabaseConnection();
         $count = $DB->pselectOne(
-            "SELECT count(s.CandID)  FROM session s,
-                candidate c, flag f, {$instrument} i
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID
-                AND s.CandID=c.CandID
-                AND s.Active='Y'
-                AND s.CenterID <> '1'
-                $this->query_criteria
-                AND f.Data_entry='Complete'
-                AND s.Current_stage <> 'Recycling Bin'
-                AND f.Administration='All'
-                AND i.CommentID NOT LIKE 'DDE%'",
-            $this->query_vars
+            "SELECT count(distinct s.CandID)  FROM 
+                flag f
+                    JOIN session s ON (s.ID=f.SessionID)
+                    JOIN candidate c ON (c.CandID=s.CandID)
+                WHERE 
+                    s.Active='Y' AND s.CenterID <> '1'
+                    AND c.Active='Y'
+                    $this->query_criteria
+                    AND f.Data_entry='Complete'
+                    AND s.Current_stage <> 'Recycling Bin'
+                    AND f.Administration='All'
+                    AND f.CommentID NOT LIKE 'DDE%'
+                    AND f.Test_name=:instrument",
+            ['instrument' => $instrument, ...$this->query_vars]
         );
         return $count;
     }
@@ -209,30 +210,30 @@ class Statistics_Site extends \NDB_Menu
     /**
      * GetResults function
      *
-     * @param \CenterID  $centerID   the value of centerID
-     * @param \ProjectID $projectID  the value of projectID
-     * @param string     $instrument the value of instrument
+     * @param ?\CenterID  $centerID   the value of centerID
+     * @param ?\ProjectID $projectID  the value of projectID
+     * @param string      $instrument the value of instrument
      *
      * @return array
      */
-    function _getResults($centerID, $projectID, $instrument)
+    function _getResults(?\CenterID $centerID, ?\ProjectID $projectID, string $instrument)
     {
         $this->_checkCriteria($centerID, $projectID);
         $DB     = $this->loris->getDatabaseConnection();
         $result = $DB->pselect(
-            "SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID,
-                s.Visit_label
-                FROM session s, candidate c, flag  f,
-                {$instrument} i
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID
-                AND s.CandID=c.CandID
-                AND s.Active='Y'
-                AND s.CenterID <> '1'
-                AND s.Current_stage <> 'Recycling Bin'
-                $this->query_criteria
-                AND (f.Data_entry is NULL OR f.Data_entry<>'Complete')
-                AND i.CommentID NOT LIKE 'DDE%' ORDER BY s.Visit_label, c.PSCID",
-            $this->query_vars
+            "SELECT DISTINCT s.CandID, f.SessionID, f.CommentID, c.PSCID, s.Visit_label
+                FROM flag f
+                    JOIN session s ON (s.ID=f.SessionID)
+                    JOIN candidate c ON (c.CandID=s.CandID)
+                WHERE s.Active='Y' AND c.Active='Y'
+                    AND s.CenterID <> '1'
+                    AND s.Current_stage <> 'Recycling Bin'
+                    $this->query_criteria
+                    AND f.Test_name=:instrument
+                    AND (f.Data_entry is NULL OR f.Data_entry<>'Complete')
+                    AND f.CommentID NOT LIKE 'DDE%'
+                ORDER BY s.Visit_label, c.PSCID",
+            ['instrument'=>$instrument, ...$this->query_vars]
         );
         return $result;
     }
@@ -256,12 +257,12 @@ class Statistics_Site extends \NDB_Menu
             $name     = $center['Name'] ?? '';
         } else {
             $name     = 'All';
-            $centerID = '';
+            $centerID = null;
         }
         if (!empty($_REQUEST['ProjectID'])) {
-            $projectID = $_REQUEST['ProjectID'];
+            $projectID = new \ProjectID($_REQUEST['ProjectID']);
         } else {
-            $projectID = '';
+            $projectID = null;
         }
         // List of all visits. Add to it any time a new one is seen, so
         // that we can iterate over it to display later, and leave blank

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -89,8 +89,8 @@ class Statistics_Site extends \NDB_Menu
     /**
      * CheckCriteria function
      *
-     * @param \CenterID  $centerID  the value of centerID
-     * @param \ProjectID $projectID the value of projectID
+     * @param ?\CenterID  $centerID  the value of centerID
+     * @param ?\ProjectID $projectID the value of projectID
      *
      * @return void
      */

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -98,8 +98,8 @@ class Statistics_Site extends \NDB_Menu
     {
 
         //SITES
-        $factory   = \NDB_Factory::singleton();
-        $user      = $factory->user();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
 
         if (!empty($centerID) && $user->hasCenter($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
@@ -183,13 +183,16 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return ?string
      */
-    function _completeCount(?\CenterID $centerID, ?\ProjectID $projectID, string $instrument): ?string
-    {
+    function _completeCount(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $instrument
+    ): ?string {
 
         $this->_checkCriteria($centerID, $projectID);
         $DB    = $this->loris->getDatabaseConnection();
         $count = $DB->pselectOne(
-            "SELECT count(distinct s.CandID)  FROM 
+            "SELECT COUNT(DISTINCT s.CandID)  FROM 
                 flag f
                     JOIN session s ON (s.ID=f.SessionID)
                     JOIN candidate c ON (c.CandID=s.CandID)
@@ -216,12 +219,19 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return array
      */
-    function _getResults(?\CenterID $centerID, ?\ProjectID $projectID, string $instrument)
-    {
+    function _getResults(
+        ?\CenterID $centerID,
+        ?\ProjectID $projectID,
+        string $instrument
+    ) {
         $this->_checkCriteria($centerID, $projectID);
         $DB     = $this->loris->getDatabaseConnection();
         $result = $DB->pselect(
-            "SELECT DISTINCT s.CandID, f.SessionID, f.CommentID, c.PSCID, s.Visit_label
+            "SELECT DISTINCT s.CandID,
+                f.SessionID,
+                f.CommentID,
+                c.PSCID,
+                s.Visit_label
                 FROM flag f
                     JOIN session s ON (s.ID=f.SessionID)
                     JOIN candidate c ON (c.CandID=s.CandID)


### PR DESCRIPTION
Update queries in statistics_site to not rely on instrument tables for the counts.

All the data required for the query was already in the flag table without having to join the data table.

Fixes #9232