### PR TITLE
[statistics] Fix timeseries graph spline bug

### DIFF
--- a/modules/statistics/jsx/widgets/chartBuilder.js
+++ b/modules/statistics/jsx/widgets/chartBuilder.js
@@ -210,8 +210,8 @@ const studyProgressionCharts = async () => {
     },
     spline: {
       interpolation: {
-        type: 'monotone'
-      }
+        type: 'monotone',
+      },
     },
     legend: {
       show: false,
@@ -289,8 +289,8 @@ const studyProgressionCharts = async () => {
     },
     spline: {
       interpolation: {
-        type: 'monotone'
-      }
+        type: 'monotone',
+      },
     },
     legend: {
       show: false,

--- a/modules/statistics/jsx/widgets/chartBuilder.js
+++ b/modules/statistics/jsx/widgets/chartBuilder.js
@@ -208,6 +208,11 @@ const studyProgressionCharts = async () => {
       columns: scanLineData,
       type: 'area-spline',
     },
+    spline: {
+      interpolation: {
+        type: 'monotone'
+      }
+    },
     legend: {
       show: false,
     },
@@ -281,6 +286,11 @@ const studyProgressionCharts = async () => {
       xFormat: '%m-%Y',
       columns: recruitmentLineData,
       type: 'area-spline',
+    },
+    spline: {
+      interpolation: {
+        type: 'monotone'
+      }
     },
     legend: {
       show: false,


### PR DESCRIPTION
This bug was noticed while testing a different module.

The `Study Progression - site scans` graph on the dashboard has a few instances of this bug: [spaces added to avoid cross-linking: github.com /c3js/ c3/issues/1885], where the timeseries goes back in time in order to make a smooth spline.

The simple fix was taken from the same issue.

Example pre-fix:
![Screenshot 2024-05-09 at 5 09 08 PM](https://github.com/aces/Loris/assets/15801528/68322814-fd83-44e7-82d7-9602d450764b)
