### PR TITLE
[dataquery] Require access to dictionary module

### DIFF
--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -17,7 +17,9 @@ class Module extends \Module
      */
     public function hasAccess(\User $user) : bool
     {
-        return parent::hasAccess($user) && $user->hasPermission('dataquery_view');
+        $dictionary = $this->loris->getModule("dictionary");
+        return parent::hasAccess($user) && $user->hasPermission('dataquery_view')
+            && $dictionary->hasAccess($user);
     }
 
     /**


### PR DESCRIPTION
The dataquery module uses the dictionary module's API to load the data dictionary. A user needs access to it for the dataquery module to load.

Fixes #9244