### PR TITLE
[dataquery] Fix strikethrough effect when field re-added

### DIFF
--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -584,7 +584,10 @@ function SelectedFieldList(props: {
             onMouseEnter={() => setRemovingIdx(i)}
             onMouseLeave={() => setRemovingIdx(null)}>
             <i
-                className="fas fa-trash-alt" onClick={() => removeField(item)}
+                className="fas fa-trash-alt" onClick={() => {
+                    removeField(item);
+                    setRemovingIdx(null);
+                }}
                 style={{cursor: 'pointer'}} />
         </div>
       </div>);


### PR DESCRIPTION
When a field is removed by the trashbin icon, the onMouseLeave for the hover effect doesn't fire as the component is unmounted. When a new field is added, the wrong "hover" index is set and it incorrectly shows a strike-through effect.

This is effectively the same fix as #9104 on a different tab.

Resolves #9249