### PR TITLE
[score_instrument] use getInstanceData to get the instrument data

### DIFF
--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -213,15 +213,9 @@ foreach ($testNames as $test) {
         );
 
         // call the score function
-        $oldRecord = $DB->pselectRow(
-            "SELECT * FROM $instrumentTable WHERE CommentID=:cid",
-            ['cid' => $record['CommentID']]
-        );
+        $oldRecord = $instrument->getInstanceData();
         $success   = $instrument->score();
-        $newRecord = $DB->pselectRow(
-            "SELECT * FROM $instrumentTable WHERE CommentID=:cid",
-            ['cid' => $record['CommentID']]
-        );
+        $newRecord = $instrument->getInstanceData();
         unset($oldRecord['Testdate']);
         unset($newRecord['Testdate']);
         $diff = array_diff_assoc($oldRecord, $newRecord);

--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -113,12 +113,14 @@ if (strtolower($test_name) != 'all') {
 }
 
 // check that the $test_name is a valid instrument
+$qparams = [];
 if ($test_name== 'all') {
     $query = "SELECT Test_name FROM test_names";
 } else {
-    $query = "SELECT Test_name FROM test_names WHERE Test_name = :tnm";
+    $query          = "SELECT Test_name FROM test_names WHERE Test_name = :tnm";
+    $qparams['tnm'] = $test_name;
 }
-$testNames = $DB->pselect($query, ['tnm' => $test_name]);
+$testNames = $DB->pselect($query, $qparams);
 
 // if nothing is returned than the instrument DNE
 if (!is_array($testNames) || count($testNames)==0) {


### PR DESCRIPTION
The score_instrument script breaks with JSON data. This updates the script to use getInstanceData() instead of trying to write an SQL query directly so that it works no matter what format the instrument saves data in.
