### PR TITLE
[EEG] Montage color map

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
@@ -20,6 +20,10 @@ type CProps = {
   setHidden: (_: number[]) => void,
   physioFileID: number,
   chunksURL: string,
+  colorMap?: {
+    color: string,
+    ids: Number[]
+  },
 };
 
 /**
@@ -33,6 +37,7 @@ const EEGMontage = (
     electrodes,
     physioFileID,
     chunksURL,
+    colorMap,
   }: CProps) => {
   if (electrodes.length === 0) return null;
 
@@ -137,6 +142,11 @@ const EEGMontage = (
     );
   };
 
+  // Remove points with no data
+  electrodes = electrodes.filter(e => e.position[0] && e.position[1]);
+
+  // Determine if the points are in an ALS or RAS coordinate system
+  // and the head ratio
   let ALSOrientation = false;
   let headRatio = 1;
   let montageRadius = 100;
@@ -168,7 +178,7 @@ const EEGMontage = (
   const scale3D = montageRadius / headRadius;
   const scale2D = montageRadius / stereographicProjection(headRadius, 0, 0, headRadius)[0];
 
-  electrodes.map((electrode) => {
+  electrodes.map((electrode, i) => {
     let electrodeCoords = electrode.position.slice();
 
     // SVG Y axis points toward bottom
@@ -206,6 +216,7 @@ const EEGMontage = (
   const Montage3D = () => (
     <Group>
       {point3D.rotateZ(angleZ).rotateX(angleX)(scatter3D).map((point, i) => {
+        const color = colorMap?.ids?.includes(i) ? colorMap?.color : '#000';
         return (
           <circle
             key={i}
@@ -255,32 +266,38 @@ const EEGMontage = (
         stroke="black"
         fill='white'
       />
-      {scatter2D.map((point, i) =>
-        <Group
-          className='electrode'
-          key={i}
-        >
-          <circle
-            cx={point.x}
-            cy={point.y}
-            r='7'
-            fill='white'
-            stroke={color}
-          >
-            <title>{electrodes[i].name}</title>
-          </circle>
-          <text
-            x={point.x}
-            y={point.y}
-            dominantBaseline="central"
-            textAnchor="middle"
-            fontSize="7px"
-          >
-            {i + 1}
-            <title>{electrodes[i].name}</title>
-          </text>
-        </Group>
-        )}
+      <Group>
+        {scatter2D.map((point, i) => {
+          const color = colorMap?.ids?.includes(i) ? colorMap?.color : '#000';
+          return (
+            <Group
+              className='electrode'
+              key={i}
+            >
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r='8'
+                fill='white'
+                stroke={color}
+              >
+                <title>{electrodes[i].name}</title>
+              </circle>
+              <text
+                x={point.x}
+                y={point.y}
+                dominantBaseline="central"
+                textAnchor="middle"
+                fontSize="8px"
+                fill={color}
+              >
+                {i + 1}
+                <title>{electrodes[i].name}</title>
+              </text>
+            </Group>
+          );
+        })}
+      </Group>
     </Group>
   );
 

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
@@ -53,8 +53,7 @@ const EEGMontage = (
   const scatter3D = [];
   const scatter2D = [];
   const startAngle = 0;
-  const color = '#000000';
-
+      
   const point3D = _3d()
     .x((d) => d.x)
     .y((d) => d.y)


### PR DESCRIPTION
Add a colormap to flag specific channels in the EEG montage:

<img width="419" alt="Screenshot 2024-06-04 at 10 04 26 AM" src="https://github.com/aces/Loris/assets/32041423/7b385fe7-7a99-4224-b0bc-bd410c8222ab">

To enable it, add the following in In `modules/electrophysiology_browser/jsx/electrophysiologySessionView.js`

```
<EEGMontage colorMap={
    { 
      color: '#FF0000',
      ids: [1,2,4,7] // index of electrodes to include in the colorMap
    }
 } />
```