### PR TITLE
Defining default decimal point for non JSON table LINST instruments

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -94,6 +94,12 @@ foreach ($instruments as $instrument) {
             case "radio":
                 $bits[0] = enumizeOptions($bits[3], $table = [], $bits[1]);
                 break;
+            case "numeric":
+                // without this option, default MySQL is simply numeric
+                // which is traduced to "decimal(10,0)"
+                // which truncates the floating point part.
+                $bits[0] = "decimal(14,4)";
+                break;
             case "select":
                 $bits[0]   = enumizeOptions(
                     $bits[3] ?? null,

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -87,6 +87,11 @@ foreach ($instruments as $instrument) {
                 $bits[0] = "varchar(255)";
             } elseif ($bits[0] == "static") {
                 $bits[0] = "varchar(255)";
+            } elseif ($bits[0] == "numeric") {
+                // without this option, default MySQL is simply numeric
+                // which is traduced to "decimal(10,0)"
+                // which truncates the floating point part.
+                $bits[0] = "decimal(14,4)";
             }
 
             $output .= "`$bits[1]` $bits[0] default NULL,\n";


### PR DESCRIPTION
## Brief summary of changes

This PR forces the `decimal(14,4)` (10 digits on the integer part, and 4 digits on the floating point part), instead of `decimal(10,0)` which is the default for `numeric` and was truncating floating point digits. 
It only applies this change for instruments that require their own table (non JSON) and have `numeric` attribute.

#### Testing instructions (if applicable)

1. use `tools/generate_tables_sql.php` and `tools/generate_tables_sql_and_testNames.php` with a **non JSON LINST instrument** with at least a `numeric` type line.
2. the resulting SQL should be a valid SQL code that add a `decimal(14,4)` type for the numeric attribute, instead of a `numeric` attribute.

#### Link(s) to related issue(s)

Resolves #9237
