### PR TITLE
[imaging_uploader] Invalid log message shown for uploads with status …

### DIFF
--- a/modules/imaging_uploader/js/imaging_uploader_helper.js
+++ b/modules/imaging_uploader/js/imaging_uploader_helper.js
@@ -129,7 +129,7 @@ function UploadProgress() {
             return UploadProgress.PIPELINE_STATUS_UNKNOWN;
         }
 
-        if(this._progressFromServer.inserting == null) {
+        if(this._progressFromServer.inserting == '') {
             return UploadProgress.PIPELINE_STATUS_NOT_STARTED;
         }
 


### PR DESCRIPTION
When you click on an upload in the `imaging_uploader'`s search result list that has a status set to 'Not Started', the log message shown in the log window says that the MRI pipeline is finished and failed for that upload. This PR sets the log message to its appropriate value: `MRI pipeline not yet executed for this upload`

Fixes #8823 (this is a special case of the problem described above)