### PR TITLE
[tools] Refactor recreate_conflicts.php to use getInstrumentNamesList()

### DIFF
--- a/tools/recreate_conflicts.php
+++ b/tools/recreate_conflicts.php
@@ -46,7 +46,7 @@ if (empty($argv[1]) || $argv[1] == 'help') {
 $action = $argv[1];
 
 if ($action=='all') {
-    $allInstruments = Utility::getAllInstruments();
+    $allInstruments = NDB_BVL_Instrument::getInstrumentNamesList($lorisInstance);
     $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 } else {
     $allInstruments = [$action => $action];


### PR DESCRIPTION
## Brief summary of changes
Refactored `recreate_conflicts.php` to replace the deprecated `Utility::getAllInstruments()` function with `NDB_BVL_Instrument::getInstrumentNamesList($lorisInstance)
`
#### Testing instructions (if applicable)

1. Navigate to /var/www/loris/tools.
2. Run the script with the command `php recreate_conflicts.php all`.
3. Verify that the script runs without the deprecation error and correctly retrieves all instrument names.

#### Link(s) to related issue(s)

* Resolves #9267 
