### PR TITLE
[imaging_uploader] Make auto-launch info popup modal

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -312,8 +312,10 @@ class UploadForm extends Component {
           title: 'Upload Successful!',
           text: text,
           type: 'success',
+          confirmButtonText: 'OK'
+        }).then((result) => {
+            window.location.assign(loris.BaseURL + '/imaging_uploader/');
         });
-        window.location.assign(loris.BaseURL + '/imaging_uploader/');
       } else {
         this.processError(xhr);
       }

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -312,7 +312,7 @@ class UploadForm extends Component {
           title: 'Upload Successful!',
           text: text,
           type: 'success',
-          confirmButtonText: 'OK'
+          confirmButtonText: 'OK',
         }).then((result) => {
             window.location.assign(loris.BaseURL + '/imaging_uploader/');
         });


### PR DESCRIPTION
When config option ImagingUploaderAutoLaunch is on and you successfully upload a scan, there is a popup that appears indicating that the MRI pipeline has been launched in order to process the scan. This PR makes the popup modal (i.e user has to click Ok for the popup to disappear).



Fixes #9286 
