### PR TITLE
[media] Remove instrument autoselect

### DIFF
--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -120,13 +120,13 @@ class MediaUploadForm extends Component {
       this.state.Data.sessionData[this.state.formData.pscid]
         .instruments[this.state.formData.visitLabel] :
           {};
-          const visitErrMsg = visits && visits.length === 0 ?
-            'No visits available for this candidate' :
-            '';
-          const instErrMsg = instruments && instruments.length === 0 ?
-            'No instruments available for this visit' :
-            '';
-          return (
+    const visitErrMsg = visits && visits.length === 0 ?
+      'No visits available for this candidate' :
+      '';
+    const instErrMsg = instruments && instruments.length === 0 ?
+      'No instruments available for this visit' :
+      '';
+    return (
       <div className='row'>
         <div className='col-md-8 col-lg-7'>
           <FormElement
@@ -172,6 +172,7 @@ class MediaUploadForm extends Component {
               ref='instrument'
               required={false}
               value={this.state.formData.instrument}
+              autoSelect={false}
               disabled={this.state.formData.pscid == null}
             />
             <DateElement

--- a/modules/media/test/TestPlan.md
+++ b/modules/media/test/TestPlan.md
@@ -49,15 +49,16 @@ is selected, the file name should should start with [PSCID]\_[Visit Label]\_[Ins
     - An error dialog should appear to notify that you must select a **PSCID** as it is a required field ❌
   2. Select PSCID and click on the 👉  **Upload file** button
     - An error dialog should appear to notify that you must select a **Visit Label** as it is a required field ❌
-  3. Select Visit Label and click on the 👉  **Upload file**
+  3. Try adding a **PSCID** and **Visit Label** combination where there is only one relevant instrument. Make sure that the instrument is not selected by default.
+  4. Select Visit Label and click on the 👉  **Upload file**
     - An error dialog should appear to notify that you must select a **File** as it is a required field ❌
-  4. Click on the 👉 **Browse** button and a select a file from your file system
+  5. Click on the 👉 **Browse** button and a select a file from your file system
     - Note: it is suggested to try different file types and sizes (e.g pdf, mp4, mov, jpg, doc, etc)
-  5. After you selected the file click on **Upload File**
+  6. After you selected the file click on **Upload File**
     - An error dialog should appear to notify that you must name the file according to the requested format (unless already done so)
     - Once file is named properly clicking on **Upload File** button should trigger file upload and display a progress bar.
-  6. Once the file finished uploading, a modal containing a success message should appear with an 'OK' button.
-  7. Click on the 👉 **OK** button and the page should refresh to the browse tab. Make sure the file you just uploaded is shown in the data table.
+  7. Once the file finished uploading, a modal containing a success message should appear with an 'OK' button.
+  8. Click on the 👉 **OK** button and the page should refresh to the browse tab. Make sure the file you just uploaded is shown in the data table.
 
 **Test file browsing** 
   1. After a couple of files are uploaded, make sure they are properly displayed in the data table


### PR DESCRIPTION
## Brief summary of changes
This PR removes autoselect for the instrument field in the upload file form. This means that if there is only one instrument in the array, the one instrument will not be selected by default.

I also fixed a spacing issue that I saw in the uploadForm.js file, but is unrelated to this change.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to the "Upload" tab of the media module
2. Find a PSCID / Visit combination that only has one instrument (if on raisinbread data, try V2 of DCC702)
3. Make sure that after both a PSCID and Visit are entered, the instrument field remains blank and is not autoselected.

#### Link(s) to related issue(s)

* Resolves #9272
