### PR TITLE
[imaging_uploader] Auto-launch failure not reported in server process manager module

### DIFF
--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -167,47 +167,84 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 || $ImagingUploaderAutoLaunch == 'true'
             ) {
                 try {
+                    $this->setMriUploadInserting($db, $this->mri_upload_id, 1);
+
                     // Perform the real upload on the server
                     $serverProcessLauncher = new SP\ServerProcessLauncher();
-                    $serverProcessLauncher->mriUpload(
+                    $mriUploadProcess      = $serverProcessLauncher->mriUpload(
                         $this->mri_upload_id,
                         $this->uploaded_file_path
                     );
-                    $db->update(
-                        'mri_upload',
-                        ['Inserting' => 1],
-                        ['UploadID' => $this->mri_upload_id]
-                    );
                 } catch (\Exception $e) {
-                    $notificationTypeID = $db->pselectOne(
-                        "SELECT NotificationTypeID
-                         FROM notification_types
-                         WHERE Type = :type",
-                        ['type' => 'mri upload handler emergency']
+                    $message = 'MRI pipeline could not be started: '
+                             . $e->getMessage() . "\n"
+                             . 'This indicates an incorrect or non-'
+                             . "existent MRI pipeline setup\n";
+                    $this->addLaunchFailureNotification(
+                        $message,
+                        $this->mri_upload_id
                     );
-                    $values = [
-                        'NotificationTypeID' => $notificationTypeID,
-                        'Message'            => 'MRI pipeline could not be '
-                                              . 'started: ' . $e->getMessage() . "\n"
-                                              . 'This indicates an incorrect or non-'
-                                              . "existent MRI pipeline setup\n",
-                        'Origin'             => 'Launch of the MRI pipeline',
-                        'ProcessID'          => $this->mri_upload_id,
-                        'Error'              => 'Y',
-                        'Verbose'            => 'N',
-                    ];
-                    $db->insert('notification_spool', $values);
-                    $db->update(
-                        'mri_upload',
-                        ['Inserting' => 0],
-                        ['UploadID' => $this->mri_upload_id]
-                    );
+                    $this->setMriUploadInserting($db, $this->mri_upload_id, null);
                     return false;
+                }
+
+                if (!$mriUploadProcess->isRunning()) {
+                    $this->setMriUploadInserting($db, $this->mri_upload_id, 0);
                 }
             }
             return true;
         }
         return false;
+    }
+
+    /**
+     * Adds a record in table notification_spool indicating that the
+     * MRI pipeline could not be launched successfully.
+     *
+     * @param $message  reason for the launch failure.
+     * @param $uploadID ID of the upload that the pipeline was meant to process.
+     *
+     * @return void.
+     */
+    function addLaunchFailureNotification($message, $uploadID)
+    {
+        $notificationTypeID = $db->pselectOne(
+            "SELECT NotificationTypeID
+             FROM notification_types
+             WHERE Type = :type",
+            ['type' => 'mri upload handler emergency']
+        );
+
+        $values = [
+            'NotificationTypeID' => $notificationTypeID,
+            'Message'            => $message,
+            'Origin'             => 'Launch of the MRI pipeline',
+            'ProcessID'          => $uploadID,
+            'Error'              => 'Y',
+            'Verbose'            => 'N',
+        ];
+
+        $db->insert('notification_spool', $values);
+    }
+
+    /**
+     * Set the value of column Inserting in table mri_upload for a
+     * given upload ID.
+     *
+     * @param $db        database object.
+     * @param $uploadID  ID of the upload for which Inserting should be
+     *                   set.
+     * @param $inserting new value for the inserting column.
+     *
+     * @return void.
+     */
+    function setMriUploadInserting($db, $uploadID, $inserting)
+    {
+        $db->update(
+            'mri_upload',
+            ['Inserting' => $inserting],
+            ['UploadID'  => $uploadID]
+        );
     }
 
     // methods available to all children

--- a/modules/server_processes_manager/php/abstractserverprocess.class.inc
+++ b/modules/server_processes_manager/php/abstractserverprocess.class.inc
@@ -123,6 +123,9 @@ abstract class AbstractServerProcess
      */
     private $_exitText;
 
+
+    private $_processSyncListeners = [];
+
     /**
      * Build a new server process
      *
@@ -168,6 +171,18 @@ abstract class AbstractServerProcess
     public function getId()
     {
         return $this->_id;
+    }
+
+    /**
+     * Mutator for field $_id.
+     *
+     * @param $id new value for field $_id.
+     *
+     * @return void.
+     */
+    public function setId($id)
+    {
+        $this->_id = $id;
     }
 
     /**
@@ -258,7 +273,9 @@ abstract class AbstractServerProcess
             $this->getStderrFile(),
             $this->getExitCodeFile()
         );
+        error_log("*** before start");
         $process->start();
+        error_log("*** after start");
 
         //-------------------------
         // Store PID and start time
@@ -306,11 +323,13 @@ abstract class AbstractServerProcess
     public function getExitCode()
     {
         if ($this->isRunning()) {
+               error_log("**** Process is running so returning null");
                return null;
         }
 
         // Check if class attribute is set
         if (!is_null($this->_exitCode)) {
+               error_log("**** exit code is set so returning it");
                return $this->_exitCode;
         }
 
@@ -318,6 +337,7 @@ abstract class AbstractServerProcess
         // attributes are up to date
         $this->_syncTaskProperties();
 
+        error_log("**** Returning " . $this->_exitCode);
         return $this->_exitCode;
     }
 
@@ -372,6 +392,18 @@ abstract class AbstractServerProcess
     }
 
     /**
+     * Adds a listener to class variable $_processSyncListeners.
+     *
+     * @param $listener listener to add.
+     *
+     * @return void.
+     */
+    public function addProcessSyncListener($listener)
+    {
+        $this->_processSyncListeners[] = $listener;
+    }
+
+    /**
      * Updates the current object and its associated information in the database
      * in order to reflect the task's current state. This should be done if
      * execution of the task is finished to update all attributes related to the
@@ -394,6 +426,7 @@ abstract class AbstractServerProcess
         ) {
             $exitCode = 'unknown';
         } else {
+            error_log("**** exit code file exists");
             //-----------------------------------------------------
             // Read the exitCodeFile and fetch the unique number
             // written in there
@@ -405,6 +438,7 @@ abstract class AbstractServerProcess
             );
 
             if ($tailReturnCode != 0) {
+                error_log("**** Failed to retrieve exit code");
                 $errorMessage
                     = "Failed to retrieve exit code of process with pid "
                       . $this->getPid() . " in "
@@ -414,6 +448,7 @@ abstract class AbstractServerProcess
             }
 
             if (count($tailOutput) != 1) {
+                error_log("**** Invalid exit code file content");
                 $errorMessage
                     = "Invalid exit code file content (pid = "
                       . $this->getPid() . "): found "
@@ -423,12 +458,15 @@ abstract class AbstractServerProcess
             }
 
             if (!is_numeric($tailOutput[0])) {
+                error_log("**** Invalid exist code file content (non-num)");
                 $errorMessage
                     = "Invalid exit code file content (pid = "
                       . $this->getPid() . "): $tailOutput[0]";
                 error_log($errorMessage);
                 throw new \UnexpectedValueException($errorMessage);
             }
+
+            error_log("**** Setting exit code to " . $tailOutput[0]);
 
             $exitCode = $tailOutput[0];
         }
@@ -453,41 +491,24 @@ abstract class AbstractServerProcess
                // Problem with the exit code file: end time is unknown (null)
             $endTime = null;
         }
-
+        error_log("**** Hello!!!!");
         $exitText = $this->computeExitText($exitCode, $endTime);
-
-        //--------------------------------------------------------------------------
-        // Update object and database values to reflect what was computed previously
-        //--------------------------------------------------------------------------
-        $setValues   = [
-            'exit_text' => $exitText,
-            'exit_code' => $exitCode,
-            'end_time'  => $endTime,
-        ];
-        $whereValues = ['id' => $this->getId()];
-
-        try {
-            $this->getDatabaseProvider()->getDatabase()->update(
-                'server_processes',
-                $setValues,
-                $whereValues
-            );
-        } catch (\DatabaseException $exception) {
-            error_log(
-                "Failed to update task (pid=" . $this->getPid() . ") status: "
-                . $exception->getMessage()
-            );
-        }
 
         $this->_exitCode = $exitCode;
         $this->_exitText = $exitText;
         $this->_endTime  = $endTime;
+
+        foreach ($this->_processSyncListeners as $listener) {
+            error_log("**** calling processSynced");
+            $listener->processSynced($this);
+        }
 
         //------------------------------------------------------------------
         // Delete the temporary (stdout stderr and exitCode) files if it is
         // required to do so
         //------------------------------------------------------------------
         if ($this->deleteProcessFiles()) {
+            error_log("*** deleting process files");
             if (file_exists($this->getStdoutFile())) {
                 unlink($this->getStdoutFile())
                     || error_log("Failed to delete file " . $this->getStdoutFile());

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -152,7 +152,7 @@ class Process
         // exit code in $_exitCodeFile
         $this->_pid = intval(
             exec(
-                "(bash -c '$mainCmd ; $getExitCodeCmd') > /dev/null 2> /dev/null & "
+                "(bash -c \"$mainCmd\"; $getExitCodeCmd) > /dev/null 2> /dev/null & "
                 . " echo $!",
                 $execOutput,
                 $returnStatus

--- a/modules/server_processes_manager/php/serverprocesslauncher.class.inc
+++ b/modules/server_processes_manager/php/serverprocesslauncher.class.inc
@@ -38,6 +38,12 @@ class ServerProcessLauncher
     private $_databaseProvider;
 
     /**
+     * List of processes that should notify this class when their _syncTaskProperties
+     * are run.
+     */
+    private $_processesMonitored = [];
+
+    /**
      * Accessor for field $_databaseProvider
      *
      * @return IDatabaseProvider value of field $_databaseProvider
@@ -70,7 +76,8 @@ class ServerProcessLauncher
      *
      * @param AbstractServerProcess $process the process that was just started
      *
-     * @return string
+     * @return int the ID of the record inserted in table server_processes.
+     *
      * @throws \InvalidArgumentException if the process is null or if either the
      *                                  PID or the process start time is null.
      */
@@ -107,7 +114,7 @@ class ServerProcessLauncher
             ]
         );
 
-        return $db->lastInsertID;
+        $process->setId($db->lastInsertID);
     }
 
     /**
@@ -116,7 +123,7 @@ class ServerProcessLauncher
      *
      * @param AbstractServerProcess $process process to launch.
      *
-     * @return ?int ID of the process saved in the database.
+     * @return void.
      *
      * @throws \LorisException if the process cannot be launched successfully.
      */
@@ -124,19 +131,21 @@ class ServerProcessLauncher
     {
         $process->execute();
 
-        // Wait one second before checking the exit code: if the command is invalid
+        // If we get here, it means that the process started successfully
+        // Save it to the database
+        $this->_saveProcess($process);
+
+        // Wait two seconds before checking the exit code: if the command is invalid
         // this will give enough time for the process to die and we can get the
-        // exit code (otherwise the check happens too soon and the process is
+        // exit code, otherwise the check happens too soon and the process is
         // considered to be "still running" (i.e. exit code undefined yet)
-        sleep(1);
+        sleep(2);
 
         if ($process->getExitCode() == self::CANNOT_EXECUTE_EXIT_CODE) {
             throw new \LorisException(
                 "Cannot run command " . $process->getShellCommand()
             );
         }
-
-        return intval($this->_saveProcess($process));
     }
 
     /**
@@ -145,16 +154,55 @@ class ServerProcessLauncher
      * @param int    $mriUploadId    ID of the MRI upload in the mri_upload table.
      * @param string $sourceLocation location of the MRI file
      *
-     * @return ?int ID (in the database) of the launched process or null
-     *             if the process could not be run
+     * @return AbstractServewrProcess the launched MRI process.
      */
     public function mriUpload($mriUploadId, $sourceLocation)
     {
-        $mriUploadProcess = new MriUploadServerProcess(
+        $mriUploadProcess           = new MriUploadServerProcess(
             $mriUploadId,
             $sourceLocation
         );
-        return $this->_launch($mriUploadProcess);
+        $this->_processesLaunched[] = $mriUploadProcess;
+
+        // Add this process to the list of monitored process:
+        // this will ensure we get notified when its _syncTaskProperties method
+        // is executed
+        $mriUploadProcess->addProcessSyncListener($this);
+        $this->_launch($mriUploadProcess);
+
+        return $mriUploadProcess;
+    }
+
+    /**
+     * This method gets called when one of the processes in list
+     * _processesMonitored executes its _syncTaskProperties method.
+     *
+     * @param $process the process that called its _syncTaskProperties method.
+     *
+     * @return void.
+     */
+    public function processSynced($process)
+    {
+        // Ensure the process is indeed a process that is monitored
+        if (in_array($process, $this->_processesLaunched)) {
+            try {
+                $setValues = [
+                    'exit_text' => $process->getExitText(),
+                    'exit_code' => $process->getExitCode(),
+                    'end_time'  => $process->getEndTime()
+                ];
+                $this->getDatabaseProvider()->getDatabase()->update(
+                    'server_processes',
+                    $setValues,
+                    ['id' => $process->getId()]
+                );
+            } catch (\DatabaseException $exception) {
+                error_log(
+                    "Failed to update task (pid=" . $process->getPid() . ") status: "
+                    . $exception->getMessage()
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes both the imaging uploader and server process manager module so that the test case #19 in the imaging uploader's test plan succeeds:
```
Set the config setting 'ImagingUploader auto launch' to 'Yes'. Then, edit your prod file (in <LORIS MRI code dir>/dicom-archive/.loris-mri) and comment out the definition of the @db array. Once these operations are done, upload any valid scan: check in the server processes manager that this fails with an error code of 4. Now try to upload the scan again. When the system asks you if you want to overwrite the existing archive, answer 'Yes'. Check that this reupload fails with error code 4 (and not 2). Related to Redmine#14093 and PR#3555. [Manual Testing]
```


Fixes #8822 