### PR TITLE
[EEG Uploader] User messaging and Documentation update

### DIFF
--- a/modules/electrophysiology_uploader/README.md
+++ b/modules/electrophysiology_uploader/README.md
@@ -2,7 +2,13 @@
 
 ## Purpose
 
-The electrophysiology uploader is intended to allow users to upload and browse electrophysiology files.
+The electrophysiology uploader is intended to allow users to upload electrophysiology files.
+
+**LORIS 26 Beta Note:** Files uploaded in this module will not be viewable 
+in 
+the Electrophysiology Browser module.
+This feature is under construction for the next release. Please get in 
+touch with the LORIS team to configure this for your project.
 
 
 ## Intended Users
@@ -26,6 +32,7 @@ EEG recordings can be re-uploaded multiple times. Previous upload attempts will 
 Permission `electrophysiology_browser_view_allsites` or `electrophysiology_browser_view_site`
 is necessary to have access to the module and gives the user the ability to 
 upload and browse all recordings uploaded to the database.
+Permission `monitor_eeg_uploads` is necessary to receive EEG upload notifications.
 
 #### Filesystem Permission
 
@@ -49,3 +56,6 @@ EEGUploadIncomingPath - This setting determines where on the filesystem the
         `EEGUploadIncomingPath` following a successful archival and insertion 
         through the LORIS-MRI pipeline. 
 
+### Caveat
+
+Archive extraction and EEG insertion have to be performed manually at the moment.

--- a/modules/electrophysiology_uploader/jsx/ElectrophysiologyUploader.js
+++ b/modules/electrophysiology_uploader/jsx/ElectrophysiologyUploader.js
@@ -56,19 +56,28 @@ export default function ElectrophysiologyUploader(props) {
   ];
 
   return (
-    <Tabs tabs={tabList} defaultTab='browse' updateURL={true}>
-      <TabPane TabId={tabList[0].id}>
-        <UploadViewer
-          data={data.Data}
-          fieldOptions={data.fieldOptions}
-        />
-      </TabPane>
-      <TabPane TabId={tabList[1].id}>
-        <UploadForm
-          uploadURL={`${props.DataURL}/upload`}
-        />
-      </TabPane>
-    </Tabs>
+    <>
+      <div className="alert alert-warning" role="alert">
+        <strong>LORIS 26 Beta Note:</strong> Files uploaded in this module
+         will not be viewable in the Electrophysiology Browser
+         module. This feature is under construction for the next release.
+         Please get in touch with the LORIS team to configure this for your
+         project.
+      </div>
+      <Tabs tabs={tabList} defaultTab='browse' updateURL={true}>
+        <TabPane TabId={tabList[0].id}>
+          <UploadViewer
+            data={data.Data}
+            fieldOptions={data.fieldOptions}
+          />
+        </TabPane>
+        <TabPane TabId={tabList[1].id}>
+          <UploadForm
+            uploadURL={`${props.DataURL}/upload`}
+          />
+        </TabPane>
+      </Tabs>
+    </>
   );
 }
 


### PR DESCRIPTION
Documentation patch to resolve #9293.

Let users and admins know that they will encounter a known issue (#9191), not a bug with their setup:

This does this by: 
- Adding text visible to Users at the top of the module 
- Adding README message
- Adding Help text note for users

This does not resolve  #9191, but it clarifies the state for LORIS users.