### PR TITLE
[Documentation] Update v26 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ core section.***
 - ***When possible please provide the number of the pull request(s) containing the 
 changes in the following format: PR #1234***
 
-## LORIS 26.0 (Release Date: ????-??-??)
+## LORIS 26.0 (Release Date: 2024-06-13)
 ### Core
 #### Features
 - Add OpenID Connect authorization support to LORIS (PR #8255)
@@ -26,7 +26,7 @@ changes in the following format: PR #1234***
 - While proposing a project or editing a project in publications module, prevent indefinite "File to upload" fields from being added if files are browsed then cancelled (PR #9179)
 - Conflict resolver fixed when Test_name is not equal to table name. This is done be replacing the "TableName" variable with "TestName" everywhere in resolved & unresolved conflicts tables as well as modules (PR #9270)
 
-## LORIS 25.0 (Release Date: ????-??-??)
+## LORIS 25.0 (Release Date: 2023-07-17)
 ### Core
 #### Features
 - Added new interface intended to be used for querying module data from PHP (PR #8215) 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 
 * Try the LORIS demo instance at https://demo.loris.ca.
 
-This Readme covers installation of LORIS version <b>25.0</b> on <b>Ubuntu</b>.
+This Readme covers installation of LORIS version <b>26.0</b> on <b>Ubuntu</b>.
 
 ([CentOS Readme also available](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -10,9 +10,9 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 # System Requirements - Install dependencies
 
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
-* MariaDB 10.3 is supported for LORIS 25.
+* MariaDB 10.3 is supported for LORIS 26.
 
-* PHP 8.1 (or higher) is supported for LORIS 25.
+* PHP 8.2 (or higher) is supported for LORIS 26.
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher  


### PR DESCRIPTION
Update the version of LORIS in documentation that references it.

This should be merged immediately before the release (with the date updated if necessary.)