### PR TITLE
[dataquery] Add ability to retrieve results of previous run from API

### DIFF
--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -70,7 +70,6 @@ class Run extends \LORIS\Http\Endpoint
 
         $values = [];
 
-        set_time_limit(300);
         $runid  = $queryRun->getRunId();
         $stream = new \LORIS\Http\DataIteratorBinaryStream(
             $data,
@@ -101,8 +100,7 @@ class Run extends \LORIS\Http\Endpoint
         );
 
         return (new \LORIS\Http\Response())
-            ->withHeader("Content-Type", "text/plain")
-        //->withHeader("Content-Type", "application/octet-stream")
+            ->withHeader("Content-Type", "application/octet-stream")
             ->withBody($stream);
     }
 }

--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -37,6 +37,11 @@ class Run extends \LORIS\Http\Endpoint
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         switch ($request->getMethod()) {
+        case 'GET':
+            $proxy = (new \LORIS\dataquery\endpoints\queries\runs($this->loris));
+            return $proxy->handle(
+                $request->withAttribute("queryid", $this->queryID),
+            );
         case 'POST':
             $user = $request->getAttribute("user");
             return $this->runQuery($user, $this->queryID);
@@ -58,14 +63,44 @@ class Run extends \LORIS\Http\Endpoint
         try {
             $query = new \LORIS\dataquery\Query($this->loris, $queryID);
 
+            $db = $this->loris->getDatabaseConnection();
+            // Put the query run in a transaction to make it atomic
+            $db->beginTransaction();
             $queryRun = $query->newRun($user);
-            $queryRun->insertCandidates($user);
-            $data = $queryRun->getQueryDataProvisioner();
+            $data     = $queryRun->getQueryDataProvisioner()->execute($user);
 
-            $table  = (new \LORIS\Data\Table())
-                ->withDataFrom($data);
-            $rows   = $table->getRows($user);
-            $stream = new \LORIS\Http\DataIteratorBinaryStream($rows);
+            $values = [];
+
+            set_time_limit(300);
+            $runid  = $queryRun->getRunId();
+            $stream = new \LORIS\Http\DataIteratorBinaryStream(
+                $data,
+                function (
+                    $candid,
+                    $rowsArray,
+                    /* @phan-suppress-next-line PhanUnusedClosureParameter */
+                    $rowsBinary,
+                    bool $end
+                ) use (&$values, &$db, &$runid) {
+                    $values[] = join(
+                        ',',
+                        [$runid, $candid, $db->quote(json_encode($rowsArray))]
+                    );
+                    if ((count($values) >= 2000 || $end) && count($values) > 0) {
+                        $insertstmt = "INSERT INTO dataquery_run_results
+            				    (RunID, CandID, RowData) VALUES "
+                        . " (" . join('),(', $values) . ')';
+                        $q          = $db->prepare($insertstmt);
+                        $q->execute([]);
+                        $values = [];
+                    }
+
+                    if ($end) {
+                             $db->commit();
+                    }
+                }
+            );
+
             return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "text/plain")
                 //->withHeader("Content-Type", "application/octet-stream")
@@ -73,30 +108,6 @@ class Run extends \LORIS\Http\Endpoint
         } catch (\LorisException $e) {
             return new \LORIS\Http\Response\JSON\NotImplemented($e->getMessage());
 
-        }
-    }
-
-    /**
-     * Return a count of the number of matches for the query with ID $queryID
-     * if it is run by $user
-     *
-     * @param \User $user The user whose number of matches should be checked
-     *
-     * @return ResponseInterface
-     */
-    public function countResults(\User $user) : ResponseInterface
-    {
-        try {
-            $query = new \LORIS\dataquery\Query($this->loris, $this->queryID);
-
-            $candidates = $query->matchCandidates($user);
-            return new \LORIS\Http\Response\JSON\OK(
-                [
-                    'count' => count($candidates),
-                ]
-            );
-        } catch (\LorisException $e) {
-            return new \LORIS\Http\Response\JSON\NotImplemented($e->getMessage());
         }
     }
 }

--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -88,7 +88,7 @@ class Run extends \LORIS\Http\Endpoint
                     $insertstmt = "INSERT INTO dataquery_run_results
     					    (RunID, CandID, RowData) VALUES "
                     . " (" . join('),(', $values) . ')';
-                    $q = $db->prepare($insertstmt);
+                    $q          = $db->prepare($insertstmt);
                     $q->execute([]);
                     $values = [];
                 }

--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -85,14 +85,12 @@ class Run extends \LORIS\Http\Endpoint
                     ',',
                     [$runid, $candid, $db->quote(json_encode($rowsArray))]
                 );
-                if ((count($values) >= 10 || $end) && count($values) > 0) {
+                if ((count($values) >= 2000 || $end) && count($values) > 0) {
                     $insertstmt = "INSERT INTO dataquery_run_results
     					    (RunID, CandID, RowData) VALUES "
                     . " (" . join('),(', $values) . ')';
-                    error_log($insertstmt);
                     $q = $db->prepare($insertstmt);
                     $q->execute([]);
-                    error_log("Inserted");
                     $values = [];
                 }
 

--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -60,54 +60,51 @@ class Run extends \LORIS\Http\Endpoint
      */
     public function runQuery(\User $user, int $queryID) : ResponseInterface
     {
-        try {
-            $query = new \LORIS\dataquery\Query($this->loris, $queryID);
+        $query = new \LORIS\dataquery\Query($this->loris, $queryID);
 
-            $db = $this->loris->getDatabaseConnection();
-            // Put the query run in a transaction to make it atomic
-            $db->beginTransaction();
-            $queryRun = $query->newRun($user);
-            $data     = $queryRun->getQueryDataProvisioner()->execute($user);
+        $db = $this->loris->getDatabaseConnection();
+        // Put the query run in a transaction to make it atomic
+        $queryRun = $query->newRun($user);
+        $db->beginTransaction();
+        $data = $queryRun->getQueryDataProvisioner()->execute($user);
 
-            $values = [];
+        $values = [];
 
-            set_time_limit(300);
-            $runid  = $queryRun->getRunId();
-            $stream = new \LORIS\Http\DataIteratorBinaryStream(
-                $data,
-                function (
-                    $candid,
-                    $rowsArray,
-                    /* @phan-suppress-next-line PhanUnusedClosureParameter */
-                    $rowsBinary,
-                    bool $end
-                ) use (&$values, &$db, &$runid) {
-                    $values[] = join(
-                        ',',
-                        [$runid, $candid, $db->quote(json_encode($rowsArray))]
-                    );
-                    if ((count($values) >= 2000 || $end) && count($values) > 0) {
-                        $insertstmt = "INSERT INTO dataquery_run_results
-            				    (RunID, CandID, RowData) VALUES "
-                        . " (" . join('),(', $values) . ')';
-                        $q          = $db->prepare($insertstmt);
-                        $q->execute([]);
-                        $values = [];
-                    }
-
-                    if ($end) {
-                             $db->commit();
-                    }
+        set_time_limit(300);
+        $runid  = $queryRun->getRunId();
+        $stream = new \LORIS\Http\DataIteratorBinaryStream(
+            $data,
+            function (
+                $candid,
+                $rowsArray,
+                /* @phan-suppress-next-line PhanUnusedClosureParameter */
+                $rowsBinary,
+                bool $end
+            ) use (&$values, &$db, &$runid) {
+                $values[] = join(
+                    ',',
+                    [$runid, $candid, $db->quote(json_encode($rowsArray))]
+                );
+                if ((count($values) >= 10 || $end) && count($values) > 0) {
+                    $insertstmt = "INSERT INTO dataquery_run_results
+    					    (RunID, CandID, RowData) VALUES "
+                    . " (" . join('),(', $values) . ')';
+                    error_log($insertstmt);
+                    $q = $db->prepare($insertstmt);
+                    $q->execute([]);
+                    error_log("Inserted");
+                    $values = [];
                 }
-            );
 
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
-                //->withHeader("Content-Type", "application/octet-stream")
-                ->withBody($stream);
-        } catch (\LorisException $e) {
-            return new \LORIS\Http\Response\JSON\NotImplemented($e->getMessage());
+                if ($end) {
+                    $db->commit();
+                }
+            }
+        );
 
-        }
+        return (new \LORIS\Http\Response())
+            ->withHeader("Content-Type", "text/plain")
+        //->withHeader("Content-Type", "application/octet-stream")
+            ->withBody($stream);
     }
 }

--- a/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\dataquery\endpoints\queries\query\run;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
+/**
+ * Handles requests to queries under the /queries/{queryID}/run
+ * endpoint of the dataquery module.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Run extends \LORIS\Http\Endpoint
+{
+    /**
+     * {@constructor}
+     *
+     * @param protected \LORIS\LorisInstance $loris   The LorisInstance object
+     * @param public readonly int            $queryID The query we are getting
+     *                                                a count for.
+     * @param public readonly int            $runID   The run of this query
+     */
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        public readonly int $queryID,
+        public readonly int $runID
+    ) {
+        parent::__construct($loris);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        switch ($request->getMethod()) {
+        case 'GET':
+            $user = $request->getAttribute("user");
+            return $this->queryResults($user);
+        default:
+            return new \LORIS\Http\Response\JSON\MethodNotAllowed(['GET']);
+        }
+    }
+
+    /**
+     * Runs a Query for a user and returns the results.
+     *
+     * @param \User $user The user running the query
+     *
+     * @return ResponseInterface
+     */
+    public function queryResults(\User $user) : ResponseInterface
+    {
+            $db = $this->loris->getDatabaseConnection();
+        // FIXME: Check permissions. Check if count(*) > 0.
+        $results = $db->pselect(
+            "SELECT RowData FROM dataquery_run_results WHERE RunID=:rid",
+            [
+                'rid' => $this->runID
+            ]
+        );
+        if (count($results) == 0) {
+            return new \LORIS\Http\Response\JSON\NotFound(
+                "No results found. Query may have expired."
+            );
+        }
+        $stream = new \LORIS\Http\DataIteratorBinaryStream(
+            $this->_jsondecoded($results)
+        );
+
+            return (new \LORIS\Http\Response())
+                ->withHeader("Content-Type", "text/plain")
+                //->withHeader("Content-Type", "application/octet-stream")
+                ->withBody($stream);
+    }
+
+    /**
+     * Convert json encoded database result back to an array
+     *
+     * @param iterable $results The results to decode
+     *
+     * @return \Traversable
+     */
+    private function _jsondecoded(iterable $results)
+    {
+        foreach ($results as $row) {
+            yield json_decode($row['RowData']);
+        }
+    }
+}

--- a/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
@@ -74,8 +74,7 @@ class Run extends \LORIS\Http\Endpoint
         );
 
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
-                //->withHeader("Content-Type", "application/octet-stream")
+                ->withHeader("Content-Type", "application/octet-stream")
                 ->withBody($stream);
     }
 

--- a/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
@@ -5,6 +5,8 @@ namespace LORIS\dataquery\endpoints\queries\query\run;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 
+use LORIS\StudyEntities\Candidate\CandID;
+
 /**
  * Handles requests to queries under the /queries/{queryID}/run
  * endpoint of the dataquery module.
@@ -56,21 +58,39 @@ class Run extends \LORIS\Http\Endpoint
      */
     public function queryResults(\User $user) : ResponseInterface
     {
-            $db = $this->loris->getDatabaseConnection();
-        // FIXME: Check permissions. Check if count(*) > 0.
-        $results = $db->pselect(
-            "SELECT RowData FROM dataquery_run_results WHERE RunID=:rid",
+        $db      = $this->loris->getDatabaseConnection();
+        $candIDs = $db->pselectCol(
+            "SELECT CandID FROM dataquery_run_results WHERE RunID=:rid",
             [
                 'rid' => $this->runID
             ]
         );
-        if (count($results) == 0) {
+        $candIDs = \iterator_to_array(
+            \Candidate::filterInaccessibleCandIDs(
+                $this->loris,
+                array_map(
+                    function ($candID) {
+                        return new CandID(strval($candID));
+                    },
+                    $candIDs
+                ),
+                $user
+            )
+        );
+
+        if (count($candIDs) == 0) {
             return new \LORIS\Http\Response\JSON\NotFound(
                 "No results found. Query may have expired."
             );
         }
-        $stream = new \LORIS\Http\DataIteratorBinaryStream(
-            $this->_jsondecoded($results)
+        $results = $db->pselect(
+            "SELECT CandID, RowData FROM dataquery_run_results WHERE RunID=:rid",
+            [
+                'rid' => $this->runID
+            ]
+        );
+        $stream  = new \LORIS\Http\DataIteratorBinaryStream(
+            $this->_jsondecoded($results, $candIDs)
         );
 
             return (new \LORIS\Http\Response())
@@ -82,13 +102,16 @@ class Run extends \LORIS\Http\Endpoint
      * Convert json encoded database result back to an array
      *
      * @param iterable $results The results to decode
+     * @param array    $CandIDs The CandIDs to limit the results to
      *
      * @return \Traversable
      */
-    private function _jsondecoded(iterable $results)
+    private function _jsondecoded(iterable $results, array $CandIDs)
     {
-        foreach ($results as $row) {
-            yield json_decode($row['RowData']);
+        foreach ($results as $row ) {
+            if (in_array(new CandID(strval($row['CandID'])), $CandIDs)) {
+                yield json_decode($row['RowData']);
+            }
         }
     }
 }

--- a/modules/dataquery/php/endpoints/queries/runs.class.inc
+++ b/modules/dataquery/php/endpoints/queries/runs.class.inc
@@ -9,8 +9,9 @@ use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Handles requests to queries under the /queries/runs endpoint of
- * to get a list of this user's queryRuns. May also be
- * the dataquery module.
+ * to get a list of this user's queryRuns. May also be used for the
+ * /queries/$queryid/run endpoint to get a list of runs for a particular
+ * query if the queryid attribute is set on the request.
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */

--- a/modules/dataquery/php/endpoints/queries/runs.class.inc
+++ b/modules/dataquery/php/endpoints/queries/runs.class.inc
@@ -3,11 +3,13 @@
 namespace LORIS\dataquery\endpoints\queries;
 
 use \LORIS\dataquery\provisioners\RecentQueries;
+use \LORIS\dataquery\provisioners\QueryRuns;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 
 /**
- * Handles requests to queries under the /queries/* endpoint of
+ * Handles requests to queries under the /queries/runs endpoint of
+ * to get a list of this user's queryRuns. May also be
  * the dataquery module.
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
@@ -25,11 +27,17 @@ class Runs extends \LORIS\Http\Endpoint
     {
         switch ($request->getMethod()) {
         case 'GET':
-            $user = $request->getAttribute("user");
+            $user    = $request->getAttribute("user");
+            $queryid = $request->getAttribute("queryid");
+            if (!empty($queryid)) {
+                $results = $this->getQueryRuns($user, $queryid);
+            } else {
+                $results = $this->getRecentRuns($user);
+            }
             return new \LORIS\Http\Response\JSON\OK(
                 [
                     'queryruns' => iterator_to_array(
-                        $this->getRecentRuns($user),
+                        $results,
                         false,
                     ),
                 ]
@@ -50,6 +58,20 @@ class Runs extends \LORIS\Http\Endpoint
     {
         return (new RecentQueries($this->loris, $user))
                 //->filter(new AccessibleResourceFilter())
+                ->execute($user);
+    }
+
+    /**
+     * Get a list of recent query runs for this user
+     *
+     * @param \User $user    The user getting the query runs
+     * @param int   $queryid The query to get runs for
+     *
+     * @return \Traversable
+     */
+    public function getQueryRuns(\User $user, int $queryid) : iterable
+    {
+        return (new QueryRuns($this->loris, $user, $queryid))
                 ->execute($user);
     }
 }

--- a/modules/dataquery/php/provisioners/queryruns.class.inc
+++ b/modules/dataquery/php/provisioners/queryruns.class.inc
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+namespace LORIS\dataquery\Provisioners;
+use \LORIS\dataquery\Query;
+use \LORIS\dataquery\QueryRun;
+
+/**
+ * A QueryRuns provisioner gets a list of runs for a particular query
+ * and user combination.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class QueryRuns extends \LORIS\Data\Provisioners\DBRowProvisioner
+{
+    /**
+     * Create a QueryRuns provisioner, which gets rows for
+     * the query runs by a given user.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance the User ran
+     *                                    queries on.
+     * @param \User                $user  The user to get a recent list of
+     *                                    queries for.
+     * @param int                  $qid   The QueryID to get Query Runs for
+     */
+    function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \User $user,
+        int $qid
+    ) {
+        parent::__construct(
+            "SELECT drq.RunID, dq.QueryID, RunTime, Query
+            FROM dataquery_queries dq
+                JOIN dataquery_run_queries drq ON (dq.QueryID=drq.QueryID)
+                LEFT JOIN dataquery_starred_queries_rel dpq ON
+                    (dq.QueryID=dpq.QueryID AND dpq.StarredBy=:userid)
+                LEFT JOIN dataquery_shared_queries_rel dsq ON
+                    (dq.QueryID=dsq.QueryID AND dsq.SharedBy=:userid)
+                LEFT JOIN dataquery_query_names name ON 
+                    (dq.QueryID=name.QueryID AND name.UserID=:userid)
+            WHERE drq.UserID=:userid AND drq.QueryID=:qid
+            ORDER BY drq.RunTime DESC",
+            ['userid' => $user->getId(), 'qid' => $qid]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array $row The database row from the LORIS Database class.
+     *
+     * @return \LORIS\Data\DataInstance An instance representing this row.
+     */
+    public function getInstance($row) : \LORIS\Data\DataInstance
+    {
+        $qr = new QueryRun(
+            loris: $this->loris,
+            query: new Query(
+                loris: $this->loris,
+                queryID: intval($row['QueryID']),
+                query: json_decode($row['Query'], true),
+            ),
+            RunID: intval($row['RunID']),
+            runTime: $row['RunTime'],
+        );
+        return $qr;
+    }
+}

--- a/modules/dataquery/php/provisioners/queryruns.class.inc
+++ b/modules/dataquery/php/provisioners/queryruns.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace LORIS\dataquery\Provisioners;
 use \LORIS\dataquery\Query;
 use \LORIS\dataquery\QueryRun;

--- a/modules/dataquery/php/queries.class.inc
+++ b/modules/dataquery/php/queries.class.inc
@@ -103,7 +103,13 @@ class Queries extends \NDB_Page
             $pieces
         ) === 1
         ) {
-            return new \LORIS\Http\Response\JSON\NotImplemented();
+            $queryID = intval($pieces[1]);
+            $runID   = intval($pieces[2]);
+            return (new \LORIS\dataquery\endpoints\queries\query\run\Run(
+                $this->loris,
+                $queryID,
+                $runID,
+            ))->handle($request);
         }
         return new \LORIS\Http\Response\JSON\NotFound();
     }

--- a/modules/dataquery/php/query.class.inc
+++ b/modules/dataquery/php/query.class.inc
@@ -549,97 +549,11 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
         } else {
             $candidates = $this->_allCandidates();
         }
-        return $this->_filterInaccessibleCandidates($candidates, $user);
-    }
-
-    /**
-     * Filter CandIDs out of $candIDs which aren't accessible to $user
-     *
-     * @param CandID[] $candIDs The CandIDs to be filtered
-     * @param \User    $user    The user whose access should check.
-     *
-     * @return iterable
-     */
-    private function _filterInaccessibleCandidates(
-        array $candIDs,
-        \User $user,
-    ) : iterable {
-        if (count($candIDs) == 0) {
-            return [];
-        }
-        $DB = $this->loris->getNewDatabaseConnection();
-        $DB->setBuffering(false);
-
-        // Put candidates into a temporary table so that it can be used in a join
-        // clause. Directly using "c.CandID IN (candid1, candid2, candid3, etc)" is
-        // too slow to be useable.
-        $DB->run("DROP TEMPORARY TABLE IF EXISTS accesscandidates");
-        $DB->run(
-            "CREATE TEMPORARY TABLE accesscandidates(
-	    CandID int(6) NOT NULL,
-	    PRIMARY KEY(CandID)
-        );"
+        return \Candidate::filterInaccessibleCandIDs(
+            $this->loris,
+            $candidates,
+            $user
         );
-        $insertstmt = "INSERT INTO accesscandidates VALUES"
-                . " (" . join('),(', $candIDs) . ')';
-        $q          = $DB->prepare($insertstmt);
-        $q->execute([]);
-
-        // Get the data which affects accessibility in bulk.
-        $rows      = $DB->pselect(
-            "SELECT c.CandID, c.RegistrationProjectID, c.RegistrationCenterID,
-                s.ProjectID as SProjectID, s.CenterID as SCenterID,
-                s.ID as sessionID
-            FROM candidate c LEFT JOIN session s ON (s.CandID=c.CandID)
-            WHERE c.Active='Y' AND COALESCE(s.Active, 'Y')='Y'
-                AND c.CandID IN (SELECT CandID FROM accesscandidates)
-            ORDER BY c.CandID",
-            []
-        );
-        $curCandID = '';
-        $canddata  = null;
-
-        // Foreach CandID, create the TimePointData object for all timepoints
-        // that were returned.
-        foreach ($rows as $row) {
-            if ($curCandID != $row['CandID']) {
-                if ($canddata !== null) {
-                     $candidate = new \Candidate($canddata);
-                    if ($candidate->isAccessibleBy($user)) {
-                        yield $canddata->CandID;
-                    }
-                }
-                $canddata  = new \CandidateData(
-                    candID: new CandID(strval($row['CandID'])),
-                    registrationProjectID: $row['RegistrationProjectID'] !== null
-                    ? \ProjectID::singleton($row['RegistrationProjectID'])
-                    : null,
-                    registrationCenterID: $row['RegistrationCenterID'] !== null
-                    ? \CenterID::singleton($row['RegistrationCenterID'])
-                    : null,
-                    timepoints: [],
-                );
-                $curCandID = $row['CandID'];
-            }
-            if ($row['sessionID'] !== null) {
-                $canddata->timepoints[] = new \TimePoint(
-                    new \TimePointData(
-                        new \SessionID(strval($row['sessionID'])),
-                        \ProjectID::singleton($row['SProjectID']),
-                        \CenterID::singleton($row['SCenterID']),
-                    )
-                );
-            }
-        }
-
-        // check the last candidate that wouldn't have entered the check in the
-        // loop
-        if ($canddata !== null) {
-            $candidate = new \Candidate($canddata);
-            if ($candidate->isAccessibleBy($user)) {
-                yield $canddata->CandID;
-            }
-        }
     }
 
     /**

--- a/modules/dataquery/php/querydataprovisioner.class.inc
+++ b/modules/dataquery/php/querydataprovisioner.class.inc
@@ -48,7 +48,7 @@ class QueryDataProvisioner extends ProvisionerInstance
      */
     public function getAllInstances() : \Traversable
     {
-        $candidates = $this->QueryRun->getCandidates();
+        $candidates = $this->QueryRun->getCandidates($this->user);
 
         $dataiterators = [];
         $fields        = [];

--- a/modules/dataquery/php/queryrun.class.inc
+++ b/modules/dataquery/php/queryrun.class.inc
@@ -94,23 +94,13 @@ class QueryRun implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Get the candidates that matched this run.
      *
+     * @param \User $user The LORIS user to retrieve matching candidates for
+     *
      * @return CandID[]
      */
-    public function getCandidates() : array
+    public function getCandidates($user) : array
     {
-        $DB      = $this->loris->getDatabaseConnection();
-        $candIDs = $DB->pselectCol(
-            "SELECT CandID FROM dataquery_run_results WHERE RunID=:run",
-            ['run' => $this->runID],
-        );
-
-        return array_map(
-            function ($val) {
-                return new CandID(strval($val));
-            },
-            $candIDs
-        );
-
+        return $this->query->matchCandidates($user);
     }
 
     /**
@@ -133,6 +123,16 @@ class QueryRun implements \LORIS\StudyEntities\AccessibleResource,
             'QueryRunID' => $this->runID,
         ];
         return $result;
+    }
+
+    /**
+     * Returns the RunID that this QueryRun is for
+     *
+     * @return int
+     */
+    public function getRunId() : int
+    {
+        return $this->runID;
     }
 }
 

--- a/modules/dataquery/php/queryrun.class.inc
+++ b/modules/dataquery/php/queryrun.class.inc
@@ -60,28 +60,6 @@ class QueryRun implements \LORIS\StudyEntities\AccessibleResource,
     }
 
     /**
-     * Insert the candidates that match the query for $user into the LORIS
-     * database results table.
-     *
-     * @param \User $user The user running the query
-     *
-     * @return void
-     */
-    public function insertCandidates(\User $user) : void
-    {
-        $DB      = $this->loris->getDatabaseConnection();
-        $candIDs = \iterator_to_array($this->query->matchCandidates($user));
-        if (count($candIDs) == 0) {
-            return;
-        }
-        $insertstmt = "INSERT INTO dataquery_run_results (RunID, CandID) VALUES 
-            ($this->runID, " . join("),($this->runID, ", $candIDs) . ')';
-        $q          = $DB->prepare($insertstmt);
-        $q->execute([]);
-        return;
-    }
-
-    /**
      * Get a data provisioner for the results of this query run.
      *
      * @return \LORIS\Data\Provisioner
@@ -100,7 +78,7 @@ class QueryRun implements \LORIS\StudyEntities\AccessibleResource,
      */
     public function getCandidates($user) : array
     {
-        return $this->query->matchCandidates($user);
+        return \iterator_to_array($this->query->matchCandidates($user));
     }
 
     /**

--- a/modules/dataquery/static/schema.yml
+++ b/modules/dataquery/static/schema.yml
@@ -143,6 +143,16 @@ paths:
                 $ref: '#/components/schemas/QueryResults'              
         '500':
           description: Something went wrong on the server running the query
+    get:
+      description: |- 
+        Return a list of summarizing previous runs of this query
+      responses:
+        '200':
+          description: Successfully operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryRunList'
   /queries/{QueryID}/count:      
     parameters:
     - name: QueryID
@@ -171,8 +181,6 @@ paths:
   /queries/{QueryID}/run/{QueryRunID}: 
     description: |-
       Returns the cached results of a previously run query
-      
-      Note: This endpoint is aspirational.
     parameters:
     - name: QueryID
       in: path

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -1240,4 +1240,97 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         return '/^'.$regex.'$/i';
     }
+
+    /**
+     * Filter CandIDs out of $candIDs which aren't accessible to $user
+     *
+     * @param \LORIS\LorisInstance $loris   The LORISInstance with a database
+     *                                      connection to use
+     * @param CandID[]             $candIDs The CandIDs to be filtered
+     * @param \User                $user    The user whose access should check.
+     *
+     * @return Generator<CandID>
+     */
+    static public function filterInaccessibleCandIDs(
+        \LORIS\LorisInstance $loris,
+        array $candIDs,
+        \User $user,
+    ) : iterable {
+        if (count($candIDs) == 0) {
+            return [];
+        }
+        $DB = $loris->getNewDatabaseConnection();
+        $DB->setBuffering(false);
+
+        // Put candidates into a temporary table so that it can be used in a join
+        // clause. Directly using "c.CandID IN (candid1, candid2, candid3, etc)" is
+        // too slow to be useable.
+        $DB->run("DROP TEMPORARY TABLE IF EXISTS accesscandidates");
+        $DB->run(
+            "CREATE TEMPORARY TABLE accesscandidates(
+	    CandID int(6) NOT NULL,
+	    PRIMARY KEY(CandID)
+        );"
+        );
+        $insertstmt = "INSERT INTO accesscandidates VALUES"
+                . " (" . join('),(', $candIDs) . ')';
+        $q          = $DB->prepare($insertstmt);
+        $q->execute([]);
+
+        // Get the data which affects accessibility in bulk.
+        $rows      = $DB->pselect(
+            "SELECT c.CandID, c.RegistrationProjectID, c.RegistrationCenterID,
+                s.ProjectID as SProjectID, s.CenterID as SCenterID,
+                s.ID as sessionID
+            FROM candidate c LEFT JOIN session s ON (s.CandID=c.CandID)
+            WHERE c.Active='Y' AND COALESCE(s.Active, 'Y')='Y'
+                AND c.CandID IN (SELECT CandID FROM accesscandidates)
+            ORDER BY c.CandID",
+            []
+        );
+        $curCandID = '';
+        $canddata  = null;
+
+        // Foreach CandID, create the TimePointData object for all timepoints
+        // that were returned.
+        foreach ($rows as $row) {
+            if ($curCandID != $row['CandID']) {
+                if ($canddata !== null) {
+                     $candidate = new \Candidate($canddata);
+                    if ($candidate->isAccessibleBy($user)) {
+                        yield $canddata->CandID;
+                    }
+                }
+                $canddata  = new \CandidateData(
+                    candID: new CandID(strval($row['CandID'])),
+                    registrationProjectID: $row['RegistrationProjectID'] !== null
+                    ? \ProjectID::singleton($row['RegistrationProjectID'])
+                    : null,
+                    registrationCenterID: $row['RegistrationCenterID'] !== null
+                    ? \CenterID::singleton($row['RegistrationCenterID'])
+                    : null,
+                    timepoints: [],
+                );
+                $curCandID = $row['CandID'];
+            }
+            if ($row['sessionID'] !== null) {
+                $canddata->timepoints[] = new \TimePoint(
+                    new \TimePointData(
+                        new \SessionID(strval($row['sessionID'])),
+                        \ProjectID::singleton($row['SProjectID']),
+                        \CenterID::singleton($row['SCenterID']),
+                    )
+                );
+            }
+        }
+
+        // check the last candidate that wouldn't have entered the check in the
+        // loop
+        if ($canddata !== null) {
+            $candidate = new \Candidate($canddata);
+            if ($candidate->isAccessibleBy($user)) {
+                yield $canddata->CandID;
+            }
+        }
+    }
 }

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -190,6 +190,7 @@ class DataIteratorBinaryStream implements StreamInterface
             $this->eof = true;
             return chr(0x04);
         }
+	$rowkey = $this->rowgen->key();
         $row = $this->rowgen->current();
         $this->rowgen->next();
 
@@ -197,7 +198,7 @@ class DataIteratorBinaryStream implements StreamInterface
         $rowVal   = join(chr(0x1e), $rowArray) . chr(0x1f);
 
         if ($this->rowCallback) {
-            call_user_func($this->rowCallback, $this->rowgen->key(), $rowArray, $rowVal, !($this->rowgen->valid()));
+            call_user_func($this->rowCallback, $rowkey, $rowArray, $rowVal, !($this->rowgen->valid()));
         }
         $this->position += strlen($rowVal);
 

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -190,8 +190,8 @@ class DataIteratorBinaryStream implements StreamInterface
             $this->eof = true;
             return chr(0x04);
         }
-	$rowkey = $this->rowgen->key();
-        $row = $this->rowgen->current();
+        $rowkey = $this->rowgen->key();
+        $row    = $this->rowgen->current();
         $this->rowgen->next();
 
         $rowArray = array_values(json_decode(json_encode($row), true));


### PR DESCRIPTION
This implements the endpoint that is listed as "aspirational" in the
dataquery api schema to load the results of a previously run query.

It was originally left out for fear of performance issues but with
this implementation performance seems to be comparable to without
it.

This does not implement a frontend to reload query results, but
the API functionality is useful for i.e. api callbacks that want
to process the results of a query without the need to re-run
it (and the possibility to get different results.)