### PR TITLE
[dataquery] Add ability for other modules to add actions

### DIFF
--- a/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
+++ b/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
@@ -33,9 +33,9 @@ function useBreadcrumbs(
                 },
             },
         ];
-        if (activeTab == Tabs.Fields
-                || activeTab == Tabs.Filters
-                || activeTab == Tabs.Data) {
+        if (activeTab === Tabs.Fields
+                || activeTab === Tabs.Filters
+                || activeTab === Tabs.Data) {
             breadcrumbs.push({
                 text: 'Define Fields',
                 /**
@@ -50,8 +50,8 @@ function useBreadcrumbs(
                 },
             });
         }
-        if (activeTab == Tabs.Filters
-                || activeTab == Tabs.Data) {
+        if (activeTab === Tabs.Filters
+                || activeTab === Tabs.Data) {
             breadcrumbs.push({
                 text: 'Define Filters',
                 /**
@@ -67,7 +67,7 @@ function useBreadcrumbs(
             });
         }
 
-        if (activeTab == Tabs.Data) {
+        if (activeTab === Tabs.Data) {
             breadcrumbs.push({
                 text: 'View Data',
                 /**

--- a/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
+++ b/modules/dataquery/jsx/hooks/usebreadcrumbs.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect} from 'react';
 import Breadcrumbs from 'jsx/Breadcrumbs';
+import {Tabs} from '../nextsteps';
 
 // Declared in smarty main.tpl
 declare const breadcrumbsRoot: any;
@@ -12,76 +13,75 @@ declare const loris: any;
  * @param {function} setActiveTab - set the state on click
  */
 function useBreadcrumbs(
-  activeTab: string,
-  setActiveTab: (newtab: string) => void
+    activeTab: Tabs,
+    setActiveTab: (newtab: Tabs) => void
 ) {
-  // update breadcrumbs breadcrumbs
-  useEffect(() => {
-    const breadcrumbs = [
-      {
-        text: 'Data Query Tool (Beta)',
-        /**
-         * OnClick handler for the main breadcrumb
-         *
-         * @param {React.MouseEvent<HTMLElement>} e - Callback for when hovering over the delete icon
-         * @returns {void}
-         */
-        onClick: (e: React.MouseEvent) => {
-          e.preventDefault();
-          setActiveTab('Info');
-        },
-      },
-    ];
-    if (activeTab == 'DefineFields'
-                || activeTab == 'DefineFilters'
-                || activeTab == 'ViewData') {
-      breadcrumbs.push({
-        text: 'Define Fields',
-        /**
-         * OnClick handler for the define fields breadcrumb
-         *
-         * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
-         * @returns {void}
-         */
-        onClick: (e) => {
-          e.preventDefault();
-          setActiveTab('DefineFields');
-        },
-      });
-    }
-    if (activeTab == 'DefineFilters'
-                || activeTab == 'ViewData') {
-      breadcrumbs.push({
-        text: 'Define Filters',
-        /**
-         * OnClick handler for the define filters breadcrumb
-         *
-         * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
-         * @returns {void}
-         */
-        onClick: (e) => {
-          e.preventDefault();
-          setActiveTab('DefineFilters');
-        },
-      });
-    }
+    // update breadcrumbs breadcrumbs
+    useEffect(() => {
+        const breadcrumbs = [
+            {
+                text: 'Data Query Tool (Beta)',
+                /**
+                 * OnClick handler for the main breadcrumb
+                 *
+                 * @param {React.MouseEvent<HTMLElement>} e - Callback for when hovering over the delete icon
+                 * @returns {void}
+                 */
+                onClick: (e: React.MouseEvent) => {
+                    e.preventDefault();
+                    setActiveTab(Tabs.Info);
+                },
+            },
+        ];
+        if (activeTab == Tabs.Fields
+                || activeTab == Tabs.Filters
+                || activeTab == Tabs.Data) {
+            breadcrumbs.push({
+                text: 'Define Fields',
+                /**
+                 * OnClick handler for the define fields breadcrumb
+                 *
+                 * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
+                 * @returns {void}
+                 */
+                onClick: (e) => {
+                    e.preventDefault();
+                    setActiveTab(Tabs.Fields);
+                },
+            });
+        }
+        if (activeTab == Tabs.Filters
+                || activeTab == Tabs.Data) {
+            breadcrumbs.push({
+                text: 'Define Filters',
+                /**
+                 * OnClick handler for the define filters breadcrumb
+                 *
+                 * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
+                 * @returns {void}
+                 */
+                onClick: (e) => {
+                    e.preventDefault();
+                    setActiveTab(Tabs.Filters);
+                },
+            });
+        }
 
-    if (activeTab == 'ViewData') {
-      breadcrumbs.push({
-        text: 'View Data',
-        /**
-         * OnClick handler for the View Data breadcrumb
-         *
-         * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
-         * @returns {void}
-         */
-        onClick: (e) => {
-          e.preventDefault();
-          setActiveTab('ViewData');
-        },
-      });
-    }
-
+        if (activeTab == Tabs.Data) {
+            breadcrumbs.push({
+                text: 'View Data',
+                /**
+                 * OnClick handler for the View Data breadcrumb
+                 *
+                 * @param {React.MouseEventHandler<HTMLElement>} e - Callback for when hovering over the delete icon
+                 * @returns {void}
+                 */
+                onClick: (e) => {
+                    e.preventDefault();
+                    setActiveTab(Tabs.Data);
+                },
+            });
+        }
     if (breadcrumbsRoot) {
       breadcrumbsRoot.render(
         <Breadcrumbs

--- a/modules/dataquery/jsx/hooks/usequery.tsx
+++ b/modules/dataquery/jsx/hooks/usequery.tsx
@@ -1,6 +1,7 @@
 import {useState} from 'react';
 import {QueryGroup, QueryTerm} from '../querydef';
 import {APIQueryField} from '../types';
+import {Tabs} from '../nextsteps';
 
 type FieldActions = {
     clear: () => void,

--- a/modules/dataquery/jsx/hooks/usewidgets.tsx
+++ b/modules/dataquery/jsx/hooks/usewidgets.tsx
@@ -9,9 +9,10 @@ import {Tabs, TabSteps} from '../nextsteps';
  * @returns {Function | null} - The callback if available
  */
 function getCallback(name: string): (() => void) | null {
-    const namepieces = name.split('.').reverse();
+    const namepieces = name.split('.');
     let level: any = window;
-    for (let name = namepieces.pop(); name; name = namepieces.pop()) {
+
+    for (const name of namepieces) {
          if (level[name]) {
              level = level[name];
          } else {

--- a/modules/dataquery/jsx/hooks/usewidgets.tsx
+++ b/modules/dataquery/jsx/hooks/usewidgets.tsx
@@ -1,0 +1,103 @@
+import {useState, useEffect} from 'react';
+import {Tabs, TabSteps} from '../nextsteps';
+
+/**
+ * Converts a string name of a callback function to the callback
+ * itself.
+ *
+ * @param {string} name - The name of the callback function
+ * @returns {Function | null} - The callback if available
+ */
+function getCallback(name: string): (() => void) | null {
+    const namepieces = name.split('.').reverse();
+    let level: any = window;
+    for (let name = namepieces.pop(); name; name = namepieces.pop()) {
+         if (level[name]) {
+             level = level[name];
+         } else {
+             // We have not reached the end, but the
+             // name was not defined, return null
+             return null;
+         }
+    }
+    return level;
+}
+
+/**
+ * React hook to load a list of valid visits from the server
+ * and manage which should be selected by default
+ *
+ * @returns {TabSteps} - list of default and all visits
+ */
+function useWidgets(): TabSteps {
+    const [steps, setSteps] = useState<TabSteps>({});
+    useEffect(() => {
+          fetch('/dataquery/widgets', {credentials: 'same-origin'})
+          .then((resp) => {
+                  if (!resp.ok) {
+                      throw new Error('Invalid response');
+                  }
+                  return resp.json();
+          }).then((result) => {
+              const steps: TabSteps = {
+                  [Tabs.Info]: [],
+                  [Tabs.Fields]: [],
+                  [Tabs.Filters]: [],
+                  [Tabs.Data]: [],
+              };
+              for (const widget of result) {
+                  const func = getCallback(widget.callback);
+                  if (func === null) {
+                      console.error(
+                          'Unknown callback function',
+                          widget.callback
+                      );
+                      continue;
+                  }
+
+                  switch (widget.tab) {
+                  case 'info':
+                      if (steps[Tabs.Info]) {
+                          steps[Tabs.Info].push({
+                             label: widget.label,
+                             action: func,
+                          });
+                      }
+                      break;
+                  case 'fields':
+                      if (steps[Tabs.Fields]) {
+                          steps[Tabs.Fields].push({
+                             label: widget.label,
+                             action: func,
+                          });
+                      }
+                      break;
+                  case 'filters':
+                      if (steps[Tabs.Filters]) {
+                          steps[Tabs.Filters].push({
+                             label: widget.label,
+                             action: func,
+                          });
+                      }
+                      break;
+                  case 'data':
+                      if (steps[Tabs.Data]) {
+                          steps[Tabs.Data].push({
+                             label: widget.label,
+                             action: func,
+                          });
+                      }
+                      break;
+                  default:
+                       throw new Error('Invalid tab');
+                  }
+             }
+             setSteps(steps);
+          }).catch( (error) => {
+                  console.error(error);
+                  });
+    }, []);
+    return steps;
+}
+
+export default useWidgets;

--- a/modules/dataquery/jsx/index.tsx
+++ b/modules/dataquery/jsx/index.tsx
@@ -1,5 +1,4 @@
 import {createRoot} from 'react-dom/client';
-
 import {useState} from 'react';
 
 import Welcome from './welcome';
@@ -11,6 +10,7 @@ import NextSteps from './nextsteps';
 
 import useBreadcrumbs from './hooks/usebreadcrumbs';
 import useVisits from './hooks/usevisits';
+import useWidgets from './hooks/usewidgets';
 import useQuery from './hooks/usequery';
 import {useSharedQueries, useLoadQueryFromURL} from './hooks/usesharedqueries';
 
@@ -72,8 +72,9 @@ function DataQueryApp(props: {
     queryAdmin: boolean,
     username: string
 }) {
-  const [activeTab, setActiveTab] = useState('Info');
-  useBreadcrumbs(activeTab, setActiveTab);
+    const [activeTab, setActiveTab] = useState<Tabs>(Tabs.Info);
+    const extrasteps = useWidgets();
+    useBreadcrumbs(activeTab, setActiveTab);
 
   const [queries, reloadQueries, queryActions]
         = useSharedQueries(props.username);
@@ -128,118 +129,15 @@ function DataQueryApp(props: {
             && categories.categories[module]) {
       return categories.categories[module][category];
     }
-    return category;
-  };
-
-  /**
-   * Function to retrieve a module's data dictionary from the server.
-   *
-   * @param {string} module - the module whole fields should be retrieved
-   * @returns {void}
-   */
-  const getModuleFields = (module: string): void => {
-    fetchModuleDictionary(module);
-  };
-
-  switch (activeTab) {
-  case 'Info':
-    content = <Welcome
-      loadQuery={loadQuery}
-      recentQueries={queries.recent}
-      sharedQueries={queries.shared}
-      topQueries={queries.top}
-
-      starQuery={queryActions.star}
-      unstarQuery={queryActions.unstar}
-      shareQuery={queryActions.share}
-      unshareQuery={queryActions.unshare}
-
-      reloadQueries={reloadQueries}
-      // Need dictionary related stuff
-      // to display saved queries
-      getModuleFields={fetchModuleDictionary}
-      mapModuleName={mapModuleName}
-      mapCategoryName={mapCategoryName}
-      fulldictionary={fulldictionary}
-      onContinue={() => setActiveTab('DefineFields')}
-
-      queryAdmin={props.queryAdmin}
-    />;
-    break;
-  case 'DefineFields':
-    content = <DefineFields allCategories={categories}
-      displayedFields={activeCategory.currentDictionary}
-
-      defaultVisits={visits.default_}
-      onChangeDefaultVisits={visits.modifyDefault}
-      allVisits={visits.all}
-
-      module={activeCategory.module}
-      category={activeCategory.category}
-      onCategoryChange={activeCategory.changeCategory}
-
-      selected={selectedFields}
-      setSelected={fieldActions.setFields}
-
-      onFieldToggle={fieldActions.addRemoveField}
-
-      onChangeVisitList={fieldActions.modifyVisits}
-
-      removeField={fieldActions.remove}
-      onAddAll={fieldActions.addMany}
-      onRemoveAll={fieldActions.removeMany}
-      onClearAll={fieldActions.clear}
-
-      fulldictionary={fulldictionary}
-    />;
-    break;
-  case 'DefineFilters':
-    content = <DefineFilters
-      fields={selectedFields}
-      module={activeCategory.module}
-      category={activeCategory.category}
-
-      displayedFields={activeCategory.currentDictionary}
-
-      categories={categories}
-      onCategoryChange={activeCategory.changeCategory}
-
-      addQueryGroupItem={criteriaActions.addQueryGroupItem}
-      removeQueryGroupItem={criteriaActions.removeQueryGroupItem}
-      addNewQueryGroup={criteriaActions.addNewQueryGroup}
-
-      query={query}
-
-      setQuery={criteriaActions.setCriteria}
-
-      getModuleFields={getModuleFields}
-      fulldictionary={fulldictionary}
-
-      mapModuleName={mapModuleName}
-      mapCategoryName={mapCategoryName}
-    />;
-    break;
-  case 'ViewData':
-    content = <ViewData
-      fields={selectedFields}
-      filters={query}
-
-      fulldictionary={fulldictionary}
-
-      onRun={reloadQueries}
-    />;
-    break;
-  default:
-    content = <div>Invalid tab</div>;
-  }
-  return <div>
-    <div>{content}</div>
-    <NextSteps page={activeTab} fields={selectedFields}
-      filters={query}
-      changePage={
-        (page) => setActiveTab(page)
-      }/>
-  </div>;
+    return <div>
+        <div>{content}</div>
+        <NextSteps page={activeTab} fields={selectedFields}
+            filters={query}
+            extrasteps={extrasteps}
+            changePage={
+                (page) => setActiveTab(page)
+        }/>
+    </div>;
 }
 
 declare const loris: any;

--- a/modules/dataquery/jsx/index.tsx
+++ b/modules/dataquery/jsx/index.tsx
@@ -6,6 +6,7 @@ import DefineFilters from './definefilters';
 import DefineFields from './definefields';
 import ViewData from './viewdata';
 
+import {Tabs} from './nextsteps';
 import NextSteps from './nextsteps';
 
 import useBreadcrumbs from './hooks/usebreadcrumbs';
@@ -127,7 +128,112 @@ function DataQueryApp(props: {
   const mapCategoryName = (module: string, category: string): string => {
     if (categories && categories.categories
             && categories.categories[module]) {
-      return categories.categories[module][category];
+            return categories.categories[module][category];
+        }
+        return category;
+    };
+
+    /**
+     * Function to retrieve a module's data dictionary from the server.
+     *
+     * @param {string} module - the module whole fields should be retrieved
+     * @returns {void}
+     */
+    const getModuleFields = (module: string): void => {
+        fetchModuleDictionary(module);
+    };
+
+    switch (activeTab) {
+        case Tabs.Info:
+            content = <Welcome
+                        loadQuery={loadQuery}
+                        recentQueries={queries.recent}
+                        sharedQueries={queries.shared}
+                        topQueries={queries.top}
+
+                        starQuery={queryActions.star}
+                        unstarQuery={queryActions.unstar}
+                        shareQuery={queryActions.share}
+                        unshareQuery={queryActions.unshare}
+
+                        reloadQueries={reloadQueries}
+                        // Need dictionary related stuff
+                        // to display saved queries
+                        getModuleFields={fetchModuleDictionary}
+                        mapModuleName={mapModuleName}
+                        mapCategoryName={mapCategoryName}
+                        fulldictionary={fulldictionary}
+                        onContinue={() => setActiveTab(Tabs.Fields)}
+
+                        queryAdmin={props.queryAdmin}
+                    />;
+            break;
+        case Tabs.Fields:
+            content = <DefineFields allCategories={categories}
+                displayedFields={activeCategory.currentDictionary}
+
+                defaultVisits={visits.default_}
+                onChangeDefaultVisits={visits.modifyDefault}
+                allVisits={visits.all}
+
+                module={activeCategory.module}
+                category={activeCategory.category}
+                onCategoryChange={activeCategory.changeCategory}
+
+                selected={selectedFields}
+                setSelected={fieldActions.setFields}
+
+                onFieldToggle={fieldActions.addRemoveField}
+
+                onChangeVisitList={fieldActions.modifyVisits}
+
+                removeField={fieldActions.remove}
+                onAddAll={fieldActions.addMany}
+                onRemoveAll={fieldActions.removeMany}
+                onClearAll={fieldActions.clear}
+
+                fulldictionary={fulldictionary}
+               />;
+            break;
+        case Tabs.Filters:
+            content = <DefineFilters
+                fields={selectedFields}
+                module={activeCategory.module}
+                category={activeCategory.category}
+
+                displayedFields={activeCategory.currentDictionary}
+
+                categories={categories}
+                onCategoryChange={activeCategory.changeCategory}
+
+                addQueryGroupItem={criteriaActions.addQueryGroupItem}
+                removeQueryGroupItem={criteriaActions.removeQueryGroupItem}
+                addNewQueryGroup={criteriaActions.addNewQueryGroup}
+
+                query={query}
+
+                setQuery={criteriaActions.setCriteria}
+
+                getModuleFields={getModuleFields}
+                fulldictionary={fulldictionary}
+
+                mapModuleName={mapModuleName}
+                mapCategoryName={mapCategoryName}
+            />;
+            break;
+        case Tabs.Data:
+            content = <ViewData
+                fields={selectedFields}
+                filters={query}
+
+                fulldictionary={fulldictionary}
+
+                onRun={reloadQueries}
+            />;
+            break;
+        default:
+            content = <div>Invalid tab</div>;
+>>>>>>> 7e41cf69d (Convert tab to an enum in preparation of adding extrasteps)
     }
     return <div>
         <div>{content}</div>

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -18,7 +18,6 @@ export type TabSteps = {
     [key in Tabs]?: TabAction[];
 };
 
-
 /**
  * Next steps options for query navigation
  *
@@ -33,53 +32,101 @@ export type TabSteps = {
 function NextSteps(props: {
     fields: APIQueryField[]
     filters: QueryGroup,
-    page: string,
+    page: Tabs,
+    changePage: (newpage: Tabs) => void,
     extrasteps: TabSteps,
-    changePage: (newpage: string) => void,
-}) {
+}) : React.ReactElement {
     const [expanded, setExpanded] = useState(true);
     const steps: React.ReactElement[] = [];
     const pluginsteps: React.ReactElement[] = [];
 
 
-  const canRun = (props.fields && props.fields.length > 0);
-  const fieldLabel = (props.fields && props.fields.length > 0)
-    ? 'Modify Fields'
-    : 'Choose Fields';
-  const filterLabel = (props.filters && props.filters.group.length > 0)
-    ? 'Modify Filters'
-    : 'Add Filters';
-  switch (props.page) {
-  case 'Info':
-    if (canRun) {
-      // A previous query was loaded, it can be either
-      // modified or run
-      steps.push(<ButtonElement
-        label={fieldLabel}
-        columnSize='col-sm-12'
-        key='fields'
-        onUserInput={() => props.changePage('DefineFields')}
-      />);
-      steps.push(<ButtonElement
-        label={filterLabel}
-        columnSize='col-sm-12'
-        key='filters'
-        onUserInput={() => props.changePage('DefineFilters')}
-      />);
-      steps.push(<ButtonElement
-        label='Run Query'
-        columnSize='col-sm-12'
-        key='runquery'
-        onUserInput={() => props.changePage('ViewData')}
-      />);
-    } else {
-      // No query loaded, must define fields
-      steps.push(<ButtonElement
-        label={fieldLabel}
-        columnSize='col-sm-12'
-        key='fields'
-        onUserInput={() => props.changePage('DefineFields')}
-      />);
+    const canRun = (props.fields && props.fields.length > 0);
+    const fieldLabel = (props.fields && props.fields.length > 0)
+        ? 'Modify Fields'
+        : 'Choose Fields';
+    const filterLabel = (props.filters && props.filters.group.length > 0)
+        ? 'Modify Filters'
+        : 'Add Filters';
+    switch (props.page) {
+    case Tabs.Info:
+        if (canRun) {
+            // A previous query was loaded, it can be either
+            // modified or run
+            steps.push(<ButtonElement
+                    label={fieldLabel}
+                    columnSize='col-sm-12'
+                    key='fields'
+                    onUserInput={() => props.changePage(Tabs.Fields)}
+            />);
+            steps.push(<ButtonElement
+                    label={filterLabel}
+                    columnSize='col-sm-12'
+                    key='filters'
+                    onUserInput={() => props.changePage(Tabs.Filters)}
+            />);
+            steps.push(<ButtonElement
+                    label='Run Query'
+                    columnSize='col-sm-12'
+                    key='runquery'
+                    onUserInput={() => props.changePage(Tabs.Data)}
+            />);
+        } else {
+            // No query loaded, must define fields
+            steps.push(<ButtonElement
+                    label={fieldLabel}
+                    columnSize='col-sm-12'
+                    key='fields'
+                    onUserInput={() => props.changePage(Tabs.Fields)}
+            />);
+        }
+        break;
+    case Tabs.Fields:
+        steps.push(<ButtonElement
+                label={filterLabel}
+                columnSize='col-sm-12'
+                key='filters'
+                onUserInput={() => props.changePage(Tabs.Filters)}
+        />);
+        if (canRun) {
+            steps.push(<ButtonElement
+                    label='Run Query'
+                    columnSize='col-sm-12'
+                    key='runquery'
+                    onUserInput={() => props.changePage(Tabs.Data)}
+            />);
+        }
+        break;
+    case Tabs.Filters:
+        if (canRun) {
+            steps.push(<ButtonElement
+                    label='Run Query'
+                    key='runquery'
+                    columnSize='col-sm-12'
+                    onUserInput={() => props.changePage(Tabs.Data)}
+            />);
+        }
+        steps.push(<ButtonElement
+                label={fieldLabel}
+                key='fields'
+                columnSize='col-sm-12'
+                onUserInput={() => props.changePage(Tabs.Fields)}
+        />);
+        break;
+    case Tabs.Data:
+        steps.push(<ButtonElement
+                label={fieldLabel}
+                key='fields'
+                columnSize='col-sm-12'
+                onUserInput={() => props.changePage(Tabs.Fields)}
+        />);
+        steps.push(<ButtonElement
+                label={filterLabel}
+                key='filters'
+                columnSize='col-sm-12'
+                onUserInput={() => props.changePage(Tabs.Filters)}
+        />);
+        break;
     }
     break;
   case 'DefineFields':

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -3,6 +3,22 @@ import {APIQueryField} from './types';
 import {ButtonElement} from 'jsx/Form';
 import {QueryGroup} from './querydef';
 
+export enum Tabs {
+    Info,
+    Fields,
+    Filters,
+    Data,
+}
+
+export type TabAction = {
+    label: string,
+    action: () => void,
+};
+export type TabSteps = {
+    [key in Tabs]?: TabAction[];
+};
+
+
 /**
  * Next steps options for query navigation
  *
@@ -11,16 +27,19 @@ import {QueryGroup} from './querydef';
  * @param {QueryGroup} props.filters - The filters selected
  * @param {string} props.page - The current page name
  * @param {function} props.changePage - A function to change the current page
+ * @param {object} props.extrasteps - Extra steps added by widgets
  * @returns {React.ReactElement} - The "Next Steps" menu
  */
 function NextSteps(props: {
     fields: APIQueryField[]
     filters: QueryGroup,
     page: string,
+    extrasteps: TabSteps,
     changePage: (newpage: string) => void,
 }) {
-  const [expanded, setExpanded] = useState(true);
-  const steps: React.ReactElement[] = [];
+    const [expanded, setExpanded] = useState(true);
+    const steps: React.ReactElement[] = [];
+    const pluginsteps: React.ReactElement[] = [];
 
 
   const canRun = (props.fields && props.fields.length > 0);
@@ -111,6 +130,13 @@ function NextSteps(props: {
     break;
   }
 
+    for (const osteps of (props.extrasteps[props.page] || [])) {
+        pluginsteps.push(<ButtonElement
+            label={osteps.label}
+            onUserInput={osteps.action}
+            columnSize='col-sm-12'
+        />);
+    }
   const expandIcon = <i
     style={{transform: 'scaleY(2)', fontSize: '2em'}}
     className='fas fa-chevron-left'
@@ -127,30 +153,46 @@ function NextSteps(props: {
     paddingLeft: '2em',
   };
 
-  return (
-    <div style={{
-      position: 'fixed',
-      bottom: 0,
-      right: 0,
-      borderWidth: 'thin',
-      borderStyle: 'solid',
-      borderColor: 'black',
-      // Fix the height size so it doesn't move when
-      // expanded or collapsed
-      height: 120,
-      // Make sure we're on top of the footer
-      zIndex: 300,
-    }}>
-      <div style={{
-        display: 'flex',
-        alignItems: 'stretch',
-        height: 120,
-        paddingRight: '14px',
-      }}>
-        <div style={style}>
-          <h3>Next Steps</h3>
-          <div style={{display: 'flex'}}>
-            {steps}
+    let externalsteps;
+    if (pluginsteps.length > 0) {
+        externalsteps = <div style={{display: 'flex'}}>
+             {pluginsteps}
+        </div>;
+    }
+    return (
+        <div style={{
+            position: 'fixed',
+            bottom: 0,
+            right: 0,
+            borderWidth: 'thin',
+            borderStyle: 'solid',
+            borderColor: 'black',
+            // Fix the height size so it doesn't move when
+            // expanded or collapsed
+            // height: 120,
+            // Make sure we're on top of the footer
+            zIndex: 300,
+        }}>
+          <div style={{
+              display: 'flex',
+              alignItems: 'stretch',
+              // height: 120,
+              paddingRight: '14px',
+            }}>
+              <div style={style}>
+                <h3 style={
+                     // Required to make sure the height doesn't change
+                     // when the width is set to 0 when collapsed
+                     {whiteSpace: 'nowrap'}
+                }>Next Steps</h3>
+                <div style={{display: 'flex'}}>
+                    {steps}
+                </div>
+                {externalsteps}
+              </div>
+              <div
+                  style={{alignSelf: 'center'}}
+              >{expandIcon}</div>
           </div>
         </div>
         <div

--- a/modules/dataquery/php/actionwidget.class.inc
+++ b/modules/dataquery/php/actionwidget.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace LORIS\dataquery;
 
 /**

--- a/modules/dataquery/php/actionwidget.class.inc
+++ b/modules/dataquery/php/actionwidget.class.inc
@@ -37,6 +37,4 @@ class ActionWidget implements \LORIS\GUI\Widget
     {
         return "";
     }
-
-
 }

--- a/modules/dataquery/php/actionwidget.class.inc
+++ b/modules/dataquery/php/actionwidget.class.inc
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+namespace LORIS\dataquery;
+
+/**
+ * A dataquery ActionWidget implements a new action that
+ * can be performed in the "Next Steps" of the dataquery
+ * module
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class ActionWidget implements \LORIS\GUI\Widget
+{
+    /**
+     * Construct a new dataquery ActionWidget
+     *
+     * @param string $label      The label to display on the action button
+     * @param string $tab        The tab to display the action on
+     * @param string $jsurl      The javascript URL defining the callback
+     * @param string $jscallback The name of the callback to call when the
+     *                           button is clicked
+     */
+    public function __construct(
+        public readonly string $label,
+        public readonly string $tab,
+        public readonly string $jsurl,
+        public readonly string $jscallback,
+    ) {
+    }
+
+    /**
+     * Implement the \LORIS\GUI\Widget interface.
+     * No-op.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return "";
+    }
+
+
+}

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -13,6 +13,7 @@
  * @link       https://www.github.com/aces/Loris/
  */
 namespace LORIS\dataquery;
+use \Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Data Querying Module
@@ -29,6 +30,7 @@ namespace LORIS\dataquery;
 class Dataquery extends \NDB_Page
 {
     public $skipTemplate = true;
+    private \User $user;
 
     /**
      * Check user access permission
@@ -44,6 +46,20 @@ class Dataquery extends \NDB_Page
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @param \User                  $user    - The user loading the page
+     * @param ServerRequestInterface $request - The page to load resources for
+     *
+     * @return void
+     */
+    public function loadResources(
+        \User $user,
+        ServerRequestInterface $request,
+    ) : void {
+        $this->user = $user;
+    }
+    /**
      * Include the column formatter required to display the feedback link colours
      * in the candidate_list menu
      *
@@ -51,11 +67,32 @@ class Dataquery extends \NDB_Page
      */
     function getJSDependencies()
     {
+        $widgetsJS = [];
+
+        foreach ($this->loris->getActiveModules() as $module) {
+            if (!$module->hasAccess($this->user)) {
+                continue;
+            }
+
+            $widgets = $module->getWidgets(
+                'dataquery:action',
+                $this->user,
+                [],
+            );
+            foreach ($widgets as $widget) {
+                assert($widget instanceof ActionWidget);
+                // de-duplicate widgets from the same javascript source
+                $widgetsJS[$widget->jsurl] = 1;
+            }
+        }
+        $widgetsJS = array_keys($widgetsJS);
+
         $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
+            $widgetsJS,
             [
                 $baseURL . "/dataquery/js/index.js",
             ]

--- a/modules/dataquery/php/widgets.class.inc
+++ b/modules/dataquery/php/widgets.class.inc
@@ -5,8 +5,9 @@ use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 
 /**
- * Handles requests to queries under the /queries/* endpoint of
- * the dataquery module.
+ * Handles requests to queries under the /widgets endpoint of
+ * the dataquery module to return a list of widgets requested
+ * by other modules.
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
@@ -52,12 +53,10 @@ class Widgets extends \NDB_Page
             );
             foreach ($mwidgets as $widget) {
                 assert($widget instanceof ActionWidget);
-                // de-duplicate widgets from the same javascript source
                 $widgets[] = [
                     "label"    => $widget->label,
                     "tab"      => $widget->tab,
                     "callback" => $widget->jscallback,
-
                 ];
             }
         }

--- a/modules/dataquery/php/widgets.class.inc
+++ b/modules/dataquery/php/widgets.class.inc
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace LORIS\dataquery;
 
 use \Psr\Http\Message\ServerRequestInterface;

--- a/modules/dataquery/php/widgets.class.inc
+++ b/modules/dataquery/php/widgets.class.inc
@@ -1,0 +1,67 @@
+<?php
+namespace LORIS\dataquery;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
+/**
+ * Handles requests to queries under the /queries/* endpoint of
+ * the dataquery module.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Widgets extends \NDB_Page
+{
+    public $skipTemplate = true;
+
+    /**
+     * Access permissions checked by Module class. Return true
+     * if we got to this point.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $user = $request->getAttribute("user");
+
+        $widgets = [];
+
+        foreach ($this->loris->getActiveModules() as $module) {
+            if (!$module->hasAccess($user)) {
+                continue;
+            }
+
+            $mwidgets = $module->getWidgets(
+                'dataquery:action',
+                $user,
+                [],
+            );
+            foreach ($mwidgets as $widget) {
+                assert($widget instanceof ActionWidget);
+                // de-duplicate widgets from the same javascript source
+                $widgets[] = [
+                    "label"    => $widget->label,
+                    "tab"      => $widget->tab,
+                    "callback" => $widget->jscallback,
+
+                ];
+            }
+        }
+
+        return new \LORIS\Http\Response\JSON\OK($widgets);
+    }
+}


### PR DESCRIPTION
This adds the ability for other modules to add custom actions to the "Next Steps" of the dataquery module. An example of an "Action" that might be added is a "Package Data Release" for the data_release module or a "Send to CBRAIN" for a theoretical CBRAIN module on the final view data page. 

To add an action, the module's getWidgets must return an array of `\LORIS\dataquery\ActionWidget`s to be added when called with the type argument of `dataquery:action`. Each ActionWidget adds a button on a particular dataquery page which, when clicked, invokes a javascript callback that can be customized by the module.

Plugin actions provided by a module are displayed in a second row underneath the "Next Steps" .