### PR TITLE
[dataquery/instruments] Handle cardinality::many instruments in DQT

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -454,11 +454,35 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                         $candData[$dict->getName()] = [];
                     }
                     $sid = $loadedInstrument->getSessionID();
-                    $candData[$dict->getName()][$sid->__toString()] = [
-                        'VisitLabel' => $loadedInstrument->getVisitLabel(),
-                        'SessionID'  => $sid->__toString(),
-                        'value'      => $loadedInstrument->getDictionaryValue($dict),
-                    ];
+                    if ($dict->getCardinality()->__toString() == "many") {
+                        $candData[$dict->getName()][$sid->__toString()] = [
+                            'keytype'    => $dict->getName() . " response",
+                            'VisitLabel' => $loadedInstrument->getVisitLabel(),
+                            'SessionID'  => $sid->__toString(),
+                            'values'     => [],
+                        ];
+                        $i = 1;
+
+                        // Line length work-arounds
+                        $candData =& $candData[$dict->getName()];
+                        $vals     =& $candData[$sid->__toString()]['values'];
+
+                        $values = explode(
+                            '{@}',
+                            $loadedInstrument->getDictionaryValue($dict)
+                        );
+                        foreach ($values as $value) {
+                            $vals["Response $i"] = $value;
+                            $i++;
+                        }
+                    } else {
+                        $candData[$dict->getName()][$sid->__toString()] = [
+                            'VisitLabel' => $loadedInstrument->getVisitLabel(),
+                            'SessionID'  => $sid->__toString(),
+                            'value'      =>
+                        $loadedInstrument->getDictionaryValue($dict),
+                        ];
+                    }
                 }
             }
             yield "$iCandID" => $candData;


### PR DESCRIPTION
The ability for the frontend to display session variables with a cardinality of "many" per session was added for the imaging, but the instrument queryengine backend was not updated to properly format multi-select elements. This adds support for multiselect elements by updating the instrument queryengine to return correctly formatted data for instruments with the many cardinality.