### PR TITLE
[database] Improve schema defaults

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -285,7 +285,7 @@ CREATE TABLE `instrument_subtests` (
 
 CREATE TABLE `flag` (
   `ID` int(10) unsigned NOT NULL auto_increment,
-  `SessionID` int(10) unsigned NOT NULL default '0',
+  `SessionID` int(10) unsigned NOT NULL,
   `Test_name` varchar(255) NOT NULL default '',
   `CommentID` varchar(255) NOT NULL default '',
   `Data_entry` enum('In Progress','Complete') default NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1611,7 +1611,7 @@ CREATE TABLE `parameter_type` (
   `SourceField` text,
   `SourceFrom` VARCHAR(255),
   `SourceCondition` text,
-  `Queryable` tinyint(1) default '1',
+  `Queryable` tinyint(1) default 1,
   `IsFile` tinyint(1) default 0,
   PRIMARY KEY  (`ParameterTypeID`),
   KEY `name` (`Name`),

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -98,7 +98,7 @@ CREATE TABLE `users` (
   `Phone` varchar(15) default NULL,
   `Fax` varchar(255) default NULL,
   `Email` varchar(255) NOT NULL default '',
-  `Privilege` tinyint(1) NOT NULL default '0',
+  `Privilege` tinyint(1) NOT NULL default 0,
   `PSCPI` enum('Y','N') NOT NULL default 'N',
   `DBAccess` varchar(10) NOT NULL default '',
   `Active` enum('Y','N') NOT NULL default 'Y',
@@ -152,14 +152,14 @@ CREATE TABLE `caveat_options` (
 
 CREATE TABLE `candidate` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandID` int(6) NOT NULL DEFAULT '0',
+  `CandID` int(6) NOT NULL,
   `PSCID` varchar(255) NOT NULL DEFAULT '',
   `ExternalID` varchar(255) DEFAULT NULL,
   `DoB` date DEFAULT NULL,
   `DoD` date DEFAULT NULL,
   `EDC` date DEFAULT NULL,
   `Sex` varchar(255) DEFAULT NULL,
-  `RegistrationCenterID` integer unsigned NOT NULL DEFAULT '0',
+  `RegistrationCenterID` integer unsigned NOT NULL,
   `RegistrationProjectID` int(10) unsigned NOT NULL,
   `Ethnicity` varchar(255) DEFAULT NULL,
   `Active` enum('Y','N') NOT NULL DEFAULT 'Y',
@@ -193,7 +193,7 @@ CREATE TABLE `candidate` (
 
 CREATE TABLE `session` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandID` int(6) NOT NULL DEFAULT '0',
+  `CandID` int(6) NOT NULL,
   `CenterID` integer unsigned NOT NULL,
   `ProjectID` int(10) unsigned NOT NULL,
   `VisitNo` smallint(5) unsigned DEFAULT NULL,
@@ -276,7 +276,7 @@ CREATE TABLE `instrument_subtests` (
   `Test_name` varchar(255) NOT NULL default '',
   `Subtest_name` varchar(255) NOT NULL default '',
   `Description` varchar(255) NOT NULL default '',
-  `Order_number` int(11) NOT NULL default '0',
+  `Order_number` int(11) NOT NULL default 0,
   UNIQUE KEY `unique_index` (`Test_name`, `Subtest_name`),
   PRIMARY KEY  (`ID`),
   KEY `FK_instrument_subtests_1` (`Test_name`),
@@ -370,13 +370,13 @@ CREATE TABLE `tarchive` (
   `DateAcquired` date default NULL,
   `DateFirstArchived` datetime default NULL,
   `DateLastArchived` datetime default NULL,
-  `AcquisitionCount` int(11) NOT NULL default '0',
-  `NonDicomFileCount` int(11) NOT NULL default '0',
-  `DicomFileCount` int(11) NOT NULL default '0',
+  `AcquisitionCount` int(11) NOT NULL default 0,
+  `NonDicomFileCount` int(11) NOT NULL default 0,
+  `DicomFileCount` int(11) NOT NULL default 0,
   `md5sumDicomOnly` varchar(255) default NULL,
   `md5sumArchive` varchar(255) default NULL,
   `CreatingUser` varchar(255) NOT NULL default '',
-  `sumTypeVersion` tinyint(4) NOT NULL default '0',
+  `sumTypeVersion` tinyint(4) NOT NULL default 0,
   `tarTypeVersion` tinyint(4) default NULL,
   `SourceLocation` varchar(255) NOT NULL default '',
   `ArchiveLocation` varchar(255) default NULL,
@@ -385,12 +385,12 @@ CREATE TABLE `tarchive` (
   `ScannerSerialNumber` varchar(255) NOT NULL default '',
   `ScannerSoftwareVersion` varchar(255) NOT NULL default '',
   `SessionID` int(10) unsigned default NULL,
-  `uploadAttempt` tinyint(4) NOT NULL default '0',
+  `uploadAttempt` tinyint(4) NOT NULL default 0,
   `CreateInfo` text,
   `AcquisitionMetadata` longtext NOT NULL,
   `TarchiveID` int(11) NOT NULL auto_increment,
   `DateSent` datetime DEFAULT NULL,
-  `PendingTransfer` tinyint(1) NOT NULL DEFAULT '0',
+  `PendingTransfer` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY  (`TarchiveID`),
   KEY `SessionID` (`SessionID`),
   CONSTRAINT `FK_tarchive_sessionID`
@@ -399,8 +399,8 @@ CREATE TABLE `tarchive` (
 
 CREATE TABLE `tarchive_series` (
   `TarchiveSeriesID` int(11) NOT NULL auto_increment,
-  `TarchiveID` int(11) NOT NULL default '0',
-  `SeriesNumber` int(11) NOT NULL default '0',
+  `TarchiveID` int(11) NOT NULL,
+  `SeriesNumber` int(11) NOT NULL default 0,
   `SeriesDescription` varchar(255) default NULL,
   `SequenceName` varchar(255) default NULL,
   `EchoTime` double default NULL,
@@ -408,7 +408,7 @@ CREATE TABLE `tarchive_series` (
   `InversionTime` double default NULL,
   `SliceThickness` double default NULL,
   `PhaseEncoding` varchar(255) default NULL,
-  `NumberOfFiles` int(11) NOT NULL default '0',
+  `NumberOfFiles` int(11) NOT NULL default 0,
   `SeriesUID` varchar(255) default NULL,
   `Modality` ENUM ('MR', 'PT') default NULL,
   PRIMARY KEY  (`TarchiveSeriesID`),
@@ -418,7 +418,7 @@ CREATE TABLE `tarchive_series` (
 
 CREATE TABLE `tarchive_files` (
   `TarchiveFileID` int(11) NOT NULL auto_increment,
-  `TarchiveID` int(11) NOT NULL default '0',
+  `TarchiveID` int(11) NOT NULL,
   `TarchiveSeriesID` INT(11) DEFAULT NULL,
   `SeriesNumber` int(11) default NULL,
   `FileNumber` int(11) default NULL,
@@ -439,8 +439,8 @@ CREATE TABLE `tarchive_files` (
 CREATE TABLE `hrrt_archive` (
   `HrrtArchiveID`     INT(11)          NOT NULL AUTO_INCREMENT,
   `SessionID`         INT(10) unsigned          DEFAULT NULL,
-  `EcatFileCount`     INT(11)          NOT NULL DEFAULT '0',
-  `NonEcatFileCount`  INT(11)          NOT NULL DEFAULT '0',
+  `EcatFileCount`     INT(11)          NOT NULL DEFAULT 0,
+  `NonEcatFileCount`  INT(11)          NOT NULL DEFAULT 0,
   `DateAcquired`      DATE                      DEFAULT NULL,
   `DateArchived`      DATETIME                  DEFAULT NULL,
   `PatientName`       VARCHAR(50)      NOT NULL DEFAULT '',
@@ -458,7 +458,7 @@ CREATE TABLE `hrrt_archive` (
 
 CREATE TABLE `hrrt_archive_files` (
   `HrrtArchiveFileID` INT(11)      NOT NULL AUTO_INCREMENT,
-  `HrrtArchiveID`     INT(11)      NOT NULL DEFAULT '0',
+  `HrrtArchiveID`     INT(11)      NOT NULL,
   `Blake2bHash`       VARCHAR(255) NOT NULL,
   `FileName`          VARCHAR(255) NOT NULL,
   PRIMARY KEY (`HrrtArchiveFileID`),
@@ -502,7 +502,7 @@ CREATE TABLE `mri_processing_protocol` (
   `ProtocolFile` varchar(255) NOT NULL DEFAULT '',
   `FileType` varchar(12) DEFAULT NULL,
   `Tool` varchar(255) NOT NULL DEFAULT '',
-  `InsertTime` int(10) unsigned NOT NULL DEFAULT '0',
+  `InsertTime` int(10) unsigned NOT NULL DEFAULT 0,
   `md5sum` varchar(32) DEFAULT NULL,
   PRIMARY KEY (`ProcessProtocolID`),
   CONSTRAINT `FK_mri_processing_protocol_FileTypes` FOREIGN KEY (`FileType`) REFERENCES `ImagingFileTypes`(`type`)
@@ -561,7 +561,7 @@ INSERT INTO `mri_scan_type` VALUES
 
 CREATE TABLE `files` (
   `FileID` int(10) unsigned NOT NULL auto_increment,
-  `SessionID` int(10) unsigned NOT NULL default '0',
+  `SessionID` int(10) unsigned NOT NULL,
   `File` varchar(255) NOT NULL default '',
   `SeriesUID` varchar(64) DEFAULT NULL,
   `EchoTime` double DEFAULT NULL,
@@ -572,10 +572,10 @@ CREATE TABLE `files` (
   `AcquisitionProtocolID` int(10) unsigned default NULL,
   `FileType` varchar(12) default NULL,
   `InsertedByUserID` varchar(255) NOT NULL default '',
-  `InsertTime` int(10) unsigned NOT NULL default '0',
+  `InsertTime` int(10) unsigned NOT NULL default 0,
   `SourcePipeline` varchar(255),
   `PipelineDate` date,
-  `SourceFileID` int(10) unsigned DEFAULT '0',
+  `SourceFileID` int(10) unsigned,
   `ProcessProtocolID` int(11) unsigned,
   `Caveat` tinyint(1) default NULL,
   `TarchiveSource` int(11) default NULL,
@@ -709,7 +709,7 @@ CREATE TABLE `mri_upload` (
   `UploadDate` DateTime DEFAULT NULL,
   `UploadLocation` varchar(255) NOT NULL DEFAULT '',
   `DecompressedLocation` varchar(255) NOT NULL DEFAULT '',
-  `InsertionComplete` tinyint(1) NOT NULL DEFAULT '0',
+  `InsertionComplete` tinyint(1) NOT NULL DEFAULT 0,
   `Inserting` tinyint(1) DEFAULT NULL,
   `PatientName` varchar(255) NOT NULL DEFAULT '',
   `number_of_mincInserted` int(11) DEFAULT NULL,
@@ -717,7 +717,7 @@ CREATE TABLE `mri_upload` (
   `TarchiveID` int(11) DEFAULT NULL,
   `SessionID` int(10) unsigned DEFAULT NULL,
   `IsCandidateInfoValidated` tinyint(1) DEFAULT NULL,
-  `IsTarchiveValidated` tinyint(1) NOT NULL DEFAULT '0',
+  `IsTarchiveValidated` tinyint(1) NOT NULL DEFAULT 0,
   `IsPhantom` enum('N','Y') NOT NULL DEFAULT 'N',
   PRIMARY KEY (`UploadID`),
   KEY (`SessionID`),
@@ -1036,7 +1036,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
 CREATE TABLE `document_repository_categories` (
   `id` int(3) unsigned NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) DEFAULT NULL,
-  `parent_id` int(3) DEFAULT '0',
+  `parent_id` int(3),
   `comments` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1057,8 +1057,8 @@ CREATE TABLE `document_repository` (
   `For_site` int(2) DEFAULT NULL,
   `comments` text,
   `multipart` enum('Yes','No') DEFAULT NULL,
-  `EARLI` tinyint(1) DEFAULT '0',
-  `hide_video` tinyint(1) DEFAULT '0',
+  `EARLI` tinyint(1) DEFAULT 0,
+  `hide_video` tinyint(1) DEFAULT 0,
   `File_category` int(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`record_id`),
   KEY `fk_document_repository_1_idx` (`File_category`),
@@ -1073,7 +1073,7 @@ CREATE TABLE `document_repository` (
 CREATE TABLE `notification_types` (
   `NotificationTypeID` int(11) NOT NULL auto_increment,
   `Type` varchar(255) NOT NULL default '',
-  `private` tinyint(1) default '0',
+  `private` tinyint(1) default 0,
   `Description` text,
   PRIMARY KEY  (`NotificationTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1098,8 +1098,8 @@ INSERT INTO `notification_types` (Type,private,Description) VALUES
 
 CREATE TABLE `notification_spool` (
   `NotificationID` int(11) NOT NULL auto_increment,
-  `NotificationTypeID` int(11) NOT NULL default '0',
-  `ProcessID` int(11) NOT NULL DEFAULT '0',
+  `NotificationTypeID` int(11) NOT NULL,
+  `ProcessID` int(11) NOT NULL,
   `TimeSpooled` datetime DEFAULT NULL,
   `Message` text,
   `Error` enum('Y','N') default NULL,
@@ -1274,7 +1274,7 @@ SET @tmp_val = NULL;
 
 CREATE TABLE `participant_status` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandID` int(6) NOT NULL DEFAULT '0',
+  `CandID` int(6) NOT NULL,
   `UserID` varchar(255) DEFAULT NULL,
   `entry_staff` varchar(255) DEFAULT NULL,
   `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1313,7 +1313,7 @@ CREATE TABLE `participant_emails` (
 
 CREATE TABLE `participant_status_history` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandID` int(6) NOT NULL DEFAULT '0',
+  `CandID` int(6) NOT NULL,
   `entry_staff` varchar(255) DEFAULT NULL,
   `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `participant_status` int(11) DEFAULT NULL,
@@ -1361,7 +1361,7 @@ CREATE TABLE `examiners_psc_rel` (
 
 CREATE TABLE `certification` (
   `certID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `examinerID` int(10) unsigned NOT NULL DEFAULT '0',
+  `examinerID` int(10) unsigned NOT NULL,
   `date_cert` date DEFAULT NULL,
   `visit_label` varchar(255) DEFAULT NULL,
   `testID` int(10) UNSIGNED NOT NULL,
@@ -1473,7 +1473,7 @@ CREATE TABLE `media` (
   `file_type` varchar(255) DEFAULT NULL,
   `data_dir` varchar(255) NOT NULL,
   `uploaded_by` varchar(255) DEFAULT NULL,
-  `hide_file` tinyint(1) DEFAULT '0',
+  `hide_file` tinyint(1) DEFAULT 0,
   `last_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `language_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -1612,7 +1612,7 @@ CREATE TABLE `parameter_type` (
   `SourceFrom` VARCHAR(255),
   `SourceCondition` text,
   `Queryable` tinyint(1) default '1',
-  `IsFile` tinyint(1) default '0',
+  `IsFile` tinyint(1) default 0,
   PRIMARY KEY  (`ParameterTypeID`),
   KEY `name` (`Name`),
   UNIQUE `name_sourceFrom_index` (`Name`, `SourceFrom`)
@@ -1756,8 +1756,8 @@ INSERT INTO `parameter_type_category` (Name, Type) VALUES
   ('Electrophysiology Variables', 'Metavars');
 
 CREATE TABLE `parameter_type_category_rel` (
-  `ParameterTypeID` int(11) unsigned NOT NULL default '0',
-  `ParameterTypeCategoryID` int(11) unsigned NOT NULL default '0',
+  `ParameterTypeID` int(11) unsigned NOT NULL,
+  `ParameterTypeCategoryID` int(11) unsigned NOT NULL,
   PRIMARY KEY  (`ParameterTypeCategoryID`,`ParameterTypeID`),
   KEY `FK_parameter_type_category_rel_1` (`ParameterTypeID`),
   CONSTRAINT `FK_parameter_type_category_rel_1` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`) ON DELETE CASCADE,
@@ -1771,10 +1771,10 @@ INSERT INTO parameter_type_category_rel (ParameterTypeID,ParameterTypeCategoryID
 
 CREATE TABLE `parameter_candidate` (
   `ParameterCandidateID` int(10) unsigned NOT NULL auto_increment,
-  `CandID` int(6) NOT NULL default '0',
-  `ParameterTypeID` int(10) unsigned NOT NULL default '0',
+  `CandID` int(6) NOT NULL,
+  `ParameterTypeID` int(10) unsigned NOT NULL,
   `Value` varchar(255) default NULL,
-  `InsertTime` int(10) unsigned NOT NULL default '0',
+  `InsertTime` int(10) unsigned NOT NULL default 0,
   PRIMARY KEY  (`ParameterCandidateID`),
   KEY `candidate_type` (`CandID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
@@ -1784,10 +1784,10 @@ CREATE TABLE `parameter_candidate` (
 
 CREATE TABLE `parameter_file` (
   `ParameterFileID` int(10) unsigned NOT NULL auto_increment,
-  `FileID` int(10) unsigned NOT NULL default '0',
-  `ParameterTypeID` int(10) unsigned NOT NULL default '0',
+  `FileID` int(10) unsigned NOT NULL,
+  `ParameterTypeID` int(10) unsigned NOT NULL,
   `Value` longtext,
-  `InsertTime` int(10) unsigned NOT NULL default '0',
+  `InsertTime` int(10) unsigned NOT NULL default 0,
   PRIMARY KEY  (`ParameterFileID`),
   UNIQUE KEY `file_type_uniq` (`FileID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
@@ -1797,10 +1797,10 @@ CREATE TABLE `parameter_file` (
 
 CREATE TABLE `parameter_session` (
   `ParameterSessionID` int(10) unsigned NOT NULL auto_increment,
-  `SessionID` int(10) unsigned NOT NULL default '0',
-  `ParameterTypeID` int(10) unsigned NOT NULL default '0',
+  `SessionID` int(10) unsigned NOT NULL,
+  `ParameterTypeID` int(10) unsigned NOT NULL,
   `Value` varchar(255) default NULL,
-  `InsertTime` int(10) unsigned NOT NULL default '0',
+  `InsertTime` int(10) unsigned NOT NULL default 0,
   PRIMARY KEY  (`ParameterSessionID`),
   KEY `session_type` (`SessionID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
@@ -1881,8 +1881,8 @@ CREATE TABLE `SNP` (
 
 CREATE TABLE `SNP_candidate_rel` (
   `ID` bigint(20) NOT NULL AUTO_INCREMENT,
-  `SNPID` bigint(20) NOT NULL DEFAULT '0',
-  `CandID` int(6) NOT NULL DEFAULT '0',
+  `SNPID` bigint(20) NOT NULL,
+  `CandID` int(6) NOT NULL,
   `AlleleA` enum('A','C','T','G') DEFAULT NULL,
   `AlleleB` enum('A','C','T','G') DEFAULT NULL,
   `ArrayReport` enum('Normal','Uncertain','Pending') DEFAULT NULL,
@@ -2189,7 +2189,7 @@ INSERT INTO `feedback_mri_comment_types` (CommentName,CommentType,CommentStatusF
 
 CREATE TABLE `feedback_mri_predefined_comments` (
   `PredefinedCommentID` int(11) unsigned NOT NULL auto_increment,
-  `CommentTypeID` int(11) unsigned NOT NULL default '0',
+  `CommentTypeID` int(11) unsigned NOT NULL,
   `Comment` text NOT NULL,
   PRIMARY KEY  (`PredefinedCommentID`),
   KEY `CommentType` (`CommentTypeID`),
@@ -2245,7 +2245,7 @@ CREATE TABLE `feedback_mri_comments` (
   `PhaseEncodingDirection` VARCHAR(3) DEFAULT NULL,
   `EchoNumber` VARCHAR(20) DEFAULT NULL,
   `SessionID` int(10) unsigned default NULL,
-  `CommentTypeID` int(11) unsigned NOT NULL default '0',
+  `CommentTypeID` int(11) unsigned NOT NULL,
   `PredefinedCommentID` int(11) unsigned default NULL,
   `Comment` text,
   `ChangeTime` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,

--- a/SQL/New_patches/2024-07-16-CleanDefault.sql
+++ b/SQL/New_patches/2024-07-16-CleanDefault.sql
@@ -1,0 +1,148 @@
+-- Drop nonsensical defaults and put use right type for others.
+
+ALTER TABLE `users`
+  ALTER `Privilege` SET DEFAULT 0;
+
+ALTER TABLE `candidate`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `candidate`
+  ALTER `RegistrationCenterID` DROP DEFAULT;
+
+ALTER TABLE `session`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `instrument_subtests`
+  ALTER `Order_number` SET DEFAULT 0;
+
+ALTER TABLE `flag`
+  ALTER `SessionID` DROP DEFAULT;
+
+ALTER TABLE `tarchive`
+  ALTER `AcquisitionCount` SET DEFAULT 0;
+
+ALTER TABLE `tarchive`
+  ALTER `NonDicomFileCount` SET DEFAULT 0;
+
+ALTER TABLE `tarchive`
+  ALTER `DicomFileCount` SET DEFAULT 0;
+
+ALTER TABLE `tarchive`
+  ALTER `sumTypeVersion` SET DEFAULT 0;
+
+ALTER TABLE `tarchive`
+  ALTER `uploadAttempt` SET DEFAULT 0;
+
+ALTER TABLE `tarchive`
+  ALTER `PendingTransfer` SET DEFAULT 0;
+
+ALTER TABLE `tarchive_series`
+  ALTER `TarchiveID` DROP DEFAULT;
+
+ALTER TABLE `tarchive_series`
+  ALTER `SeriesNumber` SET DEFAULT 0;
+
+ALTER TABLE `tarchive_series`
+  ALTER `NumberOfFiles` SET DEFAULT 0;
+
+ALTER TABLE `tarchive_files`
+  ALTER `TarchiveID` DROP DEFAULT;
+
+ALTER TABLE `hrrt_archive`
+  ALTER `EcatFileCount` SET DEFAULT 0;
+
+ALTER TABLE `hrrt_archive`
+  ALTER `NonEcatFileCount` SET DEFAULT 0;
+
+ALTER TABLE `hrrt_archive_files`
+  ALTER `HrrtArchiveID` DROP DEFAULT;
+
+ALTER TABLE `mri_processing_protocol`
+  ALTER `InsertTime` SET DEFAULT 0;
+
+ALTER TABLE `files`
+  ALTER `SessionID` DROP DEFAULT;
+
+ALTER TABLE `files`
+  ALTER `InsertTime` SET DEFAULT 0;
+
+ALTER TABLE `files`
+  ALTER `SourceFileID` DROP DEFAULT;
+
+ALTER TABLE `mri_upload`
+  ALTER `InsertionComplete` SET DEFAULT 0;
+
+ALTER TABLE `mri_upload`
+  ALTER `IsTarchiveValidated` SET DEFAULT 0;
+
+ALTER TABLE `document_repository_categories`
+  ALTER `parent_id` DROP DEFAULT;
+
+ALTER TABLE `document_repository`
+  ALTER `EARLI` SET DEFAULT 0;
+
+ALTER TABLE `document_repository`
+  ALTER `hide_video` SET DEFAULT 0;
+
+ALTER TABLE `notification_types`
+  ALTER `private` SET DEFAULT 0;
+
+ALTER TABLE `notification_spool`
+  ALTER `NotificationTypeID` DROP DEFAULT;
+
+ALTER TABLE `notification_spool`
+  ALTER `ProcessID` DROP DEFAULT;
+
+ALTER TABLE `participant_status`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `participant_status_history`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `certification`
+  ALTER `examinerID` DROP DEFAULT;
+
+ALTER TABLE `media`
+  ALTER `hide_file` SET DEFAULT 0;
+
+ALTER TABLE `parameter_type`
+  ALTER `Queryable` SET DEFAULT 1;
+
+ALTER TABLE `parameter_type`
+  ALTER `IsFile` SET DEFAULT 0;
+
+ALTER TABLE `parameter_type_category_rel`
+  ALTER `ParameterTypeID` DROP DEFAULT;
+
+ALTER TABLE `parameter_type_category_rel`
+  ALTER `ParameterTypeCategoryID` DROP DEFAULT;
+
+ALTER TABLE `parameter_candidate`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `parameter_candidate`
+  ALTER `ParameterTypeID` DROP DEFAULT;
+
+ALTER TABLE `parameter_candidate`
+  ALTER `InsertTime` SET DEFAULT 0;
+
+ALTER TABLE `parameter_session`
+  ALTER `SessionID` DROP DEFAULT;
+
+ALTER TABLE `parameter_session`
+  ALTER `ParameterTypeID` DROP DEFAULT;
+
+ALTER TABLE `parameter_session`
+  ALTER `InsertTime` SET DEFAULT 0;
+
+ALTER TABLE `SNP_candidate_rel`
+  ALTER `SNPID` DROP DEFAULT;
+
+ALTER TABLE `SNP_candidate_rel`
+  ALTER `CandID` DROP DEFAULT;
+
+ALTER TABLE `feedback_mri_predefined_comments`
+  ALTER `CommentTypeID` DROP DEFAULT;
+
+ALTER TABLE `feedback_mri_comments`
+  ALTER `CommentTypeID` DROP DEFAULT;

--- a/SQL/New_patches/2024-07-16-CleanFlagSession.sql
+++ b/SQL/New_patches/2024-07-16-CleanFlagSession.sql
@@ -1,0 +1,4 @@
+-- Drop suspicious default
+
+ALTER TABLE `flag`
+  ALTER `SessionID` DROP DEFAULT;

--- a/SQL/New_patches/2024-07-16-CleanFlagSession.sql
+++ b/SQL/New_patches/2024-07-16-CleanFlagSession.sql
@@ -1,4 +1,0 @@
--- Drop suspicious default
-
-ALTER TABLE `flag`
-  ALTER `SessionID` DROP DEFAULT;


### PR DESCRIPTION
## Brief summary of changes

While browsing the database schema, I noticed there were a lot of `default '0'` everywhere, even for foreign keys ! This is an anti-pattern that is easy to fix and should not require any change to the codebase outside of the schema, so here is a PR.

List of changes:
1. Drop the `DEFAULT 0` for foreign key fields (we do not have any table with a record at index `0` as far as I know/checked)
2. Change `DEFAULT '0'` (or `'1'`) to `DEFAULT 0` (or `1`) for other fields, which is more correct (the former can notably raise type errors with some database engines IIRC).

I don't think the `ALTER column SET DEFAULT 0` is actually useful in the SQL patch, but it cannot hurt.

I omitted the `mri_protocol.Scan_type` field as it is fixed in #9304 instead.

More broadly, it seems to me that there is an overuse of defaults in our database, but fixing everything would require a lot more work and analysis, and is therefore a job for another day.

#### Testing instructions (if applicable)

1. Apply patch and/or reset Rainsinbread
2. Use LORIS
