### PR TITLE
[statistics] Fix bracket for null coalesce

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -126,7 +126,7 @@ class Charts extends \NDB_Page
 
             $recruitmentBySiteData[] = [
                 "label" => $siteName,
-                "total" => intval($data[$siteID]) ?? 0,
+                "total" => intval($data[$siteID] ?? 0),
             ];
         }
         return new \LORIS\Http\Response\JsonResponse($recruitmentBySiteData);


### PR DESCRIPTION
If a user has a site which has no candidate has data for, the statistics chart will print a warning because of a misplaced bracket.

Move the null coalesce inside of the intval argument to fix the warning.

This should theoretically fix the second part of https://github.com/aces/Loris/discussions/9308