### PR TITLE
[tools] fix instrument SQL generator script

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -47,6 +47,12 @@ foreach ($instruments as $instrument) {
             continue;
         }
         switch ($bits[0]) {
+        // No SQL generated for these cases.
+        case "testname":
+        case "title":
+        case "header":
+            continue 2;
+
         // generate the CREATE TABLE syntax
         case "table":
             $tablename = $bits[1];
@@ -64,11 +70,6 @@ foreach ($instruments as $instrument) {
                 . "ON UPDATE CURRENT_TIMESTAMP,\n";
 
             break;
-
-        // no SQL need be generated.
-        case "title":
-        case "header":
-            continue 2;
 
         // generate specific column definitions for specific types of HTML elements
         default:


### PR DESCRIPTION
## Brief summary of changes

Fix for #9312.

The version before the regression generated broken SQL for `testname`, which was then erased when the table was created.
The regression was due to the erasement being removed.
This removes the broken SQL generation.

I don't know how critical this bug is but this PR should be in the next bugfix patch if there is one.

## Testing instructions

Use the tools `lorisform_parser.php` and `generate_tables_sql.php` script to generate instrument SQL, and ensure this SQL is correct.