### PR TITLE
fix generic_includes.php returning error "Undefined variable in /var/www/loris/tools/generic_includes.php on line 28" - 26 branch

### DIFF
--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -24,6 +24,7 @@ $client     = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize($configFile);
 $config        = NDB_Config::singleton();
+$DB            = NDB_Factory::singleton()->database();
 $lorisInstance = new \LORIS\LorisInstance(
     $DB,
     $config,
@@ -32,4 +33,3 @@ $lorisInstance = new \LORIS\LorisInstance(
         __DIR__ . "/../modules/",
     ],
 );
-$DB            = $lorisInstance->getDatabaseConnection();


### PR DESCRIPTION
## Brief summary of changes

This fixes the script `generic_includes.php` that calls the $DB variable before it is defined when calling LorisInstance.

Without this fix, anything calling `generic_includes.php` will trigger the following error:
```
Undefined variable in /var/www/loris/tools/generic_includes.php on line 28
PHP Fatal error:  Uncaught TypeError: LORIS\\LorisInstance::__construct(): Argument #1 ($db) must be of type Database, null given, called in /var/www/loris/tools/generic_includes.php on line 27
```
