### PR TITLE
[issue_tracker] Resolve issue with "watching" field in issue tracker

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1543,7 +1543,7 @@ CREATE TABLE `issues_history` (
   `issueHistoryID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `newValue` longtext NOT NULL,
   `dateAdded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description') NOT NULL DEFAULT 'comment',
+  `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description','watching') NOT NULL DEFAULT 'comment',
   `issueID` int(11) unsigned NOT NULL,
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),

--- a/SQL/New_patches/2024-08-13-issuetracker-AddWatchingToIssuesHistory.sql
+++ b/SQL/New_patches/2024-08-13-issuetracker-AddWatchingToIssuesHistory.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `issues_history`
+    MODIFY `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description', 'watching') NOT NULL DEFAULT 'comment';

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -607,9 +607,15 @@ class Edit extends \NDB_Page implements ETagCalculator
 
             // Add new watchers (if any)
             $usersWatching = explode(',', $values['othersWatching']);
+            // If the assignee is watching, add them
+            if ($values['watching'] == 'Yes'
+                && $issueValues['assignee'] == $user->getUsername()) {
+                $usersWatching[] = $issueValues['assignee'];
+            }
+
             foreach ($usersWatching as $usersWatching) {
                 if ($usersWatching) {
-                    $db->insert(
+                    $db->replace(
                         'issues_watching',
                         [
                             'userID'  => $usersWatching,

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -609,7 +609,8 @@ class Edit extends \NDB_Page implements ETagCalculator
             $usersWatching = explode(',', $values['othersWatching']);
             // If the assignee is watching, add them
             if ($values['watching'] == 'Yes'
-                && $issueValues['assignee'] == $user->getUsername()) {
+                && $issueValues['assignee'] == $user->getUsername()
+            ) {
                 $usersWatching[] = $issueValues['assignee'];
             }
 


### PR DESCRIPTION
## Brief summary of changes
- Modified the `issues_history` table to include the 'watching' field in the `fieldChanged` enum.
- Fixed the issue where the "watching" field was taking the "no" value when an issue was updated.
- Fixed the unreported issue of 500 Internal server errors, whenever watching was changed.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)
1. Go to the issue tracker and create a new issue (MainMenu -> Tools -> Issue Tracker -> New issue).
2. Create a new issue with any test information.
3. Go to the created issue and verify that all fields are populated correctly.
4. Update the issue, making changes to any field(s).
5. Click the "Update" button and observe that the "watching" field retains its previous value.
6. Verify that no 500 errors occur during the update process.

#### Link(s) to related issue(s)

* Resolves #9315
