### PR TITLE
 [DQT] Fields not updating when changing page for specific search for "1" or other numbers

### DIFF
--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -301,9 +301,6 @@ class FieldList extends Component {
     let start = (this.props.PageNumber - 1) * rowsPerPage;
     let filter = this.props.Filter.toLowerCase();
     let selectedFields;
-    if (filter > 0) {
-      start = 0;
-    }
 
     let filteredItems = items.filter((item) => {
       fieldName = item.key[1];


### PR DESCRIPTION
issue: On the DQT, displayed fields are not refreshed when changing pages to see the fields available for selection on a specific search (003) for the 'pex_bm_health_preg_i_meds' instrument. Other searches or other instruments do not appear to have this issue. 
test:
Instrument:

'pex_bm_health_preg_i_meds'
Search:
003
