### PR TITLE
[candidate_profile] Add error boundary to cards with errors

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -21,8 +21,13 @@ class Card extends Component {
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
+    this.state = {hasError: false};
   }
 
+  static getDerivedStateFromError(error) {
+    console.error(error);
+    return {hasError: true};
+  }
   /**
    * Delegate clicks on the card to the onClick handler
    *
@@ -68,7 +73,11 @@ class Card extends Component {
             onClick={this.handleClick}
             style={cursorStyle}
           >
-            {this.props.children}
+            {this.state.hasError ? <div>
+                      <strong>Something went wrong rendering this panel.
+                          Please open a bug report.</strong>
+                      </div>
+                      : this.props.children}
           </div>
         </Panel>
       </div>

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -57,17 +57,21 @@ window.addEventListener('load', () => {
         modprops = {$widget->getComponentProps()|json_encode};
         allprops = { ...baseprops, ...modprops };
 
-        cards.push({
-            Title: '{$widget->getTitle()|escape:js}',
-            Content: React.createElement(
-                {$widget->getComponentName()},
-                allprops
-            ),
-            collapsing: false
-            {if $widget->getWidth()},Width: {$widget->getWidth()}{/if}
-            {if $widget->getOrder()},Order: {$widget->getOrder()}{/if}
-            {if $widget->getHeight()},Height: {$widget->getHeight()}{/if}
-        });
+        try {
+		cards.push({
+		    Title: '{$widget->getTitle()|escape:js}',
+		    Content: React.createElement(
+			{$widget->getComponentName()},
+			allprops
+		    ),
+		    collapsing: false
+		    {if $widget->getWidth()},Width: {$widget->getWidth()}{/if}
+		    {if $widget->getOrder()},Order: {$widget->getOrder()}{/if}
+		    {if $widget->getHeight()},Height: {$widget->getHeight()}{/if}
+		});
+        } catch(err) {
+             console.error(err);
+        }
         {/section}
 
         return cards;


### PR DESCRIPTION
This adds an error boundary to the jsx/Card class, so that when a widget doesn't render properly on the candidate profile page that panel is displayed with an error and the rendering of other widgets is unaffected, instead of crashing and showing a blank page.

Fixes an issue I can't find keywords to find the reference for.