### PR TITLE
[Core] Add database query class to represent the results of a DB query

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -212,7 +212,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-        if ($visitinfo['CandID'] !== $this->_candidate->getCandID()) {
+        if ($visitinfo['CandID'] !== $this->_candidate->getCandID()->__toString()) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 'CandID does not match this candidate'
             );

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -145,7 +145,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             // came from the CandID column of a database call. If
             // something goes wrong at this point we should definitely
             // propagate an exception..
-            $candID = new CandID($pscids[0]["CandID"]);
+            $candID = new CandID(strval($pscids->getFirstRow()["CandID"]));
         }
 
         try {

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -145,6 +145,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             // came from the CandID column of a database call. If
             // something goes wrong at this point we should definitely
             // propagate an exception..
+            assert($pscids instanceof \LORIS\Database\Query);
             $candID = new CandID(strval($pscids->getFirstRow()["CandID"]));
         }
 

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -245,16 +245,20 @@ function getFamilyInfoFields()
         ['candid' => $candID]
     );
 
-    $candidatesList = $db->pselect(
-        "SELECT CandID FROM candidate ORDER BY CandID",
-        []
+    $candidatesList = iterator_to_array(
+        $db->pselect(
+            "SELECT CandID FROM candidate ORDER BY CandID",
+            []
+        )
     );
 
-    $siblingsList = $db->pselect(
-        "SELECT f1.CandID 
+    $siblingsList = iterator_to_array(
+        $db->pselect(
+            "SELECT f1.CandID 
         FROM family f1 JOIN family f2
         ON f1.FamilyID=f2.FamilyID WHERE f2.CandId=:candid GROUP BY f1.CandID",
-        ['candid' => $candID]
+            ['candid' => $candID]
+        )
     );
 
     $siblings = [];
@@ -404,7 +408,7 @@ function getParticipantStatusHistory(CandID $candID)
         ['cid' => $candID]
     );
 
-    return $unformattedComments;
+    return iterator_to_array($unformattedComments);
 }
 
 

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -137,7 +137,7 @@ class Configuration extends \NDB_Form
         // Check whether any setting is overwritten in the config.xml
         // Add this info to the array so form entries can be disabled in front end
         // Update the value for the setting to the value from the config.xml
-        foreach ($configs as &$setting) {
+        foreach ($configs as $setting) {
             try {
                 $setting['Disabled'] = 'Yes';
                 if ($setting['Parent'] != null) {
@@ -155,7 +155,7 @@ class Configuration extends \NDB_Form
 
         // Now check for config settings from the database for the fields not
         // overridden in the config.xml
-        foreach ($configs as &$setting) {
+        foreach ($configs as $setting) {
             if ($setting['Disabled'] == 'No') {
                 $value = $DB->pselect(
                     "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
@@ -171,7 +171,7 @@ class Configuration extends \NDB_Form
 
         // build a tree from configs array
         $tree = [];
-        foreach ($configs as &$node) {
+        foreach ($configs as $node) {
             $node['Children']  = [];
             $tree[$node['ID']] = &$node;
 

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -112,7 +112,7 @@ class Configuration extends \NDB_Form
             []
         );
 
-        return $parentConfigItems;
+        return iterator_to_array($parentConfigItems);
     }
 
     /**
@@ -180,7 +180,7 @@ class Configuration extends \NDB_Form
             $tree[$node['Parent']]['Children'][] = &$node;
         }
 
-        return $configs;
+        return iterator_to_array($configs);
     }
 
     /**

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -129,15 +129,17 @@ class Configuration extends \NDB_Form
         $DB     = $this->loris->getDatabaseConnection();
 
         // Get the names and meta-information for the config settings in the database
-        $configs = $DB->pselect(
-            "SELECT * FROM ConfigSettings WHERE Visible=1 ORDER BY OrderNumber",
-            []
+        $configs = iterator_to_array(
+            $DB->pselect(
+                "SELECT * FROM ConfigSettings WHERE Visible=1 ORDER BY OrderNumber",
+                []
+            )
         );
 
         // Check whether any setting is overwritten in the config.xml
         // Add this info to the array so form entries can be disabled in front end
         // Update the value for the setting to the value from the config.xml
-        foreach ($configs as $setting) {
+        foreach ($configs as &$setting) {
             try {
                 $setting['Disabled'] = 'Yes';
                 if ($setting['Parent'] != null) {
@@ -155,7 +157,7 @@ class Configuration extends \NDB_Form
 
         // Now check for config settings from the database for the fields not
         // overridden in the config.xml
-        foreach ($configs as $setting) {
+        foreach ($configs as &$setting) {
             if ($setting['Disabled'] == 'No') {
                 $value = $DB->pselect(
                     "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
@@ -171,16 +173,15 @@ class Configuration extends \NDB_Form
 
         // build a tree from configs array
         $tree = [];
-        foreach ($configs as $node) {
-            $node['Children']  = [];
-            $tree[$node['ID']] = &$node;
-
+        foreach ($configs as &$node) {
+            $node['Children']          = [];
+            $tree[intval($node['ID'])] = &$node;
         }
         foreach ($configs as &$node) {
             $tree[$node['Parent']]['Children'][] = &$node;
         }
 
-        return iterator_to_array($configs);
+        return $configs;
     }
 
     /**

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -151,7 +151,7 @@ class Module extends \Module
                 ['cand1' => $candID, 'cand2' => $candID],
             );
             // Do not show the conflicts card if there are no conflicts
-            if (empty($results)) {
+            if (count($results) === 0) {
                 return [];
             }
 
@@ -165,7 +165,7 @@ class Module extends \Module
                     $baseURL . "/conflict_resolver/js/CandidateConflictsWidget.js",
                     "lorisjs.conflict_resolver.CandidateConflictsWidget.default",
                     [
-                        'Conflicts' => $results,
+                        'Conflicts' => iterator_to_array($results),
                     ],
                     $width,
                     1,

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -309,7 +309,7 @@ class Files extends \NDB_Page
             []
         );
 
-        $dataReleaseFiles = array_column($filesList, 'file_name');
+        $dataReleaseFiles = array_column(iterator_to_array($filesList), 'file_name');
 
         $results = [
             'files'         => $dataReleaseFiles,

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -107,12 +107,14 @@ class ViewDetails extends \NDB_Form
         case "tarchive_series":
             $query        = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
-            $tarchiveData = $this->DB->pselect(
-                $query,
-                [
-                    'ID'     => $tarchiveID,
-                    "OField" => $order,
-                ]
+            $tarchiveData = iterator_to_array(
+                $this->DB->pselect(
+                    $query,
+                    [
+                        'ID'     => $tarchiveID,
+                        "OField" => $order,
+                    ]
+                )
             );
 
             if ($this->_setProtocols()) {
@@ -136,12 +138,14 @@ class ViewDetails extends \NDB_Form
         case "tarchive_files":
             $query        = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
-            $tarchiveData = $this->DB->pselect(
-                $query,
-                [
-                    'ID'     => $tarchiveID,
-                    'OField' => $order,
-                ]
+            $tarchiveData = iterator_to_array(
+                $this->DB->pselect(
+                    $query,
+                    [
+                        'ID'     => $tarchiveID,
+                        'OField' => $order,
+                    ]
+                )
             );
             break;
         }

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -291,7 +291,7 @@ DocUploadForm.propTypes = {
   dataURL: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
   refreshPage: PropTypes.func.isRequired,
-  category: PropTypes.string,
+  category: PropTypes.bool,
 };
 
 export default DocUploadForm;

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -81,9 +81,11 @@ class DocTree extends \NDB_Page
      */
     public function getTreeData()
     {
-        return $this->loris->getDatabaseConnection()->pselect(
-            "SELECT * FROM document_repository_categories",
-            []
+        return iterator_to_array(
+            $this->loris->getDatabaseConnection()->pselect(
+                "SELECT * FROM document_repository_categories",
+                []
+            )
         );
     }
     /**

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -175,9 +175,9 @@ class DocTree extends \NDB_Page
         );
         $parentcategories =   $this->getParents($tree, $id);
         $result['allsubcategories'] = $allsubcategories;
-        $result['currentcategory']  = $currentcategory;
+        $result['currentcategory']  = iterator_to_array($currentcategory);
         $result['parentcategory']   = $parentcategories;
-        $result['subcategories']    = $subcategories;
+        $result['subcategories']    = iterator_to_array($subcategories);
 
         return $result;
     }

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -85,13 +85,15 @@ class Module extends \Module
 
             $last_login = $user->getLastLogin($DB);
 
-            $docs         = $DB->pselect(
-                "SELECT File_name,
+            $docs         = iterator_to_array(
+                $DB->pselect(
+                    "SELECT File_name,
                         Date_uploaded,
                         CONCAT(uploaded_by, '/', File_name) AS Data_dir
                  FROM document_repository
                  ORDER BY Date_uploaded DESC LIMIT 4",
-                []
+                    []
+                )
             );
             $numberOfDocs = sizeof($docs);
             for ($i=0; $i < $numberOfDocs; $i++) {

--- a/modules/electrophysiology_browser/php/models/datasettags.class.inc
+++ b/modules/electrophysiology_browser/php/models/datasettags.class.inc
@@ -43,11 +43,13 @@ class DatasetTags
         $db = $this->loris->getDatabaseConnection();
 
         // TODO: Instead use schemas in project_schema_rel?
-        $this->_hedSchema = $db->pselect(
-            'SELECT * FROM hed_schema_nodes AS hsn
+        $this->_hedSchema = iterator_to_array(
+            $db->pselect(
+                'SELECT * FROM hed_schema_nodes AS hsn
               LEFT JOIN hed_schema AS hs
               ON hsn.SchemaID = hs.ID',
-            []
+                []
+            )
         );
 
         $this->_projectID = $db->pselectOneInt(

--- a/modules/electrophysiology_browser/php/models/electrophysioevents.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysioevents.class.inc
@@ -30,13 +30,15 @@ class ElectrophysioEvents
         $this->_physioFileID = $physioFileID;
         $db = $this->loris->getDatabaseConnection();
 
-        $taskEvents = $db->pselect(
-            'SELECT te.*
+        $taskEvents = iterator_to_array(
+            $db->pselect(
+                'SELECT te.*
                 FROM physiological_task_event AS te
                 JOIN physiological_event_file AS f
                 ON f.EventFileID = te.EventFileID
                 WHERE f.PhysiologicalFileID=:PFID AND f.FileType="tsv"',
-            ['PFID' => $this->_physioFileID]
+                ['PFID' => $this->_physioFileID]
+            )
         );
 
         $taskEventIDs = array_map(
@@ -172,10 +174,12 @@ class ElectrophysioEvents
                 );
             }
 
-            $taskEvent = $db->pselect(
-                'SELECT * FROM physiological_task_event
+            $taskEvent = iterator_to_array(
+                $db->pselect(
+                    'SELECT * FROM physiological_task_event
             WHERE PhysiologicalTaskEventID=:PTEID',
-                ['PTEID' => $instance_id]
+                    ['PTEID' => $instance_id]
+                )
             );
 
             $extraColumns = $db->pselect(
@@ -274,8 +278,9 @@ class ElectrophysioEvents
         $config  = \NDB_Factory::singleton()->config();
         $dataDir = $config->getSetting("dataDirBasepath");
 
-        $tsv = $db->pselect(
-            "SELECT
+        $tsv = iterator_to_array(
+            $db->pselect(
+                "SELECT
             EventFileID   AS id,
             FilePath      AS filePath,
             ProjectID     AS projectID,
@@ -284,7 +289,8 @@ class ElectrophysioEvents
           FROM physiological_event_file
           WHERE PhysiologicalFileID=:PFID
           AND FileType='tsv'",
-            ['PFID' => $this->_physioFileID]
+                ['PFID' => $this->_physioFileID]
+            )
         );
 
         $projectID = $db->pselectOneInt(
@@ -295,8 +301,9 @@ class ElectrophysioEvents
             ['PFID' => $this->_physioFileID]
         );
 
-        $json = $db->pselect(
-            "SELECT
+        $json = iterator_to_array(
+            $db->pselect(
+                "SELECT
             EventFileID   AS id,
             FilePath      AS filePath,
             LastUpdate    AS lastUpdate,
@@ -306,10 +313,11 @@ class ElectrophysioEvents
               PhysiologicalFileID=:PFID OR ProjectID=:PID
           )
           AND FileType='json'",
-            [
-                'PFID' => $this->_physioFileID,
-                'PID'  => $projectID
-            ]
+                [
+                    'PFID' => $this->_physioFileID,
+                    'PID'  => $projectID
+                ]
+            )
         );
 
         $tsvPath  = count($tsv) > 0
@@ -399,26 +407,30 @@ class ElectrophysioEvents
             // events.tsv
             $tsvFile = fopen($tsvPath, 'w'); // Will override all file content
 
-            $extraColumns = $db->pselect(
-                "SELECT *
+            $extraColumns = iterator_to_array(
+                $db->pselect(
+                    "SELECT *
                     FROM physiological_task_event_opt
                     WHERE PhysiologicalTaskEventID IN (
                         SELECT PhysiologicalTaskEventID
                         FROM physiological_task_event
                         WHERE PhysiologicalFileID=:PFID
                     )",
-                ['PFID' => $this->_physioFileID]
+                    ['PFID' => $this->_physioFileID]
+                )
             );
 
-            $hed_tags = $db->pselect(
-                "SELECT *
+            $hed_tags = iterator_to_array(
+                $db->pselect(
+                    "SELECT *
                     FROM physiological_task_event_hed_rel
                     WHERE PhysiologicalTaskEventID IN (
                         SELECT PhysiologicalTaskEventID
                         FROM physiological_task_event
                         WHERE PhysiologicalFileID=:PFID
                     )",
-                ['PFID' => $this->_physioFileID]
+                    ['PFID' => $this->_physioFileID]
+                )
             );
 
             $columnNames = $db->pselect(

--- a/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
@@ -144,8 +144,9 @@ class ElectrophysioFile implements \LORIS\Data\DataInstance
      */
     function getParameter(string $parameterName) : string
     {
-        return $this->_fileData[$parameterName] ??
+        $val = $this->_fileData[$parameterName] ??
             ($this->_parameters[$parameterName] ?? '');
+        return strval($val);
     }
 
     /**

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -170,7 +170,10 @@ class Sessions extends \NDB_Page
         $response = [];
 
         $sessions            = $db->pselect($query, []);
-        $sessions            = array_column($sessions, 'SessionID');
+        $sessions            = array_column(
+            iterator_to_array($sessions),
+            'SessionID'
+        );
         $response['patient'] = $this->getSubjectData($outputType);
         $response['database']    = array_values(
             $this->getFilesData($outputType)

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -181,16 +181,18 @@ class EditExaminer extends \NDB_Form
             } else { // update to a test certification for the examiner
 
                 //select history events
-                $oldVals = $DB->pselect(
-                    "SELECT ch.new, ch.new_date
+                $oldVals = iterator_to_array(
+                    $DB->pselect(
+                        "SELECT ch.new, ch.new_date
                      FROM certification_history ch
                      LEFT JOIN certification c ON (c.certID=ch.primaryVals)
                      WHERE c.examinerID=:EID AND ch.testID=:TID
                      ORDER BY changeDate DESC LIMIT 1",
-                    [
-                        'EID' => $examinerID,
-                        'TID' => $testID,
-                    ]
+                        [
+                            'EID' => $examinerID,
+                            'TID' => $testID,
+                        ]
+                    )
                 );
 
                 $oldVal  = null;

--- a/modules/genomic_browser/php/views/file.class.inc
+++ b/modules/genomic_browser/php/views/file.class.inc
@@ -71,7 +71,7 @@ class File
             []
         );
         return array_reduce(
-            $results,
+            iterator_to_array($results),
             function ($carry, $item) {
                 $value = array_values($item)[0];
                 if (!empty($value)) {

--- a/modules/genomic_browser/php/views/methylation.class.inc
+++ b/modules/genomic_browser/php/views/methylation.class.inc
@@ -89,7 +89,7 @@ class Methylation
             []
         );
         return array_reduce(
-            $results,
+            iterator_to_array($results),
             function ($carry, $item) {
                 $value = array_values($item)[0];
                 if (!empty($value)) {

--- a/modules/imaging_browser/php/feedback_mri_popup.class.inc
+++ b/modules/imaging_browser/php/feedback_mri_popup.class.inc
@@ -185,7 +185,7 @@ class Feedback_MRI_Popup extends \NDB_Page
 
             $qparams = ['SID' => $this->session_id];
         }
-        $result = $DB->pselect($query, $qparams);
+        $result = iterator_to_array($DB->pselect($query, $qparams));
         if (count($result) > 0) {
             $i = 0;
             foreach ($result[0] as $key => $value) {

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -103,10 +103,11 @@ class Module extends \Module
                 GROUP BY s.Visit_label, mst.Scan_type, QC",
                 ['cid' => $candidate->getCandID()],
             );
-            if (empty($scansummary)) {
+
+            if (count($scansummary) === 0) {
                 return [];
             }
-            foreach ($scansummary as &$summary) {
+            foreach ($scansummary as $summary) {
                 $summary['nfiles'] = (int )$summary['nfiles'];
             }
             return [
@@ -114,7 +115,7 @@ class Module extends \Module
                     "Imaging QC Summary",
                     $baseURL. "/imaging_browser/js/CandidateScanQCSummaryWidget.js",
                     "lorisjs.imaging_browser.CandidateScanQCSummaryWidget.default",
-                    [ 'Files' => $scansummary],
+                    [ 'Files' => iterator_to_array($scansummary)],
                     2,
                     1,
                 )

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -417,7 +417,7 @@ class ViewSession extends \NDB_Form
             AND mvl.Header NOT LIKE 'Manual Caveat Set by %';
         ";
 
-        return $this->_DB->pselect($query, ['fileID' => $fileID]);
+        return iterator_to_array($this->_DB->pselect($query, ['fileID' => $fileID]));
     }
 
     /**

--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -128,7 +128,7 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                 function ($row) {
                     return $row['CommentID'];
                 },
-                $data,
+                iterator_to_array($data),
             )
         );
 
@@ -333,8 +333,9 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $q = $DB->prepare($insertstmt);
         $q->execute([]);
 
-        $rows = $DB->pselect(
-            "SELECT c.CandID, CommentID FROM flag f 
+        $rows = iterator_to_array(
+            $DB->pselect(
+                "SELECT c.CandID, CommentID FROM flag f 
                 JOIN session s ON (f.SessionID=s.ID)
                 JOIN candidate c ON (s.CandID=c.CandID)
              WHERE f.CommentID NOT LIKE 'DDE%'
@@ -342,7 +343,8 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                 AND f.Test_name IN ('" . join("', '", $instruments). "')
                 AND c.Active='Y' AND s.Active='Y'
              ORDER BY c.CandID",
-            [],
+                [],
+            )
         );
 
         $commentID2CandID = [];

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -102,6 +102,7 @@ class VisitSummary extends \NDB_Page
             ['candid' => $candid, 'vl' => $visitLabel]
         );
 
+        $rslt = [];
         foreach ($bvl_result as $key => $row) {
             $testName  = $row['Test_name'];
             $commentID = $row['CommentID'];
@@ -121,13 +122,13 @@ class VisitSummary extends \NDB_Page
                 continue;
             }
             if ($instrument === null) {
-                $bvl_result[$key]['Completion'] = 0;
+                $rslt[$key]['Completion'] = 0;
             } else {
                 $completion = $instrument->determineDataEntryCompletionProgress();
-                $bvl_result[$key]['Completion'] = $completion;
+                $rslt[$key]['Completion'] = $completion;
             }
         }
 
-        return new \LORIS\Http\Response\JSON\OK($bvl_result);
+        return new \LORIS\Http\Response\JSON\OK($rslt);
     }
 }

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -397,7 +397,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                     = $this->formatUserInformation($comment['newValue']);
             }
         }
-        return $unformattedComments; //now formatted I guess
+        return iterator_to_array($unformattedComments); //now formatted I guess
     }
 
     /**
@@ -743,8 +743,9 @@ class Edit extends \NDB_Page implements ETagCalculator
         $msg_data['comment']     = $values['comment'];
 
         if (isset($changed_assignee) && $new_assignee_tag == 'false') {
-            $issueChangeEmailsAssignee = $db->pselect(
-                "SELECT
+            $issueChangeEmailsAssignee = iterator_to_array(
+                $db->pselect(
+                    "SELECT
                     u.Email AS Email,
                     u.First_name AS firstname
                 FROM
@@ -752,10 +753,11 @@ class Edit extends \NDB_Page implements ETagCalculator
                 WHERE
                     u.UserID = :assignee
                     AND u.UserID != :currentUser",
-                [
-                    'assignee'    => $changed_assignee,
-                    'currentUser' => $user->getUserName(),
-                ]
+                    [
+                        'assignee'    => $changed_assignee,
+                        'currentUser' => $user->getUserName(),
+                    ]
+                )
             );
             if (isset($issueChangeEmailsAssignee[0])) {
                 $msg_data['firstname'] = $issueChangeEmailsAssignee[0]['firstname'];
@@ -766,14 +768,16 @@ class Edit extends \NDB_Page implements ETagCalculator
                 );
             }
         } else if (isset($changed_assignee) && $new_assignee_tag === 'true') {
-            $issueChangeEmailsAssignee = $db->pselect(
-                "SELECT u.Email as Email, u.First_name as firstname " .
-                "FROM users u WHERE u.UserID=:assignee
+            $issueChangeEmailsAssignee = iterator_to_array(
+                $db->pselect(
+                    "SELECT u.Email as Email, u.First_name as firstname " .
+                    "FROM users u WHERE u.UserID=:assignee
                 AND u.UserID<>:currentUser",
-                [
-                    'assignee'    => $changed_assignee,
-                    'currentUser' => $user->getUserName(),
-                ]
+                    [
+                        'assignee'    => $changed_assignee,
+                        'currentUser' => $user->getUserName(),
+                    ]
+                )
             );
 
             if (isset($issueChangeEmailsAssignee[0])) {
@@ -893,14 +897,16 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
         // If both are set, return SessionID and CandID
         if (isset($result['PSCID']) && isset($result['visit'])) {
-            $session = $db->pSelect(
-                "SELECT s.ID as sessionID, c.candID as candID FROM candidate c
+            $session = iterator_to_array(
+                $db->pSelect(
+                    "SELECT s.ID as sessionID, c.candID as candID FROM candidate c
                 INNER JOIN session s on (c.CandID = s.CandID)
                 WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
-                [
-                    'PSCID'      => $result['PSCID'],
-                    'visitLabel' => $result['visit'],
-                ]
+                    [
+                        'PSCID'      => $result['PSCID'],
+                        'visitLabel' => $result['visit'],
+                    ]
+                )
             );
 
             if (isset($session[0]['sessionID'])) {

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file implements a data provisioner to get all possible rows
  * for the issue tracker menu page.

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -116,7 +116,7 @@ class Module extends \Module
                  GROUP BY i.issueID, i.Title",
                 [ 'cid' => $candidate->getCandID() ],
             );
-            if (empty($issues)) {
+            if (count($issues) === 0) {
                 return [];
             }
             return [
@@ -125,7 +125,7 @@ class Module extends \Module
                     $baseURL . "/issue_tracker/js/CandidateIssuesWidget.js",
                     "lorisjs.issue_tracker.CandidateIssuesWidget.default",
                     [
-                        'Issues' => $issues,
+                        'Issues' => iterator_to_array($issues),
                     ],
                     1,
                     1,

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -188,11 +188,13 @@ function uploadFile()
             $db->unsafeInsertOnDuplicateUpdate('media', $query);
             $uploadNotifier->notify(["file" => $fileName]);
             $qparam = ['ID' => $sessionID];
-            $result = $db->pselect(
-                'SELECT ID, CandID, CenterID, ProjectID, Visit_label
+            $result = iterator_to_array(
+                $db->pselect(
+                    'SELECT ID, CandID, CenterID, ProjectID, Visit_label
                             from session
                         where ID=:ID',
-                $qparam
+                    $qparam
+                )
             )[0];
             echo json_encode(
                 [
@@ -273,9 +275,11 @@ function getUploadFields()
     } else {
         $sessionQuery .= " ORDER BY c.PSCID ASC";
     }
-    $sessionRecords = $db->pselect(
-        $sessionQuery,
-        $qparam
+    $sessionRecords = iterator_to_array(
+        $db->pselect(
+            $sessionQuery,
+            $qparam
+        )
     );
 
     $instrumentsList = toSelect($sessionRecords, "Test_name", null);

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -72,7 +72,7 @@ class Module extends \Module
                     AND hide_file=false",
                 ['cid' => $candidate->getCandID()],
             );
-            if (empty($media)) {
+            if (count($media) === 0) {
                 return [];
             }
             return [
@@ -80,7 +80,7 @@ class Module extends \Module
                     "Candidate Media",
                     $baseurl . "/media/js/CandidateMediaWidget.js",
                     "lorisjs.media.CandidateMediaWidget.default",
-                    [ 'Files' => $media],
+                    [ 'Files' => iterator_to_array($media)],
                     1,
                     1,
                 )

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -67,14 +67,17 @@ class Mri_Violations extends \DataFrameworkMenu
         // Build a list of existing problem types based on data in db
         $db           = $this->loris->getDatabaseConnection();
         $problemTypes = array_column(
-            $db->pselect(
-                "SELECT DISTINCT MRICandidateErrors.Reason FROM MRICandidateErrors
+            iterator_to_array(
+                $db->pselect(
+                    "SELECT DISTINCT MRICandidateErrors.Reason
+			FROM MRICandidateErrors
                     UNION
                  SELECT DISTINCT 'Could not identify scan type'
                       FROM mri_protocol_violated_scans
                     UNION
                  SELECT DISTINCT 'Protocol Violation' FROM mri_violations_log",
-                []
+                    []
+                )
             ),
             'Reason'
         );

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -730,12 +730,14 @@ function editCollaborators($id) : void
         }
     }
     // update emails if any have changed
-    $currentCollabs = $db->pselect(
-        'SELECT Name, Email FROM publication_collaborator pc '.
-        'LEFT JOIN publication_collaborator_rel pcr '.
-        'ON pcr.PublicationCollaboratorID=pc.PublicationCollaboratorID '.
-        'WHERE pcr.PublicationID=:pid',
-        ['pid' => $id]
+    $currentCollabs = iterator_to_array(
+        $db->pselect(
+            'SELECT Name, Email FROM publication_collaborator pc '.
+            'LEFT JOIN publication_collaborator_rel pcr '.
+            'ON pcr.PublicationCollaboratorID=pc.PublicationCollaboratorID '.
+            'WHERE pcr.PublicationID=:pid',
+            ['pid' => $id]
+        )
     );
 
     $currCollabEmails      = array_column($currentCollabs, 'email');

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -61,10 +61,13 @@ function getData($db) : array
     );
 
     // for selecting behavioural variables of interest
-    $bvlVOIs = $db->pselect(
-        "SELECT pt.Name, pt.SourceFrom FROM parameter_type pt ".
-        "JOIN test_names tn ON tn.Test_name=pt.SourceFrom ORDER BY pt.SourceFrom",
-        []
+    $bvlVOIs = iterator_to_array(
+        $db->pselect(
+            "SELECT pt.Name, pt.SourceFrom FROM parameter_type pt 
+	    JOIN test_names tn ON tn.Test_name=pt.SourceFrom
+	    ORDER BY pt.SourceFrom",
+            []
+        )
     );
 
     $rawProject = $db->pselect(
@@ -288,12 +291,14 @@ function getCollaborators($id) : array
 {
     $db = \NDB_Factory::singleton()->database();
 
-    $collaborators = $db->pselect(
-        'SELECT Name as name, Email as email FROM publication_collaborator pc '.
-        'LEFT JOIN publication_collaborator_rel pcr '.
-        'ON pc.PublicationCollaboratorID=pcr.PublicationCollaboratorID '.
-        'WHERE pcr.PublicationID=:pid',
-        ['pid' => $id]
+    $collaborators = iterator_to_array(
+        $db->pselect(
+            'SELECT Name as name, Email as email FROM publication_collaborator pc '.
+            'LEFT JOIN publication_collaborator_rel pcr '.
+            'ON pc.PublicationCollaboratorID=pcr.PublicationCollaboratorID '.
+            'WHERE pcr.PublicationID=:pid',
+            ['pid' => $id]
+        )
     );
 
     return $collaborators;
@@ -315,12 +320,16 @@ function getFiles($id) : array
         ['pid' => $id]
     );
 
+    $results = [];
     foreach ($files as $key => $f) {
-        $files[$key]['Citation'] = htmlspecialchars_decode($f['Citation']);
-        $files[$key]['Version']  = htmlspecialchars_decode($f['Version']);
+        $val = [];
+        $val['Citation'] = htmlspecialchars_decode($f['Citation']);
+        $val['Version']  = htmlspecialchars_decode($f['Version']);
+
+        $results[$key] = $val;
     }
 
-    return $files;
+    return $results;
 }
 
 /**

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -192,8 +192,9 @@ class Charts extends \NDB_Page
         $scanData = [];
         // Run a query to get all the data. Order matters to ensure that the
         // labels are calculated in the correct order.
-        $data = $DB->pselect(
-            "SELECT s.CenterID,
+        $data = iterator_to_array(
+            $DB->pselect(
+                "SELECT s.CenterID,
                 CONCAT(MONTH(pf.Value), '-', YEAR(pf.Value)) as datelabel,
                 COUNT(distinct s.ID) as count
             FROM files f
@@ -203,7 +204,8 @@ class Charts extends \NDB_Page
             WHERE pt.Name='acquisition_date'
             GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID, datelabel
             ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
-            []
+                []
+            )
         );
 
         // Create the labels.

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -123,7 +123,7 @@ class Statistics_DD_Site extends statistics_site
                 AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID",
             $this->query_vars
         );
-        return $result;
+        return iterator_to_array($result);
     }
 }
 

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -94,7 +94,9 @@ class Statistics_Mri_Site extends Statistics_Site
         $this->_checkCriteria($centerID, $projectID);
         $DB = $this->loris->getDatabaseConnection();
 
-        $scan_types = $DB->pselect("SELECT Scan_type from mri_scan_type", []);
+        $scan_types = iterator_to_array(
+            $DB->pselect("SELECT Scan_type from mri_scan_type", [])
+        );
         $where      = "WHERE (";
         $counter    = 1;
         foreach (array_values($scan_types) as $scan) {

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -234,7 +234,7 @@ class Statistics_Site extends \NDB_Menu
                 AND i.CommentID NOT LIKE 'DDE%' ORDER BY s.Visit_label, c.PSCID",
             $this->query_vars
         );
-        return $result;
+        return iterator_to_array($result);
     }
     /**
      * Setup function

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -478,8 +478,9 @@ class Stats_Demographic extends \NDB_Form
         }
 
         //AGE AVERAGE
-        $result = $db->pselect(
-            "SELECT rowid, AVG(DATEDIFF(dr,dob)) as age
+        $result = iterator_to_array(
+            $db->pselect(
+                "SELECT rowid, AVG(DATEDIFF(dr,dob)) as age
               FROM
               (SELECT DISTINCT c.CandID, s.cohortid as rowid,
                           c.Date_registered as dr,c.DoB as dob
@@ -499,7 +500,8 @@ class Stats_Demographic extends \NDB_Form
                           $paramSite)
                                 as res
               GROUP BY rowid",
-            $this->params ?? []
+                $this->params ?? []
+            )
         );
 
         foreach ($result as $row) {
@@ -524,8 +526,9 @@ class Stats_Demographic extends \NDB_Form
                 'Complete',
                 'Incomplete',
             ];
-            $result = $db->pselect(
-                "SELECT count(*) as val,
+            $result = iterator_to_array(
+                $db->pselect(
+                    "SELECT count(*) as val,
                         f.Data_entry as Subcat,
                         c.RegistrationCenterID as CenterID,
                         s.CohortID as CohortID,
@@ -566,7 +569,8 @@ class Stats_Demographic extends \NDB_Form
                     AND (f.Data_entry IS NULL OR f.Data_entry <> 'Complete')
                 GROUP BY c.RegistrationCenterID, CohortID, VLabel, Subcat
                 ",
-                $this->params ?? []
+                    $this->params ?? []
+                )
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 'Breakdown of Registered Candidates',
@@ -588,8 +592,9 @@ class Stats_Demographic extends \NDB_Form
                 'Male',
                 'Female',
             ];
-            $result        = $db->pselect(
-                "SELECT s.CenterID as CenterID,
+            $result        = iterator_to_array(
+                $db->pselect(
+                    "SELECT s.CenterID as CenterID,
                         s.CohortID as CohortID,
                         s.visit_label as VLabel,
                         c.sex as Subcat,
@@ -605,7 +610,8 @@ class Stats_Demographic extends \NDB_Form
                 AND COALESCE(s.Screening,'') NOT IN ('Failure', 'Withdrawal')
                 AND COALESCE(s.Visit,'') NOT IN ('Failure', 'Withdrawal')
                 GROUP BY s.CenterID, CohortID, VLabel, Subcat",
-                []
+                    []
+                )
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 'Breakdown of Registered Candidates',

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -279,8 +279,9 @@ class Stats_MRI extends \NDB_Form
         }
         $sitesString = implode(",", array_keys($list_of_sites));
 
-        $centers   = $DB->pselect(
-            "SELECT CONCAT('C', CenterID) as ID,
+        $centers   = iterator_to_array(
+            $DB->pselect(
+                "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
                     IFNULL(PSCArea,Name) as LongName,
                     Name as ShortName
@@ -288,7 +289,8 @@ class Stats_MRI extends \NDB_Form
               WHERE CenterID <> '1'
                 AND Study_site = 'Y'
 	        AND CenterID IN (" . $sitesString . ")",
-            []
+                []
+            )
         );
         $sites     = [];
         $sites[''] ="All sites";

--- a/modules/statistics/php/widgets.class.inc
+++ b/modules/statistics/php/widgets.class.inc
@@ -65,8 +65,9 @@ class Widgets extends \NDB_Page implements ETagCalculator
 
         $recruitmentTarget = $config->getSetting('recruitmentTarget');
 
-        $recruitmentRaw = $db->pselect(
-            "SELECT
+        $recruitmentRaw = iterator_to_array(
+            $db->pselect(
+                "SELECT
                 COUNT(*) as Count,
                 c.Sex as Sex,
                 c.RegistrationProjectID as ProjectID
@@ -74,7 +75,8 @@ class Widgets extends \NDB_Page implements ETagCalculator
                  WHERE c.Active='Y' AND c.Entity_type='Human'
                  AND c.RegistrationCenterID <> 1
              GROUP BY c.Sex, c.RegistrationProjectID",
-            []
+                []
+            )
         );
         $totalScans     = array_sum(array_column($recruitmentRaw, 'Count'));
         $recruitment    = [

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -460,6 +460,8 @@ class Edit_User extends \NDB_Form
                         'userID' => $uid
                     ]
                 );
+
+                $examinerID = iterator_to_array($examinerID);
                 $examinerID = $examinerID[0]['examinerID'];
 
                 //get existing sites for examiner

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -78,7 +78,7 @@ class BVL_Feedback_Panel
     function display(): string
     {
         $feedbackProfile = $this->feedbackThread->_feedbackCandidateProfileInfo;
-        $candidateID     = new CandID($feedbackProfile["CandID"]);
+        $candidateID     = new CandID(strval($feedbackProfile["CandID"]));
 
         $this->tpl_data['candID'] = (string) $candidateID;
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -138,9 +138,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $registrationCenterID      = new \CenterID(strval($value));
                 $this->candidateInfo[$key] = $registrationCenterID;
                 break;
-	    case 'CandID':
-		$this->candidateInfo[$key] = new CandID(strval($value));
-		break;
+            case 'CandID':
+                $this->candidateInfo[$key] = new CandID(strval($value));
+                break;
             default:
                 $this->candidateInfo[$key] = $value;
             }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -107,7 +107,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         $row = $db->pselectRow($query, $CandArray);
 
-        if (!is_array($row) || sizeof($row) == 0) {
+        if ($row === null) {
             throw new \LorisException(
                 "Could not select Candidate data from the database (DCCID: $candID)",
                 CANDIDATE_INVALID
@@ -131,13 +131,16 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
             case 'RegistrationProjectID':
-                $registrationProjectID     = new \ProjectID($value);
+                $registrationProjectID     = new \ProjectID(strval($value));
                 $this->candidateInfo[$key] = $registrationProjectID;
                 break;
             case 'RegistrationCenterID':
-                $registrationCenterID      = new \CenterID($value);
+                $registrationCenterID      = new \CenterID(strval($value));
                 $this->candidateInfo[$key] = $registrationCenterID;
                 break;
+	    case 'CandID':
+		$this->candidateInfo[$key] = new CandID(strval($value));
+		break;
             default:
                 $this->candidateInfo[$key] = $value;
             }
@@ -575,7 +578,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Returns the CandID of this candidate
      *
-     * @return integer 6 digit CandID
+     * @return CandID
      */
     function getCandID()
     {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -809,12 +809,12 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
           WHERE CandID=:cid AND Date_visit IS NOT NULL
           ORDER BY Date_visit DESC LIMIT 1";
         $where  = ['cid' => $candID];
-        $result = $db->pselect($query, $where);
+        $result = $db->pselectRow($query, $where);
 
         if (empty($result)) {
             return null;
         }
-        return $result[0];
+        return $result;
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -732,11 +732,7 @@ class Database implements LoggerAwareInterface
      * @param array<string,mixed> $params Values to use for binding to the
      *                                    prepared statement
      *
-     * @return array<int,array<string,string>> An array of arrays containing
-     *                                          the data.
-     *               The outside (non-associative array contains 1 element per
-     *               row returned by the query, and each element is an associative
-     *               array representing the row in the format ColumnName => Value
+     * @return \LORIS\Database\Query
      */
     function pselect(string $query, array $params): \LORIS\Database\Query
     {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -738,11 +738,9 @@ class Database implements LoggerAwareInterface
      *               row returned by the query, and each element is an associative
      *               array representing the row in the format ColumnName => Value
      */
-    function pselect(string $query, array $params): array
+    function pselect(string $query, array $params): \LORIS\Database\Query
     {
-        $this->_printQuery($query, $params);
-        $stmt = $this->prepare($query);
-        return $this->execute($stmt, $params);
+	return new \LORIS\Database\Query($this->_PDO, $query, $params);
     }
 
     /**
@@ -839,12 +837,16 @@ class Database implements LoggerAwareInterface
     function pselectRow(string $query, array $params): ?array
     {
         $rows = $this->pselect($query . " LIMIT 2", $params);
-        if (count($rows) > 1) {
+	switch(count($rows)) {
+	case 0: return null;
+	case 1:
+		$val = $rows->fetch();
+		return $val;
+	default:
             throw new \DomainException(
                 "Attempt to use pselectRow on a query that returns multiple rows"
             );
-        }
-        return $rows[0] ?? null;
+	}
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -740,7 +740,7 @@ class Database implements LoggerAwareInterface
      */
     function pselect(string $query, array $params): \LORIS\Database\Query
     {
-	return new \LORIS\Database\Query($this->_PDO, $query, $params);
+        return new \LORIS\Database\Query($this->_PDO, $query, $params);
     }
 
     /**
@@ -836,17 +836,17 @@ class Database implements LoggerAwareInterface
      */
     function pselectRow(string $query, array $params): ?array
     {
-        $rows = $this->pselect($query . " LIMIT 2", $params);
-	switch(count($rows)) {
-	case 0: return null;
-	case 1:
-		$val = $rows->fetch();
-		return $val;
-	default:
+        $query = $this->pselect($query . " LIMIT 2", $params);
+        switch (count($query)) {
+        case 0:
+            return null;
+        case 1:
+            return $query->getFirstRow();
+        default:
             throw new \DomainException(
                 "Attempt to use pselectRow on a query that returns multiple rows"
             );
-	}
+        }
     }
 
     /**

--- a/php/libraries/DicomTar.class.inc
+++ b/php/libraries/DicomTar.class.inc
@@ -129,7 +129,7 @@ class DicomTar
                     $row['seriesuid']
                 );
             },
-            $dbrow
+            iterator_to_array($dbrow)
         );
     }
 }

--- a/php/libraries/DicomTar.class.inc
+++ b/php/libraries/DicomTar.class.inc
@@ -121,10 +121,16 @@ class DicomTar
                     intval($row['id']),
                     $row['seriesdescription'],
                     intval($row['seriesnumber']),
-                    $row['echotime'],
-                    $row['repetitiontime'],
-                    $row['inversiontime'],
-                    $row['slicethickness'],
+                    is_null($row['echotime']) ? null : strval($row['echotime']),
+                    is_null($row['repetitiontime'])
+                    ? null
+                    : strval($row['repetitiontime']),
+                    $row['inversiontime'] === null
+                    ? null
+                    : strval($row['inversiontime']),
+                    $row['slicethickness'] === null
+                    ? null
+                    : strval($row['slicethickness']),
                     $row['modality'],
                     $row['seriesuid']
                 );

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -79,7 +79,9 @@ class Image
             $this->_outputtype   = $dbrow['outputtype'];
             $this->_acquisitionprotocol = $dbrow['acquisitionprotocol'];
             $this->_filetype            = $dbrow['filetype'];
-            $this->_centerid            = new \CenterID($dbrow['centerid']);
+            $this->_centerid            = $dbrow['centerid'] === null
+            ? null
+            : new \CenterID(strval($dbrow['centerid']));
             $this->_entitytype          = $dbrow['entitytype'];
         }
     }

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -143,7 +143,7 @@ class Image
                 ['v_fileid' => $this->_fileid]
             );
         return array_reduce(
-            $dbrows,
+            iterator_to_array($dbrows),
             function ($carry, $row) {
                 $carry[$row['name']] = $row['value'];
                 return $carry;
@@ -239,7 +239,7 @@ class Image
                 $values = array_values($row);
                 return new \LORIS\ImageCaveats(...$values);
             },
-            $rows
+            iterator_to_array($rows)
         );
     }
 

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -77,6 +77,6 @@ trait LegacyInstrumentTrait
 
         $results = $db->pselect($query, ['TN' => $this->testName]);
 
-        return $results;
+        return iterator_to_array($results);
     }
 }

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -210,7 +210,7 @@ class NDB_BVL_Battery
                 "Failed to get SessionID, and UserID when trying to add $testName"
             );
         }
-        $sessionData = $rows[0];
+        $sessionData = $rows->getFirstRow();
 
         // generate a commentID
         $commentID = $this->_createCommentID($testName);
@@ -356,7 +356,7 @@ class NDB_BVL_Battery
         $rows = $DB->pselect($query, $qparams);
 
         // return all the data selected
-        return $rows;
+        return iterator_to_array($rows);
     }
 
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -202,7 +202,7 @@ class NDB_BVL_Feedback
         }
         $query .= " LIMIT 1";
 
-        $result = $db->pselect($query, $qparams);
+        $result = iterator_to_array($db->pselect($query, $qparams));
         if (!is_array($result) || count($result) == 0) {
             throw new LorisException(
                 "Error, unable to select data for the feedback object"

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -515,7 +515,7 @@ class NDB_BVL_Feedback
 
         $result = $db->pselect($query, $qparams);
 
-        return $result;
+        return iterator_to_array($result);
     }
 
     /**
@@ -624,7 +624,7 @@ class NDB_BVL_Feedback
 
             $result = $db->pselect($query, $qparams);
 
-        return $result;
+        return iterator_to_array($result);
     }
 
     /**
@@ -656,7 +656,7 @@ class NDB_BVL_Feedback
 
         $result = $db->pselect($query, ['FID' => $feedbackID]);
 
-        return $result;
+        return iterator_to_array($result);
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2264,7 +2264,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
                     return $newinst;
                 },
-                $jsondata
+                iterator_to_array($jsondata)
             );
         } else {
             $defaults = $db->pselect(
@@ -2291,7 +2291,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
                     return $newinst;
                 },
-                $defaults
+                iterator_to_array($defaults)
             );
         }
     }
@@ -2726,12 +2726,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $smarty   = new Smarty_NeuroDB();
         $tpl_data = [];
 
-        $tpl_data['questions'] = $DB->pselect(
-            "SELECT Description as question,
+        $tpl_data['questions'] = iterator_to_array(
+            $DB->pselect(
+                "SELECT Description as question,
             SourceField FROM parameter_type
             WHERE SourceFrom=:TN AND
             SourceField NOT IN ('Validity', 'Administration')",
-            ['TN' => $this->testName]
+                ['TN' => $this->testName]
+            )
         );
 
         $Responses = $this->getInstanceData();

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -321,7 +321,7 @@ class NDB_Config
         // with what would have come from the config.xml.
         if (count($configSetting) === 1) {
             // Trying to get a single value from the database.
-            $configSetting = $configSetting[0];
+            $configSetting = $configSetting->getFirstRow();
             if ($configSetting['AllowMultiple'] == '0') {
                 $val = $db->pselectOne(
                     "SELECT Value FROM Config WHERE ConfigID=:CID",

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This class defines a factory which can be used to generate other objects that
  * are usually singletons. Instead of directly calling class::singleton staticly,

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -461,7 +461,7 @@ class NDB_Menu_Filter extends NDB_Menu
                           ." OFFSET " . (($pageNum-1)*$resultsPerPage);
         $result         = $DB->pselect($query . $limit, $qparams);
 
-        return $result;
+        return iterator_to_array($result);
     }
 
     /**
@@ -803,7 +803,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // get the list
         $result = $DB->pselect($query, $qparams);
 
-        return $result;
+        return iterator_to_array($result);
     }
 
     /**

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -803,7 +803,23 @@ class NDB_Menu_Filter extends NDB_Menu
         // get the list
         $result = $DB->pselect($query, $qparams);
 
-        return iterator_to_array($result);
+        // StaticDataTable makes assumptions about values being strings,
+        // so convert all values to strings.
+        return array_map(
+            function ($row) {
+                    return array_map(
+                        function ($cell) {
+                            if ($cell === null) {
+                                return $cell;
+                            }
+                            return strval($cell);
+
+                        },
+                        $row
+                    );
+            },
+            iterator_to_array($result)
+        );
     }
 
     /**

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -299,8 +299,8 @@ abstract class NDB_Notifier_Abstract
             ]
         );
 
-        $reqPerm  = array_column($necessary, 'perm_id');
-        $userPerm = array_column($current, 'permID');
+        $reqPerm  = array_column(iterator_to_array($necessary), 'perm_id');
+        $userPerm = array_column(iterator_to_array($current), 'permID');
 
         $diff = array_diff($reqPerm, $userPerm);
 

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -81,7 +81,7 @@ class Project implements \JsonSerializable
 
             $project = new Project();
 
-            $project->_projectId         = new ProjectID($projectData['projectId']);
+            $project->_projectId         = new ProjectID(strval($projectData['projectId']));
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
             $project->_recruitmentTarget = (integer) $projectData['recTarget'];

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -380,7 +380,7 @@ class Project implements \JsonSerializable
             ['v_project_id' => $this->_projectId]
         );
 
-        return $cohortData;
+        return iterator_to_array($cohortData);
     }
 
     /**
@@ -409,7 +409,7 @@ class Project implements \JsonSerializable
             function ($row) {
                 return $row['candid'];
             },
-            $candidatesData
+            iterator_to_array($candidatesData)
         );
     }
 

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -409,7 +409,7 @@ class Project implements \JsonSerializable
         );
         return array_map(
             function ($row) {
-                return $row['candid'];
+                return strval($row['candid']);
             },
             iterator_to_array($candidatesData)
         );

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -81,7 +81,9 @@ class Project implements \JsonSerializable
 
             $project = new Project();
 
-            $project->_projectId         = new ProjectID(strval($projectData['projectId']));
+            $project->_projectId         = new ProjectID(
+                strval($projectData['projectId'])
+            );
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
             $project->_recruitmentTarget = (integer) $projectData['recTarget'];

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -182,7 +182,7 @@ class Recording
                 ['v_fileid' => $this->_fileid]
             );
         return array_reduce(
-            $dbrows,
+            iterator_to_array($dbrows),
             function ($carry, $row) {
                 $carry[$row['name']] = $row['value'];
                 return $carry;
@@ -324,7 +324,7 @@ class Recording
                 $values = array_values($row);
                 return new \LORIS\RecordingChannels(...$values);
             },
-            $dbrows
+            iterator_to_array($dbrows)
         );
     }
 
@@ -369,7 +369,7 @@ class Recording
                 $values = array_values($row);
                 return new \LORIS\RecordingElectrodes(...$values);
             },
-            $dbrows
+            iterator_to_array($dbrows)
         );
     }
 
@@ -408,7 +408,7 @@ class Recording
                 $values = array_values($row);
                 return new \LORIS\RecordingEvents(...$values);
             },
-            $dbrows
+            iterator_to_array($dbrows)
         );
     }
 

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -115,7 +115,7 @@ class Recording
             $this->_outputtype   = $dbrow['outputtype'];
             $this->_acquisitionmodality = $dbrow['acquisitionmodality'];
             $this->_filetype            = $dbrow['filetype'];
-            $this->_centerid            = new \CenterID($dbrow['centerid']);
+            $this->_centerid            = new \CenterID(strval($dbrow['centerid']));
             $this->_entitytype          = $dbrow['entitytype'];
             $this->_channel_file_path   = $dbrow['channel_file_path'];
             $this->_electrode_file_path = $dbrow['electrode_file_path'];
@@ -366,7 +366,12 @@ class Recording
             );
         return array_map(
             function ($row) {
-                $values = array_values($row);
+                $values = array_map(
+                    function ($val) {
+                           return $val === null ? null : strval($val);
+                    },
+                    array_values($row)
+                );
                 return new \LORIS\RecordingElectrodes(...$values);
             },
             iterator_to_array($dbrows)

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -168,7 +168,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         );
 
         // store user data in object property
-        if (count($row) > 0) {
+        if (is_array($row) && count($row) > 0) {
             $this->_timePointInfo = $row;
             $cohortSettings       = $config->getCohortSettings(
                 intval($row['CohortID'] ?? null)

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -175,7 +175,8 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             );
             $title = $cohortSettings['title'] ?? '';
             $this->_timePointInfo['CohortTitle'] = $title;
-	    $this->_timePointInfo['CandID'] = new CandID(strval($row['CandID']));
+
+            $this->_timePointInfo['CandID'] = new CandID(strval($row['CandID']));
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -160,21 +160,22 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         $this->data = new TimePointData(
             $sessionID,
             isset($row['ProjectID'])
-                ? new ProjectID($row['ProjectID'])
+                ? new ProjectID(strval($row['ProjectID']))
                 : null,
             isset($row['CenterID'])
-                ? new \CenterID($row['CenterID'])
+                ? new \CenterID(strval($row['CenterID']))
                 : null,
         );
 
         // store user data in object property
-        if (is_array($row) && count($row) > 0) {
+        if (count($row) > 0) {
             $this->_timePointInfo = $row;
             $cohortSettings       = $config->getCohortSettings(
                 intval($row['CohortID'] ?? null)
             );
             $title = $cohortSettings['title'] ?? '';
             $this->_timePointInfo['CohortTitle'] = $title;
+	    $this->_timePointInfo['CandID'] = new CandID(strval($row['CandID']));
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(
@@ -278,7 +279,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         }
 
         $insertData = [
-            'CandID'          => $candidate->getCandID(),
+            'CandID'          => $candidate->getCandID()->__toString(),
             'CohortID'        => $CohortID,
             'VisitNo'         => $visitNo,
             'Visit_label'     => $VisitLabel,
@@ -423,7 +424,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
          * which returns values in string format. CandID is used here to
          * ensure we return a validated CandID object.
          */
-        return new CandID($this->_timePointInfo["CandID"]);
+        return $this->_timePointInfo["CandID"];
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -100,7 +100,7 @@ class User extends UserPermissions implements
         $sitenames = [];
         foreach ($user_centerID_query as $key=>$val) {
             // Convert string representation of ID to int
-            $user_cid[$key] = new \CenterID($val['CenterID']);
+            $user_cid[$key] = new \CenterID(strval($val['CenterID']));
             $sitenames[]    = $val['Name'];
         }
         $row['Sites'] = implode(';', $sitenames);
@@ -110,7 +110,7 @@ class User extends UserPermissions implements
             ['uid' => $row['ID']]
         );
         foreach ($user_pid as $k=>$pid) {
-            $user_pid[$k] = new ProjectID($pid);
+            $user_pid[$k] = new ProjectID(strval($pid));
         }
 
         // Get examiner information

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -299,22 +299,23 @@ class UserPermissions
 
         //If not superuser, get the permissions that the user has
         if (!$this->hasPermission('superuser')) {
-            $query  .= "JOIN user_perm_rel up ON (p.permID=up.PermID)
+            $query .= "JOIN user_perm_rel up ON (p.permID=up.PermID)
                 LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
                 LEFT JOIN modules m ON p.moduleID=m.ID
             WHERE up.userID = :UID and m.Active='Y'
                 ORDER BY p.categoryID, m.Name, p.description";
-            $results = $DB->pselect($query, ['UID' => $this->userID]);
+            $dbrows = $DB->pselect($query, ['UID' => $this->userID]);
         } else {
-            $query  .= "LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
+            $query .= "LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
                 LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'
                 ORDER BY p.categoryID, m.Name, p.description";
-            $results = $DB->pselect($query, []);
+            $dbrows = $DB->pselect($query, []);
         }
         $modules = \Module::getActiveModulesIndexed($loris);
         // Build new meaningful description from combination of columns
         // Module Long Name: action description
-        foreach ($results as $key=>$perm) {
+        $results = [];
+        foreach ($dbrows as $key=>$perm) {
             $newDesc = '';
             if (!empty($perm['moduleID'])) {
                 $newDesc = $modules[$perm['moduleID']]->getLongName() . ": ";

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -323,6 +323,7 @@ class UserPermissions
             $newDesc .= empty($perm['action']) ? "" : $perm['action'] . " ";
             $newDesc .= $perm['description'];
 
+	    $results[$key] = $perm;
             $results[$key]['label'] = $newDesc;
         }
         return $results;

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -87,11 +87,9 @@ class UserPermissions
 
         // Fill the permissions array of this UserPermissions object with the
         // values extracted for this user from the database.
-        if (is_array($results) and !empty($results)) {
-            foreach ($results as $row) {
-                $userMatch = $row['userID'] === $this->userID;
-                $this->permissions[$row['code']] = $userMatch;
-            }
+        foreach ($results as $row) {
+            $userMatch = $row['userID'] == $this->userID;
+            $this->permissions[$row['code']] = $userMatch;
         }
     }
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -88,7 +88,8 @@ class UserPermissions
         // Fill the permissions array of this UserPermissions object with the
         // values extracted for this user from the database.
         foreach ($results as $row) {
-            $userMatch = $row['userID'] == $this->userID;
+            $userMatch = $row !== null && ($row['userID'] == $this->userID);
+            assert($row['code'] !== null);
             $this->permissions[$row['code']] = $userMatch;
         }
     }
@@ -323,7 +324,7 @@ class UserPermissions
             $newDesc .= empty($perm['action']) ? "" : $perm['action'] . " ";
             $newDesc .= $perm['description'];
 
-	    $results[$key] = $perm;
+            $results[$key]          = $perm;
             $results[$key]['label'] = $newDesc;
         }
         return $results;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -265,7 +265,7 @@ class Utility
             $ExtraProject_Criteria ORDER BY Visit_label";
         $result = $db->pselect($query, $qparams);
         // The result has several columns; we only want the visit labels.
-        $visitLabels = array_column($result, 'Visit_label');
+        $visitLabels = array_column(iterator_to_array($result), 'Visit_label');
 
         // Generates an array where the keys are equal to the values.
         return array_combine($visitLabels, $visitLabels);

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -671,7 +671,7 @@ class Utility
         $query = "select DISTINCT Current_stage from session where ".
             "CandID = :Cand_id";
         $stage = $db->pselect($query, ['Cand_id' => $Cand_id->__toString()]);
-        return $stage[0]['Current_stage'];
+        return $stage->getFirstRow()['Current_stage'];
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -706,7 +706,6 @@ class Utility
         $DB      = $factory->database();
 
         //get sourcefield using instrument
-        $sourcefields = [];
         if (!is_null($instrument)) {
             $sourcefields = $DB->pselect(
                 "SELECT SourceField, Name FROM parameter_type
@@ -726,12 +725,14 @@ class Utility
                 ['instrument' => $instrument]
             );
         } elseif (!is_null($name)) { //get all source fields
-            $sourcefields = $DB->pselectRow(
+            return $DB->pselectRow(
                 "SELECT * FROM parameter_type WHERE Name = :pn",
                 ['pn' => $name]
             );
+        } else {
+            return [];
         }
-        return $sourcefields;
+        return iterator_to_array($sourcefields);
     }
 
 

--- a/php/libraries/VisitController.class.inc
+++ b/php/libraries/VisitController.class.inc
@@ -58,9 +58,11 @@ class VisitController
                     $row['VisitLabel']
                 );
             },
-            $this->database->pselect(
-                'SELECT VisitName, VisitLabel FROM visit ORDER BY VisitName',
-                []
+            iterator_to_array(
+                $this->database->pselect(
+                    'SELECT VisitName, VisitLabel FROM visit ORDER BY VisitName',
+                    []
+                )
             )
         );
     }
@@ -95,8 +97,9 @@ class VisitController
                     $row['ID']
                 );
             },
-            $this->database->pselect(
-                'SELECT
+            iterator_to_array(
+                $this->database->pselect(
+                    'SELECT
                  v.VisitID as "ID", v.VisitName as "name"
                 FROM
                  visit v
@@ -104,7 +107,8 @@ class VisitController
                  v.VisitName = :name
                 ORDER BY ID
                 ',
-                ['name' => $visit]
+                    ['name' => $visit]
+                )
             )
         );
     }
@@ -155,8 +159,9 @@ class VisitController
                     $row['cohort'], // available
                 ];
             },
-            $this->database->pselect(
-                'SELECT
+            iterator_to_array(
+                $this->database->pselect(
+                    'SELECT
                   v.VisitID as "ID",
                   v.VisitName as "name",
                   psr.ProjectID as "project",
@@ -171,7 +176,8 @@ class VisitController
                  ON vps.ProjectCohortRelID = psr.ProjectCohortRelID
                 ORDER BY ID, project, cohort
                 ',
-                []
+                    []
+                )
             )
         );
     }

--- a/raisinbread/test/api/LorisApiAuthenticatedTest.php
+++ b/raisinbread/test/api/LorisApiAuthenticatedTest.php
@@ -42,7 +42,7 @@ class LorisApiAuthenticatedTest extends LorisIntegrationTest
         $this->_version = 'v0.0.4-dev';
 
         // store the original JWT key for restoring it later
-        $jwtConfig = $this->DB->pselect(
+        $jwtConfig = $this->DB->pselectRow(
             '
             SELECT
               Value, ConfigID
@@ -53,7 +53,7 @@ class LorisApiAuthenticatedTest extends LorisIntegrationTest
             (SELECT ID FROM ConfigSettings WHERE Name="JWTKey")
             ',
             []
-        )[0] ?? null;
+        );
 
         if ($jwtConfig === null) {
             throw new \LorisException('There is no Config for "JWTKey"');

--- a/raisinbread/test/api/LorisApiAuthenticated_v0_0_3_Test.php
+++ b/raisinbread/test/api/LorisApiAuthenticated_v0_0_3_Test.php
@@ -42,7 +42,7 @@ class LorisApiAuthenticated_v0_0_3_Test extends LorisIntegrationTest
         $this->_version = 'v0.0.3';
 
         // store the original JWT key for restoring it later
-        $jwtConfig = $this->DB->pselect(
+        $jwtConfig = $this->DB->pselectRow(
             '
             SELECT
               Value, ConfigID
@@ -53,7 +53,7 @@ class LorisApiAuthenticated_v0_0_3_Test extends LorisIntegrationTest
             (SELECT ID FROM ConfigSettings WHERE Name="JWTKey")
             ',
             []
-        )[0] ?? null;
+        );
 
         if ($jwtConfig === null) {
             throw new \LorisException('There is no Config for "JWTKey"');

--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -130,7 +130,7 @@ abstract class SQLQueryEngine implements QueryEngine
 
         return array_map(
             function ($cid) {
-                return new CandID($cid);
+                return new CandID(strval($cid));
             },
             $rows
         );

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+namespace LORIS\Database;
+
+class Query implements \Countable, \IteratorAggregate
+{
+    protected \PDOStatement $stmt;
+
+    public function __construct(
+        protected \PDO $DB,
+        protected string $query,
+        protected array $params = [],
+        protected bool $buffered = true
+    ) {
+        $this->stmt = $DB->prepare($query);
+    }
+
+    public function count(): int
+    {
+	// PDOStatement->rowCount only works for buffered connections
+        if ($this->buffered == true) {
+		$this->stmt->execute($this->params);
+		return $this->stmt->rowCount();
+	} else {
+		$stmt = $DB->prepare("SELECT COUNT('x') FROM ($query)");
+		$stmt->execute($this->params);
+		return $stmt->fetch();
+	}
+    }
+
+    public function getIterator() : \Traversable
+    {
+        $this->stmt->execute($this->params);
+	return $this->stmt;
+    }
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -16,20 +16,29 @@ class Query implements \Countable, \IteratorAggregate
 
     public function count(): int
     {
-	// PDOStatement->rowCount only works for buffered connections
+        // PDOStatement->rowCount only works for buffered connections
         if ($this->buffered == true) {
-		$this->stmt->execute($this->params);
-		return $this->stmt->rowCount();
-	} else {
-		$stmt = $DB->prepare("SELECT COUNT('x') FROM ($query)");
-		$stmt->execute($this->params);
-		return $stmt->fetch();
-	}
+            $this->stmt->execute($this->params);
+            return $this->stmt->rowCount();
+        } else {
+            $stmt = $this->DB->prepare("SELECT COUNT('x') FROM ({$this->query})");
+            $stmt->execute($this->params);
+            return $stmt->fetch();
+        }
+    }
+
+    public function getFirstRow() : array
+    {
+         $rows = $this->getIterator();
+         assert($rows instanceof \PDOStatement);
+         $val = $rows->fetch();
+         $rows->closeCursor();
+         return $val;
     }
 
     public function getIterator() : \Traversable
     {
         $this->stmt->execute($this->params);
-	return $this->stmt;
+        return $this->stmt;
     }
 }

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -50,31 +50,6 @@ class LorisInstance
         return $this->DB;
     }
 
-    public function getNewDatabaseConnection() : \Database
-    {
-        $settings = \NDB_Factory::singleton()->settings();
-
-        // Pass the credentials in environment variables, so that they
-        // don't potentially show up in a stack trace if something goes
-        // wrong.
-        $dbname = $settings->dbName();
-        putenv("LORIS_{$dbname}_USERNAME=" . $settings->dbUserName());
-        putenv("LORIS_{$dbname}_PASSWORD=" . $settings->dbPassword());
-        putenv("LORIS_{$dbname}_HOST=" . $settings->dbHost());
-
-        $db = new \Database();
-        $db->connect(
-            $settings->dbName(),
-            true,
-        );
-
-        // Unset the variables now that they're no longer needed.
-        putenv("LORIS_{$dbname}_USERNAME=");
-        putenv("LORIS_{$dbname}_PASSWORD=");
-        putenv("LORIS_{$dbname}_HOST=");
-        return $db;
-    }
-
     /**
      * Return a list of directories on the filesystem which
      * may contain modules.

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -50,6 +50,31 @@ class LorisInstance
         return $this->DB;
     }
 
+    public function getNewDatabaseConnection() : \Database
+    {
+        $settings = \NDB_Factory::singleton()->settings();
+
+        // Pass the credentials in environment variables, so that they
+        // don't potentially show up in a stack trace if something goes
+        // wrong.
+        $dbname = $settings->dbName();
+        putenv("LORIS_{$dbname}_USERNAME=" . $settings->dbUserName());
+        putenv("LORIS_{$dbname}_PASSWORD=" . $settings->dbPassword());
+        putenv("LORIS_{$dbname}_HOST=" . $settings->dbHost());
+
+        $db = new \Database();
+        $db->connect(
+            $settings->dbName(),
+            true,
+        );
+
+        // Unset the variables now that they're no longer needed.
+        putenv("LORIS_{$dbname}_USERNAME=");
+        putenv("LORIS_{$dbname}_PASSWORD=");
+        putenv("LORIS_{$dbname}_HOST=");
+	return $db;
+    }
+
     /**
      * Return a list of directories on the filesystem which
      * may contain modules.

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -72,7 +72,7 @@ class LorisInstance
         putenv("LORIS_{$dbname}_USERNAME=");
         putenv("LORIS_{$dbname}_PASSWORD=");
         putenv("LORIS_{$dbname}_HOST=");
-	return $db;
+        return $db;
     }
 
     /**

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -196,7 +196,7 @@ class LorisInstance
 
         return array_map(
             function ($center) {
-                return \Site::singleton(new \CenterID($center));
+                return \Site::singleton(new \CenterID(strval($center)));
             },
             $centers
         );

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -184,22 +184,26 @@ class CandidateTest extends TestCase
     {
         $this->_setUpTestDoublesForSelectCandidate();
 
-        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')->disableOriginalConstructor()->getMock();
-	$resultMock->method("getIterator")
-	    ->willReturn(
-                new ArrayIterator([
+        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resultMock->method("getIterator")
+            ->willReturn(
+                new ArrayIterator(
                     [
-                        "ID"        => 97,
-                        "ProjectID" => 1,
-                        "CenterID"  => 2,
-                    ],
-                    [
-                        "ID"        => 98,
-                        "ProjectID" => 1,
-                        "CenterID"  => 2,
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        => 98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
                     ]
-		])
-	    );
+                )
+            );
         $this->_dbMock
             ->method('pselect')
             ->willReturn($resultMock);
@@ -1357,26 +1361,30 @@ class CandidateTest extends TestCase
     private function _setUpTestDoublesForSelectCandidate()
     {
 
-        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')->disableOriginalConstructor()->getMock();
-	$resultMock->method("getIterator")
-	    ->willReturn(
-                new ArrayIterator([
+        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resultMock->method("getIterator")
+            ->willReturn(
+                new ArrayIterator(
                     [
-                        "ID"        => 97,
-                        "ProjectID" => 1,
-                        "CenterID"  => 2,
-                    ],
-                    [
-                        "ID"        => 98,
-                        "ProjectID" => 1,
-                        "CenterID"  => 2,
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        => 98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
                     ]
-		])
-	    );
+                )
+            );
         $this->_dbMock
             ->method('pselect')
             ->willReturn($resultMock);
-	/*
+        /*
                 $this->onConsecutiveCalls(
                     [
                         [
@@ -1393,7 +1401,7 @@ class CandidateTest extends TestCase
                     $this->_listOfTimePoints
                 )
             );
-	*/
+        */
 
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -183,10 +183,11 @@ class CandidateTest extends TestCase
     public function testSelectRetrievesCandidateInfo()
     {
         $this->_setUpTestDoublesForSelectCandidate();
-        $this->_dbMock
-            ->method('pselect')
-            ->willReturn(
-                [
+
+        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')->disableOriginalConstructor()->getMock();
+	$resultMock->method("getIterator")
+	    ->willReturn(
+                new ArrayIterator([
                     [
                         "ID"        => 97,
                         "ProjectID" => 1,
@@ -197,8 +198,11 @@ class CandidateTest extends TestCase
                         "ProjectID" => 1,
                         "CenterID"  => 2,
                     ]
-                ]
-            );
+		])
+	    );
+        $this->_dbMock
+            ->method('pselect')
+            ->willReturn($resultMock);
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
@@ -242,6 +246,7 @@ class CandidateTest extends TestCase
     public function testSetDataWithArraySucceeds()
     {
         $this->_setUpTestDoublesForSelectCandidate();
+
         $this->_candidate->select($this->_candidateInfo['CandID']);
 
         $data = ['Active' => 'N'];
@@ -572,6 +577,7 @@ class CandidateTest extends TestCase
             2 => 2
         ];
 
+        $this->_setUpTestDoublesForSelectCandidate();
         $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->_dbMock->expects($this->once())
             ->method('pselect')
@@ -634,6 +640,7 @@ class CandidateTest extends TestCase
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
 
+        $this->_setUpTestDoublesForSelectCandidate();
         $this->_candidate->select($this->_candidateInfo['CandID']);
 
         $this->_dbMock->expects($this->any())
@@ -674,6 +681,7 @@ class CandidateTest extends TestCase
             ->method('pselectRow')
             ->willReturn($this->_candidateInfo);
 
+        $this->_setUpTestDoublesForSelectCandidate();
         $this->_candidate->select($this->_candidateInfo['CandID']);
 
         $this->_dbMock->expects($this->any())
@@ -1348,9 +1356,27 @@ class CandidateTest extends TestCase
      */
     private function _setUpTestDoublesForSelectCandidate()
     {
+
+        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')->disableOriginalConstructor()->getMock();
+	$resultMock->method("getIterator")
+	    ->willReturn(
+                new ArrayIterator([
+                    [
+                        "ID"        => 97,
+                        "ProjectID" => 1,
+                        "CenterID"  => 2,
+                    ],
+                    [
+                        "ID"        => 98,
+                        "ProjectID" => 1,
+                        "CenterID"  => 2,
+                    ]
+		])
+	    );
         $this->_dbMock
             ->method('pselect')
-            ->will(
+            ->willReturn($resultMock);
+	/*
                 $this->onConsecutiveCalls(
                     [
                         [
@@ -1367,6 +1393,7 @@ class CandidateTest extends TestCase
                     $this->_listOfTimePoints
                 )
             );
+	*/
 
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -131,9 +131,11 @@ class Database_Test extends TestCase
      */
     function testSetFakeData()
     {
+	    /*
         $client = new NDB_Client();
         $client->makeCommandLine();
         $client->initialize();
+	     */
 
         $this->DB->setFakeTableData(
             "Config",
@@ -149,7 +151,7 @@ class Database_Test extends TestCase
         $allCandidates = $this->DB->pselect("SELECT * FROM Config", []);
 
         $this->assertEquals(
-            $allCandidates,
+            iterator_to_array($allCandidates),
             [
                 0 => [
                     'ID'       => 99999,
@@ -308,10 +310,10 @@ class Database_Test extends TestCase
             "ConfigSettings",
             ['Visible' => 1, 'Description' => null]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -357,10 +359,10 @@ class Database_Test extends TestCase
             "ConfigSettings",
             ['Visible' => 1, 'Description' => 'deleting']
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -408,10 +410,10 @@ class Database_Test extends TestCase
             ['Visible' => null, 'Description' => 'new description'],
             ['Description' => null]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -463,10 +465,10 @@ class Database_Test extends TestCase
             ['Visible' => null, 'Description' => 'new description'],
             ['Description' => 'first description']
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -517,10 +519,10 @@ class Database_Test extends TestCase
                 'Description' => null
             ]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -570,10 +572,10 @@ class Database_Test extends TestCase
                 'Description' => 'test description'
             ]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -633,10 +635,10 @@ class Database_Test extends TestCase
                 'Description' => null
             ]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -695,10 +697,10 @@ class Database_Test extends TestCase
                 'Description' => 'description 2'
             ]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -757,10 +759,10 @@ class Database_Test extends TestCase
                 'Description' => 'description updated'
             ]
         );
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -1007,10 +1009,10 @@ class Database_Test extends TestCase
             [':id' => 99991, ':name' => 'new name'],
             ['nofetch' => "true"]
         );
-        $check      = $this->DB->pselect(
+        $check      = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $check,
@@ -1024,32 +1026,6 @@ class Database_Test extends TestCase
             ]
         );
         $this->assertEquals($allSetting, []);
-    }
-
-    /**
-     * Tests that pselect calls the "prepare" and "execute" functions with the proper
-     * parameters.
-     *
-     * @return void
-     * @covers Database::pselect
-     */
-    function testPselectCallsFunctions()
-    {
-        $stub = $this->getMockBuilder('FakeDatabase')
-            ->onlyMethods($this->_getAllMethodsExcept(['pselect']))->getMock();
-
-        '@phan-var \Database $stub';
-        $stmt   = $stub->prepare("SHOW TABLES");
-        $params = ['test' => 'test'];
-
-        '@phan-var \PHPUnit\Framework\MockObject\MockObject $stub';
-        $stub->expects($this->once())
-            ->method("prepare")->with($this->equalTo("SHOW TABLES"));
-        $stub->expects($this->once())->method("execute")
-            ->with($this->equalTo($stmt), $this->equalTo($params), []);
-
-        '@phan-var \Database $stub';
-        $stub->pselect("SHOW TABLES", $params);
     }
 
     /**
@@ -1076,10 +1052,10 @@ class Database_Test extends TestCase
         ];
         $this->DB->setFakeTableData("ConfigSettings", $data);
 
-        $allSetting = $this->DB->pselect(
+        $allSetting = iterator_to_array($this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",
             []
-        );
+        ));
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals($allSetting, $data);
     }

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -131,11 +131,11 @@ class Database_Test extends TestCase
      */
     function testSetFakeData()
     {
-	    /*
+        /*
         $client = new NDB_Client();
         $client->makeCommandLine();
         $client->initialize();
-	     */
+        */
 
         $this->DB->setFakeTableData(
             "Config",
@@ -310,10 +310,12 @@ class Database_Test extends TestCase
             "ConfigSettings",
             ['Visible' => 1, 'Description' => null]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -359,10 +361,12 @@ class Database_Test extends TestCase
             "ConfigSettings",
             ['Visible' => 1, 'Description' => 'deleting']
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -410,10 +414,12 @@ class Database_Test extends TestCase
             ['Visible' => null, 'Description' => 'new description'],
             ['Description' => null]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -465,10 +471,12 @@ class Database_Test extends TestCase
             ['Visible' => null, 'Description' => 'new description'],
             ['Description' => 'first description']
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -519,10 +527,12 @@ class Database_Test extends TestCase
                 'Description' => null
             ]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -572,10 +582,12 @@ class Database_Test extends TestCase
                 'Description' => 'test description'
             ]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -635,10 +647,12 @@ class Database_Test extends TestCase
                 'Description' => null
             ]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -697,10 +711,12 @@ class Database_Test extends TestCase
                 'Description' => 'description 2'
             ]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -759,10 +775,12 @@ class Database_Test extends TestCase
                 'Description' => 'description updated'
             ]
         );
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -1009,10 +1027,12 @@ class Database_Test extends TestCase
             [':id' => 99991, ':name' => 'new name'],
             ['nofetch' => "true"]
         );
-        $check      = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $check      = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $check,
@@ -1052,10 +1072,12 @@ class Database_Test extends TestCase
         ];
         $this->DB->setFakeTableData("ConfigSettings", $data);
 
-        $allSetting = iterator_to_array($this->DB->pselect(
-            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
-            []
-        ));
+        $allSetting = iterator_to_array(
+            $this->DB->pselect(
+                "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+                []
+            )
+        );
         $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals($allSetting, $data);
     }

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -78,7 +78,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
 
         $this->Client = new \NDB_Client;
         $this->Client->makeCommandLine();
-        $this->Client->initialize(__DIR__ . "/../../project/config.xml");
+        //$this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
         $i = $this
             ->getMockBuilder('\Loris\Behavioural\NDB_BVL_Instrument_LINST')

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1346,7 +1346,9 @@ class NDB_BVL_Instrument_Test extends TestCase
             'arthritis_age_status' => 'status'
         ];
         $this->_instrument->_saveValues($values);
-        $dbData = $this->_DB->pselect("SELECT * FROM medical_history", []);
+        $dbData = iterator_to_array(
+            $this->_DB->pselect("SELECT * FROM medical_history", [])
+        );
         $this->assertEquals('77.2', $dbData[0]['Candidate_Age']);
         $this->assertEquals('0', $dbData[0]['Window_Difference']);
         $this->assertEquals(null, $dbData[0]['arthritis_age']);
@@ -1669,15 +1671,19 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table     = 'medical_history';
-        $conflictsBefore = $this->_DB->pselect(
-            "SELECT * FROM conflicts_unresolved",
-            []
+        $conflictsBefore = iterator_to_array(
+            $this->_DB->pselect(
+                "SELECT * FROM conflicts_unresolved",
+                []
+            )
         );
         $this->_instrument->clearInstrument();
         $data           = $this->_instrument->getInstanceData();
-        $conflictsAfter = $this->_DB->pselect(
-            "SELECT * FROM conflicts_unresolved",
-            []
+        $conflictsAfter = iterator_to_array(
+            $this->_DB->pselect(
+                "SELECT * FROM conflicts_unresolved",
+                []
+            )
         );
         $this->_DB->run("DROP TEMPORARY TABLE IF EXISTS conflicts_unresolved");
         $this->assertEquals(null, $data['Examiner']);

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -240,10 +240,28 @@ class NDB_Factory_Test extends TestCase
             ->method('pselectRow')
             ->willReturn(['DCCID'=>'300001', 'RegistrationProjectID' => '1']);
 
-        '@phan-var \Database $mockdb';
-
-        $this->_factory->setDatabase($mockdb);
-
+        // Mock call for Candidate->select()
+        $resultMock = $this->getMockBuilder('\LORIS\Database\Query')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resultMock->method("getIterator")
+            ->willReturn(
+                new ArrayIterator(
+                    [
+                        [
+                            "ID"        => 97,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ],
+                        [
+                            "ID"        => 98,
+                            "ProjectID" => 1,
+                            "CenterID"  => 2,
+                        ]
+                    ]
+                )
+            );
+        $mockdb->method('pselect')->willReturn($resultMock);
         '@phan-var \Database $mockdb';
 
         $this->_factory->setDatabase($mockdb);
@@ -269,7 +287,13 @@ class NDB_Factory_Test extends TestCase
 
         $mockdb->expects($this->any())
             ->method('pselectRow')
-            ->willReturn(['SessionID' => '1', 'ProjectID' => '1']);
+            ->willReturn(
+                [
+                    'SessionID' => '1',
+                    'ProjectID' => '1',
+                    'CandID'    => 123456
+                ]
+            );
 
         '@phan-var \NDB_Config $mockconfig';
         '@phan-var \Database $mockdb';

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -91,12 +91,12 @@ class UserTest extends TestCase
      * @var array
      */
     private $_projectInfo = [0 => ['ProjectID' => '1',
-	    'Name'      => 'project_test',
-	    'Alias'	=> 'TST1',
+        'Name'      => 'project_test',
+        'Alias'     => 'TST1',
     ],
         1 => ['ProjectID' => '3',
             'Name'      => 'project_test2',
-	    'Alias'	=> 'TST2',
+            'Alias'     => 'TST2',
         ]
     ];
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -91,10 +91,12 @@ class UserTest extends TestCase
      * @var array
      */
     private $_projectInfo = [0 => ['ProjectID' => '1',
-        'Name'      => 'project_test'
+	    'Name'      => 'project_test',
+	    'Alias'	=> 'TST1',
     ],
         1 => ['ProjectID' => '3',
-            'Name'      => 'project_test2'
+            'Name'      => 'project_test2',
+	    'Alias'	=> 'TST2',
         ]
     ];
 


### PR DESCRIPTION
This adds `\LORIS\Database\Query` class which is both an iterator an countable to replace the return value of `Database->pselect()`. This improves the memory consumption of large datasets, because the iterator only needs to load the row that is being foreach'd over, instead of loading the entire query result into memory.

Places that currently depend on it being an array are wrapped in `iterator_to_array` (They are mostly queries returning small results, so this isn't expensive. The optimization is mostly useful for places like the dataquery module which iterate over large amounts of data.)