### PR TITLE
[Tests] Remove PHP 8.1 and 8.2 from automated tests

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.3']
     steps:
       - uses: actions/checkout@v3
 
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.3']
         apiversion: ['v0.0.3', 'v0.0.4-dev']
     steps:
     - uses: actions/checkout@v3
@@ -209,7 +209,7 @@ jobs:
         fail-fast: false
         matrix:
             testsuite: ['integration']
-            php: ['8.1','8.2', '8.3']
+            php: ['8.3']
             ci_node_index: [0,1,2,3]
 
             include:
@@ -217,15 +217,7 @@ jobs:
             - ci_node_total: 4
 
             - testsuite: 'static'
-              php: '8.1'
-            - testsuite: 'static'
-              php: '8.2'
-            - testsuite: 'static'
               php: '8.3'
-            - testsuite: 'unit'
-              php: '8.1'
-            - testsuite: 'unit'
-              php: '8.2'
             - testsuite: 'unit'
               php: '8.3'
 


### PR DESCRIPTION
We're running 3 versions of PHP on every pull request and commit, even though only the last 2 are supported by LORIS. By the time of the next LORIS release, PHP 8.4 will be released (scheduled to be released in November), so this removes 8.1 and 8.2 from the development branch. (A different PR will add 8.4 as it's likely that it will require code changes.)