### PR TITLE
[Core] Add ProjectID Singleton

### DIFF
--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -43,7 +43,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance,
         $this->_candid      = $row['CandID'] ?? null;
         $this->_projectname = $row['ProjectName'] ?? null;
         if ($row['ProjectID'] !== null) {
-            $this->_projectid = new \ProjectID($row['ProjectID']);
+            $this->_projectid = \ProjectID::singleton(intval($row['ProjectID']));
         }
         $this->_pscid    = $row['PSCID'] ?? null;
         $this->_sitename = $row['SiteName'] ?? null;

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -51,9 +51,9 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
     /**
      * The project
      *
-     * @var string
+     * @var int
      */
-    private $_project = '';
+    private $_project;
 
     /**
      * The feedback_status
@@ -137,7 +137,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_project));
+        return \ProjectID::singleton($this->_project);
     }
 
     /**

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -51,9 +51,9 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
     /**
      * The project
      *
-     * @var string
+     * @var int
      */
-    private $_project = '';
+    private $_project;
 
     /**
      * The feedback_status
@@ -123,7 +123,7 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_project));
+        return \ProjectID::singleton($this->_project);
     }
 
     /**

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -51,9 +51,9 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
     /**
      * The project
      *
-     * @var string
+     * @var int
      */
-    private $_project = '';
+    private $_project;
 
     /**
      * The feedback_status
@@ -123,7 +123,7 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_project));
+        return \ProjectID::singleton($this->_project);
     }
 
     /**

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -100,7 +100,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // behaviour of requiring the registration site to match
         // one of the user's sites.
         $cid = \CenterID::singleton(intval($row['RegistrationCenterID']));
-        $pid = new \ProjectID($row['RegistrationProjectID']);
+        $pid = \ProjectID::singleton(intval($row['RegistrationProjectID']));
         if ($row['DoB'] !== null) {
             $dob = new \DateTimeImmutable($row['DoB']);
             switch ($this->dobFormat) {

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -645,11 +645,11 @@ function getDiagnosisEvolutionFields(): array
     foreach ($candProjIDs as $projectID) {
         $candProjects[$projectID]   = $projectList[$projectID];
         $latestDiagnosis[]          = $candidate->getLatestDiagnosis(
-            new \ProjectID($projectID),
+            \ProjectID::singleton(intval($projectID)),
             false
         );
         $latestConfirmedDiagnosis[] = $candidate->getLatestDiagnosis(
-            new \ProjectID($projectID),
+            \ProjectID::singleton(intval($projectID)),
             true
         );
     }

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -69,7 +69,7 @@ if ($projectID == 'new') {
     }
 
     // Update Project fields
-    $project = \Project::getProjectFromID(new \ProjectID($projectID));
+    $project = \Project::getProjectFromID(\ProjectID::singleton(intval($projectID)));
     $project->updateName($projectName);
     $project->updateAlias($projectAlias);
     $project->updateRecruitmentTarget($recTarget);

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -57,7 +57,7 @@ class Project extends \NDB_Form
             $projects[$ProjectID] = $config->getProjectSettings($ProjectID);
             $projects[$ProjectID]['projectCohorts']
                 = \Utility::getCohortsForProject(
-                    new \ProjectID(strval($ProjectID))
+                    \ProjectID::singleton($ProjectID)
                 );
         }
         $this->tpl_data['projects'] = $projects;

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -98,6 +98,6 @@ class ResolvedDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->projectid));
+        return \ProjectID::singleton($this->projectid);
     }
 }

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -88,6 +88,6 @@ class UnresolvedDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->projectid));
+        return \ProjectID::singleton($this->projectid);
     }
 }

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -82,7 +82,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $cohortGroups = [];
         foreach ($projectOptions as $pid=>$pname) {
             $cohortGroups[$pid] = \Utility::getCohortList(
-                new \ProjectID(strval($pid))
+                \ProjectID::singleton($pid)
             );
         }
         $values['cohortGroups'] = $cohortGroups;
@@ -92,7 +92,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         foreach ($cohortGroups as $pid=>$cohortList) {
             foreach ($cohortList as $sid=>$title) {
                 $visitGroups[$pid][$sid] = \Utility::getVisitsForProjectCohort(
-                    new \ProjectID(strval($pid)),
+                    \ProjectID::singleton($pid),
                     $sid
                 );
             }
@@ -161,7 +161,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             // if there is only one project, autoselect first project from array of 1
             $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
         } else if (count($user_list_of_projects) > 1) {
-            $project_id = new \ProjectID($values['project']);
+            $project_id = \ProjectID::singleton($values['project']);
             $project    = \Project::getProjectFromID($project_id);
         }
 
@@ -261,7 +261,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
 
         $candid    = $values['candID'];
         $cohortID  = intval($values['cohort']);
-        $projectID = new \ProjectID($values['project']);
+        $projectID = \ProjectID::singleton($values['project']);
 
         //Visit - Get all visits to map ID back to label for session table
         $visits     = \Utility::getVisitsForProjectCohort(

--- a/modules/dataquery/php/query.class.inc
+++ b/modules/dataquery/php/query.class.inc
@@ -612,7 +612,7 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
                 $organized[$candid]['Timepoints'][] = new \TimePoint(
                     new \TimePointData(
                         new \SessionID($row['sessionID']),
-                        new \ProjectID($row['SProjectID']),
+                        \ProjectID::singleton($row['SProjectID']),
                         \CenterID::singleton($row['SCenterID']),
                     )
                 );
@@ -623,7 +623,9 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
         foreach ($organized as $vals) {
             $canddata  = new \CandidateData(
                 candID: $vals['CandID'],
-                registrationProjectID: new \ProjectID($vals['RegistrationProject']),
+                registrationProjectID: \ProjectID::singleton(
+                    $vals['RegistrationProject']
+                ),
                 registrationCenterID: \CenterID::singleton(
                     $vals['RegistrationCenter']
                 ),

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
@@ -83,7 +83,7 @@ class ElectrophysiologyBrowserRowProvisioner
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         $cid = \CenterID::singleton(intval($row['CenterID']));
-        $pid = new \ProjectID($row['ProjectID']);
+        $pid = \ProjectID::singleton(intval($row['ProjectID']));
         unset($row['CenterID']);
         unset($row['ProjectID']);
         return new ElectrophysiologyBrowserRow($row, $cid, $pid);

--- a/modules/electrophysiology_uploader/php/electrophysiologyuploaderprovisioner.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiologyuploaderprovisioner.class.inc
@@ -58,7 +58,7 @@ class ElectrophysiologyUploaderProvisioner
     public function getInstance($row): DataInstance
     {
         $cid = \CenterID::singleton($row['RegistrationCenterID']);
-        $pid = new \ProjectID($row['RegistrationProjectID']);
+        $pid = \ProjectID::singleton($row['RegistrationProjectID']);
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new ElectrophysiologyUploaderRow($row, $cid, $pid);

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -33,9 +33,9 @@ class CnvDTO implements DataInstance, SiteHaver
     /**
      * The projectID
      *
-     * @var string
+     * @var int
      */
-    private $_projectID = "";
+    private $_projectID;
 
     /**
      * The PSC
@@ -265,6 +265,6 @@ class CnvDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_projectID));
+        return \ProjectID::singleton($this->_projectID);
     }
 }

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -33,9 +33,9 @@ class MethylationDTO implements DataInstance, SiteHaver
     /**
      * The projectID
      *
-     * @var string
+     * @var int
      */
-    private $_projectID = "";
+    private $_projectID;
 
     /**
      * The PSC
@@ -329,6 +329,6 @@ class MethylationDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_projectID));
+        return \ProjectID::singleton($this->_projectID);
     }
 }

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -43,9 +43,9 @@ class ProfileDTO implements DataInstance, SiteHaver
     /**
      * The projectID
      *
-     * @var string
+     * @var int
      */
-    private $_projectID = "";
+    private $_projectID;
 
     /**
      * The PSC name
@@ -163,6 +163,6 @@ class ProfileDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_projectID));
+        return \ProjectID::singleton($this->_projectID);
     }
 }

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -42,9 +42,9 @@ class SnpDTO implements DataInstance, SiteHaver
     /**
      * The projectID
      *
-     * @var string
+     * @var int
      */
-    private $_projectID = "";
+    private $_projectID;
 
     /**
      * The PSC
@@ -314,6 +314,6 @@ class SnpDTO implements DataInstance, SiteHaver
      */
     public function getProjectID(): \ProjectID
     {
-        return new \ProjectID(strval($this->_projectID));
+        return \ProjectID::singleton($this->_projectID);
     }
 }

--- a/modules/mri_violations/php/mriviolation.class.inc
+++ b/modules/mri_violations/php/mriviolation.class.inc
@@ -56,6 +56,6 @@ class MRIViolation implements \LORIS\Data\DataInstance
         if ($this->DBRow['Project'] === null) {
             return null;
         }
-        return new \ProjectID($this->DBRow['Project']);
+        return \ProjectID::singleton($this->DBRow['Project']);
     }
 }

--- a/modules/mri_violations/php/userprojectmatchornull.class.inc
+++ b/modules/mri_violations/php/userprojectmatchornull.class.inc
@@ -51,9 +51,7 @@ class UserProjectMatchOrNull implements \LORIS\Data\Filter
         if (method_exists($res, 'getProjectID')) {
             $resourceProject = $res->getProjectID();
             if (!is_null($resourceProject)) {
-                return $user->hasProject(
-                    new \ProjectID(strval($resourceProject))
-                );
+                return $user->hasProject($resourceProject);
             }
             return true;
         }

--- a/modules/schedule_module/php/schedulemoduleprovisioner.class.inc
+++ b/modules/schedule_module/php/schedulemoduleprovisioner.class.inc
@@ -120,7 +120,7 @@ ON
         // behaviour of requiring the registration site to match
         // one of the user's sites.
         $cid = \CenterID::singleton(intval($row['RegistrationCenterID']));
-        $pid = new \ProjectID($row['RegistrationProjectID']);
+        $pid = \ProjectID::singleton(intval($row['RegistrationProjectID']));
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new ScheduleRow($row, $cid, $pid);

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -214,7 +214,7 @@ class Statistics_Mri_Site extends Statistics_Site
         // template
         $visits    = [];
         $projectID = isset($_REQUEST['ProjectID'])
-            ? new \ProjectID($_REQUEST['ProjectID'])
+            ? \ProjectID::singleton(intval($_REQUEST['ProjectID']))
             : null;
 
         $data = [];

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -94,13 +94,12 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return void
      */
-    function _checkCriteria($centerID, $projectID)
+    function _checkCriteria(\CenterID $centerID, \ProjectID $projectID)
     {
 
         //SITES
-        $projectID = new \ProjectID(strval($projectID));
-        $factory   = \NDB_Factory::singleton();
-        $user      = $factory->user();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
 
         if (!empty($centerID) && $user->hasCenter($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -121,7 +121,9 @@ class Stats_Behavioural extends \NDB_Form
         }
 
         if ($_REQUEST['BehaviouralProject'] ?? '') {
-            $currentProject = new \ProjectID($_REQUEST['BehaviouralProject']);
+            $currentProject = \ProjectID::singleton(
+                intval($_REQUEST['BehaviouralProject'])
+            );
             $this->tpl_data['CurrentProject']
                 = [
                     'ID'   => $currentProject,

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -63,20 +63,20 @@ class Stats_Demographic extends \NDB_Form
     /**
      * RenderStatsTable function
      *
-     * @param string  $sectionHeader    the value of sectionHeader
-     * @param string  $tableHeader      the value of tableHeader
-     * @param array   $subcats          the value of subcats
-     * @param ?array  $visits           the value of visits
-     * @param string  $dropdownName     the value of dropdownName
-     * @param array   $dropdownOpt      the value of dropdownOpt
-     * @param string  $dropdownSelected the value of dropdownSelected
-     * @param array   $centers          the value of centers
-     * @param array   $data             the value of data
-     * @param string  $subsection       the value of subsection=''
-     * @param string  $disclamer        the value of disclamer=''
-     * @param ?string $projectID        the value of projectID is null
-     * @param bool    $renderTable      whether to render the table or display a
-     *                                  default error message
+     * @param string $sectionHeader    the value of sectionHeader
+     * @param string $tableHeader      the value of tableHeader
+     * @param array  $subcats          the value of subcats
+     * @param ?array $visits           the value of visits
+     * @param string $dropdownName     the value of dropdownName
+     * @param array  $dropdownOpt      the value of dropdownOpt
+     * @param string $dropdownSelected the value of dropdownSelected
+     * @param array  $centers          the value of centers
+     * @param array  $data             the value of data
+     * @param string $subsection       the value of subsection=''
+     * @param string $disclamer        the value of disclamer=''
+     * @param ?int   $projectID        the value of projectID is null
+     * @param bool   $renderTable      whether to render the table or display a
+     *                                 default error message
      *
      * @return string
      */
@@ -97,7 +97,7 @@ class Stats_Demographic extends \NDB_Form
     ): string {
         // This line replaces the empty $projectID string with null
         // `$projectID ?? null` would retain empty strings.
-        $projectID = empty($projectID) ? null : new \ProjectID($projectID);
+        $projectID = empty($projectID) ? null : \ProjectID::singleton($projectID);
         $tpl_data  = [];
         $tpl_data['test_name']  = isset($_REQUEST['test_name']) ?
             htmlspecialchars($_REQUEST['test_name']) : '';
@@ -257,7 +257,7 @@ class Stats_Demographic extends \NDB_Form
         // Only search for cohorts if $demographicProject is a positive int.
         if (is_numeric($demographicProject) && intval($demographicProject) >= 0) {
             $cohorts     = \Utility::getCohortsForProject(
-                new \ProjectID($demographicProject)
+                \ProjectID::singleton(intval($demographicProject))
             );
             $subprojList = implode(',', array_keys($cohorts));
             if (!empty($subprojList)) {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -241,7 +241,7 @@ class Stats_MRI extends \NDB_Form
 
         $currentProject = null;
         if ($_REQUEST['MRIProject'] ?? '') {
-            $currentProject = new \ProjectID($_REQUEST['MRIProject']);
+            $currentProject = \ProjectID::singleton(intval($_REQUEST['MRIProject']));
             $this->tpl_data['CurrentProject']
                 = [
                     'ID'   => $currentProject,

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -120,7 +120,7 @@ class AddSurvey extends \NDB_Form
             ];
         }
 
-        $projectID = $db->pselectOne(
+        $projectID = $db->pselectOneInt(
             "SELECT ProjectID FROM session
             WHERE CandID=:v_CandID
             AND Visit_Label=:v_VL",
@@ -131,7 +131,7 @@ class AddSurvey extends \NDB_Form
         );
 
         $user = \NDB_Factory::singleton()->user();
-        if (!$user->hasProject(new \ProjectID($projectID))) {
+        if (!$user->hasProject(\ProjectID::singleton($projectID))) {
             return [
                 'Project' => "You are not affiliated with this session's project"
             ];

--- a/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
@@ -68,7 +68,7 @@ class SurveyAccountsProvisioner
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         $cid = \CenterID::singleton(intval($row['CenterID']));
-        $pid = new \ProjectID($row['ProjectID']);
+        $pid = \ProjectID::singleton((intval($row['ProjectID'])));
         return new SurveyAccountsRow($row, $cid, $pid);
     }
 }

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -57,7 +57,7 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
         if (isset($row['projectIds'])) {
             $pids = array_map(
                 function (string $pid) : \ProjectID {
-                    return new \ProjectID($pid);
+                    return \ProjectID::singleton((int )$pid);
                 },
                 explode(',', $row['projectIds'])
             );

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -131,7 +131,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
             case 'RegistrationProjectID':
-                $registrationProjectID     = new \ProjectID(strval($value));
+                $registrationProjectID     = \ProjectID::singleton($value);
                 $this->candidateInfo[$key] = $registrationProjectID;
                 break;
             case 'RegistrationCenterID':
@@ -212,7 +212,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             $timepoints[] = new TimePoint(
                 new TimePointData(
                     new SessionID(strval($value["ID"])),
-                    new ProjectID(strval($value["ProjectID"])),
+                    ProjectID::singleton($value["ProjectID"]),
                     CenterID::singleton($value["CenterID"]),
                 )
             );

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -81,8 +81,8 @@ class Project implements \JsonSerializable
 
             $project = new Project();
 
-            $project->_projectId         = new ProjectID(
-                strval($projectData['projectId'])
+            $project->_projectId         = ProjectID::singleton(
+                $projectData['projectId']
             );
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
@@ -514,7 +514,9 @@ class Project implements \JsonSerializable
             }
             $project = new Project();
 
-            $project->_projectId         = new ProjectID($projectData['projectId']);
+            $project->_projectId         = ProjectID::singleton(
+                $projectData['projectId']
+            );
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
             $project->_recruitmentTarget = (integer)$projectData['recTarget'];

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -7,6 +7,23 @@
 class ProjectID extends ValidatableIdentifier implements \JsonSerializable
 {
     /**
+     * Acts as a constructor for a ProjectID , using a cached instantiation
+     * if available
+     *
+     * @param int $id The ProjectID to get a singleton for.
+     *
+     * @return ProjectID
+     */
+    static public function singleton(int $id)
+    {
+        static $cache = [];
+        if (!isset($cache[$id])) {
+            $cache[$id] = new \ProjectID(strval($id));
+        }
+        return $cache[$id];
+    }
+
+    /**
      * Returns this identifier type
      *
      * @return string

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -160,7 +160,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         $this->data = new TimePointData(
             $sessionID,
             isset($row['ProjectID'])
-                ? new ProjectID(strval($row['ProjectID']))
+                ? ProjectID::singleton($row['ProjectID'])
                 : null,
             isset($row['CenterID'])
                 ? \CenterID::singleton($row['CenterID'])

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -110,7 +110,7 @@ class User extends UserPermissions implements
             ['uid' => $row['ID']]
         );
         foreach ($user_pid as $k=>$pid) {
-            $user_pid[$k] = new ProjectID(strval($pid));
+            $user_pid[$k] = ProjectID::singleton(intval($pid));
         }
 
         // Get examiner information

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -154,7 +154,7 @@ class CandidateTest extends TestCase
             'Active'                => 'Y',
             'RegisteredBy'          => 'Admin Admin',
             'UserID'                => 'admin',
-            'RegistrationProjectID' => "1",
+            'RegistrationProjectID' => 1,
             'ProjectTitle'          => '',
         ];
         $this->_candidate     = new Candidate();
@@ -323,7 +323,7 @@ class CandidateTest extends TestCase
         $this->_candidate->select($this->_candidateInfo['CandID']);
 
         $this->assertEquals(
-            $this->_candidateInfo['RegistrationProjectID'],
+            \ProjectID::singleton($this->_candidateInfo['RegistrationProjectID']),
             $this->_candidate->getProjectID()
         );
     }

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1054,7 +1054,7 @@ class NDB_BVL_Instrument_Test extends TestCase
             ->willReturn('123');
         $this->_mockDB->expects($this->any())->method('pselectRow')
             ->willReturn(
-                ['CohortID' => '2', 'ProjectID' => '1',
+                ['CohortID' => '2', 'ProjectID' => 1,
                     'Visit_label' => 'V1', 'CandID' => '300123'
                 ]
             );

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -238,7 +238,7 @@ class NDB_Factory_Test extends TestCase
         $mockdb = $this->getMockBuilder("\Database")->getMock();
         $mockdb->expects($this->any())
             ->method('pselectRow')
-            ->willReturn(['DCCID'=>'300001', 'RegistrationProjectID' => '1']);
+            ->willReturn(['DCCID'=>'300001', 'RegistrationProjectID' => 1]);
 
         // Mock call for Candidate->select()
         $resultMock = $this->getMockBuilder('\LORIS\Database\Query')
@@ -290,7 +290,7 @@ class NDB_Factory_Test extends TestCase
             ->willReturn(
                 [
                     'SessionID' => '1',
-                    'ProjectID' => '1',
+                    'ProjectID' => 1,
                     'CandID'    => 123456
                 ]
             );


### PR DESCRIPTION
This adds a ProjectID singleton and uses it throughout LORIS. The reasoning is similar to CenterID::singleton, the values are often repeated and need to be converted to a class for many function calls, in particular when doing permission checking in batch (ie when querying data in the dataquery module.) By using a singleton, the pressure on the garbage collector is lowered as it's not constantly creating/collecting the same values.