### PR TITLE
[Raisinbread] Add missing modules to RB

### DIFF
--- a/raisinbread/RB_files/RB_modules.sql
+++ b/raisinbread/RB_files/RB_modules.sql
@@ -48,6 +48,7 @@ INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (45,'api_docs','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (46,'dictionary','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (47,'electrophysiology_uploader','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (48,'schedule_module','Y');
-
+INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (49,'dataquery','Y');
+INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (50,'oidc','N');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
The dataquery table and oidc modules were not in the "modules" table in Raisinbread. This adds them (dataquery enabled since it's a core part of LORIS and oidc disabled by default since it's an optional part that can be enabled in the module manager for those who need it.)