### PR TITLE
[Utility] Cache getVisitList result

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -245,8 +245,9 @@ class Utility
     static function getVisitList(?ProjectID $projectID = null) : array
     {
         static $cache = [];
-        if (isset($cache[$projectID])) {
-            return $cache[$projectID];
+        $projStr      = strval($projectID);
+        if (isset($cache[$projStr])) {
+            return $cache[$projStr];
         }
         $factory = \NDB_Factory::singleton();
         $db      = $factory->database();
@@ -272,8 +273,8 @@ class Utility
         $visitLabels = array_column(iterator_to_array($result), 'Visit_label');
 
         // Generates an array where the keys are equal to the values.
-        $cache[$projectID] = array_combine($visitLabels, $visitLabels);
-        return $cache[$projectID];
+        $cache[$projStr] = array_combine($visitLabels, $visitLabels);
+        return $cache[$projStr];
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -244,6 +244,10 @@ class Utility
      */
     static function getVisitList(?ProjectID $projectID = null) : array
     {
+        static $cache = [];
+        if (isset($cache[$projectID])) {
+            return $cache[$projectID];
+        }
         $factory = \NDB_Factory::singleton();
         $db      = $factory->database();
         $qparams = [];
@@ -268,7 +272,8 @@ class Utility
         $visitLabels = array_column(iterator_to_array($result), 'Visit_label');
 
         // Generates an array where the keys are equal to the values.
-        return array_combine($visitLabels, $visitLabels);
+        $cache[$projectID] = array_combine($visitLabels, $visitLabels);
+        return $cache[$projectID];
     }
 
     /**


### PR DESCRIPTION
getVisitList can be called many times within the same query, in particular when trying to get dictionaries for the dataquery module which include a visit list.

This caches the result instead of re-running the same query multiple times.