### PR TITLE
[battery manager] duplicate check fix

### DIFF
--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -158,17 +158,18 @@ class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
         $testArray = json_decode($request->getBody()->getContents(), true);
         $test      = new Test($this->loris, null, $testArray);
         $test->row['active'] = 'Y';
-        return $this->_saveInstance($test);
+        return $this->_saveInstance($test,"post");
     }
 
     /**
      * Generic save function for Test Instances.
      *
      * @param Test $test The Test Instance to be saved.
+     * @param string $method check the request method
      *
      * @return ResponseInterface response
      */
-    private function _saveInstance(Test $test)
+    private function _saveInstance(Test $test , $method=null)
     {
         if (!$this->user->hasPermission('battery_manager_edit')) {
             return new \LORIS\Http\Response\JSON\Forbidden('Edit Permission Denied');
@@ -183,7 +184,7 @@ class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
         }
 
         // check if instance is duplicate
-        if ($this->_isDuplicate($test)) {
+        if ($this->_isDuplicate($test) && $method =='post') {
             return new \LORIS\Http\Response\JSON\Conflict(
                 'This Test already exists in the database'
             );

--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -158,13 +158,13 @@ class TestEndpoint extends \NDB_Page implements RequestHandlerInterface
         $testArray = json_decode($request->getBody()->getContents(), true);
         $test      = new Test($this->loris, null, $testArray);
         $test->row['active'] = 'Y';
-        return $this->_saveInstance($test,"post");
+        return $this->_saveInstance($test, "post");
     }
 
     /**
      * Generic save function for Test Instances.
      *
-     * @param Test $test The Test Instance to be saved.
+     * @param Test   $test   The Test Instance to be saved.
      * @param string $method check the request method
      *
      * @return ResponseInterface response

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -292,7 +292,7 @@ class BatteryManagerTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("#swal2-title")
         )->getText();
         $this->assertStringContainsString(
-            "OK",
+            "Submission successful!"",
             $bodyText
         );
     }

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -292,7 +292,7 @@ class BatteryManagerTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("#swal2-title")
         )->getText();
         $this->assertStringContainsString(
-            "Submission successful!"",
+            "Submission successful!",
             $bodyText
         );
     }

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -292,7 +292,7 @@ class BatteryManagerTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("#swal2-title")
         )->getText();
         $this->assertStringContainsString(
-            "Submission successful!",
+            "OK",
             $bodyText
         );
     }


### PR DESCRIPTION
The new integration test catched a new bug in battery manager. 
Add a request method param to check and avoid performing duplicate checks during the update operation.