### PR TITLE
[dicom archive] add project permission check based on tarchiveID

### DIFF
--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -76,9 +76,9 @@ class ViewDetails extends \NDB_Form
      *
      * @return ProjectID|null a ProjectID if found, else null
      */
-    private static function getProjectFromTarchiveID(int $tarchiveID): ?\ProjectID
+    private static function _getProjectFromTarchiveID(int $tarchiveID): ?\ProjectID
     {
-        $db = \NDB_Factory::singleton()->database();
+        $db  = \NDB_Factory::singleton()->database();
         $pid = $db->pselectOne(
             "SELECT p.ProjectID
             FROM tarchive t

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -96,7 +96,7 @@ class ViewDetails extends \NDB_Form
      */
     private function _getProjectFromTarchiveID(): ?\ProjectID
     {
-        $db  = \NDB_Factory::singleton()->database();
+        $db  = $this->loris->getDatabaseConnection();
         $pid = $db->pselectOne(
             "SELECT p.ProjectID
             FROM tarchive t

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -60,7 +60,7 @@ class ViewDetails extends \NDB_Form
         }
 
         // get project ID from Tarchive ID.
-        $projectID  = $this->_getProjectFromTarchiveID();
+        $projectID = $this->_getProjectFromTarchiveID();
         if (is_null($projectID)) {
             return false;
         }

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -51,7 +51,48 @@ class ViewDetails extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('dicom_archive_view_allsites');
+        // remove the possibility to have no tarchive ID in this page
+        if (empty($_REQUEST['tarchiveID'])) {
+            // defaults to permission denied
+            return false;
+        }
+
+        // get project ID from Tarchive ID.
+        $tarchiveID = intval($_REQUEST['tarchiveID']);
+        $projectID  = self::getProjectFromTarchiveID($tarchiveID);
+        if (is_null($projectID)) {
+            return false;
+        }
+
+        // check permissions
+        return $user->hasPermission('dicom_archive_view_allsites')
+            && $user->hasProject($projectID);
+    }
+
+    /**
+     * Get the ProjectID attached to a given tarchive ID.
+     *
+     * @param int $tarchiveID a tarchiveID
+     *
+     * @return ProjectID|null a ProjectID if found, else null
+     */
+    private static function getProjectFromTarchiveID(int $tarchiveID): ?\ProjectID
+    {
+        $db = \NDB_Factory::singleton()->database();
+        $pid = $db->pselectOne(
+            "SELECT p.ProjectID
+            FROM tarchive t
+                JOIN session s ON (t.SessionID = s.ID)
+                JOIN Project p ON (p.ProjectID = s.ProjectID)
+            WHERE t.TarchiveID = :tar
+            ORDER BY 1",
+            ['tar' => $tarchiveID]
+        );
+        //
+        if (is_null($pid)) {
+            return null;
+        }
+        return new \ProjectID($pid);
     }
 
     /**

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -84,8 +84,7 @@ class ViewDetails extends \NDB_Form
             FROM tarchive t
                 JOIN session s ON (t.SessionID = s.ID)
                 JOIN Project p ON (p.ProjectID = s.ProjectID)
-            WHERE t.TarchiveID = :tar
-            ORDER BY 1",
+            WHERE t.TarchiveID = :tar",
             ['tar' => $tarchiveID]
         );
         //

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -91,7 +91,7 @@ class ViewDetails extends \NDB_Form
         if (is_null($pid)) {
             return null;
         }
-        return new \ProjectID($pid);
+        return \ProjectID::singleton($pid);
     }
 
     /**

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -13,6 +13,8 @@
  */
 namespace LORIS\dicom_archive;
 
+use \Psr\Http\Message\ServerRequestInterface;
+
 /**
  * Implements the ViewDetails subpage of the dicom_archive module.
  *
@@ -52,14 +54,13 @@ class ViewDetails extends \NDB_Form
     function _hasAccess(\User $user) : bool
     {
         // remove the possibility to have no tarchive ID in this page
-        if (empty($_REQUEST['tarchiveID'])) {
+        if (is_null($this->tarchiveID)) {
             // defaults to permission denied
             return false;
         }
 
         // get project ID from Tarchive ID.
-        $tarchiveID = intval($_REQUEST['tarchiveID']);
-        $projectID  = self::getProjectFromTarchiveID($tarchiveID);
+        $projectID  = $this->_getProjectFromTarchiveID();
         if (is_null($projectID)) {
             return false;
         }
@@ -70,13 +71,30 @@ class ViewDetails extends \NDB_Form
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @param \User                  $user    The user this request is for
+     * @param ServerRequestInterface $request The PSR7 request
+     *
+     * @return void
+     */
+    public function loadResources(
+        \User $user, ServerRequestInterface $request
+    ) : void {
+        $gets = $request->getQueryParams();
+        if (is_null($gets['tarchiveID'])) {
+            $this->tarchiveID = null;
+        } else {
+            $this->tarchiveID = intval($gets['tarchiveID']);
+        }
+    }
+
+    /**
      * Get the ProjectID attached to a given tarchive ID.
      *
-     * @param int $tarchiveID a tarchiveID
-     *
-     * @return ProjectID|null a ProjectID if found, else null
+     * @return \ProjectID|null a ProjectID if found, else null
      */
-    private static function _getProjectFromTarchiveID(int $tarchiveID): ?\ProjectID
+    private function _getProjectFromTarchiveID(): ?\ProjectID
     {
         $db  = \NDB_Factory::singleton()->database();
         $pid = $db->pselectOne(
@@ -85,7 +103,7 @@ class ViewDetails extends \NDB_Form
                 JOIN session s ON (t.SessionID = s.ID)
                 JOIN Project p ON (p.ProjectID = s.ProjectID)
             WHERE t.TarchiveID = :tar",
-            ['tar' => $tarchiveID]
+            ['tar' => $this->tarchiveID]
         );
         //
         if (is_null($pid)) {

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -109,7 +109,7 @@ class ViewDetails extends \NDB_Form
         if (is_null($pid)) {
             return null;
         }
-        return \ProjectID::singleton($pid);
+        return \ProjectID::singleton(intval($pid));
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This PR checks the user attached projects on top of the `dicom_archive_view_allsites` permission when trying to access the `view details` page.

#### Link(s) to related issue(s)

Resolves #6658
