### PR TITLE
[dataquery] Filter candidates from SQL instead of PHP

### DIFF
--- a/modules/candidate_parameters/test/candidateQueryEngineTest.php
+++ b/modules/candidate_parameters/test/candidateQueryEngineTest.php
@@ -137,33 +137,39 @@ class CandidateQueryEngineTest extends TestCase
     {
         $candiddict = $this->_getDictItem("CandID");
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("123456"))
+            )
         );
-        $this->assertTrue(is_array($result));
-        assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
         // 123456 is equal, and 123458 is Active='N', so we should only get 123457
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("123456"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("123457"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("123457"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("123457", "123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("123457", "123456"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -171,8 +177,10 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThanOrEqual("123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThanOrEqual("123456"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -180,16 +188,20 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThan("123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThan("123456"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThanOrEqual("123457"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThanOrEqual("123457"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -197,23 +209,29 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThan("123457"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThan("123457"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -221,8 +239,10 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("1"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("1"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -230,23 +250,29 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("2"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("2"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("123456"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("123456"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new EndsWith("6"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new EndsWith("6"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -254,15 +280,19 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
 
         // 123458 is inactive
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new EndsWith("8"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new EndsWith("8"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Substring("5"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Substring("5"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -280,32 +310,40 @@ class CandidateQueryEngineTest extends TestCase
     public function testPSCIDMatches()
     {
         $candiddict = $this->_getDictItem("PSCID");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("test1"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("test1"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("test1"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("test1"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("test1"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("test1"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("te"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("te"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -313,16 +351,20 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new EndsWith("t2"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new EndsWith("t2"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Substring("es"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Substring("es"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -330,15 +372,19 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -358,39 +404,49 @@ class CandidateQueryEngineTest extends TestCase
     public function testDoBMatches()
     {
         $candiddict = $this->_getDictItem("DoB");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("1920-01-30"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("1920-01-30"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("1920-01-30"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("1920-01-30"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("1920-01-30"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("1920-01-30"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -398,8 +454,10 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThanOrEqual("1930-05-03"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThanOrEqual("1930-05-03"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -407,24 +465,30 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThan("1930-05-03"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThan("1930-05-03"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThan("1920-01-30"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThan("1920-01-30"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThanOrEqual("1920-01-30"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThanOrEqual("1920-01-30"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -444,8 +508,10 @@ class CandidateQueryEngineTest extends TestCase
     public function testDoDMatches()
     {
         $candiddict = $this->_getDictItem("DoD");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("1950-11-16"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("1950-11-16"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -455,64 +521,80 @@ class CandidateQueryEngineTest extends TestCase
         // XXX: Is this what users expect? It's what SQL logic is, but it's
         // not clear that a user would expect of the DQT when a field is not
         // equal compared to null.
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("1950-11-16"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("1950-11-16"))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(0, count($result));
         // $this->assertEquals(1, count($result));
         // $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("1950-11-16"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("1950-11-16"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThanOrEqual("1951-05-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThanOrEqual("1951-05-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThan("1951-05-03"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThan("1951-05-03"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThan("1950-01-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThan("1950-01-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThanOrEqual("1950-01-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThanOrEqual("1950-01-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -530,38 +612,48 @@ class CandidateQueryEngineTest extends TestCase
     public function testSexMatches()
     {
         $candiddict = $this->_getDictItem("Sex");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("Male"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("Male"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("Male"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("Male"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("Female"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("Female"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -569,16 +661,20 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("Fe"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("Fe"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new EndsWith("male"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new EndsWith("male"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -586,8 +682,10 @@ class CandidateQueryEngineTest extends TestCase
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Substring("fem"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Substring("fem"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -605,8 +703,10 @@ class CandidateQueryEngineTest extends TestCase
     public function testEDCMatches()
     {
         $candiddict = $this->_getDictItem("EDC");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("1930-04-01"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -615,63 +715,79 @@ class CandidateQueryEngineTest extends TestCase
 
         // XXX: It's not clear that this is what a user would expect from != when
         // a value is null. It's SQL logic.
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("1930-04-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
         //$this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("1930-04-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThanOrEqual("1930-04-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThanOrEqual("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new LessThan("1930-04-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new LessThan("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThan("1930-03-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThan("1930-03-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new GreaterThanOrEqual("1930-04-01"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new GreaterThanOrEqual("1930-04-01"))
+            )
         );
         $this->assertTrue(is_array($result));
         assert(is_array($result)); // for phan to know the type
@@ -710,11 +826,11 @@ class CandidateQueryEngineTest extends TestCase
         );
         $this->assertMatchAll($result);
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("TestProject"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("TestProject"))
+            )
         );
-        $this->assertTrue(is_array($result));
-        assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
         $result = $this->engine->getCandidateMatches(
@@ -727,11 +843,11 @@ class CandidateQueryEngineTest extends TestCase
         );
         $this->assertMatchAll($result);
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
-        $this->assertTrue(is_array($result));
-        assert(is_array($result)); // for phan to know the type
         $this->assertEquals(0, count($result));
 
         $result = $this->engine->getCandidateMatches(
@@ -787,53 +903,62 @@ class CandidateQueryEngineTest extends TestCase
         );
 
         $candiddict = $this->_getDictItem("RegistrationSite");
-        $result     = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Equal("TestSite"))
+        $result     = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Equal("TestSite"))
+            )
         );
-        $this->assertTrue(is_array($result));
-        assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotEqual("TestSite"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotEqual("TestSite"))
+            )
         );
-        $this->assertTrue(is_array($result)); // for the test
-        assert(is_array($result)); // for phan to know the type
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new In("TestSite", "Test Site 2"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new In("TestSite", "Test Site 2"))
+            )
         );
         $this->assertMatchAll($result);
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new IsNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new IsNull())
+            )
         );
-        $this->assertTrue(is_array($result));
         $this->assertEquals(0, count($result));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new NotNull())
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new NotNull())
+            )
         );
         $this->assertMatchAll($result);
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new StartsWith("Test"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new StartsWith("Test"))
+            )
         );
         $this->assertMatchAll($result);
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new EndsWith("2"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new EndsWith("2"))
+            )
         );
-        $this->assertTrue(is_array($result));
-        assert(is_array($result));
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($candiddict, new Substring("Site"))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($candiddict, new Substring("Site"))
+            )
         );
         $this->assertMatchAll($result);
 

--- a/modules/imaging_browser/test/ImagingQueryEngineTest.php
+++ b/modules/imaging_browser/test/ImagingQueryEngineTest.php
@@ -233,8 +233,10 @@ class ImagingQueryEngineTest extends TestCase
     {
         $dict = $this->_getDictItem("ScanDone");
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new Equal(true))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new Equal(true))
+            )
         );
 
         // 123456 has a ScanDone = true result for visit TestMRIVisit
@@ -246,8 +248,10 @@ class ImagingQueryEngineTest extends TestCase
 
         // 123456 has a ScanDone = false result for visit TestBvlVisit
         // No other candidate has a ScanDone=false session.
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new NotEqual(true))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new NotEqual(true))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(1, count($result));
@@ -263,8 +267,10 @@ class ImagingQueryEngineTest extends TestCase
     {
         $dict = $this->_getDictItem("ScanType1_file");
 
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new Equal('test/abc.file'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new Equal('test/abc.file'))
+            )
         );
 
         // 123456 has ScanType1 at session 1
@@ -274,16 +280,20 @@ class ImagingQueryEngineTest extends TestCase
 
         // 123456 has no files that aren't equal to test/abc.file
         // 123457 has files that are not equal to test/abc.file.
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new NotEqual('test/abc.file'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new NotEqual('test/abc.file'))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
         // Both 123456 and 123457 have files that start with test/abc
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new StartsWith('test/abc'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new StartsWith('test/abc'))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(2, count($result));
@@ -291,8 +301,10 @@ class ImagingQueryEngineTest extends TestCase
         $this->assertEquals($result[1], new CandID("123457"));
 
         // Both 123456 and 123457 have files that contain abc
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new Substring('abc'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new Substring('abc'))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(2, count($result));
@@ -300,8 +312,10 @@ class ImagingQueryEngineTest extends TestCase
         $this->assertEquals($result[1], new CandID("123457"));
 
         // Only 123457 has files that end with abc.file1
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new EndsWith('abc.file1'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new EndsWith('abc.file1'))
+            )
         );
         $this->assertTrue(is_array($result));
         $this->assertEquals(1, count($result));
@@ -318,31 +332,39 @@ class ImagingQueryEngineTest extends TestCase
         $dict = $this->_getDictItem("ScanType1_QCStatus");
 
         // Both candidates have a passed scan
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new Equal('Pass'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new Equal('Pass'))
+            )
         );
         $this->assertEquals(2, count($result));
         $this->assertEquals($result[0], new CandID("123456"));
         $this->assertEquals($result[1], new CandID("123457"));
 
         // Only 123457 has a failed scan.
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new Equal('Fail'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new Equal('Fail'))
+            )
         );
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
         // The failed scan is the only not Equal to pass Scan
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new NotEqual('Pass'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new NotEqual('Pass'))
+            )
         );
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));
 
         // The failed scan is still the only failed scan with an "IN" criteria
         // The failed scan is the only not Equal to pass Scan
-        $result = $this->engine->getCandidateMatches(
-            new QueryTerm($dict, new In('Fail'))
+        $result = iterator_to_array(
+            $this->engine->getCandidateMatches(
+                new QueryTerm($dict, new In('Fail'))
+            )
         );
         $this->assertEquals(1, count($result));
         $this->assertEquals($result[0], new CandID("123457"));

--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -1,6 +1,5 @@
 <?php
 namespace LORIS\instruments;
-use LORIS\StudyEntities\Candidate\CandID;
 
 /**
  * InstrumentQueryEngine implements a LORIS QueryEngine for querying
@@ -84,19 +83,19 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         //
         // We walk the existing test names ordered by length to look for the
         // longest prefix match to find out what the instrument for the fieldname is.
-        $DB   = $this->loris->getDatabaseConnection();
+        $DB = $this->loris->getNewDatabaseConnection();
+        $DB->setBuffering(false);
+
         $rows = $DB->pselectCol(
             "SELECT Test_name FROM test_names ORDER BY Length(Test_name) DESC",
             []
         );
 
-        $testname  = null;
-        $fieldname = null;
-        $fullname  = $term->dictionary->getName();
+        $testname = null;
+        $fullname = $term->dictionary->getName();
         foreach ($rows as $testcandidate) {
             if (strpos($fullname, $testcandidate) === 0) {
-                $testname  = $testcandidate;
-                $fieldname = substr($fullname, strlen($testname)+1);
+                $testname = $testcandidate;
                 break;
             }
         }
@@ -104,139 +103,15 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
             throw new \DomainException("Field for unknown instrument");
         }
 
-        $query       = "SELECT c.CandID, f.CommentID
-            FROM flag f 
-		JOIN test_names tn ON (f.TestID=tn.ID)
-            JOIN session s ON (s.ID=f.SessionID AND s.Active='Y')
-            JOIN candidate c ON (s.CandID=c.CandID AND c.Active='Y')
-            WHERE tn.Test_name=:tn AND f.CommentID NOT LIKE 'DDE%'";
-        $queryparams = ['tn' => $testname];
-        if ($visitlist !== null) {
-            $query .= ' AND s.Visit_label IN (';
-            foreach ($visitlist as $vnum => $visit) {
-                if ($vnum !== 0) {
-                    $query .=', ';
-                }
-                $query .= ":visit$vnum";
-                $queryparams["visit$vnum"] = $visit;
-            }
-            $query .= ')';
-        }
-        $data   = $DB->pselect($query, $queryparams);
         $inst   = \NDB_BVL_Instrument::factory($this->loris, $testname);
         $values = $inst->bulkLoadInstanceData(
-            array_map(
-                function ($row) {
-                    return $row['CommentID'];
-                },
-                iterator_to_array($data),
-            )
+            null,
+            $term,
         );
-
-        $map = [];
-        foreach ($data as $row) {
-            $map[$row['CommentID']] = new CandID($row['CandID']);
+        foreach ($values as $match) {
+            yield $match->getCandID();
         }
-        return $this->_filtered($values, $map, $fieldname, $term->criteria);
-    }
-
-    /**
-     * Filter out candidates which do not match a criteria
-     *
-     * @param array                      $values    The values from the
-     *                                              instrument
-     * @param array                      $candidmap CandID map from
-     *                                              commentID=>candID
-     *                                              commentID=>candID
-     * @param string                     $fieldname The field to compare
-     * @param \LORIS\Data\Query\Criteria $criteria  The criteria which the field
-     *                                              must match.
-     *
-     * @return \Traversable CandIDs that matched criteria
-     */
-    private function _filtered(
-        $values,
-        $candidmap,
-        $fieldname,
-        $criteria
-    ) : \Traversable {
-        foreach ($values as $inst) {
-            $value = $inst->getFieldValue($fieldname);
-
-            switch (get_class($criteria)) {
-            case \LORIS\Data\Query\Criteria\In::class:
-                foreach ($criteria->getValue() as $valuecandidate) {
-                    if ($value == $valuecandidate) {
-                        yield $candidmap[$inst->getCommentID()];
-                    }
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\LessThan::class:
-                if ($value !== null && $value < $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\LessThanOrEqual::class:
-                if ($value !== null && $value <= $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\Equal::class:
-                if ($value !== null && $value == $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\NotEqual::class:
-                if ($value !== null && $value != $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\GreaterThanOrEqual::class:
-                if ($value !== null && $value >= $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\GreaterThan::class:
-                if ($value !== null && $value > $criteria->getValue()) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-
-            case \LORIS\Data\Query\Criteria\IsNull::class:
-                if ($value === null) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\NotNull::class:
-                if ($value !== null) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-
-            case \LORIS\Data\Query\Criteria\StartsWith::class:
-                if ($value !== null && strpos($value, $criteria->getValue()) === 0) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\EndsWith::class:
-                $critval = $criteria->getValue();
-                $matches = strrpos($value, $critval)
-                    === strlen($value)-strlen($critval);
-                if ($value !== null && $matches) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            case \LORIS\Data\Query\Criteria\Substring::class:
-                if ($value !== null
-                    && strpos($value, $criteria->getValue()) !== false
-                ) {
-                    yield $candidmap[$inst->getCommentID()];
-                }
-                break;
-            default:
-                throw new \Exception("Unhandled operator: " . get_class($criteria));
-            }
-        }
+        return;
     }
 
     /**
@@ -323,7 +198,8 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $DB->run("DROP TEMPORARY TABLE IF EXISTS querycandidates");
         $DB->run(
             "CREATE TEMPORARY TABLE querycandidates (
-                 CandID int(6)
+                 CandID int(6),
+                 PRIMARY KEY (CandID)
             );"
         );
         $insertstmt = "INSERT INTO querycandidates VALUES ("

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -3,7 +3,7 @@ use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Server\RequestHandlerInterface;
 use \Psr\Http\Message\ResponseInterface;
 
-use \Loris\StudyEntities\Candidate\CandID;
+use \LORIS\StudyEntities\Candidate\CandID;
 use \LORIS\Data\Dictionary\DictionaryItem;
 
 /**
@@ -2212,12 +2212,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * will return an array of copies of the instrument type with the data for
      * the given commentIDs loaded.
      *
-     * @param $commentIDs string[] A list of commentIDs to load in bulk.
+     * @param $commentIDs ?string[]                   A list of commentIDs to load
+     *                    in bulk. If null, load all
+     *                    CommentIDs for this instrument
+     * @param ?\LORIS\Data\Query\QueryTerm $condition  A single QueryTerm that
+     *                                                 matched instances must
+     *                                                 meet to be loaded
      *
      * @return Generator<\NDB_BVL_Instrument>
      */
-    function bulkLoadInstanceData(iterable $commentIDs): iterable
-    {
+    function bulkLoadInstanceData(
+        ?iterable $commentIDs,
+        ?\LORIS\Data\Query\QueryTerm $condition = null,
+    ): iterable {
         if ($this->commentID !== null && $this->commentID !== '') {
             throw new \LogicException(
                 "Must bulk load from instrument loaded without commentID"
@@ -2226,36 +2233,77 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $db = $this->loris->getNewDatabaseConnection();
         $db->setBuffering(false);
 
-        $prepBindings = [];
-        $prepValues   = [];
+        $prepValues = [];
 
-        $i = 0;
-        foreach ($commentIDs as $commentID) {
-            $i++;
-
-            $prepBindings[]      = ":cid$i";
-            $prepValues["cid$i"] = $commentID;
+        if ($commentIDs !== null) {
+            $db->run(
+                "CREATE TEMPORARY TABLE load_comment_ids(
+			CommentID varchar(255) CHARACTER SET utf8mb3 NOT NULL,
+			PRIMARY KEY(CommentID)
+			-- FOREIGN KEY (CommentID) REFERENCES flag(CommentID)
+		);"
+            ); // temporary tables can't have foreign keys
+            foreach ($commentIDs as $commentID) {
+                $prepValues[] = $commentID;
+                if (count($prepValues) > 500) {
+                    $db->run(
+                        "INSERT INTO load_comment_ids (CommentID) VALUES ('"
+                        . join("'), ('", $prepValues)
+                        . "');"
+                    );
+                    $prepValues = [];
+                }
+            }
+            if (count($prepValues) > 0) {
+                $db->run(
+                    "INSERT INTO load_comment_ids (CommentID) VALUES ('"
+                    . join("'), ('", $prepValues)
+                    . "');"
+                );
+            }
         }
-        if ($i === 0) {
-            return [];
-        }
 
+        $params = [];
         if ($this->jsonData) {
-            $jsondata = $db->pselect(
-                "SELECT SessionID,
+            $conditions   = ['tn.test_name=:tn'];
+            $params['tn'] = $this->testName;
+            if ($commentIDs !== null) {
+                $conditions[] = "CommentID IN 
+			    (SELECT CommentID FROM load_comment_ids)";
+            }
+            if ($condition !== null) {
+                $conditions[] = 'JSON_VALUE(Data, "$.'
+                . substr(
+                    $condition->dictionary->getName(),
+                    strlen($this->testName)+1
+                )
+                . '") '
+                . \LORIS\Data\Query\SQLQueryEngine::sqlOperator($condition->criteria)
+                . ' '
+                . \LORIS\Data\Query\SQLQueryEngine::sqlValue(
+                    $condition->dictionary,
+                    $condition->criteria,
+                    $params
+                )
+                . ' ';
+            }
+            $where = 'WHERE ' . join(' AND ', $conditions);
+            $query = "SELECT CandID,
+		    	SessionID,
                         CommentID,
                         session.Visit_Label as VisitLabel,
                         Data
                     FROM flag
                         JOIN session ON (session.ID=flag.SessionID)
                         JOIN instrument_data ON (flag.DataID=instrument_data.ID)
-                    WHERE CommentID IN ("
-                . join(',', $prepBindings) . ')',
-                $prepValues,
-            );
+			JOIN test_names tn ON (tn.ID=flag.TestID)
+			$where";
+
+            $jsondata = $db->pselect($query, $params);
             foreach ($jsondata as $row) {
                     $newinst = clone $this;
 
+                $newinst->candID           = new CandID($row['CandID']);
                     $newinst->commentID    = $row['CommentID'];
                     $newinst->visitLabel   = $row['VisitLabel'];
                     $newinst->sessionID    = new SessionID($row['SessionID']);
@@ -2267,20 +2315,46 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             }
             return;
         } else {
-            $defaults = $db->pselect(
-                "SELECT flag.CommentID as CommentID,
-                        session.Visit_Label as VisitLabel,
-                        session.ID as SessionID, t.*
+            $conditions   = ['tn.test_name=:tn'];
+            $params['tn'] = $this->testName;
+            if ($commentIDs !== null) {
+                $conditions[] = "t.CommentID IN
+			    (SELECT CommentID FROM load_comment_ids)";
+            }
+            if ($condition !== null) {
+                $conditions[] = 't.'
+                . substr(
+                    $condition->dictionary->getName(),
+                    strlen($this->testName)+1
+                )
+                . ' '
+                . \LORIS\Data\Query\SQLQueryEngine::sqlOperator(
+                    $condition->criteria
+                )
+                . ' '
+                . \LORIS\Data\Query\SQLQueryEngine::sqlValue(
+                    $condition->dictionary,
+                    $condition->criteria,
+                    $params
+                )
+                . ' ';
+            }
+            $where = 'WHERE ' . join(' AND ', $conditions);
+            $query = "SELECT 
+		    session.CandID as CandID,
+		    t.CommentID as CommentID,
+                    session.Visit_Label as VisitLabel,
+                    session.ID as SessionID, t.*
                  FROM $this->table t
-                    JOIN flag ON (t.CommentID=flag.CommentID)
-                    JOIN session ON (flag.SessionID=session.ID)
-                 WHERE t.CommentID IN ("
-                . join(',', $prepBindings) . ')',
-                $prepValues,
-            );
-            foreach ($defaults as $row) {
+                    JOIN flag f ON (t.CommentID=f.CommentID)
+		    JOIN test_names tn ON (tn.ID=f.TestID)
+                    JOIN session ON (f.SessionID=session.ID)
+		 $where";
+            $data  = $db->pselect($query, $params);
+            foreach ($data as $row) {
                     $newinst = clone $this;
 
+                $newinst->candID         = new CandID($row['CandID']);
                     $newinst->commentID  = $row['CommentID'];
                     $newinst->visitLabel = $row['VisitLabel'];
                     $newinst->sessionID  = new SessionID($row['SessionID']);
@@ -2503,6 +2577,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         return $pscid;
     }
 
+    protected ?CandID $candID = null;
     /**
      * Get the candidate's CandID
      *
@@ -2510,21 +2585,25 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getCandID() : ?CandID
     {
+        if ($this->candID !== null) {
+            return $this->candID;
+        }
+
         $db        = $this->loris->getDatabaseConnection();
         $CommentID = $this->getCommentID();
 
-        $candID = $db->pselectOne(
+        $candIDVal = $db->pselectOne(
             "SELECT c.CandID FROM flag f
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
             WHERE f.CommentID=:CID",
             ['CID' => $CommentID]
         );
-        if ($candID === null) {
+        if ($candIDVal === null) {
             return null;
         }
-        return new CandID($candID);
-
+        $this->candID = new CandID(strval($candIDVal));
+        return $this->candID;
     }
 
     /**

--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -104,7 +104,7 @@ abstract class SQLQueryEngine implements QueryEngine
      * @param ?string[]                   $visitlist The optional list of visits
      *                                               to match at.
      *
-     * @return CandID[]
+     * @return \Generator<CandID>
      */
     public function getCandidateMatches(
         \LORIS\Data\Query\QueryTerm $term,
@@ -127,13 +127,9 @@ abstract class SQLQueryEngine implements QueryEngine
 
         $DB   = $this->loris->getDatabaseConnection();
         $rows = $DB->pselectCol($query, $prepbindings);
-
-        return array_map(
-            function ($cid) {
-                return new CandID(strval($cid));
-            },
-            $rows
-        );
+        foreach ($rows as $candID) {
+            yield new CandID(strval($candID));
+        }
     }
 
     /**
@@ -237,7 +233,7 @@ abstract class SQLQueryEngine implements QueryEngine
      *
      * @return string
      */
-    protected function sqlOperator(Criteria $criteria) : string
+    public static function sqlOperator(Criteria $criteria) : string
     {
         if ($criteria instanceof LessThan) {
             return '<';
@@ -285,7 +281,7 @@ abstract class SQLQueryEngine implements QueryEngine
      *
      * @return string
      */
-    protected function sqlValue(DictionaryItem $dict, Criteria $criteria, array &$prepbindings) : string
+    public static function sqlValue(DictionaryItem $dict, Criteria $criteria, array &$prepbindings) : string
     {
         static $i = 1;
 


### PR DESCRIPTION
This updates the bulkLoadInstanceData function to optionally take a single QueryTerm to load candidates for, in addition (or instead of) a list of CommentIDs. If provided, the bulk load will filter for instruments matching the term from SQL, rather than loading them all into memory and filtering from the PHP side.

This should significantly reduce the memory consumption for large data sets.