### PR TITLE
[candidate parameters] diagnosis fix

### DIFF
--- a/modules/candidate_parameters/jsx/DiagnosisEvolution.js
+++ b/modules/candidate_parameters/jsx/DiagnosisEvolution.js
@@ -61,6 +61,7 @@ class DiagnosisEvolution extends Component {
   formattedDiagnosisEvolution() {
     const dxEvolution = this.state.data.diagnosisEvolution;
     let formattedDxEvolution = [];
+    try {
     dxEvolution.map((record) => {
       let formattedDiagnosis = [];
       Object.entries(JSON.parse(record.Diagnosis)).map((entry, index) => {
@@ -94,6 +95,9 @@ class DiagnosisEvolution extends Component {
         ]
       );
     });
+    } catch (error) {
+        console.error('Error parsing JSON:', error);
+    }
     return formattedDxEvolution;
   }
 


### PR DESCRIPTION
After We merge the diagnosis new feature into 26.0-release([New Feature] Tracking and Configuration of Candidate's Diagnosis Evolution (https://github.com/aces/Loris/pull/7560)), it cause a bug. 
if diagnosis is empty. the whole candidate param page will be broken. 