### PR TITLE
[issue_tracker] Resolve Iterator Error in getComments() Method

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -349,13 +349,15 @@ class Edit extends \NDB_Page implements ETagCalculator
     {
         $db = $this->loris->getDatabaseConnection();
 
-        $unformattedComments = $db->pselect(
-            "SELECT newValue, fieldChanged, dateAdded, addedBy " .
-            "FROM issues_history where issueID=:issueID " .
-            "UNION " .
-            "SELECT issueComment, 'comment', dateAdded, addedBy " .
-            "FROM issues_comments where issueID=:issueID ",
-            ['issueID' => $issueID]
+        $unformattedComments = iterator_to_array(
+            $db->pselect(
+                "SELECT newValue, fieldChanged, dateAdded, addedBy " .
+                "FROM issues_history where issueID=:issueID " .
+                "UNION " .
+                "SELECT issueComment, 'comment', dateAdded, addedBy " .
+                "FROM issues_comments where issueID=:issueID ",
+                ['issueID' => $issueID]
+            )
         );
 
         // looping by reference so can edit in place
@@ -397,7 +399,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                     = $this->formatUserInformation($comment['newValue']);
             }
         }
-        return iterator_to_array($unformattedComments); //now formatted I guess
+        return $unformattedComments; //now formatted I guess
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
- Modified getComments() to convert Query object to array
- Resolved "An iterator cannot be used with foreach by reference" error

#### Testing instructions
1. Navigate to the Issue Tracker module
2. View an existing issue
3. Confirm the issue loads without errors

#### Explanation
The pselect() function returns a Query object (iterator), which caused an error when used in a foreach loop by reference. This PR fixes the issue by converting the Query object to an array using iterator_to_array(), ensuring compatibility with the foreach loop and resolving the loading error in the Issue Tracker.

#### Link(s) to related issue(s)
* Resolves #9366