### PR TITLE
[API] Fix PUT request not updating image's QC values

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
@@ -165,7 +165,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-        $inputqcstatus = $data['QCStatus'] ?? null;
+        $inputqcstatus = $data['QC'] ?? null;
         $inputselected = $data['Selected'] ?? null;
 
         // TODO :: This is (and was) not checking or handling Caveats

--- a/raisinbread/test/api/LorisApiImagesTest.php
+++ b/raisinbread/test/api/LorisApiImagesTest.php
@@ -137,7 +137,7 @@ class LorisApiImagesTest extends LorisApiAuthenticatedTest
             ),
             true
         );
-        $this->assertEquals(null, $imagesArray);    
+        $this->assertEquals(null, $imagesArray);
     }
 
     /**
@@ -286,7 +286,7 @@ class LorisApiImagesTest extends LorisApiAuthenticatedTest
                 'Visit'  => $visit,
                 'File'   => $filename
             ],
-            "QC"       => 'pass',
+            "QC"       => 'Pass',
             "Selected" => false,
             'Caveats'  => [
                 '0' => [
@@ -335,7 +335,7 @@ class LorisApiImagesTest extends LorisApiAuthenticatedTest
                 "candidates/$this->candidTest/$this->visitTest/images/" .
                 "$this->imagefileTest/format/brainbrowser"
             );
-        } 
+        }
         $this->assertEquals(200, $response->getStatusCode());
         // Verify the endpoint has a body
         $body = $response->getBody();
@@ -401,7 +401,7 @@ class LorisApiImagesTest extends LorisApiAuthenticatedTest
         $this->assertArrayHasKey('zspace', $imagesArray);
         $this->assertArrayHasKey('space_length', $imagesArray['zspace']);
         $this->assertArrayHasKey('start', $imagesArray['zspace']);
-        $this->assertArrayHasKey('step', $imagesArray['zspace']);    
+        $this->assertArrayHasKey('step', $imagesArray['zspace']);
     }
 
     /**

--- a/raisinbread/test/api/LorisApiImages_v0_0_3_Test.php
+++ b/raisinbread/test/api/LorisApiImages_v0_0_3_Test.php
@@ -136,7 +136,7 @@ class LorisApiImages_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
             ),
             true
         );
-        $this->assertEquals(null, $imagesArray);    
+        $this->assertEquals(null, $imagesArray);
     }
 
     /**
@@ -285,7 +285,7 @@ class LorisApiImages_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
                 'Visit'  => $visit,
                 'File'   => $filename
             ],
-            "QC"       => 'pass',
+            "QC"       => 'Pass',
             "Selected" => false,
             'Caveats'  => [
                 '0' => [
@@ -334,7 +334,7 @@ class LorisApiImages_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
                 "candidates/$this->candidTest/$this->visitTest/images/" .
                 "$this->imagefileTest/format/brainbrowser"
             );
-        } 
+        }
         $this->assertEquals(200, $response->getStatusCode());
         // Verify the endpoint has a body
         $body = $response->getBody();
@@ -400,7 +400,7 @@ class LorisApiImages_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
         $this->assertArrayHasKey('zspace', $imagesArray);
         $this->assertArrayHasKey('space_length', $imagesArray['zspace']);
         $this->assertArrayHasKey('start', $imagesArray['zspace']);
-        $this->assertArrayHasKey('step', $imagesArray['zspace']);    
+        $this->assertArrayHasKey('step', $imagesArray['zspace']);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This fixes the PUT request not updating the image's QC values when testing the API via the Swagger.

#### Testing instructions (if applicable)

1. Go to the API documentation module and scroll down to the specified request section
2. Click on "Try it out" and enter a CandID, visit label, and filename. You can use the GET requests above this section to get the visit labels and filenames for a given candidate.
3. Fill in the request body section with updated QC values for the image.
4. Click on "Execute" (should return a 204 code and successfully update the QC status of the given file)

#### Link(s) to related issue(s)

* Resolves #7917
* Replaces #9375
