### PR TITLE
[gitaction]  - update "artifact" from V3 to V4

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -109,19 +109,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       name: Download node_modules artifact
       with:
         name: node_modules
         path: .
 
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       name: Download compiled LORIS javascript artifact
       with:
         name: lorisjs
         path: .
 
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       name: Download PHP dependencies artifact
       with:
         name: vendor-php${{matrix.php}}

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -116,7 +116,7 @@ jobs:
         path: .
 
     - name: Extract node_modules
-       run: tar xfvz node_modules.tar.gz        
+      run: tar xfvz node_modules.tar.gz        
 
     - uses: actions/download-artifact@v4
       name: Download compiled LORIS javascript artifact

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -136,8 +136,6 @@ jobs:
         path: .
 
 
-    - name: Extract node_modules
-      run: tar xfvz node_modules.tar.gz
     - name: Extract compiled JS
       run: tar xfvz lorisjs.tar.gz
 

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -109,34 +109,37 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
-      name: Download node_modules artifact
+    # Cache node_modules to avoid downloading dependencies if already cached
+    - name: Cache node_modules
+      uses: actions/cache@v3
       with:
-        name: Cache node_modules
-        path: .
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
 
-    - name: Extract node_modules
-      run: tar xfvz node_modules.tar.gz        
+    # Install npm dependencies if cache is not available
+    - name: Install node.js dependencies
+      run: npm install
 
-    - uses: actions/download-artifact@v4
-      name: Download compiled LORIS javascript artifact
+    # Download and extract compiled LORIS JavaScript artifact (from build job)
+    - name: Download compiled LORIS javascript artifact
+      uses: actions/download-artifact@v4
       with:
         name: lorisjs
         path: .
 
-    - uses: actions/download-artifact@v4
-      name: Download PHP dependencies artifact
-      with:
-        name: vendor-php${{matrix.php}}
-        path: .
-
-
-    - name: Extract node_modules
-      run: tar xfvz node_modules.tar.gz
-
     - name: Extract compiled JS
       run: tar xfvz lorisjs.tar.gz
 
+    # Cache PHP vendor directory to speed up Composer dependencies
+    - name: Cache PHP vendor directory
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ matrix.php }}-
     - name: Extract composer vendor directory
       run: tar xfvz vendor-php${{matrix.php}}.tar.gz
 

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -66,7 +66,7 @@ jobs:
         run: composer validate
 
       - name: Cache Composer packages
-     checkout   id: composer-cache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Composer cache

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -129,17 +129,18 @@ jobs:
         name: lorisjs
         path: .
 
+    - uses: actions/download-artifact@v4
+      name: Download PHP dependencies artifact
+      with:
+        name: vendor-php${{matrix.php}}
+        path: .
+
+
+    - name: Extract node_modules
+      run: tar xfvz node_modules.tar.gz
     - name: Extract compiled JS
       run: tar xfvz lorisjs.tar.gz
 
-    # Cache PHP vendor directory to speed up Composer dependencies
-    - name: Cache PHP vendor directory
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php }}-
     - name: Extract composer vendor directory
       run: tar xfvz vendor-php${{matrix.php}}.tar.gz
 

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -118,10 +118,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
 
-    # Install npm dependencies if cache is not available
-    - name: Install node.js dependencies
-      run: npm install
-
     # Download and extract compiled LORIS JavaScript artifact (from build job)
     - name: Download compiled LORIS javascript artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -107,21 +107,21 @@ jobs:
         php: ['8.3']
         apiversion: ['v0.0.3', 'v0.0.4-dev']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4.1.7
       name: Download node_modules artifact
       with:
         name: node_modules
         path: .
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4.1.7
       name: Download compiled LORIS javascript artifact
       with:
         name: lorisjs
         path: .
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4.1.7
       name: Download PHP dependencies artifact
       with:
         name: vendor-php${{matrix.php}}

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -11,7 +11,7 @@ jobs:
       EEG_VIS_ENABLED: 'true'
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install EEG package dependencies
       # We only need to install protobuf-compiler
@@ -36,13 +36,13 @@ jobs:
       - name: Create node_modules tarball
         run: tar cfvz node_modules.tar.gz node_modules
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload node_modules artifact
         with:
           name: node_modules
           path: node_modules.tar.gz
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload lorisjs.tar.gz artifact
         with:
           name: lorisjs
@@ -54,7 +54,7 @@ jobs:
       matrix:
         php: ['8.3']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -83,7 +83,7 @@ jobs:
       - name: Create vendor tarball
         run: tar cfvz vendor-php${{matrix.php}}.tar.gz vendor
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload vendor-php${{matrix.php}}.tar.gz artifact
         with:
           name: vendor-php${{matrix.php}}
@@ -225,7 +225,7 @@ jobs:
               php: '8.3'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -66,7 +66,7 @@ jobs:
         run: composer validate
 
       - name: Cache Composer packages
-        id: composer-cache
+     checkout   id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Composer cache
@@ -112,8 +112,11 @@ jobs:
     - uses: actions/download-artifact@v4
       name: Download node_modules artifact
       with:
-        name: node_modules
+        name: Cache node_modules
         path: .
+
+    - name: Extract node_modules
+       run: tar xfvz node_modules.tar.gz        
 
     - uses: actions/download-artifact@v4
       name: Download compiled LORIS javascript artifact


### PR DESCRIPTION
fix this PR Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows #9330
