### PR TITLE
[document_repository] Remove File Type Restriction

### DIFF
--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -364,15 +364,7 @@ class Files extends \NDB_Page
             $targetdir = new \SplFileInfo($path);
 
             try {
-                $uploader = (new \LORIS\FilesUploadHandler($targetdir))
-                    ->withPermittedMIMETypes(
-                        'application/pdf',
-                        'image/jpeg',
-                        'image/png',
-                        'image/gif',
-                        'image/svg+xml',
-                        'text/plain'
-                    );
+                $uploader = (new \LORIS\FilesUploadHandler($targetdir));
             } catch (\ConfigurationException $e) {
                 $responseMessages[] = "$filename: {$e->getMessage()}";
                 $errorCounter      += 1;


### PR DESCRIPTION
## Brief summary of changes
- Updated Document Repository to no longer have a file type restriction
- Restriction was introduced in #5234 however there was no specific reason listed for the addition, and it is restricting for projects

#### Testing instructions (if applicable)

1. Try uploading a document that is not of the types listed. (Example a .etf file)

[ORIGINAL CCNA PR](https://github.com/aces/CCNA/pull/7466)
