### PR TITLE
[dictionary] Cohort Filter

### DIFF
--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -199,6 +199,15 @@ class DataDictIndex extends Component {
                 },
             },
         },
+        {
+          label: 'Cohorts',
+          show: true,
+          filter: {
+              name: 'Cohorts',
+              type: 'multiselect',
+              options: options.cohorts,
+          },
+      },
     ];
     return (
         <FilterableDataTable

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -47,10 +47,13 @@ class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     WHEN COALESCE(pto.description,pt.description) = '' THEN 'Empty'
                     WHEN pto.name IS NOT NULL THEN 'Modified'
                     WHEN pto.name IS NULL THEN 'Unchanged'
-                END as description_status
+                END as description_status,
+                GROUP_CONCAT(DISTINCT tb.CohortID) AS cohorts
             FROM parameter_type pt
             LEFT JOIN parameter_type_override pto USING (Name)
+            LEFT JOIN test_battery tb ON pt.sourceFrom=tb.Test_name
             WHERE pt.Queryable=1
+            GROUP BY pt.sourceFrom, pt.name, pt.sourceField, description, description_status
             ",
             []
         );

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -23,8 +23,14 @@ class Fields extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
+        $user     = \NDB_Factory::singleton()->user();
+        $projects = $user->getProjectIDs();
+        $cohorts  = [];
+        foreach ($projects AS $projectID) {
+            $cohorts = $cohorts + \Utility::getCohortList($projectID);
+        }
         return new \LORIS\Http\Response\JSON\OK(
-            ['sourceFrom' => \Utility::getAllInstruments()]
+            ['sourceFrom' => \Utility::getAllInstruments(), 'cohorts' => $cohorts]
         );
     }
 }

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -317,6 +317,15 @@ class DataDictIndex extends Component {
             show: false,
             filter: null,
         },
+        {
+            label: 'Cohorts',
+            show: false,
+            filter: {
+                name: 'Cohorts',
+                type: 'multiselect',
+                options: options.cohorts,
+            },
+        },
     ];
     return (
         <FilterableDataTable

--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -20,6 +20,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
     protected string $desc;
     protected string $status;
     protected ?array $visits;
+    protected ?array $cohorts;
 
     /**
      * Construct a DataDictRow
@@ -31,6 +32,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
      * @param string         $desc       The (possibly overridden) description
      * @param string         $descstatus The status of the description override
      * @param ?string[]      $visits     List of visits for the item.
+     * @param ?string[]      $cohorts    List of cohorts for the item.
      */
     public function __construct(
         \Module $itemmodule,
@@ -39,6 +41,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         string $desc,
         string $descstatus,
         ?array $visits,
+        ?array $cohorts
     ) {
         $this->itemmodule   = $itemmodule;
         $this->itemcategory = $cat;
@@ -46,6 +49,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         $this->desc         = $desc;
         $this->status       = $descstatus;
         $this->visits       = $visits;
+        $this->cohorts      = $cohorts;
     }
 
     /**
@@ -73,6 +77,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         }
         if ($scope->__toString() == "session") {
             $val['visits'] = $this->visits;
+            $val['cohorts'] = $this->cohorts;
         }
 
         return $val;

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -69,6 +69,14 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
                     $status = 'Empty';
                 }
 
+                $cohorts = $DB->pselectCol(
+                    "SELECT DISTINCT tb.CohortID FROM test_names tn
+                        JOIN test_battery tb ON tn.Test_name=tb.Test_name
+                        WHERE tn.Test_name=:tn
+                    ORDER BY tb.CohortID",
+                    ['tn' => $cat->getName()]
+                );
+                
                 $visits = $qe->getVisitList($cat, $item);
                 $dict[] = $this->getInstance(
                     $module,
@@ -77,6 +85,7 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
                     $desc,
                     $status,
                     $visits,
+                    $cohorts,
                 );
             }
         }
@@ -96,6 +105,7 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
      * @param string         $desc       The overridden description of the item
      * @param string         $descstatus The status of the description override
      * @param ?[]string      $visits     The visits for session scoped variables
+     * @param ?[]string      $cohorts    The cohorts for session scoped variables
      *
      * @return \LORIS\Data\DataInstance An instance representing this row.
      */
@@ -106,7 +116,8 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
         string $desc,
         string $descstatus,
         array $visits,
+        array $cohorts,
     ) : \LORIS\Data\DataInstance {
-        return new DataDictRow($module, $cat, $item, $desc, $descstatus, $visits);
+        return new DataDictRow($module, $cat, $item, $desc, $descstatus, $visits, $cohorts);
     }
 }

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -52,9 +52,16 @@ class Dictionary extends \DataFrameworkMenu
         foreach ($this->modules as $module) {
             $amodules[$module->getName()] = $module->getLongName();
         }
+        $user     = \NDB_Factory::singleton()->user();
+        $projects = $user->getProjectIDs();
+        $cohorts = [];
+        foreach ($projects AS $projectID) {
+            $cohorts = $cohorts + \Utility::getCohortList($projectID);
+        }
         return [
             'modules'    => $amodules,
             'categories' => $this->categories,
+            'cohorts'    => $cohorts
         ];
     }
 


### PR DESCRIPTION
## Brief summary of changes
- Allow filtering by cohort in data dictionary and data dictionary (legacy)

#### Testing instructions (if applicable)

1. Open data dictionary
2. Try to filter by cohort, and confirm by using the test battery that only instruments with sessions in that cohort appear
3. Confirm for data dictionary (legacy) as well

[CCNA OVERRIDE PR](https://github.com/aces/CCNA/pull/6332)
