### PR TITLE
Update Typescript

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/filterEpochs.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/store/logic/filterEpochs.tsx
@@ -65,7 +65,7 @@ export const createToggleEpochEpic = (fromState: (_: any) => any) => (
     ofType(TOGGLE_EPOCH),
     Rx.map(R.prop('payload')),
     Rx.withLatestFrom(state$),
-    Rx.map(([payload, state]) => {
+    Rx.map(([payload, state]: [any, any]) => {
       const {filteredEpochs, epochs} = fromState(state);
       const index = payload;
       let newFilteredEpochs;
@@ -106,7 +106,7 @@ export const createActiveEpochEpic = (fromState: (_: any) => any) => (
     ofType(UPDATE_ACTIVE_EPOCH),
     Rx.map(R.prop('payload')),
     Rx.withLatestFrom(state$),
-    Rx.map(([payload, state]) => {
+    Rx.map(([payload, state]: [any, any]) => {
       const {epochs} = fromState(state);
       const index = payload;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
                 "terser-webpack-plugin": "^5.3.6",
                 "ts-loader": "^8.3.0",
                 "ts-node": "^10.9.2",
-                "typescript": "^4.9.5",
+                "typescript": "^5.6.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^4.10.0"
             }
@@ -11340,16 +11340,17 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "terser-webpack-plugin": "^5.3.6",
         "ts-loader": "^8.3.0",
         "ts-node": "^10.9.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.6.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^4.10.0"
     },


### PR DESCRIPTION
#9393 requires to update Typescript to 5+, however this breaks the EEG viewer compilation.

Fix: add some `any` (the module is already full of those so hard to confidently do something cleaner).