### PR TITLE
[imaging_qc] fix module to display only data affliated to user's site and project

### DIFF
--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -102,9 +102,9 @@ class Imaging_QC extends \NDB_Menu_Filter
      */
     function _buildQuery($scan_type, $scan_done, $acqID): string
     {
-        $user =     \User::singleton();
+        $user     = \User::singleton();
         $siteList = implode(',', array_keys($user->getStudySites()));
-        $select =   " SELECT DISTINCT
+        $select   = " SELECT DISTINCT
            c.PSCID,
            s.ID as SessionID,
            s.CandID as cand_id,

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -102,7 +102,8 @@ class Imaging_QC extends \NDB_Menu_Filter
      */
     function _buildQuery($scan_type, $scan_done, $acqID): string
     {
-
+        $user = \User::singleton();
+        $siteList = implode(',', array_keys($user->getStudySites()));
         $select =  " SELECT DISTINCT
            c.PSCID,
            s.ID as SessionID,
@@ -170,7 +171,7 @@ class Imaging_QC extends \NDB_Menu_Filter
           AND tn.Test_name='mri_parameter_form'
           AND c.Active='Y'
           AND s.Active='Y'
-          AND s.CenterID <> '1' ";
+          AND s.CenterID IN ($siteList) ";
 
         $query = $select.$joins.$where;
         return $query;
@@ -211,10 +212,10 @@ class Imaging_QC extends \NDB_Menu_Filter
 
         $scan_types = $this->_getScanTypes();
 
-        $projectList  = \Utility::getProjectList();
+        $userProjects = $user->getProjects();
         $projectList2 = [];
-        foreach (array_values($projectList) as $value) {
-            $projectList2[$value] = $value;
+        foreach ($userProjects as $project) {
+            $projectList2[$project->getName()] = $project->getName();
         }
         $cohortList  = \Utility::getCohortList();
         $cohortList2 = [];

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -102,9 +102,9 @@ class Imaging_QC extends \NDB_Menu_Filter
      */
     function _buildQuery($scan_type, $scan_done, $acqID): string
     {
-        $user = \User::singleton();
+        $user =     \User::singleton();
         $siteList = implode(',', array_keys($user->getStudySites()));
-        $select =  " SELECT DISTINCT
+        $select =   " SELECT DISTINCT
            c.PSCID,
            s.ID as SessionID,
            s.CandID as cand_id,

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -102,9 +102,10 @@ class Imaging_QC extends \NDB_Menu_Filter
      */
     function _buildQuery($scan_type, $scan_done, $acqID): string
     {
-        $user     = \User::singleton();
-        $siteList = implode(',', array_keys($user->getStudySites()));
-        $select   = " SELECT DISTINCT
+        $user         = \User::singleton();
+        $userSites    = implode(',', array_keys($user->getStudySites()));
+        $userProjects = implode(',', array_values($user->getProjectIDs()));
+        $select       = " SELECT DISTINCT
            c.PSCID,
            s.ID as SessionID,
            s.CandID as cand_id,
@@ -171,7 +172,8 @@ class Imaging_QC extends \NDB_Menu_Filter
           AND tn.Test_name='mri_parameter_form'
           AND c.Active='Y'
           AND s.Active='Y'
-          AND s.CenterID IN ($siteList) ";
+          AND s.ProjectID IN ($userProjects)
+          AND s.CenterID IN ($userSites) ";
 
         $query = $select.$joins.$where;
         return $query;


### PR DESCRIPTION
…nd project

Fixes #6591

**To Test**

1. Create a user with the following permission only:
> Imaging Quality Control: View Flagged Imaging Entries

Make sure not to include `View all-sites Imaging Browser pages` or any other permissions
2. Assign the user site e.g "Ottawa" and project "Pumpernickel"
3. Log in as this user, and navigate to the imaging quality control module
4. Observe that the front page loads with data pertaining only to the user site and project  
5. Observe that the `site` filter only allows filtering only to the user's site
6. Observe that the `project` filter allows filtering only to the user's project