### PR TITLE
[JSX] Relax Strictness of Filter for Multiselect in Filter Component

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -49,7 +49,7 @@ function Filter(props) {
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'
-      || type === 'datetime'));
+      || type === 'datetime' || type === 'multiselect'));
     if (value === null || value === '' ||
       (value.constructor === Array && value.length === 0) ||
       (type === 'checkbox' && value === false)) {


### PR DESCRIPTION
## Brief summary of changes

This PR reduces the strictness of the filter logic in the Filter.js component by adjusting the conditions for the exactMatch variable, functionally changing the multiselect filter from an AND to an OR boolean operators.

If this change is contentious, I can work on a way of have this be decided either by individual modules via a prop, or by use input by incorporating some sort of toggle button.