### PR TITLE
[Test] update selenium image from V3 to V4 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.8'
 services:
   db:
     build:
@@ -13,12 +13,9 @@ services:
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
 
   selenium:
-    image: selenium/standalone-firefox-debug:3.141.59-zirconium
-    volumes:
-      - /dev/shm:/dev/shm
+    image: selenium/standalone-firefox:4.25
     ports:
       - "5900:5900"
-
   web:
     build:
       context: .
@@ -61,59 +58,4 @@ services:
       - db
       - selenium
       - web
-    entrypoint: /app/test/wait-for-services.sh
-
-  selenium-debug:
-    image: selenium/standalone-firefox-debug:3.141.59-zirconium
-    links:
-      - web-debug:web
-    ports:
-      - "5901:5900"
-
-  web-debug:
-    build:
-      context: .
-      dockerfile: Dockerfile.test.php8.debug
-    volumes:
-      - ./:/app
-      - ./test/test_instrument:/app/project/instruments
-    environment:
-      - LORIS_DB_CONFIG=/app/test/config.xml
-      - XDEBUG_CONFIG=remote_host=${XDEBUG_REMOTE_HOST}
-      - PHP_IDE_CONFIG=serverName=LorisTests
-    depends_on:
-      - db
-    command: php -S 0.0.0.0:8000 -t /app/htdocs /app/htdocs/router.php
-
-  unit-tests-debug:
-    build:
-      context: .
-      dockerfile: Dockerfile.test.php8.debug
-    volumes:
-      - ./:/app
-    working_dir: /app
-    environment:
-      - LORIS_DB_CONFIG=test/config.xml
-      - XDEBUG_CONFIG=remote_host=${XDEBUG_REMOTE_HOST}
-      - PHP_IDE_CONFIG=serverName=LorisTests
-    depends_on:
-      - db
-    entrypoint: /app/test/wait-for-services.sh
-
-  integration-tests-debug:
-    build:
-      context: .
-      dockerfile: Dockerfile.test.php8.debug
-    volumes:
-      - ./:/app
-    working_dir: /app
-    environment:
-      - LORIS_DB_CONFIG=test/config.xml
-      - SELENIUM_REQUIRED=true
-      - XDEBUG_CONFIG=remote_host=${XDEBUG_REMOTE_HOST}
-      - PHP_IDE_CONFIG=serverName=LorisTests
-    links:
-      - db
-      - selenium-debug:selenium
-      - web-debug:web
     entrypoint: /app/test/wait-for-services.sh

--- a/test/wait-for-services.sh
+++ b/test/wait-for-services.sh
@@ -14,10 +14,11 @@ done
 if [ -v SELENIUM_REQUIRED ]; 
 then
   echo "Waiting for Selenium..."
-  until $(curl --output /dev/null --silent --head --fail http://selenium:4444/wd/hub); do
+  until $(curl --output /dev/null --silent --head --fail http://selenium:4444/wd/hub/status); do
     sleep 1
   done
   echo "Selenium is alive"
 fi
 
 exec $cmd
+


### PR DESCRIPTION
Update selenium image from V3 to V4 to support new JS fetures(i18next ...) in firefox browser.  
Selenium standalone-firefox-debug now is part of standalone-firefox: 4.25. 