### PR TITLE
[Conflict_resolver] Show examiner name

### DIFF
--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -1,5 +1,4 @@
 <?php declare(strict_types=1);
-
 /**
  * PHP version 7
  *
@@ -39,12 +38,25 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               candidate.PSCID as pscid,
               session.Visit_label as visitlabel,
               Project.Name as project,
-              conflicts_resolved.FieldName as question,
-              conflicts_resolved.OldValue1 as value1,
-              conflicts_resolved.OldValue2 as value2,
-              CASE
-                WHEN conflicts_resolved.NewValue = 1
+	      conflicts_resolved.FieldName as question,
+	      CASE
+    		WHEN conflicts_resolved.FieldName <> "Examiner"
+        	THEN conflicts_resolved.OldValue1
+    	      	    ELSE
+              CONCAT(conflicts_resolved.OldValue1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
+ 		END as value1,
+	      CASE
+    		WHEN conflicts_resolved.FieldName <> "Examiner"
+        	    THEN conflicts_resolved.OldValue2
+    		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
+		END as value2,
+	      CASE
+                WHEN conflicts_resolved.NewValue = 1 AND conflicts_resolved.FieldName <> "Examiner"
                     THEN conflicts_resolved.OldValue1
+		WHEN conflicts_resolved.NewValue = 1 AND conflicts_resolved.FieldName = "Examiner"
+		    THEN CONCAT(conflicts_resolved.OldValue1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
+		WHEN conflicts_resolved.NewValue <> 1 AND conflicts_resolved.FieldName = "Examiner"
+		    THEN CONCAT(conflicts_resolved.OldValue2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
                     ELSE conflicts_resolved.OldValue2
                 END AS correctanswer,
               conflicts_resolved.ResolutionTimestamp as resolutiontimestamp,

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 /**
  * PHP version 7
  *
@@ -43,20 +44,25 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
     		WHEN conflicts_resolved.FieldName <> "Examiner"
         	THEN conflicts_resolved.OldValue1
     	      	    ELSE
-              CONCAT(conflicts_resolved.OldValue1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
+	      CONCAT(conflicts_resolved.OldValue1, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
  		END as value1,
 	      CASE
     		WHEN conflicts_resolved.FieldName <> "Examiner"
         	    THEN conflicts_resolved.OldValue2
-    		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
+		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
 		END as value2,
 	      CASE
-                WHEN conflicts_resolved.NewValue = 1 AND conflicts_resolved.FieldName <> "Examiner"
-                    THEN conflicts_resolved.OldValue1
+		WHEN conflicts_resolved.NewValue = 1
+			AND conflicts_resolved.FieldName <> "Examiner"
+			THEN conflicts_resolved.OldValue1
 		WHEN conflicts_resolved.NewValue = 1 AND conflicts_resolved.FieldName = "Examiner"
-		    THEN CONCAT(conflicts_resolved.OldValue1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
+		    THEN CONCAT(conflicts_resolved.OldValue1, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
 		WHEN conflicts_resolved.NewValue <> 1 AND conflicts_resolved.FieldName = "Examiner"
-		    THEN CONCAT(conflicts_resolved.OldValue2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
+		    THEN CONCAT(conflicts_resolved.OldValue2, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
                     ELSE conflicts_resolved.OldValue2
                 END AS correctanswer,
               conflicts_resolved.ResolutionTimestamp as resolutiontimestamp,

--- a/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
@@ -1,5 +1,4 @@
 <?php declare(strict_types=1);
-
 /**
  * PHP version 7
  *
@@ -40,8 +39,16 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.Visit_label as visitlabel,
               Project.Name as project,
               conflicts_unresolved.FieldName as question,
-              conflicts_unresolved.Value1 as value1,
-              conflicts_unresolved.Value2 as value2,
+	    CASE
+                WHEN conflicts_unresolved.FieldName = "Examiner"
+                    THEN CONCAT(conflicts_unresolved.Value1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value1))
+                ELSE conflicts_unresolved.Value1
+            END AS value1,
+            CASE
+                WHEN conflicts_unresolved.FieldName = "Examiner"
+                    THEN CONCAT(conflicts_unresolved.Value2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value2))
+                ELSE conflicts_unresolved.Value2
+            END AS value2,
               psc.name as site,
               session.CenterID as centerid,
               Project.ProjectID as projectid

--- a/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 /**
  * PHP version 7
  *
@@ -41,12 +42,14 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               conflicts_unresolved.FieldName as question,
 	    CASE
                 WHEN conflicts_unresolved.FieldName = "Examiner"
-                    THEN CONCAT(conflicts_unresolved.Value1, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value1))
+		    THEN CONCAT(conflicts_unresolved.Value1, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value1))
                 ELSE conflicts_unresolved.Value1
             END AS value1,
             CASE
                 WHEN conflicts_unresolved.FieldName = "Examiner"
-                    THEN CONCAT(conflicts_unresolved.Value2, " - ", (SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value2))
+		    THEN CONCAT(conflicts_unresolved.Value2, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_unresolved.Value2))
                 ELSE conflicts_unresolved.Value2
             END AS value2,
               psc.name as site,


### PR DESCRIPTION
## Brief summary of changes

- Show the examiner name in the conflict resolver as well as the ID, as just the ID makes it difficult for users.
- This was [previously done](https://github.com/aces/Loris/pull/2891) as well but the change was likely lost in the shuffle 

#### Testing instructions (if applicable)

1. create a data entry conflict for the Examiner field if your DB does not have any already
2. see that the conflict has the examiner names and not just the ID
3. resolve Examiner conflict & make sure examiner name is there as well
4. check respective instrument table that ExaminerID is valid for the resolved conflict
5. comment "Good job, Saagar! 🍻" and approve PR

[CCNA OVERRIDE PR](https://github.com/aces/CCNA/pull/7220/files)
