### PR TITLE
[conflict_resolver] Add Cohort filter and field

### DIFF
--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -132,6 +132,11 @@ class ResolvedFilterableDataTable extends Component {
         type: 'select',
         options: options.project,
       }},
+      {label: 'Cohort', show: true, filter: {
+        name: 'Cohort',
+        type: 'select',
+        options: options.cohort,
+      }},
       {label: 'Site', show: true, filter: {
         name: 'Site',
         type: 'select',

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -144,6 +144,11 @@ class UnresolvedFilterableDataTable extends Component {
         type: 'select',
         options: options.project,
       }},
+      {label: 'Cohort', show: true, filter: {
+        name: 'cohort',
+        type: 'select',
+        options: options.cohort,
+      }},
       {label: 'Site', show: true, filter: {
         name: 'Site',
         type: 'select',

--- a/modules/conflict_resolver/php/endpoints/resolved.class.inc
+++ b/modules/conflict_resolver/php/endpoints/resolved.class.inc
@@ -88,12 +88,14 @@ class Resolved extends Endpoint implements ETagCalculator
         $sites       = array_values(\Utility::getSiteList(false));
         $visitlabels = array_values(\Utility::getVisitList());
         $projects    = array_values(\Utility::getProjectList());
+        $cohorts     = array_values(\Utility::getCohortList());
 
         return [
             'site'       => array_combine($sites, $sites),
             'instrument' => \NDB_BVL_Instrument::getInstrumentNamesList($loris),
             'visitLabel' => array_combine($visitlabels, $visitlabels),
             'project'    => array_combine($projects, $projects),
+            'cohort'     => array_combine($cohorts, $cohorts),
         ];
     }
 

--- a/modules/conflict_resolver/php/endpoints/unresolved.class.inc
+++ b/modules/conflict_resolver/php/endpoints/unresolved.class.inc
@@ -96,12 +96,14 @@ class Unresolved extends Endpoint implements ETagCalculator
         $sites       = array_values(\Utility::getSiteList(false));
         $visitlabels = array_values(\Utility::getVisitList());
         $projects    = array_values(\Utility::getProjectList());
+        $cohorts     = array_values(\Utility::getCohortList());
 
         return [
             'site'       => array_combine($sites, $sites),
             'instrument' => \NDB_BVL_Instrument::getInstrumentNamesList($loris),
             'visitLabel' => array_combine($visitlabels, $visitlabels),
             'project'    => array_combine($projects, $projects),
+            'cohort'     => array_combine($cohorts, $cohorts),
         ];
     }
 

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -37,6 +37,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
     protected $resolvedid;
     protected $projectid;
     protected $project;
+    protected $cohort;
     protected $centerid;
     protected $site;
     protected $candid;
@@ -63,6 +64,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
         return [
             'ResolvedID'          => $this->resolvedid,
             'Project'             => $this->project,
+            'Cohort'              => $this->cohort,
             'Site'                => $this->site,
             'CandID'              => $this->candid,
             'PSCID'               => $this->pscid,

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -37,6 +37,7 @@ class UnresolvedDTO implements DataInstance, SiteHaver
     protected $conflictid;
     protected $projectid;
     protected $project;
+    protected $cohort;
     protected $centerid;
     protected $site;
     protected $candid;
@@ -58,6 +59,7 @@ class UnresolvedDTO implements DataInstance, SiteHaver
         return [
             'ConflictID'  => $this->conflictid,
             'Project'     => $this->project,
+            'Cohort'      => $this->cohort,
             'Site'        => $this->site,
             'CandID'      => $this->candid,
             'PSCID'       => $this->pscid,

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -53,7 +53,8 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               conflicts_resolved.UserID as resolver,
               psc.name as site,
               session.CenterID as centerid,
-              Project.ProjectID as projectid
+              Project.ProjectID as projectid,
+              cohort.title as cohort
              FROM
               conflicts_resolved
              LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)
@@ -61,6 +62,7 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)
              LEFT JOIN Project ON (session.ProjectID=Project.ProjectID )
              LEFT JOIN psc ON (session.CenterID = psc.CenterID)
+             LEFT JOIN cohort ON (session.CohortID=cohort.CohortID)
              WHERE session.Active="Y" AND candidate.Active ="Y"
             ',
             [],

--- a/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/unresolvedprovisioner.class.inc
@@ -44,7 +44,8 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               conflicts_unresolved.Value2 as value2,
               psc.name as site,
               session.CenterID as centerid,
-              Project.ProjectID as projectid
+              Project.ProjectID as projectid,
+              cohort.title as cohort
              FROM
               conflicts_unresolved
              LEFT JOIN flag ON (conflicts_unresolved.CommentId1=flag.CommentID)
@@ -52,6 +53,7 @@ class UnresolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
              LEFT JOIN candidate ON (candidate.CandID=session.CandID)
              LEFT JOIN Project ON (session.ProjectID=Project.ProjectID)
              LEFT JOIN psc ON (session.CenterID = psc.CenterID)
+             LEFT JOIN cohort ON (cohort.CohortID=session.CohortID)
              WHERE session.Active="Y" AND candidate.Active ="Y"
             ',
             [],


### PR DESCRIPTION
## Brief summary of changes
Adds a 'Cohort' filter and field to both unresolved and resolved tabs of the conflict resolver

#### Testing instructions (if applicable)

In the Unresolved & Resolved tabs:
1. In the Selection filter, verify that the 'Cohort' filter exists and has the appropriate options in the dropdown
2. Check that the 'Cohort' field appears as a column
3. Select any option and check that only conflicts of that cohort appear

[CCNA Override](https://github.com/aces/CCNA/pull/6562)
