### PR TITLE
[timepoint] Add Default Site to Dropdown

### DIFF
--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -134,6 +134,9 @@ class CreateTimepoint extends React.Component {
           if (data.psc) {
             state.form.options.psc = data.psc;
             state.form.display.psc = true;
+            if (data.defaultpsc) {
+              state.form.value.psc = data.defaultpsc;
+            }
           }
           // Populate the select options for project.
           if (data.project) {

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -109,6 +109,10 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         }
         if (empty($values['psc'])) {
             unset($values['psc']);
+        } else {
+            // set default site value as site of the candidate
+            $candidate            = \Candidate::singleton(new CandID($values['candID']));
+            $values['defaultpsc'] = $candidate->getCenterID()->__toString();
         }
 
         return new \LORIS\Http\Response\JsonResponse(


### PR DESCRIPTION
## Brief summary of changes
In the create timepoint module, adds a candidate's default site (if they belong to many sites) to the 'Site' dropdown

#### Testing instructions (if applicable)

1. Create a new timepoint for any candidate
2. Under the 'Site' option, verify that the candidate's default site is already populated
3. Create the timepoint and ensure all functions correctly

[CCNA Override](https://github.com/aces/CCNA/pull/816)
