### PR TITLE
[User_Accounts] Fix examiner always pending & bugfix

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -362,6 +362,7 @@ class Edit_User extends \NDB_Form
             }
         }
         unset($values['examiner_radiologist']);
+        $ex_pending = $values['examiner_pending'];
         unset($values['examiner_pending']);
         // END SETUP EXAMINER VALUES
 
@@ -407,8 +408,6 @@ class Edit_User extends \NDB_Form
 
         // START EXAMINER UPDATE
         if ($editor->hasPermission('examiner_multisite')) {
-            $ex_pending = 'Y';
-
             $examinerID = $DB->pselect(
                 "SELECT e.examinerID
              FROM examiners e
@@ -422,7 +421,7 @@ class Edit_User extends \NDB_Form
             if (!empty($ex_radiologist)
                 && !empty($ex_pending)
                 && !empty($ex_curr_sites)
-                && empty($examinerID)
+                && count($examinerID) === 0
             ) {
                 // If examiner not in table and radiologist, pending and current
                 // sites fields set add the examiner to the examiner table
@@ -441,7 +440,7 @@ class Edit_User extends \NDB_Form
                             WHERE userID=:uid",
                     ['uid' => $uid]
                 );
-            } elseif (!empty($examinerID)
+            } elseif (!count($examinerID) !== 0
                 && ((!empty($ex_radiologist)
                 && !empty($ex_pending)
                 && !empty($ex_curr_sites))

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -440,7 +440,7 @@ class Edit_User extends \NDB_Form
                             WHERE userID=:uid",
                     ['uid' => $uid]
                 );
-            } elseif (!count($examinerID) !== 0
+            } elseif (count($examinerID) > 0
                 && ((!empty($ex_radiologist)
                 && !empty($ex_pending)
                 && !empty($ex_curr_sites))


### PR DESCRIPTION
## Brief summary of changes

- Fixed bug in user_accounts when examiner details are selected caused by the introduction of the /Database/Query class. It thought that new examiner's IDs existed and tried to use it, even when that examiner did not exist and needed to be created
- Fixed bug where examiner status is always reset to pending from user accounts (CCNA OVERRIDE)

#### Testing instructions (if applicable)

1. Create a new user and modify examiner details
2. Confirm an examiner is added to examiners
3. Change the pending to No and confirm the database reflects that

[CCNA OVERRIDE PR](https://github.com/aces/CCNA/pull/7128)
