### PR TITLE
[NDB_BVL_Instrument] Fix for clearing instrument

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2623,7 +2623,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if (!$this->jsonData) {
             $columns = $db->pselect(
                 "SELECT COLUMN_NAME FROM information_schema.columns
-            WHERE TABLE_NAME=:table AND TABLE_SCHEMA=:db",
+            WHERE IS_NULLABLE!='NO' AND TABLE_NAME=:table AND TABLE_SCHEMA=:db",
                 [
                     'table' => $this->table,
                     'db'    => $dbconfig['database'],

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2623,7 +2623,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if (!$this->jsonData) {
             $columns = $db->pselect(
                 "SELECT COLUMN_NAME FROM information_schema.columns
-            WHERE IS_NULLABLE!='NO' AND TABLE_NAME=:table AND TABLE_SCHEMA=:db",
+            WHERE COLUMN_NAME<>'CommentID' AND TABLE_NAME=:table AND TABLE_SCHEMA=:db",
                 [
                     'table' => $this->table,
                     'db'    => $dbconfig['database'],


### PR DESCRIPTION
## Brief summary of changes

- When running clear instrument on a non JSON instrument with non NULLABLE fields, it tries to set values to null which results in an error, this is resolved

#### Testing instructions (if applicable)

1. Set a field of an instrument to NULLABLE = 'NO' in information_schema
2. Try clearing the instrument with the LORIS API, see that it works now

[CCNA OVERRIDE PR](https://github.com/aces/CCNA/pull/7603)
