### PR TITLE
[fix_candidate_age] Avoid bulk instance load without commentIDs

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2231,6 +2231,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "Must bulk load from instrument loaded without commentID"
             );
         }
+        // Return empty array if no commentIDs given
+        if (!$commentIDs) {
+            return [];
+        }
         $db = $this->loris->getNewDatabaseConnection();
         $db->setBuffering(false);
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2231,10 +2231,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "Must bulk load from instrument loaded without commentID"
             );
         }
-        // Return empty array if no commentIDs given
-        if (!$commentIDs) {
-            return [];
-        }
         $db = $this->loris->getNewDatabaseConnection();
         $db->setBuffering(false);
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -783,7 +783,7 @@ class Utility
             JOIN candidate c ON (c.CandID=s.CandID)
             JOIN psc ON (s.CenterID=psc.CenterID)
             JOIN flag f ON (f.sessionID=s.id)
-            JOIN test_names t ON (f.test_name=t.Test_name)
+            JOIN test_names t ON (f.TestID=t.ID)
             WHERE c.Active='Y' AND s.Active='Y' AND s.Visit_label =:vl
             AND psc.CenterID != '1' AND c.Entity_type != 'Scanner'
             ORDER BY t.Full_name",

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -142,10 +142,11 @@ class CouchDBInstrumentImporter
         $from = "FROM flag f
             JOIN session s ON(s.ID=f.SessionID)
             JOIN candidate c ON(c.CandID=s.CandID)
-            LEFT JOIN flag ddef ON(ddef.CommentID=CONCAT('DDE_', f.CommentID))";
+            LEFT JOIN flag ddef ON(ddef.CommentID=CONCAT('DDE_', f.CommentID))
+            JOIN test_names tn ON tn.ID = f.TestID";
 
         $where = "WHERE f.CommentID NOT LIKE 'DDE%'
-            AND f.Test_name=:inst AND s.Active='Y' AND c.Active='Y'";
+            AND tn.Test_name=:inst AND s.Active='Y' AND c.Active='Y'";
 
         if ($tablename === "") {
             // the data is in the flag table, add the data column to the query

--- a/tools/data_integrity/fix_candidate_age.php
+++ b/tools/data_integrity/fix_candidate_age.php
@@ -82,8 +82,10 @@ foreach ($instruments as $testName=>$instrument) {
         "SELECT f.CommentID FROM flag f
             JOIN session s ON s.ID=f.SessionID
             JOIN candidate c ON c.CandID=s.CandID
+            JOIN test_names tn ON tn.ID = f.TestID
         WHERE c.Active='Y' AND s.Active='Y'
-        AND f.Test_name=:tn",
+
+        AND tn.Test_name=:tn",
         ['tn' => $testName]
     );
 

--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -144,9 +144,10 @@ foreach ($testNames as $test) {
         FROM candidate c 
             JOIN session s ON c.CandID=s.CandID
             JOIN flag f ON s.ID=f.SessionID
+            JOIN test_names tn ON tn.ID = f.TestID
         WHERE s.Active = 'Y' 
             AND c.Active='Y' 
-            AND f.Test_name = :tnm 
+            AND tn.Test_name = :tnm 
             AND f.Administration <> 'None' 
             AND f.Administration IS NOT NULL
             ";

--- a/tools/data_integrity/update_candidate_latest_diagnosis.php
+++ b/tools/data_integrity/update_candidate_latest_diagnosis.php
@@ -80,8 +80,9 @@ foreach ($candIDs as $candID) {
                 // Find instance of instrument
                 $commentID = $DB->pselectOne(
                     "SELECT CommentID FROM flag f
+                    JOIN test_names tn ON tn.ID = f.TestID
                     WHERE f.SessionID=:sid
-                    AND f.Test_name=:tn
+                    AND tn.Test_name=:tn
                     AND CommentID NOT LIKE 'DDE%'",
                     [
                         'sid' => $sessionID,

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -302,12 +302,13 @@ function getCommentIDs($test_name, $visit_label = null, $candid = null)
     $query  = "SELECT CommentID, s.visit_label,Test_name,
         CONCAT('DDE_', CommentID) AS DDECommentID FROM flag f
         JOIN session s ON (s.ID=f.SessionID)
-        JOIN candidate c ON (c.CandID=s.CandID)";
+        JOIN candidate c ON (c.CandID=s.CandID)
+        JOIN test_names tn ON tn.ID = f.TestID";
     $where  = " WHERE CommentID NOT LIKE 'DDE%'
         AND s.Active='Y' AND c.Active='Y'
         AND s.Visit <> 'Failure'";
     if ($test_name!=null) {
-        $where .= " AND f.Test_name= :instrument ";
+        $where .= " AND tn.Test_name= :instrument ";
         $params['instrument'] = $test_name;
 
         if (($visit_label!=null) && (isset($visit_label))) {
@@ -336,12 +337,13 @@ function getCurrentUnresolvedConflicts($test_name, $visit_label = null): array
     $query  = "SELECT cu.* FROM conflicts_unresolved cu
         JOIN flag f on (f.commentid = cu.commentid1)
         JOIN session s on (s.id = f.sessionid)
-        JOIN candidate c on (c.CandID = s.CandID)";
+        JOIN candidate c on (c.CandID = s.CandID)
+        JOIN test_names tn ON tn.ID = f.TestID";
 
     $where = " WHERE c.Active='Y' AND  s.Active='Y'
         AND s.Visit <> 'Failure'";
     if ($test_name!=null) {
-        $where .= " AND f.Test_name= :instrument ";
+        $where .= " AND tn.Test_name= :instrument ";
         $params['instrument'] = $test_name;
 
         if ($visit_label!=null) {

--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -107,7 +107,8 @@ foreach ($instruments as $instrument => $full_name) {
                     "SELECT DISTINCT s.Visit_label,s.ID from session s
                     JOIN candidate c on (c.candid=s.candid)
                     JOIN flag f on (f.sessionid=s.id)
-                    WHERE s.candID = :cid AND f.test_name = :fname AND
+                    JOIN test_names tn ON tn.ID = f.TestID
+                    WHERE s.candID = :cid AND tn.test_name = :fname AND
                     s.cohortid = :subid",
                     [
                         'cid'   => $candid,

--- a/tools/importers/InstrumentImporter.php
+++ b/tools/importers/InstrumentImporter.php
@@ -76,9 +76,10 @@ class InstrumentImporter extends DataImporter
             FROM flag f
             INNER JOIN session s ON s.ID = f.SessionID
             INNER JOIN candidate c ON c.CandID = s.CandID
+            JOIN test_names tn ON tn.ID = f.TestID
             WHERE c.CandID = :newCandID 
             AND s.Visit_label = :visitLabel 
-            AND f.test_name = :table
+            AND tn.test_name = :table
             AND f.CommentID NOT LIKE "DDE%"';
 
         $newCommentID = $this->DB->pselectOne(


### PR DESCRIPTION
## Brief summary of changes

- Found a couple more instances of code requiring flag to have the Test_name table after the change in #9338 
