### PR TITLE
[publication] Allow same name lead investigators

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -73,10 +73,9 @@ function uploadPublication() : void
     $leadInvID = $db->pselectOne(
         'SELECT PublicationCollaboratorID '.
         'FROM publication_collaborator '.
-        'WHERE Name = :n AND Email = :e',
+        'WHERE Email = :e',
         [
             'e' => $leadInvestEmail,
-            'n' => $leadInvest,
         ]
     );
     if (empty($leadInvID)) {


### PR DESCRIPTION
## Brief summary of changes
Allows lead investigators with the same name but different emails to exist with distinct `PublicationCollaboratorID`s in the Publications module


#### Testing instructions (if applicable)

1. Either modify or create two publications: enter the same name for the lead investigator but enter a different email for both and check that both can save
2. Verify that both exist with the correct emails in the `publication_collaborator` table under different IDs
3. Modify one of the lead investigators' emails and verify that the other is not affected

[CCNA Override](https://github.com/aces/CCNA/pull/4556)
