### PR TITLE
Escape `LorisForm` value in HTML

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -821,8 +821,9 @@ class LorisForm
         if (empty($el['name'])) {
             return $el['label'];
         }
-        $val = $this->getValue($el['name']);
-        return $val;
+        $value = $this->getValue($el['name']);
+        $value = $value !== null ? htmlspecialchars($value) : null;
+        return $value;
     }
     /**
      * Generates the HTML to add to the page when rendered for a date
@@ -859,6 +860,7 @@ class LorisForm
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg':''" : "''";
         $value    = $this->getValue($el['name']);
+        $value    = $value !== null ? htmlspecialchars($value, ENT_QUOTES) : null;
         $format   = 'date';
 
         if (array_key_exists('options', $el) && isset($el['options']['format'])) {
@@ -885,11 +887,7 @@ class LorisForm
             . "onChange=\"this.setCustomValidity($required)\" "
             . (isset($el['required']) ? "required " : '')
             . (!empty($disabled) ? "disabled " : '')
-            . (
-            !empty($value)
-                ? ' value="' . $value . '" '
-                : ''
-            )
+            . (!empty($value) ? ' value="' . $value . '" ' : '')
             . ">";
 
         return $elmnt;
@@ -948,6 +946,7 @@ class LorisForm
             $readonly = 'readonly';
         }
         $value = $this->getValue($el['name']);
+        $value = $value !== null ? htmlspecialchars($value, ENT_QUOTES) : null;
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
                 isset($el['onchange']) && $el['onchange']
@@ -972,7 +971,7 @@ class LorisForm
 
             . (
                 (!empty($value) || $value === '0')
-                ? ' value="' . $this->getValue($el['name']) . '"'
+                ? ' value="' . $value . '"'
                 : ''
               )
             . $disabled
@@ -1133,14 +1132,15 @@ class LorisForm
     {
         $cls      = empty($el['class']) ? "" : "class=\"$el[class]\"";
         $disabled = '';
-        $val      = $this->getValue($el['name']);
+        $value    = $this->getValue($el['name']);
+        $value    = $value !== null ? htmlspecialchars($value, ENT_QUOTES) : null;
         if (isset($el['disabled']) || $this->frozen) {
             $disabled = 'disabled';
         }
         return "<input name=\"$el[name]\" type=\"file\" $cls"
             . (
-                !empty($val)
-                ? ' value="' . $val . '"'
+                !empty($value)
+                ? ' value="' . $value . '"'
                 : ''
               )
             . $disabled
@@ -1173,11 +1173,9 @@ class LorisForm
             $dims .= " cols=\"$el[cols]\"";
         }
         $value = $this->getValue($el['name']);
+        $value = $value !== null ? htmlspecialchars($value) : null;
         return "<textarea name=\"$el[name]\" $cls $dims $disabled>"
-            . (
-                !empty($value)
-                ? $this->getValue($el['name']) : ''
-              )
+            . (!empty($value) ? $value : '')
             ."</textarea>";
     }
 


### PR DESCRIPTION
The `LorisForm` class contains an XSS vulnerability as it can paste data from the GET parameters directly into the HTML.

The `getValue` function reads the GET parameters, but it is also used by code unrelated to the HTML, therefore the escape should be done at the call site, not in the function directly. There may be a risk of double escape as `getValue` can get its value from other sources.

Having now looked a the code, I agree that we should get rid of `LorisForm`, building HTML as strings directly (and with so many layers of indirection) is a practice that is 15~20 years old (LORIS is that old so that makes sense !) and unmaintainable IMO.
 
 Testing: Not tested (which page should I try ?).