### PR TITLE
[CouchDB] Hide instrument fields from DQT

### DIFF
--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -86,8 +86,10 @@ class CouchDBInstrumentImporter
                 "AND Queryable=1",
                 ['inst' => $instrument]
             );
+            $inst = \NDB_BVL_Instrument::factory($this->loris, $instrument);
+            $hiddenColumnsFromDQT = !empty($inst->hiddenColumnsFromDQT) ? $inst->hiddenColumnsFromDQT : [];
             foreach ($Fields as $field) {
-                if (isset($field['SourceField'])) {
+                if (isset($field['SourceField']) && !in_array($field['SourceField'], $hiddenColumnsFromDQT)) {
                     $fname        = $field['SourceField'];
                     $Dict[$fname] = [];
                     $Dict[$fname]['Type']        = $field['Type'];


### PR DESCRIPTION
## Brief summary of changes

- Add ability to prevent certain instrument fields from being imported into the CouchDB

#### Testing instructions (if applicable)

1. Find a field in the DQT
<kbd>
<img width="547" alt="image" src="https://github.com/user-attachments/assets/c3540952-b4b3-4d63-8eb9-6cb3d58918ad">
</kbd>

2. Hide that field from an instrument by adding $hiddenColumnsFromDQT
<img width="619" alt="image" src="https://github.com/user-attachments/assets/9670a162-34b3-44e0-a368-403fdad43f69">

3. Run `php ./tools/CouchDB_Import_Instruments.php`
4. See that the field is no longer in the DQT
<kbd>
<img width="537" alt="image" src="https://github.com/user-attachments/assets/79b8588f-7959-43e2-ad6e-5782c0dff9de">
</kbd>


[CCNA OVERRIDE PR](https://github.com/aces/CCNA/pull/7481)
