### PR TITLE
[Survey Accounts] Batch send surveys

### DIFF
--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -93,19 +93,21 @@ $instrument_list = $db->pselect(
     ]
 );
 
-$instr_string=$_REQUEST['TN'];
-$selected_instr=explode(",", $instr_string);
+$instr_string   =$_REQUEST['TN'];
+$selected_instr =explode(",", $instr_string);
 
 foreach ($instrument_list as $instrument) {
-    foreach ($selected_instr as $testName)
-    if ($testName == $instrument['Test_name']) {
-        echo json_encode(
-            [
-                'error_msg' => "Instrument ". $testName.
-                " already exists for given candidate for visit ". $_REQUEST['VL'],
-            ]
-        );
-        exit(0);
+    foreach ($selected_instr as $testName) {
+        if ($testName == $instrument['Test_name']) {
+            echo json_encode(
+                [
+                    'error_msg' => "Instrument ". $testName.
+                    " already exists for given candidate for visit ".
+                    $_REQUEST['VL'],
+                ]
+            );
+            exit(0);
+        }
     }
 }
 

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -92,11 +92,16 @@ $instrument_list = $db->pselect(
         'v_VL'     => $_REQUEST['VL'],
     ]
 );
+
+$instr_string=$_REQUEST['TN'];
+$selected_instr=explode(",", $instr_string);
+
 foreach ($instrument_list as $instrument) {
-    if ($_REQUEST['TN'] == $instrument['Test_name']) {
+    foreach ($selected_instr as $testName)
+    if ($testName == $instrument['Test_name']) {
         echo json_encode(
             [
-                'error_msg' => "Instrument ". $_REQUEST['TN'].
+                'error_msg' => "Instrument ". $testName.
                 " already exists for given candidate for visit ". $_REQUEST['VL'],
             ]
         );

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -82,7 +82,7 @@ if (empty($_REQUEST['TN'])) {
 $instrument_list = $db->pselect(
     "SELECT tn.Test_name FROM flag f
              JOIN session s on s.ID = f.SessionID
-             JOIN candidate ON c.ID = s.CandidateID
+             JOIN candidate c ON c.ID = s.CandidateID
              JOIN test_names tn ON tn.ID = f.TestID
              WHERE c.CandID=:v_CandID
              AND UPPER(s.Visit_label)=UPPER(:v_VL)

--- a/modules/survey_accounts/js/survey_accounts_helper.js
+++ b/modules/survey_accounts/js/survey_accounts_helper.js
@@ -61,12 +61,14 @@ $(document).ready(function () {
         $("#participant_accounts_form").submit();
     });
     $("input[type=submit]").click(function (e) {
+        var test_name_array=$('[name="Test_name[]"]').val();
+        var tn=test_name_array.toString();
         if(e.currentTarget.classList.contains('email')) {
             $.get(loris.BaseURL + "/survey_accounts/ajax/ValidateEmailSubmitInput.php", {
                 dccid: $("input[name=CandID]").val(),
                 pscid: $("input[name=PSCID]").val(),
                 VL: $("select[name=VL]").val(),
-                TN: $("select[name=Test_name]").val(),
+                TN: tn,
                 Email: $("input[name=Email]").val(),
                 Email2: $("input[name=Email2]").val()
             },

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -206,7 +206,7 @@ class AddSurvey extends \NDB_Form
             ]
         );
 
-        $url = '';
+        $url       = '';
         $baseURL   = \NDB_Factory::singleton()->settings()->getBaseURL();
         $sendEmail = false;
         if (isset($_REQUEST['send_email'])) {

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -206,10 +206,21 @@ class AddSurvey extends \NDB_Form
             ]
         );
 
-        // $battery = new \NDB_BVL_Battery($this->loris);
-        // $battery->selectBattery(
-        //     new \SessionID($SessionID)
-        // );
+        $baseURL   = \NDB_Factory::singleton()->settings()->getBaseURL();
+        $sendEmail = false;
+        if (isset($_REQUEST['send_email'])) {
+            $sendEmail = true;
+        }
+        if ($sendEmail) {
+            $status = 'Sent';
+        } else {
+            $status = 'Created';
+        }
+
+        $battery = new \NDB_BVL_Battery($this->loris);
+        $battery->selectBattery(
+            new \SessionID($SessionID)
+        );
 
         foreach ($values['Test_name'] as $testName) {
             $InstrumentExists = $db->pselectOne(
@@ -224,16 +235,8 @@ class AddSurvey extends \NDB_Form
                 return;
             }
 
-            $commentID = $db->pselectOne(
-                "SELECT CommentID FROM flag 
-                WHERE Test_name=:TN AND SessionID=:SID
-                AND CommentID NOT LIKE 'DDE%'",
-                [
-                 'TN'  => $testName,
-                 'SID' => $SessionID,
-                ]
-            );
-            $key = $this->_generateSurveyKey();
+            $commentID = $battery->addInstrument($this->loris, $testName);
+            $key       = $this->_generateSurveyKey();
 
             try {
                 $db->insert(
@@ -251,25 +254,14 @@ class AddSurvey extends \NDB_Form
                 error_log($e->getMessage());
                 $this->tpl_data['success'] = false;
             }
-        }
-
-        $sendEmail = false;
-        if (isset($_REQUEST['send_email'])) {
-            $sendEmail = true;
-        }
-        if ($sendEmail) {
-            $status = 'Sent';
-        } else {
-            $status = 'Created';
+            $url .= $baseURL . '/survey.php?key=' . urlencode($key) . "\n";
         }
 
         if ($email && ($values['send_email'] == 'true')) {
             $config   = \NDB_Config::singleton();
-            $baseURL  = \NDB_Factory::singleton()->settings()->getBaseURL();
             $msg_data = [
                 'study'     => $config->getSetting("title"),
-                'url'       => $baseURL . '/survey.php?key=' .
-                        urlencode($key),
+                'url'       => $url,
                 'EmailForm' => $values['email_dialog'],
             ];
             \Email::send($email, 'new_survey.tpl', $msg_data);

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -152,16 +152,18 @@ class AddSurvey extends \NDB_Form
         );
         $reminder        = " already exists for given candidate for visit ";
         foreach ($instrument_list as $instrument) {
-            if ($values['Test_name'] == $instrument['Test_name']) {
-                $instrument_instance = \NDB_BVL_Instrument::factory(
-                    $this->loris,
-                    $instrument['Test_name']
-                );
-                return [
-                    'Test_name' => "Instrument ".
-                        $instrument_instance->getFullName().
-                        $reminder. $values['VL'],
-                ];
+            foreach ($values['Test_name'] as $testName) {
+                if ($testName == $instrument['Test_name']) {
+                    $instrument_instance = \NDB_BVL_Instrument::factory(
+                        $this->loris,
+                        $instrument['Test_name']
+                    );
+                    return [
+                        'Test_name' => "Instrument ".
+                            $instrument_instance->getFullName().
+                            $reminder. $values['VL'],
+                    ];
+                }
             }
         }
         if (!isset($_REQUEST['fire_away'])
@@ -204,25 +206,52 @@ class AddSurvey extends \NDB_Form
             ]
         );
 
-        $InstrumentExists = $db->pselectOne(
-            "SELECT 'x' FROM participant_accounts
-            WHERE Test_name=:TN AND SessionID=:SID",
-            [
-                'TN'  => $values['Test_name'],
-                'SID' => $SessionID,
-            ]
-        );
-        if ($InstrumentExists == 'x') {
-            return;
+        // $battery = new \NDB_BVL_Battery($this->loris);
+        // $battery->selectBattery(
+        //     new \SessionID($SessionID)
+        // );
+
+        foreach ($values['Test_name'] as $testName) {
+            $InstrumentExists = $db->pselectOne(
+                "SELECT 'x' FROM participant_accounts
+                WHERE Test_name=:TN AND SessionID=:SID",
+                [
+                    'TN'  => $testName,
+                    'SID' => $SessionID,
+                ]
+            );
+            if ($InstrumentExists == 'x') {
+                return;
+            }
+
+            $commentID = $db->pselectOne(
+                "SELECT CommentID FROM flag 
+                WHERE Test_name=:TN AND SessionID=:SID
+                AND CommentID NOT LIKE 'DDE%'",
+                [
+                 'TN'  => $testName,
+                 'SID' => $SessionID,
+                ]
+            );
+            $key = $this->_generateSurveyKey();
+
+            try {
+                $db->insert(
+                    "participant_accounts",
+                    [
+                        'SessionID'       => $SessionID,
+                        'Test_name'       => $testName,
+                        'Status'          => $status,
+                        'OneTimePassword' => $key,
+                        'CommentID'       => $commentID,
+                    ]
+                );
+                $this->tpl_data['success'] = true;
+            } catch (\DatabaseException $e) {
+                error_log($e->getMessage());
+                $this->tpl_data['success'] = false;
+            }
         }
-        $battery = new \NDB_BVL_Battery($this->loris);
-        $battery->selectBattery(
-            new \SessionID($SessionID)
-        );
-
-        $commentID = $battery->addInstrument($this->loris, $values['Test_name']);
-
-        $key = $this->_generateSurveyKey();
 
         $sendEmail = false;
         if (isset($_REQUEST['send_email'])) {
@@ -232,23 +261,6 @@ class AddSurvey extends \NDB_Form
             $status = 'Sent';
         } else {
             $status = 'Created';
-        }
-
-        try {
-            $db->insert(
-                "participant_accounts",
-                [
-                    'SessionID'       => $SessionID,
-                    'Test_name'       => $values['Test_name'],
-                    'Status'          => $status,
-                    'OneTimePassword' => $key,
-                    'CommentID'       => $commentID,
-                ]
-            );
-            $this->tpl_data['success'] = true;
-        } catch (\DatabaseException $e) {
-            error_log($e->getMessage());
-            $this->tpl_data['success'] = false;
         }
 
         if ($email && ($values['send_email'] == 'true')) {
@@ -293,10 +305,10 @@ class AddSurvey extends \NDB_Form
         $this->addSelect(
             "Test_name",
             "Instrument",
-            array_merge(
-                ['' => ''],
-                \NDB_BVL_Instrument::getDirectEntryInstrumentNamesList($this->loris)
-            )
+            \NDB_BVL_Instrument::getDirectEntryInstrumentNamesList($this->loris),
+            [
+                'multiple' => 'multiple',
+            ]
         );
         $this->addBasicText("Email", "Email address");
         $this->addBasicText("Email2", "Confirm Email address");

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -206,6 +206,7 @@ class AddSurvey extends \NDB_Form
             ]
         );
 
+        $url = '';
         $baseURL   = \NDB_Factory::singleton()->settings()->getBaseURL();
         $sendEmail = false;
         if (isset($_REQUEST['send_email'])) {
@@ -257,7 +258,7 @@ class AddSurvey extends \NDB_Form
             $url .= $baseURL . '/survey.php?key=' . urlencode($key) . "\n";
         }
 
-        if ($email && ($values['send_email'] == 'true')) {
+        if ($email && ($sendEmail == 'true')) {
             $config   = \NDB_Config::singleton();
             $msg_data = [
                 'study'     => $config->getSetting("title"),

--- a/modules/survey_accounts/test/TestPlan.md
+++ b/modules/survey_accounts/test/TestPlan.md
@@ -10,20 +10,20 @@
 4.  Ensure all columns are sortable (ascending and descending).
     [Manual Testing]
 5.  Click on a URL fill out field, make sure “Save and Continue” works
-    (if mandatory fields are not filled out make sure it doesn’t allow you to save.
+    (if mandatory fields are not filled out make sure it doesn’t allow you to save).
     Make sure that if you don’t fill out a field that is required,
     and you hit save and continue fields you have filled out are not erased.
     [Manual Testing]
 6.  Add Survey button:
-    * Try sending the URL to yourself -  make sure that both email addresses match in order for the “Email Survey” button to work
+    * Try sending the URLs to yourself -  make sure that both email addresses match in order for the “Email Survey” button to work
       (try mismatched email addresses to make sure that the "Email Survey" button remains inactive).
-    * Once you hit “Email Survey” you should get a blank page where you can customize an email to go along with the URL –
+    * Once you hit “Email Survey” you should get a blank page where you can customize an email to go along with the URLs –
     enter in a message and make sure it sends (also try the "Close" button on this page).
     The email can be pre-populated for each instrument using participant_emails table.
-    * Ensure that the instrument being sent is what you get (and that the URL brings you to the correct survey).
+    * Ensure that the instruments being sent are what you get (and that the URLs brings you to the correct survey).
     * Use the `Create Survey` button (no email address should be specified).
     * Use the `Email survey` button by specifying email address.
-    * Check that the survey list shows the newly created survey with all the correct information.
+    * Check that the survey list shows the newly created surveys with all the correct information.
     * Try creating a survey for a candidate in a Project that the user is not affiliated with. This should not be allowed.
     * Try mismatched PSCID and DCCID and should get an error message.
     * Try creating duplicate instrument for a candidate for a visit, should get an error message.

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -267,9 +267,11 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         );
         $visitOption = new WebDriverSelect($visitField);
         $visitOption->selectByValue($visitLabel);
-        $this->safeFindElement(
-            WebDriverBy::Name("Test_name")
-        )->sendKeys($instrument);
+        $testNameField = $this->safeFindElement(
+            WebDriverBy::Name("Test_name[]")
+        );
+        $testNameOption = new WebDriverSelect($testNameField);
+        $testNameOption->selectByValue($instrument);
         $this->safeFindElement(
             WebDriverBy::Name("fire_away")
         )->click();
@@ -288,9 +290,11 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("PSCID")
         )->sendKeys("8889");
-        $this->safeFindElement(
-            WebDriverBy::Name("Test_name")
-        )->sendKeys($instrument);
+        $testNameField = $this->safeFindElement(
+            WebDriverBy::Name("Test_name[]")
+        );
+        $testNameOption = new WebDriverSelect($testNameField);
+        $testNameOption->selectByValue($instrument);
         $this->safeFindElement(
             WebDriverBy::Name("fire_away")
         )->click();

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -267,7 +267,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         );
         $visitOption = new WebDriverSelect($visitField);
         $visitOption->selectByValue($visitLabel);
-        $testNameField = $this->safeFindElement(
+        $testNameField  = $this->safeFindElement(
             WebDriverBy::Name("Test_name[]")
         );
         $testNameOption = new WebDriverSelect($testNameField);
@@ -290,7 +290,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->safeFindElement(
             WebDriverBy::Name("PSCID")
         )->sendKeys("8889");
-        $testNameField = $this->safeFindElement(
+        $testNameField  = $this->safeFindElement(
             WebDriverBy::Name("Test_name[]")
         );
         $testNameOption = new WebDriverSelect($testNameField);


### PR DESCRIPTION
## Brief summary of changes
In add survey, changes the instrument select to a multiselect and includes a link to every selected instrument in the email

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Add a survey in the Survey Accounts module
2. For some candidate, select multiple instruments and set an email
3. Submit with "Email survey" and verify the email is sent and received with a link to each instrument + both surveys exist in the table with distinct links

#### Link(s) to related issue(s)

* Resolves #8984 
