### PR TITLE
Relax Typescript JSdoc linting configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,8 +111,9 @@
           }}
         ],
         "jsdoc/require-param-description": "error",
-        "jsdoc/require-returns": "error",
         "jsdoc/require-returns-description": "error",
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-returns-type": "off",
         "no-undef": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off"


### PR DESCRIPTION
As discussed in private message with @driusan, this PR relaxes the Typescript JSDoc linting configuration by doing the following:
- Remove the need for a `@returns` annotations, since the rest of the documentation and the return type are often sufficient.
- Remove warnings for no `@param` and `@returns` type in the documentation, since those are already provided by Typescript.

The doc comment for functions is still required and there is still a warning when no `@param` is present.