### PR TITLE
[Survey Module] Update survey status upon data_entry

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -201,6 +201,12 @@ class NDB_BVL_InstrumentStatus
             ['CommentID' => $this->_commentID]
         );
 
+        $GLOBALS['DB']->update(
+            'participant_accounts',
+            ['Status' => $status],
+            ['CommentID' => $this->_commentID]
+        );
+
         $this->select($this->_commentID);
 
         // Run the ConflictDetector if the new status is Complete


### PR DESCRIPTION
## Brief summary of changes
When an instrument's data entry is updated, the Status field in `participant_accounts` is also updated

#### Testing instructions (if applicable)

1. In the survey accounts module, add a new survey for an instrument for which `isDirectEntry` = 1
2. Change the data entry status directly in the candidate's instrument page
3. Check that the status in participant_accounts / in the survey accounts table is also updated to the correct value

[CCNA Override](https://github.com/aces/CCNA/pull/4822)
