### PR TITLE
[Instrument_Status] Keep flag Required_elements_completed Up-to-date

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -105,6 +105,17 @@ class NDB_BVL_InstrumentStatus
         // set the _commentID property
         $this->_commentID = $commentID;
 
+        $instrumentName   = NDB_BVL_Battery::getInstrumentNameForCommentId(
+            $this->_commentID
+        );
+        $instrument       = NDB_BVL_Instrument::factory(
+            $this->loris,
+            $instrumentName,
+            $this->_commentID,
+            '',
+        );
+        $instrument->updateRequiredElementsCompletedFlag();
+
         $db = \NDB_Factory::singleton()->database();
 
         // get candidate data from database


### PR DESCRIPTION
## Brief summary of changes

- Update Instrument_Status to calculate and update the Required_elements_completed flag again on load / save
- CCNA has had a recurring issue where instruments could not be set to Data_entry = 'Complete' because Required_elements_completed was set to 'N' even though the elements were completed.

#### Testing instructions (if applicable)

1. Find a completed instrument
2. set Required_elements_completed = 'N'
3. Open the instrument and see that it was changed to 'Y'