### PR TITLE
[dictionary] optimize unique scan types

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -967,7 +967,7 @@ class Utility
     {
 
         $scan_types_DB = \NDB_Factory::singleton()->database()->pselect(
-            "SELECT ID, Scan_type
+            "SELECT DISTINCT ID, Scan_type
              FROM mri_scan_type mri
                 JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
             []


### PR DESCRIPTION
## Brief summary of changes

- optimize the list of scan types returned.
- HBCD has a lot of scan types, only returning unique ones fixes `dictionary` module (it is not loading with the new QueryEngine).

Rebase #9453