### PR TITLE
[candidate_list] Fix 'Access Profile' link on timepoint list page

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -65,7 +65,7 @@ class CandidateListIndex extends Component {
    * Called by React when the component has been rendered on the page.
    */
   componentDidMount() {
-    fetch('/candidate_list/options',
+    fetch(loris.BaseURL+'/candidate_list/options',
         {credentials: 'same-origin'}).then(
             (resp) => resp.json()
         ).then(

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -65,7 +65,7 @@ class CandidateListIndex extends Component {
    * Called by React when the component has been rendered on the page.
    */
   componentDidMount() {
-    fetch('options',
+    fetch('/candidate_list/options',
         {credentials: 'same-origin'}).then(
             (resp) => resp.json()
         ).then(


### PR DESCRIPTION
[v26 Upgrade HBCD] Selection Filter boxes on 'Access Profile' page are empty when accessed via direct link
When the 'Access Profile' is reached via clicking on the direct link at the top left of the page (e.g. from participant's profile page), the page will load, but the multi-select boxes in the 'Selection Filter' Menu appear empty. This is not the case if the page is accessed via the link in the 'Candidate' menu.

This PR fixes the issue.
