### PR TITLE
Add JSON HTTP responses for "accepted" and "see other"

### DIFF
--- a/src/Http/Response/JSON/Accepted.php
+++ b/src/Http/Response/JSON/Accepted.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response\JSON;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 202 Accepted.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Accepted extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 202 Accepted
+     *
+     * @param array|null $body The error message
+     */
+    public function __construct(?array $body)
+    {
+        parent::__construct($body, 202);
+    }
+}

--- a/src/Http/Response/JSON/SeeOther.php
+++ b/src/Http/Response/JSON/SeeOther.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * See Other responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response\JSON;
+
+use \LORIS\Http\Response\JsonResponse;
+use \Psr\Http\Message\UriInterface;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 303 See Other.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class SeeOther extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 303 See Other.
+     *
+     * @param UriInterface $location The endpoint etag
+     */
+    public function __construct(UriInterface $location)
+    {
+        $headers = array('Location' => $location->__toString());
+        parent::__construct(null, 303, $headers);
+    }
+}


### PR DESCRIPTION
Extracted from #9154.

## Brief summary of changes

Add JSON responses for HTTP codes [Accepted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) and [See other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303).

#### Testing instructions (if applicable)

It works in #9154 

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
