### PR TITLE
[server process monitor] minor doc comment changes

### DIFF
--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -52,25 +52,25 @@ class MriUploadServerProcess extends AbstractServerProcess
     private $_sourceLocation;
 
     /**
-     * Root of the MRI files directory.
+     * The value of MRICodePath config setting.
      *
      * @var string
      */
     private $_mriCodePath;
 
     /**
-     * Path of the environment file (relative to $_mriCodePath).
-     *
-     * @var string
-     */
-    private $_environmentFile;
-
-    /**
-     * Path of the prod file (relative to $_mriCodePath/dicom-archive/.loris-mri).
+     * The value of MriConfigFile config setting.
      *
      * @var string
      */
     private $_prodFile;
+
+    /**
+     * The value of EnvironmentFile config setting.
+     *
+     * @var string
+     */
+    private $_environmentFile;
 
     /**
      * Builds a new MriUploadServerProcess
@@ -99,7 +99,7 @@ class MriUploadServerProcess extends AbstractServerProcess
         $config =& \NDB_Config::singleton();
         if (is_null($config)) {
             throw new \RuntimeException(
-                "Cannot construct MriUploadTask: unable to instantiate 
+                "Cannot construct MriUploadTask: unable to instantiate
                  configuration object"
             );
         }

--- a/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
+++ b/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
@@ -72,14 +72,14 @@ class ServerProcessesMonitor
      * whatever is stored in the database for that process, the information
      * stored in the database is updated to reflect the current process state.
      *
-     * @param array  $idsToMonitor IDs of the server processes to monitor.
-     *                             If null, then the state of all the processes
-     *                             stored in the database is returned.
-     * @param string $userid       only the processes run by the user with name
-     *                             $userid are considered. If null, then the userid
-     *                             check is not performed.
-     * @param string $type         the type of server processes to retrieve. If null
-     *                             then all types are considered.
+     * @param array       $idsToMonitor IDs of the server processes to monitor.
+     *                                  If null, then the state of all the processes
+     *                                  stored in the database is returned.
+     * @param string|null $userid       Only the processes run by the user with name
+     *                                  $userid are considered. If null, then the
+     *                                  userid check is not performed.
+     * @param string|null $type         The type of server processes to retrieve. If
+     *                                  null then all types are considered.
      *
      * @return array (associative) of the current state of the processes.
      * @throws \DatabaseException if connection to the database cannot be
@@ -93,7 +93,7 @@ class ServerProcessesMonitor
         //------------------------------------------------------
         $db = $this->getDatabaseProvider()->getDatabase();
 
-        $query = "SELECT id, pid, type, userid, stdout_file, stderr_file, 
+        $query = "SELECT id, pid, type, userid, stdout_file, stderr_file,
                          exit_code_file, exit_code, start_time, end_time,
                          exit_text
                   FROM server_processes


### PR DESCRIPTION
Extracted from #9154

## Brief summary of changes

Those are minor documentation changes of the server process monitor that were present in #9154. I don't remember writing these changes so those were probably in the original PR. I do not have a strong opinion myself on the doc changes, but the doc type changes certainly better fit the function behaviour.

@driusan feel free to ping someone more knowledgeable than us on this subject.