### PR TITLE
[API] Fix API DICOM get documentation

### DIFF
--- a/modules/api/docs/LorisRESTAPI.md
+++ b/modules/api/docs/LorisRESTAPI.md
@@ -813,7 +813,7 @@ object of the form:
             "SeriesInfo" :
                 [{
                     "SeriesDescription" : "MPRAGE_ipat2",
-                    "SeriesNumber" : "2",
+                    "SeriesNumber" : 2,
                     "EchoTime" : "2.98",
                     "RepetitionTime" : "2300",
                     "InversionTime" : "900",
@@ -823,7 +823,7 @@ object of the form:
                     },
                     {
                     "SeriesDescription" : "BOLD Resting State",
-                    "SeriesNumber" : "5",
+                    "SeriesNumber" : 5,
                     "EchoTime" : "30",
                     "RepetitionTime" : "2100",
                     "InversionTime" : NULL,
@@ -837,7 +837,7 @@ object of the form:
             "SeriesInfo" :
                 [{
                 "SeriesDescription" : "MPRAGE_ipat2",
-                "SeriesNumber" : "2",
+                "SeriesNumber" : 2,
                 "EchoTime" : "2.98",
                 "RepetitionTime" : "2300",
                 "InversionTime" : "900",

--- a/modules/api/docs/LorisRESTAPI_v0.0.4-dev.md
+++ b/modules/api/docs/LorisRESTAPI_v0.0.4-dev.md
@@ -852,7 +852,7 @@ object of the form:
             "SeriesInfo" :
                 [{
                     "SeriesDescription" : "MPRAGE_ipat2",
-                    "SeriesNumber" : "2",
+                    "SeriesNumber" : 2,
                     "EchoTime" : "2.98",
                     "RepetitionTime" : "2300",
                     "InversionTime" : "900",
@@ -862,7 +862,7 @@ object of the form:
                     },
                     {
                     "SeriesDescription" : "BOLD Resting State",
-                    "SeriesNumber" : "5",
+                    "SeriesNumber" : 5,
                     "EchoTime" : "30",
                     "RepetitionTime" : "2100",
                     "InversionTime" : NULL,
@@ -877,7 +877,7 @@ object of the form:
             "SeriesInfo" :
                 [{
                 "SeriesDescription" : "MPRAGE_ipat2",
-                "SeriesNumber" : "2",
+                "SeriesNumber" : 2,
                 "EchoTime" : "2.98",
                 "RepetitionTime" : "2300",
                 "InversionTime" : "900",


### PR DESCRIPTION
Extracted from #9154.

## Brief summary of changes

The current documentation does not match the behavior of the DICOM get endpoint. The documentation says it returns a string, whereas the endpoint actually returns an int. @driusan makes a point that it might either be the code or the documentation that is wrong ([message](https://github.com/aces/Loris/pull/9154#discussion_r1832850537)). I personally think an integer ID should be encoded as an int, but this is not a strong opinion.