### PR TITLE
[document_repository] Error for filenames with comma

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -183,7 +183,7 @@ class DocIndex extends React.Component {
         <a
           href={downloadURL}
           target="_blank"
-          download={row['File Name']}
+          download={encodeURIComponent(row['File Name'])}
         >
           {cell}
         </a>

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -16,7 +16,6 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Files extends \NDB_Page
 {
-    const COMMA_IN_FILENAME = 'Filename cannot contain a comma.';
     const FILE_EXISTS_IN_DB = 'A file with this name already exists in the ' .
         'database. If the file does not appear in the document repository, ' .
         'please contact your administrator.';
@@ -344,10 +343,6 @@ class Files extends \NDB_Page
 
         foreach ($uploadedFiles as $uploadedFile) {
             $filename = urldecode($uploadedFile->getClientFilename());
-
-            if (strpos($filename, ',') !== false) {
-                $responseMessages[] = "$filename: " . self::COMMA_IN_FILENAME;
-            }
 
             if ($this->existFilename($filename)) {
                 // If a record of this a file with the same name already exists

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -99,7 +99,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
         return (new \LORIS\Http\Response\JSON\OK())
             ->withHeader(
                 'Content-Disposition',
-                'attachment; filename=' . $filename
+                'attachment; filename=' . urlencode($filename)
             )
             ->withHeader(
                 'Content-Type',


### PR DESCRIPTION
## Brief summary of changes
In the Document Repository module's upload file section, have an error message appear when an uploaded file's name contains a comma

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Upload a file containing a comma in its name in the document repository module and check that the appropriate error message appears
2. Upload a properly formatted file and ensure that the upload is successful

[CCNA Override](https://github.com/aces/CCNA/pull/6369)
