### PR TITLE
[NDB_BVL_Instrument] Modify InstanceData Setting

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -879,6 +879,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ['CommentID' => $this->getCommentID()],
         );
 
+        if (!$this->jsonData) {
+            $newData = array_merge($this->getInstanceData() ?? [], $values);
+        }
         $this->instanceData = $newData;
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -843,18 +843,22 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         // Extract the old data and merge it with what was submitted so that we
         // don't overwrite data from other pages.
-        $oldData = $db->pselectOne(
-            "SELECT id.Data FROM flag f
-                    JOIN instrument_data id ON (id.ID=f.DataID)
-                WHERE CommentID=:cid",
-            ['cid' => $this->getCommentID()]
-        );
-
-        // (The PDO driver seems to return null as "null" for JSON column types)
-        if (!empty($oldData) && $oldData !== "null") {
-            $oldData = json_decode($oldData, true);
+        if (!$this->jsonData) {
+            $oldData = $this->getInstanceData() ?? [];
         } else {
-            $oldData = [];
+            $oldData = $db->pselectOne(
+                "SELECT id.Data FROM flag f
+                        JOIN instrument_data id ON (id.ID=f.DataID)
+                    WHERE CommentID=:cid",
+                ['cid' => $this->getCommentID()]
+            );
+
+            // (The PDO driver seems to return null as "null" for JSON column types)
+            if (!empty($oldData) && $oldData !== "null") {
+                $oldData = json_decode($oldData, true);
+            } else {
+                $oldData = [];
+            }
         }
         $newData = array_merge($oldData ?? [], $values);
 
@@ -879,9 +883,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ['CommentID' => $this->getCommentID()],
         );
 
-        if (!$this->jsonData) {
-            $newData = array_merge($this->getInstanceData() ?? [], $values);
-        }
         $this->instanceData = $newData;
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -843,24 +843,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         // Extract the old data and merge it with what was submitted so that we
         // don't overwrite data from other pages.
-        if (!$this->jsonData) {
-            $oldData = $this->getInstanceData() ?? [];
-        } else {
-            $oldData = $db->pselectOne(
-                "SELECT id.Data FROM flag f
-                        JOIN instrument_data id ON (id.ID=f.DataID)
-                    WHERE CommentID=:cid",
-                ['cid' => $this->getCommentID()]
-            );
-
-            // (The PDO driver seems to return null as "null" for JSON column types)
-            if (!empty($oldData) && $oldData !== "null") {
-                $oldData = json_decode($oldData, true);
-            } else {
-                $oldData = [];
-            }
-        }
-        $newData = array_merge($oldData ?? [], $values);
+        $newData = array_merge($this->getInstanceData() ?? [], $values);
 
         // If there's already a row with the same data, re-use the DataID.
         // Otherwise, insert it, then update the DataID on flag.

--- a/tools/data_integrity/score_instrument.php
+++ b/tools/data_integrity/score_instrument.php
@@ -124,7 +124,7 @@ if ($test_name== 'all') {
 $testNames = $DB->pselect($query, $qparams);
 
 // if nothing is returned than the instrument DNE
-if (!is_array($testNames) || count($testNames)==0) {
+if (count($testNames) === 0) {
     printError("Invalid Instrument ($test_name)!");
     return false;
 }
@@ -174,7 +174,7 @@ foreach ($testNames as $test) {
     $instrumentMetaData = $DB->pselect($query, $params);
 
     // return error if no candidates/timepoint matched the args
-    if (!is_array($instrumentMetaData) || empty($instrumentMetaData)) {
+    if (count($instrumentMetaData) === 0) {
         // given that the tool might be run with all
         // $candID and $sessionID might not be defined
         if (!empty($candID) && !empty($sessionID)) {


### PR DESCRIPTION
## Brief summary of changes
In the Instrument class' `_save()` function, updates the instance data if the instrument has an SQL table so that the instance data only needs to be saved once to calculate the correct score

This also updates the `score_instrument.php` script to resolve issue relating to the `Query` class update


#### Testing instructions (if applicable)

1. Run the scoring script for a candidate with the bmi instrument and verify that the scores are correct
2. Modify the instrument data in the instrument table only, not in data_instrument
3. Re-run the scoring script and verify that the scores are updated according to the changes made

#### Link(s) to related issue(s)

[CCNA Override](https://github.com/aces/CCNA/pull/7270)
[CCNA Override 2](https://github.com/aces/CCNA/pull/7452)
