### PR TITLE
[NDB_BVL_Instrument] Fix addHourMinElement being never required

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1202,7 +1202,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
             //If the answer is empty (or its a group and one of answers in the
             //group is empty) then run the rules
-            if ($elvalue==="" || $flag==false) {
+            if ($elvalue=="" || $flag==false) {
                 if ($this->XINDebug) {
                     //debugging code
                     echo "<p><b>$elname</b><br> ";


### PR DESCRIPTION
## Brief summary of changes
Resolves addHourMinElement never being required due to the XIN rule checking strictly for an empty string, excluding `NULL`

#### Link(s) to related issue(s)
[CCNA Override](https://github.com/aces/CCNA/pull/4443)
