### PR TITLE
[issue_tracker] 'My Issues' filter for users with no issues

### DIFF
--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -271,15 +271,22 @@ class IssueTrackerIndex extends Component {
       {label: 'Closed Issues', filter: {
         status: {value: ['closed'], exactMatch: true},
       }},
-      {label: 'My Issues', filter: {
-        assignee: {
-          value: this.state.data.fieldOptions.userID, exactMatch: true,
-        },
-        status: {
-          value: ['acknowledged', 'assigned', 'feedback', 'new', 'resolved'],
-        },
-      }},
     ];
+
+    // Add "My Issues" filter only if user has any issues
+    if (this.state.data.userIssueCount > 0) {
+      filterPresets.push({
+        label: 'My Issues',
+        filter: {
+          assignee: {
+            value: this.state.data.fieldOptions.userID, exactMatch: true,
+          },
+          status: {
+            value: ['acknowledged', 'assigned', 'feedback', 'new', 'resolved'],
+          },
+        },
+      });
+    }
 
     const addIssue = () => {
       window.location.replace(

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -183,6 +183,13 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             }
         }
 
+        $userIssueCount = $db->pselectOne(
+            "SELECT COUNT(*) FROM issues
+                WHERE assignee=:username
+                AND status <> 'closed'",
+            ['username' => $user->getUsername()]
+        );
+
         $fieldOptions = [
             'modules'    => $modules,
             'categories' => $categories,
@@ -191,7 +198,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             'statuses'   => $statuses,
             'priorities' => $priorities,
             'sites'      => $sites,
-            'userID'     => $user->getUsername(),
+            'userID'     => $user->getFullname(),
         ];
 
         $table = (new \LORIS\Data\Table())
@@ -204,9 +211,10 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         );
         return json_encode(
             [
-                'data'         => $arr,
-                'fieldOptions' => $fieldOptions,
-                'centerIDs'    => \Utility::getSiteList()
+                'data'           => $arr,
+                'fieldOptions'   => $fieldOptions,
+                'centerIDs'      => \Utility::getSiteList(),
+                'userIssueCount' => $userIssueCount,
             ]
         );
     }


### PR DESCRIPTION
## Brief summary of changes
This PR only shows the "My Issues" filter if the user has any issues assigned to them. Since there is no way to filter for issues assigned to no one and the drop down only includes users who have issues assigned to them, this filter will always break for a user with no issues. 

The alternative would be to include all users in the "Assignee" filter drop down. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Compile code on this branch
2. Create a new user and do not assign them to any issues
3. Go to the issue tracker and look in the preset filters
4. There should not be any "My issues" filter for this user
5. From the Admin account assign an issue to the user that you just created
6. Sign in with that user again and check the preset filters again
7. Make sure that the "My Issues" filter does show up now. 
8. Select "My Issues" filter and make sure that it works as intended.

#### Link(s) to related issue(s)

* Resolves #8879
