### PR TITLE
[Tools] assign_missing_instruments.php - fix wrong tpye

### DIFF
--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -91,7 +91,7 @@ function populateVisitLabel($result, $visit_label)
     $battery->selectBattery($sessionID);
     $timePoint = TimePoint::singleton($sessionID);
 
-    $candidate         = Candidate::singleton(new CandID($result['CandID']));
+    $candidate         = Candidate::singleton(new CandID(strval($result['CandID'])));
     $result_firstVisit = $candidate->getFirstVisit();
     $isFirstVisit      = false;//adding check for first visit
     if ($result_firstVisit == $visit_label) {


### PR DESCRIPTION
assign_missing_instruments.php - fix wrong tpye
 **[php assign_missing_instruments.php 
PHP Fatal error:  Uncaught TypeError: LORIS\StudyEntities\Candidate\ValidatableIdentifier::__construct(): Argument #1 ($value) must be of type string, int given, called in /var/www/Loris/tools/assign_missing_instruments.php on line 94 and defined in /var/www/Loris/src/StudyEntities/Candidate/ValidatableIdentifier.php:59]** 


test: run "php assign_missing_instruments.php"