### PR TITLE
[Candidate] RE-add support to create candidates from the backend (unix user)

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -264,7 +264,15 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
 
         $project = \Project::getProjectFromID($registrationProjectID);
 
-        $user = \User::singleton($_SESSION['State']->getUsername());
+        if (isset($_SESSION['State'])) {
+            $user = \User::singleton($_SESSION['State']->getUsername());
+        } elseif (!empty(getenv('USER'))) {
+            $user = \User::singleton(getenv('USER'));
+        } else {
+            throw new \LorisException(
+                "No username found to associate with the creation of this candidate"
+            );
+        }
 
         // figure out how to generate PSCID
         $config        = $factory->config();


### PR DESCRIPTION
## Brief summary of changes

The current code tries to get a username from the session. the session does not have a state when the candidate::createnew function is called from a script on the backend. 

The new code is inpired by the database class which tries to use the environment username to create the data.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. make sure you can still create a candidate with no issue the standard way
2. try to create a candidate fro ma script in the backend

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
