### PR TITLE
[NDB_BVL_Instrument_LINST] - fix

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -166,8 +166,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     foreach ($rules as $rule) {
                         //If this is an OR rule using two different controllers
                         //explode it at the pipe.
-                        //ex: q_1{@}=={@}yes|q_2{@}=={@}yes
-                        if (stristr(substr($rule, strpos($rule, "|")), "{@}")) {
+			//ex: q_1{@}=={@}yes|q_2{@}=={@}yes
+			$s_r = strpos($rule, "|");
+                        if ($s_r !== false && stristr(substr($rule, $s_r), "{@}")) {
                             $rules_array = explode("|", $rule);
                         } else {
                             //Otherwise its a regular rule.  ex: q_1{@}=={@}yes

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -166,8 +166,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     foreach ($rules as $rule) {
                         //If this is an OR rule using two different controllers
                         //explode it at the pipe.
-			//ex: q_1{@}=={@}yes|q_2{@}=={@}yes
-			$s_r = strpos($rule, "|");
+                        //ex: q_1{@}=={@}yes|q_2{@}=={@}yes
+                        $s_r = strpos($rule, "|");
                         if ($s_r !== false && stristr(substr($rule, $s_r), "{@}")) {
                             $rules_array = explode("|", $rule);
                         } else {


### PR DESCRIPTION
 PHP Fatal error:  Uncaught TypeError: substr(): Argument #2 ($offset) must be of type int, false given in /var/www/Loris/php/libraries/NDB_BVL_Instrument_LINST.class.inc:172

test: save data in the BMI instrument without issue. 