### PR TITLE
[conflict_resolver] Resolved tab load speed

### DIFF
--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -127,8 +127,8 @@ class ResolvedFilterableDataTable extends Component {
 
     const fields = [
       {label: 'Resolved ID', show: false},
-      {label: 'Project', show: true, filter: {
-        name: 'Project',
+      {label: 'Project', show: false, filter: {
+        name: 'projectid',
         type: 'select',
         options: options.project,
       }},
@@ -138,7 +138,7 @@ class ResolvedFilterableDataTable extends Component {
         options: options.cohort,
       }},
       {label: 'Site', show: true, filter: {
-        name: 'Site',
+        name: 'centerid',
         type: 'select',
         options: options.site,
       }},

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -169,8 +169,12 @@ class ResolvedFilterableDataTable extends Component {
         name: 'Description',
         type: 'text',
       }},
-      {label: 'Incorrect Answer', show: true, filter: {
-        name: 'oldValue',
+      {label: 'Value 1', show: true, filter: {
+        name: 'Value1',
+        type: 'text',
+      }},
+      {label: 'Value 2', show: true, filter: {
+        name: 'Value2',
         type: 'text',
       }},
       {label: 'Correct Answer', show: true, filter: {

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -169,12 +169,8 @@ class ResolvedFilterableDataTable extends Component {
         name: 'Description',
         type: 'text',
       }},
-      {label: 'Value 1', show: true, filter: {
-        name: 'Value1',
-        type: 'text',
-      }},
-      {label: 'Value 2', show: true, filter: {
-        name: 'Value2',
+      {label: 'Incorrect Answer', show: true, filter: {
+        name: 'oldValue',
         type: 'text',
       }},
       {label: 'Correct Answer', show: true, filter: {

--- a/modules/conflict_resolver/php/endpoints/resolved.class.inc
+++ b/modules/conflict_resolver/php/endpoints/resolved.class.inc
@@ -85,16 +85,14 @@ class Resolved extends Endpoint implements ETagCalculator
      */
     private function _getFieldOptions(\LORIS\LorisInstance $loris) : array
     {
-        $sites       = array_values(\Utility::getSiteList(false));
         $visitlabels = array_values(\Utility::getVisitList());
-        $projects    = array_values(\Utility::getProjectList());
         $cohorts     = array_values(\Utility::getCohortList());
 
         return [
-            'site'       => array_combine($sites, $sites),
+            'site'       => \Utility::getSiteList(false),
             'instrument' => \NDB_BVL_Instrument::getInstrumentNamesList($loris),
             'visitLabel' => array_combine($visitlabels, $visitlabels),
-            'project'    => array_combine($projects, $projects),
+            'project'    => \Utility::getProjectList(),
             'cohort'     => array_combine($cohorts, $cohorts),
         ];
     }

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -44,7 +44,8 @@ class ResolvedDTO implements DataInstance, SiteHaver
     protected $instrument;
     protected $question;
     protected $description;
-    protected $oldValue;
+    protected $value1;
+    protected $value2;
     protected $correctanswer;
     protected $user1;
     protected $user2;
@@ -69,7 +70,8 @@ class ResolvedDTO implements DataInstance, SiteHaver
             'Instrument'          => $this->instrument,
             'Question'            => $this->question,
             'Description'         => "",
-            'Incorrect Answer'    => $this->oldValue,
+            'Value 1'             => $this->value1,
+            'Value 2'             => $this->value2,
             'Correct Answer'      => $this->correctanswer,
             'User 1'              => $this->user1,
             'User 2'              => $this->user2,

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -36,18 +36,15 @@ class ResolvedDTO implements DataInstance, SiteHaver
      */
     protected $resolvedid;
     protected $projectid;
-    protected $project;
     protected $cohort;
     protected $centerid;
-    protected $site;
     protected $candid;
     protected $pscid;
     protected $visitlabel;
     protected $instrument;
     protected $question;
     protected $description;
-    protected $value1;
-    protected $value2;
+    protected $oldValue;
     protected $correctanswer;
     protected $user1;
     protected $user2;
@@ -63,17 +60,16 @@ class ResolvedDTO implements DataInstance, SiteHaver
     {
         return [
             'ResolvedID'          => $this->resolvedid,
-            'Project'             => $this->project,
+            'ProjectID'           => $this->projectid,
             'Cohort'              => $this->cohort,
-            'Site'                => $this->site,
+            'CenterId'            => $this->centerid,
             'CandID'              => $this->candid,
             'PSCID'               => $this->pscid,
             'Visit Label'         => $this->visitlabel,
             'Instrument'          => $this->instrument,
             'Question'            => $this->question,
             'Description'         => "",
-            'Value 1'             => $this->value1,
-            'Value 2'             => $this->value2,
+            'Incorrect Answer'    => $this->oldValue,
             'Correct Answer'      => $this->correctanswer,
             'User 1'              => $this->user1,
             'User 2'              => $this->user2,

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -41,18 +41,21 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.Name as project,
 	      conflicts_resolved.FieldName as question,
 	      CASE
-    		WHEN conflicts_resolved.FieldName <> "Examiner"
-        	THEN conflicts_resolved.OldValue1
-    	      	    ELSE
-	      CONCAT(conflicts_resolved.OldValue1, " - ",
-			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
- 		END as value1,
-	      CASE
-    		WHEN conflicts_resolved.FieldName <> "Examiner"
-        	    THEN conflicts_resolved.OldValue2
-		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ",
-			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
-		END as value2,
+            WHEN conflicts_resolved.NewValue <> 1 
+                AND conflicts_resolved.FieldName <> "Examiner"
+                THEN conflicts_resolved.OldValue1
+            WHEN conflicts_resolved.NewValue <> 1 
+                AND conflicts_resolved.FieldName = "Examiner"
+                THEN CONCAT(conflicts_resolved.OldValue1, " - ", 
+                (SELECT full_name FROM examiners 
+                WHERE examinerID = conflicts_resolved.OldValue1))
+            WHEN conflicts_resolved.NewValue = 1 
+            AND conflicts_resolved.FieldName = "Examiner"
+                THEN CONCAT(conflicts_resolved.OldValue2, " - ", 
+                (SELECT full_name FROM examiners 
+                WHERE examinerID = conflicts_resolved.OldValue2))
+            ELSE conflicts_resolved.OldValue2
+            END AS oldValue,
 	      CASE
 		WHEN conflicts_resolved.NewValue = 1
 			AND conflicts_resolved.FieldName <> "Examiner"
@@ -73,6 +76,8 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.CenterID as centerid,
               Project.ProjectID as projectid,
               cohort.title as cohort
+
+
              FROM
               conflicts_resolved
              LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -41,21 +41,18 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.Name as project,
 	      conflicts_resolved.FieldName as question,
 	      CASE
-            WHEN conflicts_resolved.NewValue <> 1 
-                AND conflicts_resolved.FieldName <> "Examiner"
-                THEN conflicts_resolved.OldValue1
-            WHEN conflicts_resolved.NewValue <> 1 
-                AND conflicts_resolved.FieldName = "Examiner"
-                THEN CONCAT(conflicts_resolved.OldValue1, " - ", 
-                (SELECT full_name FROM examiners 
-                WHERE examinerID = conflicts_resolved.OldValue1))
-            WHEN conflicts_resolved.NewValue = 1 
-            AND conflicts_resolved.FieldName = "Examiner"
-                THEN CONCAT(conflicts_resolved.OldValue2, " - ", 
-                (SELECT full_name FROM examiners 
-                WHERE examinerID = conflicts_resolved.OldValue2))
-            ELSE conflicts_resolved.OldValue2
-            END AS oldValue,
+    		WHEN conflicts_resolved.FieldName <> "Examiner"
+        	THEN conflicts_resolved.OldValue1
+    	      	    ELSE
+	      CONCAT(conflicts_resolved.OldValue1, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
+ 		END as value1,
+	      CASE
+    		WHEN conflicts_resolved.FieldName <> "Examiner"
+        	    THEN conflicts_resolved.OldValue2
+		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ",
+			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
+		END as value2,
 	      CASE
 		WHEN conflicts_resolved.NewValue = 1
 			AND conflicts_resolved.FieldName <> "Examiner"
@@ -76,8 +73,6 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               session.CenterID as centerid,
               Project.ProjectID as projectid,
               cohort.title as cohort
-
-
              FROM
               conflicts_resolved
              LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -34,6 +34,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
     static $PSCID      = 'input[name="PSCID"]';
     static $Question   = 'input[name="Question"]';
     static $Project    = 'select[name="Project"]';
+    static $CenterID   = 'select[name="centerid"]';
     //filter location on resolved_conflicts page
     static $Timestamp = 'input[name="ResolutionTimestamp"]';
 
@@ -170,7 +171,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url."/conflict_resolver/");
         $this->safeClick(WebDriverBy::cssSelector("#tab-resolved"));
         $this->_filterTest(
-            self::$ForSite,
+            self::$CenterID,
             self::$display,
             self::$clearFilter,
             "Montreal",


### PR DESCRIPTION
## Brief summary of changes
Fixes load speed of the CR's resolved conflicts tab that was failing because of too much data. 
- Queries for the `projectid` and `centerid` while keeping their full names in the filter for Project & Site
- Replaces fields "Value 1" and "Value 2" with "Incorrect Value" -> moved to [this PR](https://github.com/aces/Loris/pull/9506)

#### Testing instructions (if applicable)

1. Check that both resolved/unresolved tabs of the module load properly
2. In the resolved tab, check that the Project & Site filters works 

[CCNA Override](https://github.com/aces/CCNA/pull/6856)
