### PR TITLE
[data_release] FileUpload version permission

### DIFF
--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -215,6 +215,15 @@ class Files extends \NDB_Page
             ['project' => $projectName]
         );
 
+        // Get information on users with permission to the version
+
+        $releasePage = $this->Module->loadPage(
+            $this->loris,
+            'data_release',
+        );
+        assert($releasePage instanceof Data_Release);
+        $userVersionFiles = $releasePage->getUserVersionFiles($DB);
+
         $upload_date = date('Y-m-d');
         if ($overwrite) {
             // update file in data_release table.
@@ -252,6 +261,21 @@ class Files extends \NDB_Page
                 'data_release_id' => $fileID,
             ]
         );
+
+        // add permission for file to users with permission to the version
+        foreach ($userVersionFiles as $userid => $userVersionFile) {
+            if (array_key_exists('versions', $userVersionFile)
+                && in_array($version, $userVersionFile['versions'])
+            ) {
+                $DB->insertIgnore(
+                    'data_release_permissions',
+                    [
+                        'userid'          => $userid,
+                        'data_release_id' => $fileID,
+                    ]
+                );
+            }
+        }
         return $files->handle($request);
     }
 


### PR DESCRIPTION
## Brief summary of changes
When uploading a new file with an existing version, users with permission to that version would be reset. This ensures users with access to the version gain permission to the new file

#### Testing instructions (if applicable)

1. In Data Release, upload a new file with a new version and give a non-admin user permissions to that version in 'Manage Permissions'
2. Upload another file under that version
3. In 'Manage Permissions', verify that the non-admin user still has access to the version
4. Access the data release module as the non-admin user and check that you have access to the files under that version

[CCNA Override](https://github.com/aces/CCNA/pull/6854)
