### PR TITLE
[Tools] Update fix_candidate_age.php speed

### DIFF
--- a/tools/data_integrity/fix_candidate_age.php
+++ b/tools/data_integrity/fix_candidate_age.php
@@ -84,10 +84,15 @@ foreach ($instruments as $testName=>$instrument) {
             JOIN candidate c ON c.CandID=s.CandID
             JOIN test_names tn ON tn.ID=f.TestID
         WHERE c.Active='Y' AND s.Active='Y'
-
-        AND tn.Test_name=:tn",
+            AND f.DataID IS NOT NULL
+            AND tn.Test_name=:tn",
         ['tn' => $testName]
     );
+
+    if (empty($CommentIDs)) {
+        echo "\tNo data found for $testName\n";
+        continue;
+    }
 
     $instrumentInstances = $instrument->bulkLoadInstanceData($CommentIDs);
 


### PR DESCRIPTION
## Brief summary of changes

- Updated the fix_candidate_age php tool to only consider candidates with Data, and to skip bulk loading when there are no participants

#### Testing instructions (if applicable)

1. Try running the fix_candidate_age script and confirm it works

CCNA OVERRIDE
