### PR TITLE
[publication] Fix edit PI issue

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -608,7 +608,6 @@ function editProject() : void
 
     if ($pubData['LeadInvestigatorEmail'] !== $leadInvestigatorEmail) {
         // check if email exists in database
-        $cid = null;
         $cid = $db->pselectOne(
             'SELECT PublicationCollaboratorID '.
             'FROM publication_collaborator '.

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -604,11 +604,42 @@ function editProject() : void
     if ($pubData['link'] !== $link) {
         $toUpdate['link'] = $link;
     }
-    if ($pubData['LeadInvestigator'] !== $leadInvestigator) {
-        $leadInvToUpdate['Name'] = $leadInvestigator;
-    }
+    $leadInvToUpdate['Name'] = $leadInvestigator;
+
     if ($pubData['LeadInvestigatorEmail'] !== $leadInvestigatorEmail) {
+        // check if email exists in database
+        $cid = null;
+        $cid = $db->pselectOne(
+            'SELECT PublicationCollaboratorID '.
+            'FROM publication_collaborator '.
+            'WHERE Email=:email',
+            ['email' => $leadInvestigatorEmail]
+        );
         $leadInvToUpdate['Email'] = $leadInvestigatorEmail;
+
+        // if email exists in database, update new email association to name & cid
+        if ($cid) {
+            $db->update(
+                'publication_collaborator',
+                $leadInvToUpdate,
+                ['PublicationCollaboratorID' => $cid]
+            );
+             $toUpdate['LeadInvestigatorID'] = $cid;
+        } else {
+            // otherwise, create new collaborator with a new id
+            $db->insert(
+                'publication_collaborator',
+                $leadInvToUpdate
+            );
+            $toUpdate['LeadInvestigatorID'] = $db->getLastInsertId();
+        }
+        // if only name is updated, update name associated to the email
+    } else if ($pubData['LeadInvestigator'] !== $leadInvestigator) {
+        $db->update(
+            'publication_collaborator',
+            $leadInvToUpdate,
+            ['PublicationCollaboratorID' => $pubData['LeadInvestigatorID']]
+        );
     }
 
     editEditors($id);
@@ -629,13 +660,6 @@ function editProject() : void
             'publication',
             $toUpdate,
             ['PublicationID' => $id]
-        );
-    }
-    if (!empty($leadInvToUpdate)) {
-        $db->update(
-            'publication_collaborator',
-            $leadInvToUpdate,
-            ['PublicationCollaboratorID' => $pubData['LeadInvestigatorID']]
         );
     }
 }


### PR DESCRIPTION
## Brief summary of changes
In the Publication module, when editing a PI for a project (name/email), all other projects with the same PI would be modified. This PR takes the PI's email as the PI's identifier and
- if the email is updated to an existing email in the db, updates the name associated to the email and the project's `LeadInvestigatorID`
- if the email is updated to a new email, creates a new collaborator with a new ID
- if the email is not updated and the name is updated, updates the name associated to the email

#### Testing instructions (if applicable)

1. Create new projects with different PIs
2. Edit the PI information (name & email) in various ways and check that the projects are updated accordingly
3. Verify in the `publication_collaborator` table that when an email is updated to a new email that does not exist, a new collaborator is created, and the original collaborator is not replaced in the database

[CCNA Override](https://github.com/aces/CCNA/pull/6222)
