### PR TITLE
[dictionary] Field level permissions

### DIFF
--- a/SQL/New_patches/2024-11-29-Dictionary-Field-Permissions.sql
+++ b/SQL/New_patches/2024-11-29-Dictionary-Field-Permissions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `parameter_type_permissions_rel` (
+  `ParameterTypeID` int(10) unsigned NOT NULL,
+  `permID` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`ParameterTypeID`,`permID`),
+  KEY `FK_parameter_type_permissions_rel_perm` (`permID`),
+  CONSTRAINT `FK_parameter_type_permissions_rel_perm` FOREIGN KEY (`permID`) REFERENCES `permissions` (`permID`),
+  CONSTRAINT `FK_parameter_type_permissions_rel_test` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`)
+)

--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -20,17 +20,19 @@ class DataDictRow implements \LORIS\Data\DataInstance,
     protected string $desc;
     protected string $status;
     protected ?array $visits;
+    protected ?array $permissions;
 
     /**
      * Construct a DataDictRow
      *
-     * @param \Module        $itemmodule The module that the item is from
-     * @param Category       $cat        The way the module is categorized in the
-     *                                   item
-     * @param DictionaryItem $item       The DictionaryItem for this row
-     * @param string         $desc       The (possibly overridden) description
-     * @param string         $descstatus The status of the description override
-     * @param ?string[]      $visits     List of visits for the item.
+     * @param \Module        $itemmodule  The module that the item is from
+     * @param Category       $cat         The way the module is categorized in the
+     *                                    item
+     * @param DictionaryItem $item        The DictionaryItem for this row
+     * @param string         $desc        The (possibly overridden) description
+     * @param string         $descstatus  The status of the description override
+     * @param ?string[]      $visits      List of visits for the item.
+     * @param ?string[]      $permissions List of permissionsRequired for the item.
      */
     public function __construct(
         \Module $itemmodule,
@@ -39,6 +41,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         string $desc,
         string $descstatus,
         ?array $visits,
+        ?array $permissions,
     ) {
         $this->itemmodule   = $itemmodule;
         $this->itemcategory = $cat;
@@ -46,6 +49,7 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         $this->desc         = $desc;
         $this->status       = $descstatus;
         $this->visits       = $visits;
+        $this->permissions  = $permissions;
     }
 
     /**
@@ -73,6 +77,9 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         }
         if ($scope->__toString() == "session") {
             $val['visits'] = $this->visits;
+        }
+        if ($this->permissions) {
+            $val['permissions'] = $this->permissions;
         }
 
         return $val;

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -69,14 +69,25 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
                     $status = 'Empty';
                 }
 
-                $visits = $qe->getVisitList($cat, $item);
-                $dict[] = $this->getInstance(
+                $visits      = $qe->getVisitList($cat, $item);
+                $permissions = $DB->pselectCol(
+                    "SELECT GROUP_CONCAT(p.code) as Permissions_Required
+                    FROM parameter_type pt
+                    LEFT JOIN parameter_type_permissions_rel rel
+                    ON (rel.ParameterTypeID=pt.ParameterTypeID)
+	                LEFT JOIN permissions p ON (rel.permID=p.permID)
+                    WHERE pt.Name=:name
+                    ",
+                    ['name' => $name]
+                );
+                $dict[]      = $this->getInstance(
                     $module,
                     $cat,
                     $item,
                     $desc,
                     $status,
                     $visits,
+                    $permissions,
                 );
             }
         }
@@ -87,15 +98,16 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
      * Returns an instance of a DataDict object for a given
      * table row, adding the category and description override
      *
-     * @param \Module        $module     The module that this DictionaryItem came
-     *                                   from.
-     * @param Category       $cat        The category within the module of the
-     *                                   DictionaryItem.
-     * @param DictionaryItem $item       The DictionaryItem for this row of the
-     *                                   table
-     * @param string         $desc       The overridden description of the item
-     * @param string         $descstatus The status of the description override
-     * @param ?[]string      $visits     The visits for session scoped variables
+     * @param \Module        $module      The module that this DictionaryItem came
+     *                                    from.
+     * @param Category       $cat         The category within the module of the
+     *                                    DictionaryItem.
+     * @param DictionaryItem $item        The DictionaryItem for this row of the
+     *                                    table
+     * @param string         $desc        The overridden description of the item
+     * @param string         $descstatus  The status of the description override
+     * @param ?[]string      $visits      The visits for session scoped variables
+     * @param ?[]string      $permissions The permissions required for this item
      *
      * @return \LORIS\Data\DataInstance An instance representing this row.
      */
@@ -106,7 +118,16 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
         string $desc,
         string $descstatus,
         array $visits,
+        array $permissions,
     ) : \LORIS\Data\DataInstance {
-        return new DataDictRow($module, $cat, $item, $desc, $descstatus, $visits);
+        return new DataDictRow(
+            $module,
+            $cat,
+            $item,
+            $desc,
+            $descstatus,
+            $visits,
+            $permissions
+        );
     }
 }

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -52,9 +52,12 @@ class Dictionary extends \DataFrameworkMenu
         foreach ($this->modules as $module) {
             $amodules[$module->getName()] = $module->getLongName();
         }
+        $db    = $this->loris->getDatabaseConnection();
+        $perms = $db->pselectCol("SELECT code FROM permissions", []);
         return [
-            'modules'    => $amodules,
-            'categories' => $this->categories,
+            'modules'            => $amodules,
+            'categories'         => $this->categories,
+            'allPermissionCodes' => $perms,
         ];
     }
 

--- a/modules/dictionary/php/permissions.class.inc
+++ b/modules/dictionary/php/permissions.class.inc
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\dictionary;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
+/**
+ * Manage the permissions for access to a field.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Permissions extends \NDB_Page
+{
+    /**
+     * The LORIS base path
+     *
+     * @var string
+     */
+    private string $_path;
+
+    const PERMISSIONS = [
+        'user_accounts'
+    ];
+
+    /**
+     * Does the setup required for this page. By default, sets up elements
+     * that are common to every type of page. May be overridden by a specific
+     * page or specific page type.
+     *
+     * @param \LORIS\LorisInstance $loris     The LORIS Instance that is serving
+     *                                        the page
+     * @param Module               $module    The test name being accessed
+     * @param string               $page      The subtest being accessed (may be
+     *                                        an empty string)
+     * @param string               $id        The identifier for the data to load
+     *                                        on this page
+     * @param string               $commentID The CommentID to load the data for
+     * @param string               $formname  The name to give this form
+     */
+    public function __construct(
+        \LORIS\LorisInstance $loris,
+        $module,
+        $page,
+        $id,
+        $commentID,
+        $formname
+    ) {
+        $this->skipTemplate = true;
+        parent::__construct($loris, $module, $page, $id, $commentID);
+    }
+
+    /**
+     * Checking permissions
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        return $user->hasAnyPermission(self::PERMISSIONS);
+    }
+
+    /**
+     * Handle a PSR7 Request for that endpoint.
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface The PSR15 response for the page.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if ($request->getMethod() != 'POST') {
+            return new \LORIS\Http\Response\JSON\MethodNotAllowed(['POST']);
+        }
+
+        // Ensure the user is allowed to upload.
+        if (! $request->getAttribute('user')->hasPermission(
+            'user_accounts'
+        )
+        ) {
+            return new \LORIS\Http\Response\JSON\Forbidden();
+        }
+
+        $values = json_decode((string) $request->getBody(), true);
+
+        $DB = $this->loris->getDatabaseConnection();
+        if (empty($values['fieldName'])) {
+            return new \LORIS\Http\Response\JSON\BadRequest();
+        }
+        $ParameterTypeID = $DB->pselectOneInt(
+            "SELECT ParameterTypeID FROM parameter_type
+            WHERE Name=:fieldName
+            ",
+            ['fieldName' => $values['fieldName'],],
+        );
+        if (empty($ParameterTypeID)) {
+            return new \LORIS\Http\Response\JSON\NotFound();
+        }
+        if (empty($values['permissions'])) {
+            $DB->delete(
+                'parameter_type_permissions_rel',
+                ['ParameterTypeID' => $ParameterTypeID]
+            );
+            return new \LORIS\Http\Response\JSON\OK(
+                [
+                    'message' => 'No permissions required for '
+                        . $values['fieldName']
+                ]
+            );
+        } else {
+            $DB->delete(
+                'parameter_type_permissions_rel',
+                ['ParameterTypeID' => $ParameterTypeID]
+            );
+            foreach ($values['permissions'] as $permCode) {
+                $permID = $DB->pselectOneInt(
+                    "SELECT permID FROM permissions WHERE code=:permcode",
+                    ['permcode' => $permCode],
+                );
+                $DB->insert(
+                    'parameter_type_permissions_rel',
+                    [
+                        'ParameterTypeID' => $ParameterTypeID,
+                        'PermID'          => $permID,
+                    ]
+                );
+            }
+        }
+        return new \LORIS\Http\Response\JSON\OK(
+            [
+                'message' => 'Updated required permissions for '
+                    . $values['fieldName']
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Brief summary of changes

- Introduced field level permissions for the data dictionary, so that permissions for specific fields can be removed from users.
- Capability is copied from Instrument Manager
TODO:
- Work with @driusan to make the dqt actually use this
- Currently is saved by the parameter_type ID, however candidate level fields are not in parameter_type, not sure how to go around that.
