### PR TITLE
[composer] manage project dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^1.4",
         "slevomat/coding-standard": "^6.4",
-        "php-webdriver/webdriver" : "dev-main"
+        "php-webdriver/webdriver" : "dev-main",
+        "wikimedia/composer-merge-plugin": "^2.0"
 
     },
     "scripts": {
@@ -37,7 +38,22 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "wikimedia/composer-merge-plugin": true
+        }
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "project/composer.json"
+            ],
+            "recurse": false,
+            "replace": false,
+            "ignore-duplicates": true,
+            "merge-dev": true,
+            "merge-extra": false,
+            "merge-extra-deep": false,
+            "merge-scripts": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47b37af4379a5b81dffb3575b44bd2f4",
+    "content-hash": "1ebc282ded1b8c7f6f9f7feb0de9228e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5234,6 +5234,62 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1||^2.0",
+                "ext-json": "*",
+                "mediawiki/mediawiki-phan-config": "0.11.1",
+                "php-parallel-lint/php-parallel-lint": "~1.3.1",
+                "phpspec/prophecy": "~1.15.0",
+                "phpunit/phpunit": "^8.5||^9.0",
+                "squizlabs/php_codesniffer": "~3.7.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                },
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\Merge\\V2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "support": {
+                "issues": "https://github.com/wikimedia/composer-merge-plugin/issues",
+                "source": "https://github.com/wikimedia/composer-merge-plugin/tree/v2.1.0"
+            },
+            "time": "2023-04-15T19:07:00+00:00"
         }
     ],
     "aliases": [],
@@ -5247,5 +5303,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docs/wiki/99_Developers/Code_Customization.md
+++ b/docs/wiki/99_Developers/Code_Customization.md
@@ -1,15 +1,15 @@
 # Code customization
 ## The project/ directory
 
-The `project/` directory is designed to house project-specific code and some data such as documents.  This includes instrument forms, instrument table schemas, and any customizations to other pages or modules in the Loris codebase.  
+The `project/` directory is designed to house project-specific code and some data such as documents.  This includes instrument forms, instrument table schemas, and any customizations to other pages or modules in the Loris codebase.
 The `project/` folder and its subdirectories are created by the install script, which also installs the `_config.xml_` file there.
 
-[[Instrument forms|Behavioural-Database]] (_.linst_ or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/` 
+[[Instrument forms|Behavioural-Database]] (_.linst_ or php) should be stored under `project/instruments/` and their table schemas (.sql) should be stored under `project/tables_sql/`
 
 ## Backing up `project/`
 
 * Important: Commit your project/ directory and its contents to a separate private repo - e.g. on GitHub
-* Equally Important: Exclude all data and the _config.xml_ file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub).  Back up this data and the config file elsewhere on another server, using a cronjob. 
+* Equally Important: Exclude all data and the _config.xml_ file (which contains a database credential) stored under project/ from commits/backups to your online repo (such as on GitHub).  Back up this data and the config file elsewhere on another server, using a cronjob.
 
 ## Tracking changes
 
@@ -25,5 +25,29 @@ i.e. `/var/www/loris/project/libraries/_filename.class.inc` will override `/var/
 
 ## Module override
 
-For projects wishing to customize existing modules, the recommended best practice is to copy _all_ module code from `$lorisroot/modules/_module_name_/*` to a new `project/modules/` subdirectory (project/modules/_module_name_/* ) and modify code there.  
-This will use the `project/` override functionality of Loris.  These changes should be added and committed to your project-specific private repo. 
+For projects wishing to customize existing modules, the recommended best practice is to copy _all_ module code from `$lorisroot/modules/_module_name_/*` to a new `project/modules/` subdirectory (project/modules/_module_name_/* ) and modify code there.
+This will use the `project/` override functionality of Loris.  These changes should be added and committed to your project-specific private repo.
+
+
+## Manage additional dependencies
+
+### Additional composer dependencies
+
+In case your project requires additional composer dependencies or different dependency version requirements, you can create a `composer.json` file in `project/` folder by running `composer init`. Any existing or new dependencies in this file will be merged with the main composer dependencies in `vendor/` after `composer update` has been run. For any change in the `project/composer.json` file, run `composer update` again in the root folder.
+
+### Additional npm dependencies
+
+To add new npm packages to your project, you can create a `package.json` file in `project/` by running `npm init`. Any dependencies in this file will be automatically installed under `project/` when make or npm ci/npm install is run from loris root.
+
+## Webpack compilation
+
+Modules overriden js files will automatically compile and replace the file they intend to modify. On the other hand, new js files will need to be registered in order to be compiled with `npm run compile`. To register, for example, a new React components located in `project/modules/_new_module_name_/jsx/_react_component_.js` you can create `project/webpack-project.config.js` with the following template:
+
+```
+const entry = {
+  '_new_module_name_': [
+    '_react_component_',
+  ],
+};
+module.exports = entry;
+```

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -295,7 +295,7 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @return array
      */
-    function getIssueData(int $issueID=null, \User $user): array
+    function getIssueData(int|null $issueID=null, \User $user): array
     {
         $db = $this->loris->getDatabaseConnection();
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -295,7 +295,7 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @return array
      */
-    function getIssueData(int|null $issueID=null, \User $user): array
+    function getIssueData(?int $issueID=null, \User $user): array
     {
         $db = $this->loris->getDatabaseConnection();
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -255,7 +255,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         ?string $edc,
         Sex $sex,
         ?string $PSCID = null,
-        ProjectID $registrationProjectID = null
+        ?ProjectID $registrationProjectID = null
     ): CandID {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -86,7 +86,7 @@ class FeedbackMRI
      *
      * @return bool true if operation succeeded
      */
-    function setPredefinedComments(array|null $predefinedCommentIDs=null): bool
+    function setPredefinedComments(?array $predefinedCommentIDs=null): bool
     {
         // choke if we are passed an empty array
         if (empty($predefinedCommentIDs)) {

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -86,7 +86,7 @@ class FeedbackMRI
      *
      * @return bool true if operation succeeded
      */
-    function setPredefinedComments(array $predefinedCommentIDs=null): bool
+    function setPredefinedComments(array|null $predefinedCommentIDs=null): bool
     {
         // choke if we are passed an empty array
         if (empty($predefinedCommentIDs)) {


### PR DESCRIPTION
## Brief summary of changes

- Allow additional composer deps to be managed in `project/` without the need to override the main `composer.json`.
- Adds the documentation section to cover how to override LORIS.


#### Testing instructions (if applicable)

1. create a `project/composer.json` with additional deps.
2. run `composer update`


#### Related PR

Reopening #8319 as a new dependency is needed in HBCD.
