### PR TITLE
[NDB_Page] Add default maxYear for date elements

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -102,7 +102,9 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
      *
      * @var array
      */
-    public $dateOptions;
+    public $dateOptions = [
+        'maxYear' => '9999'
+    ];
 
     /**
      * Does the setup required for this page. By default, sets up elements
@@ -315,9 +317,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
             'style' => 'max-width:33%; display:inline-block;',
         ]
     ) {
-        if ($options === [] && !empty($this->dateOptions)) {
-            $options = $this->dateOptions;
-        }
+        $options = $options + $this->dateOptions;
         $this->form->addElement('date', $field, $label, $options, $attribs);
     }
 
@@ -598,11 +598,12 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
             'style' => 'max-width:33%; display:inline-block;',
         ]
     ) {
+        
         return $this->form->createElement(
             "date",
             $field,
             $label,
-            $dateOptions,
+            $dateOptions + $this->dateOptions,
             $attribs
         );
     }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -98,7 +98,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
      * The default dateOptions to send to LorisForm to render elements
      * on this page. This is usually set by subclasses of NDB_Page which
      * need to modify the options to show on a date (ie. min year, max year,
-     * etc.)
+     * etc.). Default values can be added here, which can be overriden.
      *
      * @var array
      */


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Open user accounts and edit a user, confirm that you can edit the Active To and Active From dates, and that it does not let you enter a year greater than 9999 anymore.

#### Link(s) to related issue(s)

* Resolves #9497
