### PR TITLE
[create_timepoint] Add error swal

### DIFF
--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -305,6 +305,14 @@ class CreateTimepoint extends React.Component {
             // display conflicts on form.
             this.setState({messages: JSON.parse(data.error)});
           }
+        })
+        .catch((error) => {
+          swal.fire({
+            type: 'error',
+            title: 'Error!',
+            text: error,
+          });
+          console.error(error);
         });
       }
     }).catch((error) => {


### PR DESCRIPTION
## Brief summary of changes
In the Create Timepoint module, if there was a PHP error upon submission, the entered data would not save without any error message. This adds an error swal if a PHP error occurs

#### Testing instructions (if applicable)

1. Revert the changes made in [this](https://github.com/aces/Loris/issues/9357) PR to cause a PHP error
2. In the Create Timepoint module of any candidate, create a new valid visit
3. Submit and verify that the error swal appears
4. Restore the changes in the create_timepoint class (such that there are no PHP errors) and check that new visits can be created

#### Link(s) to related issue(s)

* Resolves #9358 
