### PR TITLE
[conflict_resolver] Replace 'Value 1 & 2' with 'Incorrect Answer'

### DIFF
--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -169,12 +169,8 @@ class ResolvedFilterableDataTable extends Component {
         name: 'Description',
         type: 'text',
       }},
-      {label: 'Value 1', show: true, filter: {
-        name: 'Value1',
-        type: 'text',
-      }},
-      {label: 'Value 2', show: true, filter: {
-        name: 'Value2',
+      {label: 'Incorrect Answer', show: true, filter: {
+        name: 'OldValue',
         type: 'text',
       }},
       {label: 'Correct Answer', show: true, filter: {

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -46,8 +46,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
     protected $instrument;
     protected $question;
     protected $description;
-    protected $value1;
-    protected $value2;
+    protected $oldValue;
     protected $correctanswer;
     protected $user1;
     protected $user2;
@@ -72,8 +71,7 @@ class ResolvedDTO implements DataInstance, SiteHaver
             'Instrument'          => $this->instrument,
             'Question'            => $this->question,
             'Description'         => "",
-            'Value 1'             => $this->value1,
-            'Value 2'             => $this->value2,
+            'Incorrect Answer'    => $this->oldValue,
             'Correct Answer'      => $this->correctanswer,
             'User 1'              => $this->user1,
             'User 2'              => $this->user2,

--- a/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
+++ b/modules/conflict_resolver/php/provisioners/resolvedprovisioner.class.inc
@@ -41,18 +41,21 @@ class ResolvedProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
               Project.Name as project,
 	      conflicts_resolved.FieldName as question,
 	      CASE
-    		WHEN conflicts_resolved.FieldName <> "Examiner"
-        	THEN conflicts_resolved.OldValue1
-    	      	    ELSE
-	      CONCAT(conflicts_resolved.OldValue1, " - ",
-			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue1))
- 		END as value1,
-	      CASE
-    		WHEN conflicts_resolved.FieldName <> "Examiner"
-        	    THEN conflicts_resolved.OldValue2
-		    ELSE CONCAT(conflicts_resolved.OldValue2, " - ",
-			(SELECT full_name FROM examiners WHERE examinerID = conflicts_resolved.OldValue2))
-		END as value2,
+    		WHEN conflicts_resolved.NewValue <> 1
+                AND conflicts_resolved.FieldName <> "Examiner"
+                THEN conflicts_resolved.OldValue1
+            WHEN conflicts_resolved.NewValue <> 1
+                AND conflicts_resolved.FieldName = "Examiner"
+                THEN CONCAT(conflicts_resolved.OldValue1, " - ",
+                (SELECT full_name FROM examiners
+                WHERE examinerID = conflicts_resolved.OldValue1))
+            WHEN conflicts_resolved.NewValue = 1
+            AND conflicts_resolved.FieldName = "Examiner"
+                THEN CONCAT(conflicts_resolved.OldValue2, " - ",
+                (SELECT full_name FROM examiners
+                WHERE examinerID = conflicts_resolved.OldValue2))
+            ELSE conflicts_resolved.OldValue2
+            END AS oldValue,
 	      CASE
 		WHEN conflicts_resolved.NewValue = 1
 			AND conflicts_resolved.FieldName <> "Examiner"


### PR DESCRIPTION
## Brief summary of changes
In the Conflict Resolver's Resolved tab, replaces the fields 'Value 1' and 'Value 2' with 'Incorrect Answer'
(changes brought over from https://github.com/aces/Loris/pull/9488)

#### Testing instructions (if applicable)

1. In the Conflict Resolver's 'Resolved' tab, check that the Value 1 & 2 filters & data columns have been replaced with 'Incorrect Answer'
2. Verify that the filters function properly

#### Link(s) to related issue(s)
[CCNA Override](https://github.com/aces/CCNA/pull/6856)
