### PR TITLE
[Cleanup] Make DBRowProvisioner use Database class

### DIFF
--- a/modules/api/php/endpoints/candidate/candidate.class.inc
+++ b/modules/api/php/endpoints/candidate/candidate.class.inc
@@ -38,10 +38,14 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Candidate $candidate The requested candidate
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param \Candidate           $candidate The requested candidate.
      */
-    public function __construct(\Candidate $candidate)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Candidate $candidate
+    ) {
         $this->_candidate = $candidate;
     }
 
@@ -121,6 +125,7 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $handler = new $subendpoint(
+            $this->loris,
             $this->_candidate,
             $visit
         );

--- a/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
@@ -44,10 +44,14 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Timepoint $visit The requested visit
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \Timepoint           $visit The requested visit.
      */
-    public function __construct(\Timepoint $visit)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $visit
+    ) {
         $this->_visit = $visit;
     }
 
@@ -131,6 +135,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $dicomtars = $this->_visit->getDicomTars(
+            $this->loris,
             $request->getAttribute('user')
         );
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -43,11 +43,16 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Timepoint $visit    The requested visit
-     * @param string     $filename The requested recording.class filename
+     * @param \LORIS\LorisInstance $loris    The LORIS instance that the module
+     *                                       is serving.
+     * @param \Timepoint           $visit    The requested visit
+     * @param string               $filename The requested recording.class filename
      */
-    public function __construct(\Timepoint $visit, string $filename)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $visit,
+        string $filename
+    ) {
         $this->_visit    = $visit;
         $this->_filename = $filename;
     }

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -106,6 +106,7 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $user = $request->getAttribute('user');
         try {
             $recording = $this->_visit->getRecordingByFilename(
+                $this->loris,
                 $user,
                 $this->_filename
             );
@@ -156,6 +157,7 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         try {
             $recording = $this->_visit->getRecordingByFilename(
+                $this->loris,
                 $user,
                 $this->_filename
             );
@@ -202,6 +204,7 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         try {
             $recording = $this->_visit->getRecordingByFilename(
+                $this->loris,
                 $user,
                 $this->_filename
             );

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -45,11 +45,16 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Timepoint $visit    The requested visit
-     * @param string     $filename The requested image filename
+     * @param \LORIS\LorisInstance $loris    The LORIS instance to retrieve data
+     *                                       from.
+     * @param \Timepoint           $visit    The requested visit
+     * @param string               $filename The requested image filename
      */
-    public function __construct(\Timepoint $visit, string $filename)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $visit,
+        string $filename
+    ) {
         $this->_visit    = $visit;
         $this->_filename = $filename;
     }

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -108,7 +108,11 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         // At this point, the image must exist
         $user = $request->getAttribute('user');
         try {
-            $image = $this->_visit->getImageByFilename($user, $this->_filename);
+            $image = $this->_visit->getImageByFilename(
+                $this->loris,
+                $user,
+                $this->_filename
+            );
         } catch (\NotFound $e) {
             return new \LORIS\Http\Response\JSON\NotFound($e->getMessage());
         }
@@ -149,7 +153,11 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $user = $request->getAttribute('user');
 
         try {
-            $image = $this->_visit->getImageByFilename($user, $this->_filename);
+            $image = $this->_visit->getImageByFilename(
+                $this->loris,
+                $user,
+                $this->_filename
+            );
         } catch (\NotFound $e) {
             return new \LORIS\Http\Response\JSON\NotFound($e->getMessage());
         }
@@ -200,7 +208,11 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $user = $request->getAttribute('user');
 
         try {
-            $image = $this->_visit->getImageByFilename($user, $this->_filename);
+            $image = $this->_visit->getImageByFilename(
+                $this->loris,
+                $user,
+                $this->_filename
+            );
         } catch (\Throwable $e) {
             return '';
         }

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -111,6 +111,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ->withAttribute('pathparts', $pathparts);
 
         $handler = new Image\Image(
+            $this->loris,
             $this->_visit,
             $filename
         );

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -44,10 +44,14 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Timepoint $visit The requested visit
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \Timepoint           $visit The requested visit
      */
-    public function __construct(\Timepoint $visit)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $visit
+    ) {
         $this->_visit = $visit;
     }
 
@@ -131,6 +135,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $images = $this->_visit->getImages(
+            $this->loris,
             $request->getAttribute('user')
         );
 

--- a/modules/api/php/endpoints/candidate/visit/recordings.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/recordings.class.inc
@@ -42,10 +42,14 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Timepoint $visit The requested visit
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \Timepoint           $visit The requested visit
      */
-    public function __construct(\Timepoint $visit)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $visit
+    ) {
         $this->_visit = $visit;
     }
 
@@ -128,6 +132,7 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $recordings = $this->_visit->getRecordings(
+            $this->loris,
             $request->getAttribute('user')
         );
 

--- a/modules/api/php/endpoints/candidate/visit/recordings.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/recordings.class.inc
@@ -108,6 +108,7 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ->withAttribute('pathparts', $pathparts);
 
         $handler = new Electrophysiology\Recording(
+            $this->loris,
             $this->_visit,
             $filename
         );

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -46,11 +46,17 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Candidate  $candidate The requested candidate
-     * @param ?\Timepoint $visit     The requested visit; can be null in PUT requests
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param \Candidate           $candidate The requested candidate.
+     * @param ?\Timepoint          $visit     The requested visit; can be null
+     *                                        in PUT requests
      */
-    public function __construct(\Candidate $candidate, ?\Timepoint $visit)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Candidate $candidate,
+        ?\Timepoint $visit
+    ) {
         $this->_candidate = $candidate;
         $this->_visit     = $visit;
     }
@@ -136,10 +142,10 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $handler = new Qc($this->_visit);
             break;
         case 'dicoms':
-            $handler = new Dicoms($this->_visit);
+            $handler = new Dicoms($this->loris, $this->_visit);
             break;
         case 'recordings':
-            $handler = new Recordings($this->_visit);
+            $handler = new Recordings($this->loris, $this->_visit);
             break;
         default:
             return new \LORIS\Http\Response\JSON\NotFound();

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -136,7 +136,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $handler = new Instruments($this->_visit);
             break;
         case 'images':
-            $handler = new Images($this->_visit);
+            $handler = new Images($this->loris, $this->_visit);
             break;
         case 'qc':
             $handler = new Qc($this->_visit);

--- a/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit_0_0_4_dev.class.inc
@@ -62,11 +62,16 @@ class Visit_0_0_4_Dev extends Endpoint implements \LORIS\Middleware\ETagCalculat
     /**
      * Contructor
      *
-     * @param \Candidate  $candidate The requested candidate
-     * @param ?\Timepoint $visit     The requested visit; can be null in PUT requests
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param \Candidate           $candidate The requested candidate
+     * @param ?\Timepoint          $visit     The requested visit; can be null
+     *                                        in PUT requests
      */
-    public function __construct(\Candidate $candidate, ?\Timepoint $visit)
-    {
+    public function __construct(protected \LORIS\LorisInstance $loris,
+        \Candidate $candidate,
+        ?\Timepoint $visit
+    ) {
         $this->_candidate = $candidate;
         $this->_visit     = $visit;
     }
@@ -145,16 +150,16 @@ class Visit_0_0_4_Dev extends Endpoint implements \LORIS\Middleware\ETagCalculat
             $handler = new Instruments($this->_visit);
             break;
         case 'images':
-            $handler = new Images($this->_visit);
+            $handler = new Images($this->loris, $this->_visit);
             break;
         case 'qc':
             $handler = new Qc($this->_visit);
             break;
         case 'dicoms':
-            $handler = new Dicoms($this->_visit);
+            $handler = new Dicoms($this->loris, $this->_visit);
             break;
         case 'recordings':
-            $handler = new Recordings($this->_visit);
+            $handler = new Recordings($this->loris, $this->_visit);
             break;
         default:
             return new \LORIS\Http\Response\JSON\NotFound();

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -160,7 +160,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return new \LORIS\Http\Response\JSON\Forbidden();
         }
 
-        $endpoint = new Candidate\Candidate($candidate);
+        $endpoint = new Candidate\Candidate($this->loris, $candidate);
 
         $pathparts = array_slice($pathparts, 2);
         $request   = $request->withAttribute('pathparts', $pathparts);
@@ -186,7 +186,10 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ['access_all_profiles']
         );
 
-        $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner())
+        $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner(
+            $this->loris
+        )
+        )
             ->filter($filter)
             ->filter(new \LORIS\Data\Filters\UserProjectMatch());
 

--- a/modules/api/php/endpoints/project/images.class.inc
+++ b/modules/api/php/endpoints/project/images.class.inc
@@ -42,10 +42,14 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Project $project The requested project
+     * @param \LORIS\LorisInstance $loris   The LORIS instance to retrieve data
+     *                                      from.
+     * @param \Project             $project The requested project
      */
-    public function __construct(\Project $project)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Project $project
+    ) {
         $this->_project = $project;
     }
 
@@ -124,6 +128,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $provisioner = new \LORIS\api\Provisioners\ProjectImagesRowProvisioner(
+            $this->loris,
             $this->_project,
             $since
         );

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -42,10 +42,13 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Project $project    The requested project
-     * @param string   $apiversion The version of the API being used
+     * @param \LORIS\LorisInstance $loris      The LORIS instance to retrieve data
+     *                                         from.
+     * @param \Project             $project    The requested project
+     * @param string               $apiversion The version of the API being used
      */
     public function __construct(
+        protected \LORIS\LorisInstance $loris,
         \Project $project,
         private string $apiversion = 'v0.0.3'
     ) {
@@ -140,7 +143,9 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return $this->_cache;
         }
 
-        $prov = new \LORIS\api\Provisioners\ProjectInstrumentsRowProvisioner();
+        $prov = new \LORIS\api\Provisioners\ProjectInstrumentsRowProvisioner(
+            $this->loris
+        );
         $user = $request->getAttribute('user');
 
         $instruments = (new \LORIS\Data\Table())

--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -42,10 +42,14 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Project $project The requested project
+     * @param \LORIS\LorisInstance $loris   The LORIS instance to retrieve data
+     *                                      from.
+     * @param \Project             $project The requested project.
      */
-    public function __construct(\Project $project)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Project $project
+    ) {
         $this->_project = $project;
     }
 
@@ -109,16 +113,16 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $handler = new Candidates($this->_project);
             break;
         case 'images':
-            $handler = new Images($this->_project);
+            $handler = new Images($this->loris, $this->_project);
             break;
         case 'instruments':
-            $handler = new Instruments($this->_project, $apiversion);
+            $handler = new Instruments($this->loris, $this->_project, $apiversion);
             break;
         case 'visits':
             $handler = new Visits($this->_project);
             break;
         case 'recordings':
-            $handler = new Recordings($this->_project);
+            $handler = new Recordings($this->loris, $this->_project);
             break;
         default:
             return new \LORIS\Http\Response\JSON\NotFound();

--- a/modules/api/php/endpoints/project/recordings.class.inc
+++ b/modules/api/php/endpoints/project/recordings.class.inc
@@ -60,10 +60,14 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Contructor
      *
-     * @param \Project $project The requested project
+     * @param \LORIS\LorisInstance $loris   The LORIS instance to retrieve data
+     *                                      from.
+     * @param \Project             $project The requested project
      */
-    public function __construct(\Project $project)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Project $project
+    ) {
         $this->_project = $project;
     }
 
@@ -154,6 +158,7 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
         );
 
         $provisioner = new \LORIS\api\Provisioners\ProjectRecordingsRowProvisioner(
+            $this->loris,
             $this->_project,
             $since
         );

--- a/modules/api/php/endpoints/projects.class.inc
+++ b/modules/api/php/endpoints/projects.class.inc
@@ -109,7 +109,7 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return new \LORIS\Http\Response\JSON\NotFound();
         }
 
-        $endpoint = new Project\Project($project);
+        $endpoint = new Project\Project($this->loris, $project);
 
         // Removing `/projects/<project_name>` from pathparts.
         $pathparts = array_slice($pathparts, 2);

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -41,7 +41,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance,
      */
     public function __construct(array $row)
     {
-        $this->_candid      = $row['CandID'] ?? null;
+        $this->_candid      = strval($row['CandID']) ?? null;
         $this->_projectname = $row['ProjectName'] ?? null;
         if ($row['ProjectID'] !== null) {
             $this->_projectid = \ProjectID::singleton(intval($row['ProjectID']));

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -44,7 +44,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance,
      */
     public function __construct(array $row)
     {
-        $this->_candid     = $row['Candidate'] ?? null;
+        $this->_candid     = strval($row['Candidate']) ?? null;
         $this->_pscid      = $row['PSCID'] ?? null;
         $this->_entitytype = $row['Entity_type'] ?? null;
         $this->_visitlabel = $row['Visit'] ?? null;

--- a/modules/api/php/models/projectrecordingsrow.class.inc
+++ b/modules/api/php/models/projectrecordingsrow.class.inc
@@ -40,7 +40,7 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
      */
     public function __construct(array $row)
     {
-        $this->_candid     = $row['Candidate'] ?? null;
+        $this->_candid     = strval($row['Candidate']) ?? null;
         $this->_pscid      = $row['PSCID'] ?? null;
         $this->_entitytype = $row['Entity_type'] ?? null;
         $this->_visitlabel = $row['Visit'] ?? null;

--- a/modules/api/php/provisioners/candidatesprovisioner.class.inc
+++ b/modules/api/php/provisioners/candidatesprovisioner.class.inc
@@ -34,10 +34,15 @@ class CandidatesProvisioner extends DBRowProvisioner
     /**
      * Create a RowProvisioner, which gets rows for candidates/
      * endpoint.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
-    {
+    function __construct(
+        protected \LORIS\LorisInstance $loris
+    ) {
         parent::__construct(
+            $this->loris,
             '
              SELECT 
                c.CandID as CandID,

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -34,12 +34,20 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
     /**
      * Create a RowProvisioner
      *
-     * @param \Project  $project The project from which images are requested
-     * @param \DateTime $since   The project from which images are requested
+     * @param \LORIS\LorisInstance $loris   The LORIS instance to retrieve data
+     *                                      from.
+     * @param \Project             $project The project from which images are
+     *                                      requested.
+     * @param \DateTime            $since   The project from which images are
+     *                                      requested.
      */
-    function __construct(\Project $project, \DateTime $since)
-    {
+    function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Project $project,
+        \DateTime $since
+    ) {
         parent::__construct(
+            $this->loris,
             '
              SELECT
                s.CandID as Candidate,

--- a/modules/api/php/provisioners/projectinstrumentsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectinstrumentsrowprovisioner.class.inc
@@ -35,10 +35,14 @@ class ProjectInstrumentsRowProvisioner extends DBRowProvisioner
     /**
      * Create a RowProvisioner, which gets rows for projects/$projectname/instruments
      * endpoint.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $this->loris,
             '
              SELECT
                tn.Test_name as shortname,

--- a/modules/api/php/provisioners/projectrecordingsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectrecordingsrowprovisioner.class.inc
@@ -32,17 +32,25 @@ class ProjectRecordingsRowProvisioner extends DBRowProvisioner
     /**
      * Create a RowProvisioner.
      *
-     * @param \Project  $project The project from which recordings are requested
-     * @param \DateTime $since   The project from which recordings are requested
+     * @param \LORIS\LorisInstance $loris   The LORIS instance to retrieve data
+     *                                      from.
+     * @param \Project             $project The project from which recordings are
+     *                                      requested.
+     * @param \DateTime            $since   The project from which recordings are
+     *                                      requested.
      */
-    function __construct(\Project $project, \DateTime $since)
-    {
+    function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Project $project,
+        \DateTime $since
+    ) {
         // NOTE: we use string concatenation instead of a bind parameter for
         // the $since parameter. PDOStatement->bindValues converts the parameter to
         // a string. Timestamp > '0' is either a warning or exception depending
         // on SQL configuration, (Timestamp > 0 is correct). The string concatenation
         // ensures that it remains an int.
         parent::__construct(
+            $this->loris,
             '
              SELECT
                s.CandID as Candidate,

--- a/modules/api/php/provisioners/visitdicomsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/visitdicomsrowprovisioner.class.inc
@@ -34,11 +34,16 @@ class VisitDicomsRowProvisioner extends DBRowProvisioner
     /**
      * Create a RowProvisioner, which gets rows for a Visit Dicoms
      *
-     * @param \Timepoint $timepoint The requested timepoint
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param \Timepoint           $timepoint The requested timepoint
      */
-    function __construct(\Timepoint $timepoint)
-    {
+    function __construct(
+        protected \LORIS\LorisInstance $loris,
+        \Timepoint $timepoint
+    ) {
         parent::__construct(
+            $this->loris,
             '
              SELECT
                t.TarchiveID as tarchiveid
@@ -68,7 +73,7 @@ class VisitDicomsRowProvisioner extends DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        return (new \LORIS\DicomTar(intval($row['tarchiveid'])))
+        return (new \LORIS\DicomTar($row['tarchiveid']))
             ->asDTO();
     }
 }

--- a/modules/battery_manager/php/testprovisioner.class.inc
+++ b/modules/battery_manager/php/testprovisioner.class.inc
@@ -31,17 +31,15 @@ namespace LORIS\battery_manager;
  */
 class TestProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-    private \LORIS\LorisInstance $loris;
-
     /**
      * Create a Test Instance, which get rows from the test_battery table.
      *
      * @param \LORIS\LorisInstance $loris The LORIS instance with the battery
      */
-    public function __construct(\LORIS\LorisInstance $loris)
+    public function __construct(protected \LORIS\LorisInstance $loris)
     {
-        $this->loris = $loris;
         parent::__construct(
+            $this->loris,
             "SELECT b.id,
                t.Test_name as testName,
                b.AgeMinDays as ageMinDays,
@@ -75,7 +73,7 @@ class TestProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         return new Test(
             $this->loris,
             isset($row['centerId'])
-                ? \CenterID::singleton(intval($row['centerId']))
+                ? \CenterID::singleton($row['centerId'])
                 : null,
             $row
         );

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -323,8 +323,8 @@ class BatteryManagerTest extends LorisIntegrationTest
             self::$minimumAge,
             self::$display,
             self::$clearFilter,
-            '0',
-            '0 rows'
+            '4300',
+            '1 row'
         );
         $this->_filterTest(
             self::$maximumAge,

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -324,7 +324,7 @@ class BatteryManagerTest extends LorisIntegrationTest
             self::$display,
             self::$clearFilter,
             '0',
-            '2 rows'
+            '0 rows'
         );
         $this->_filterTest(
             self::$maximumAge,

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -162,7 +162,7 @@ class Candidate_List extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new CandidateListRowProvisioner();
+        return new CandidateListRowProvisioner($this->loris);
     }
 }
 

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -32,11 +32,15 @@ namespace LORIS\candidate_list;
 class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     private string $dobFormat;
+
     /**
      * Create a CandidateListRowProvisioner, which gets rows for
      * the candidate_list menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         $factory  = \NDB_Factory::singleton();
         $config   = $factory->config();
@@ -48,6 +52,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         $this->dobFormat = $config->getSetting("dobFormat");
 
         parent::__construct(
+            $this->loris,
             "SELECT
                 c.PSCID,
                 c.CandID AS DCCID,
@@ -100,8 +105,8 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // user's sites, but for now this maintains the previous
         // behaviour of requiring the registration site to match
         // one of the user's sites.
-        $cid = \CenterID::singleton(intval($row['RegistrationCenterID']));
-        $pid = \ProjectID::singleton(intval($row['RegistrationProjectID']));
+        $cid = \CenterID::singleton($row['RegistrationCenterID']);
+        $pid = \ProjectID::singleton($row['RegistrationProjectID']);
         if ($row['DoB'] !== null) {
             $dob = new \DateTimeImmutable($row['DoB']);
             switch ($this->dobFormat) {

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -272,7 +272,7 @@ class Data_Release extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new DataReleaseProvisioner();
+        return new DataReleaseProvisioner($this->loris);
     }
 
     /**

--- a/modules/data_release/php/datareleaseprovisioner.class.inc
+++ b/modules/data_release/php/datareleaseprovisioner.class.inc
@@ -35,8 +35,11 @@ class DataReleaseProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     /**
      * Create a DataReleaseProvisioner, which gets releases for the
      * data release menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         $user  =& \User::singleton();
         $query = "
@@ -65,7 +68,7 @@ class DataReleaseProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 
         $query .= " ORDER BY uploadDate";
 
-        parent::__construct($query, []);
+        parent::__construct($loris, $query, []);
     }
 
     /**

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -61,6 +61,7 @@ class Datadict extends \DataFrameworkMenu
     {
         $instruments     = \Utility::getAllInstruments();
         $dictInstruments = [];
+        $user            = \User::singleton();
 
         foreach ($instruments as $instrument => $name) {
             // Since the testname does not always match the table name in the
@@ -110,7 +111,7 @@ class Datadict extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new DataDictRowProvisioner();
+        return new DataDictRowProvisioner($this->loris);
     }
 
     /**

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -34,10 +34,14 @@ class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     /**
      * Create a DataDictRowProvisioner, which gets rows for
      * the datadict menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT DISTINCT
                 pt.sourceFrom as source_from,
                 pt.name as name,

--- a/modules/dataquery/php/provisioners/alluserqueries.class.inc
+++ b/modules/dataquery/php/provisioners/alluserqueries.class.inc
@@ -23,6 +23,7 @@ class AllUserQueries extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris, \User $user)
     {
         parent::__construct(
+            $loris,
             "SELECT DISTINCT dq.QueryID, dq.Query,
                 name.Name,
                 GROUP_CONCAT(dsq.Name) as AdminName,

--- a/modules/dataquery/php/provisioners/recentqueries.class.inc
+++ b/modules/dataquery/php/provisioners/recentqueries.class.inc
@@ -24,6 +24,7 @@ class RecentQueries extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris, \User $user)
     {
         parent::__construct(
+            $loris,
             "SELECT drq.RunID, dq.QueryID, RunTime, Query
             FROM dataquery_queries dq
                 JOIN dataquery_run_queries drq ON (dq.QueryID=drq.QueryID)

--- a/modules/dataquery/php/provisioners/starredqueries.class.inc
+++ b/modules/dataquery/php/provisioners/starredqueries.class.inc
@@ -29,6 +29,7 @@ class StarredQueries extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris, \User $user)
     {
         parent::__construct(
+            $loris,
             "SELECT
                  dpq.QueryID,
                  COALESCE(dqn.Name, CONCAT('Query ', dpq.QueryID)) as Name

--- a/modules/dataquery/php/provisioners/studyqueries.class.inc
+++ b/modules/dataquery/php/provisioners/studyqueries.class.inc
@@ -21,6 +21,7 @@ class StudyQueries extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris, $pintype)
     {
         parent::__construct(
+            $loris,
             "SELECT dq.QueryID, Query, dsq.Name
             FROM dataquery_queries dq
                 LEFT JOIN dataquery_study_queries_rel dsq ON

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -85,7 +85,7 @@ class Dicom_Archive extends \DataFrameworkMenu
      */
     function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new DicomArchiveRowProvisioner();
+        $provisioner = new DicomArchiveRowProvisioner($this->loris);
 
         $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
 

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -34,10 +34,14 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
     /**
      * Create a DicomArchiveRowProvisioner, which gets rows for the dicom_archive
      * menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT t.PatientID AS patientID,
             t.PatientName AS patientName,
             t.PatientSex AS sex,

--- a/modules/document_repository/php/docrepoprovisioner.class.inc
+++ b/modules/document_repository/php/docrepoprovisioner.class.inc
@@ -32,12 +32,16 @@ namespace LORIS\document_repository;
 class DocRepoProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     /**
-     * Create a ModuleManagerProvisioner, which gets modules for the
-     * module manager menu table.
+     * Create a DocPepoProvisioner, which gets documents for the
+     * document repository menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(\LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "
 SELECT
     v.File_name,

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -182,7 +182,7 @@ class Document_Repository extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new DocRepoProvisioner();
+        return new DocRepoProvisioner($this->loris);
     }
     /**
      * Tells the base class that this page's provisioner can support the

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -93,7 +93,7 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
      */
     function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new ElectrophysiologyBrowserRowProvisioner();
+        return new ElectrophysiologyBrowserRowProvisioner($this->loris);
     }
 
 

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
@@ -35,11 +35,15 @@ class ElectrophysiologyBrowserRowProvisioner
     /**
      * Create an ElectrophysiologyBrowserRowProvisioner, which gets rows for the
      * electrophysiology browser menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
 
         parent::__construct(
+            $loris,
             "SELECT
               psc.Name                                  AS Site,
               c.PSCID                                   AS PSCID,

--- a/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiology_uploader.class.inc
@@ -89,7 +89,7 @@ class Electrophysiology_Uploader extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new ElectrophysiologyUploaderProvisioner();
+        return new ElectrophysiologyUploaderProvisioner($this->loris);
     }
 
     /**

--- a/modules/electrophysiology_uploader/php/electrophysiologyuploaderprovisioner.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiologyuploaderprovisioner.class.inc
@@ -23,10 +23,14 @@ class ElectrophysiologyUploaderProvisioner
     /**
      * Create a ElectrophysiologyUploaderProvisioner, which gets rows for
      * the Electrophysiology Uploader menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT
                 e.UploadID,
                 psc.Name,

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -105,7 +105,7 @@ class Examiner extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new ExaminerProvisioner();
+        return new ExaminerProvisioner($this->loris);
     }
     /**
      * Include the index examiner javascript dependency

--- a/modules/examiner/php/examinerprovisioner.class.inc
+++ b/modules/examiner/php/examinerprovisioner.class.inc
@@ -34,10 +34,14 @@ class ExaminerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     /**
      * Create a ModuleManagerProvisioner, which gets modules for the
      * module manager menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT 
                 e.full_name as Examiner,
                 u.Email,

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -48,7 +48,7 @@ class Help_Editor extends \NDB_Menu_Filter
      */
     function getDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new HelpRowProvisioner();
+        return new HelpRowProvisioner($this->loris);
     }
 
     /**

--- a/modules/help_editor/php/helprowprovisioner.class.inc
+++ b/modules/help_editor/php/helprowprovisioner.class.inc
@@ -34,10 +34,14 @@ class HelpRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     /**
      * Create a HelpRowProvisioner, which gets rows for the help_editory
      * menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT help.helpID as helpID,
                     help.topic as Topic,
                     help.content as Content

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -162,7 +162,7 @@ class Imaging_Browser extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new ImagingBrowserRowProvisioner();
+        return new ImagingBrowserRowProvisioner($this->loris);
     }
 
     /**

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -35,9 +35,12 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
      * Create an ImagingBrowserRowProvisioner, which gets rows for
      * the imaging browser menu table.
      *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     *
      * @throws \ConfigurationException
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         $config = \NDB_Config::singleton();
         $DB     = \NDB_Factory::singleton()->database();
@@ -183,6 +186,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // Final query
         // =================================================
         parent::__construct(
+            $loris,
             "SELECT
               p.Name as Site,
               c.PSCID as PSCID,

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -209,7 +209,7 @@ class Instrument_Manager extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new InstrumentManagerProvisioner();
+        return new InstrumentManagerProvisioner($this->loris);
     }
 
     /**

--- a/modules/instrument_manager/php/instrumentmanagerprovisioner.class.inc
+++ b/modules/instrument_manager/php/instrumentmanagerprovisioner.class.inc
@@ -31,13 +31,17 @@ namespace LORIS\instrument_manager;
  */
 class InstrumentManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-     /**
-      * Create a ModuleManagerProvisioner, which gets modules for the
-      * module manager menu table.
-      */
-    function __construct()
+    /**
+     * Create a ModuleManagerProvisioner, which gets modules for the
+     * module manager menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     */
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT
 	    tn.test_name as Instrument,
             'type' as Instrument_Type,

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -52,6 +52,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 
         //note that this needs to be in the same order as the headers array
         parent::__construct(
+            $loris,
             "SELECT i.issueID,
                     i.title,
                     m.name as module,

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -47,6 +47,7 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT m.file_name as fileName,
                     m.instrument as testName,
                     c.PSCID as pscid,

--- a/modules/module_manager/php/modulemanagerprovisioner.class.inc
+++ b/modules/module_manager/php/modulemanagerprovisioner.class.inc
@@ -40,6 +40,7 @@ class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT name, active FROM modules",
             []
         );

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -84,7 +84,7 @@ class Module extends \Module
             if (!class_exists('Provisioner')) {
                 self::registerAutoloader();
             }
-            $provisioner = new Provisioner();
+            $provisioner = new Provisioner($this->loris);
 
             if ($user->hasPermission('violated_scans_view_allsites')) {
                 $siteLabel = 'Site: All';

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -138,16 +138,24 @@ class Mri_Violations extends \DataFrameworkMenu
     {
         switch ($this->violationType) {
         case 'protocolviolation':
-            return (new ProtocolViolationProvisioner($this->seriesUID));
+            return (new ProtocolViolationProvisioner(
+                $this->loris,
+                $this->seriesUID
+            )
+        );
         case 'protocolcheck':
-            return (new ProtocolCheckViolationProvisioner($this->seriesUID))
+            return (new ProtocolCheckViolationProvisioner(
+                $this->loris,
+                $this->seriesUID
+            )
+        )
             ->filter(
                 new UserCenterMatchOrNullOrAnyPermission(
                     $this->allSitePermissionNames(),
                 )
             );
         default:
-            return (new Provisioner())
+            return (new Provisioner($this->loris))
                 ->filter(
                     new UserCenterMatchOrNullOrAnyPermission(
                         $this->allSitePermissionNames(),

--- a/modules/mri_violations/php/protocolcheckviolationprovisioner.class.inc
+++ b/modules/mri_violations/php/protocolcheckviolationprovisioner.class.inc
@@ -14,12 +14,15 @@ class ProtocolCheckViolationProvisioner
     /**
      * Create a ProtocolCheckViolationProvisioner
      *
-     * @param string $seriesUID the SeriesUID with violations
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param string               $seriesUID the SeriesUID with violations
      */
-    function __construct(string $seriesUID)
+    function __construct(protected \LORIS\LorisInstance $loris, string $seriesUID)
     {
         parent::__construct(
-            "SELECT
+            $loris,
+            "SELECT 
                 l.PatientName,
                 l.CandID,
                 l.Visit_label,

--- a/modules/mri_violations/php/protocolviolationprovisioner.class.inc
+++ b/modules/mri_violations/php/protocolviolationprovisioner.class.inc
@@ -14,11 +14,16 @@ class ProtocolViolationProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
      * Create a ProtocolViolationProvisioner, which gets all mri_protocol violations
      * for a specific SeriesUID.
      *
-     * @param string $seriesUID The SeriesUID
+     * @param \LORIS\LorisInstance $loris     The LORIS instance to retrieve data
+     *                                        from.
+     * @param string               $seriesUID The SeriesUID.
      */
-    function __construct(string $seriesUID)
-    {
+    function __construct(
+        protected \LORIS\LorisInstance $loris,
+        string $seriesUID
+    ) {
         parent::__construct(
+            $loris,
             "SELECT 
                 mpv.CandID,
                 mpv.PSCID,

--- a/modules/mri_violations/php/provisioner.class.inc
+++ b/modules/mri_violations/php/provisioner.class.inc
@@ -13,10 +13,14 @@ class Provisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     /**
      * Create a Provisioner for the module.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT v.PatientName,
                     v.Project,
                     v.Cohort,

--- a/modules/schedule_module/php/schedule_module.class.inc
+++ b/modules/schedule_module/php/schedule_module.class.inc
@@ -96,7 +96,7 @@ class Schedule_Module extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new ScheduleModuleProvisioner();
+        return new ScheduleModuleProvisioner($this->loris);
     }
 
     /**

--- a/modules/schedule_module/php/schedulemoduleprovisioner.class.inc
+++ b/modules/schedule_module/php/schedulemoduleprovisioner.class.inc
@@ -32,10 +32,14 @@ class ScheduleModuleProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
     /**
      * Create a ScheduleModuleProvisioner, which gets modules for the
      * Schedule Module menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             $this->getQuery(),
             []
         );

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -101,7 +101,7 @@ class Survey_Accounts extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new SurveyAccountsProvisioner();
+        return new SurveyAccountsProvisioner($this->loris);
     }
 
     /**

--- a/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
@@ -35,11 +35,15 @@ class SurveyAccountsProvisioner
     /**
      * Create a SurveyAccountsProvisioner, which gets rows for the
      * survey accounts menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
 
         parent::__construct(
+            $loris,
             "SELECT
                 c.PSCID AS PSCID,
                 s.Visit_label AS Visit,

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -94,7 +94,7 @@ class User_Accounts extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new UserAccountRowProvisioner();
+        return new UserAccountRowProvisioner($this->loris);
     }
 
     /**

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -15,10 +15,14 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
     /**
      * Create a UserAccountsProvisioner, which gets modules for the
      * module manager menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
      */
-    function __construct()
+    function __construct(protected \LORIS\LorisInstance $loris)
     {
         parent::__construct(
+            $loris,
             "SELECT GROUP_CONCAT(DISTINCT upsr.CenterID) as centerIds,
                     GROUP_CONCAT(DISTINCT uprr.ProjectID) as projectIds,
                     u.UserID as username,

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1014,16 +1014,21 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets the first Image of that session matching a given filename.
      *
-     * @param \User  $user     The requesting user
-     * @param string $filename The requested filename
+     * @param \LORIS\LorisInstance $loris    The LORIS instance to retrieve data
+     *                                       from.
+     * @param \User                $user     The requesting user.
+     * @param string               $filename The requested filename.
      *
      * @throws \NotFound
      * @return \LORIS\Image
      */
-    public function getImageByFilename(\User $user, string $filename): \LORIS\Image
-    {
+    public function getImageByFilename(
+        \LORIS\LorisInstance $loris,
+        \User $user,
+        string $filename
+    ): \LORIS\Image {
         $filtered = array_filter(
-            $this->getImages($user),
+            $this->getImages($loris, $user),
             function ($dto) use ($filename) {
                 return $dto->getFilename() == $filename;
             }
@@ -1046,10 +1051,12 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      *                                    from.
      * @param \User                $user  The requesting user.
      *
-     * @return \LORIS\Data\Models\RecordingDTO[] A traversable of RecordingDTO.php
+     * @return \Traversable
      */
-    public function getRecordings(\LORIS\LorisInstance $loris, \User $user): iterable
-    {
+    public function getRecordings(
+        \LORIS\LorisInstance $loris,
+        \User $user
+    ): \Traversable {
         $provisioner
             = new \LORIS\Data\Provisioners\TimepointRecordingsRowProvisioner(
                 $loris,
@@ -1067,17 +1074,21 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets the first Recording of that session matching a given filename.
      *
-     * @param \User  $user     The requesting user
-     * @param string $filename The requested filename
+     * @param \LORIS\LorisInstance $loris    The LORIS instance to retrieve data
+     *                                       from.
+     * @param \User                $user     The requesting user
+     * @param string               $filename The requested filename
      *
      * @throws \NotFound
      * @return \LORIS\Recording
      */
-    public function getRecordingByFilename(\User $user, string $filename):
-    \LORIS\Recording
-    {
+    public function getRecordingByFilename(
+        \LORIS\LorisInstance $loris,
+        \User $user,
+        string $filename
+    ): \LORIS\Recording {
         $filtered = array_filter(
-            $this->getRecordings($user),
+            iterator_to_array($this->getRecordings($loris, $user)),
             function ($dto) use ($filename) {
                 return $dto->getFilename() == $filename;
             }
@@ -1109,7 +1120,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             $loris,
             $this
         );
-        return $provisioner->execute($user);
+        return iterator_to_array($provisioner->execute($user));
     }
 
     /**

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -987,13 +987,16 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets the Images of that session.
      *
-     * @param \User $user The requesting user
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \User                $user  The requesting user.
      *
      * @return \LORIS\Data\Models\ImageDTO[] A traversable of ImageDTO
      */
-    public function getImages(\User $user): array
+    public function getImages(\LORIS\LorisInstance $loris, \User $user): array
     {
         $provisioner = new \LORIS\Data\Provisioners\TimepointImagesRowProvisioner(
+            $loris,
             $this
         );
 
@@ -1039,14 +1042,17 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets the Electrophysiology recordings of that session.
      *
-     * @param \User $user The requesting user
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \User                $user  The requesting user.
      *
      * @return \LORIS\Data\Models\RecordingDTO[] A traversable of RecordingDTO.php
      */
-    public function getRecordings(\User $user): array
+    public function getRecordings(\LORIS\LorisInstance $loris, \User $user): iterable
     {
         $provisioner
             = new \LORIS\Data\Provisioners\TimepointRecordingsRowProvisioner(
+                $loris,
                 $this
             );
 
@@ -1055,12 +1061,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         );
 
         $provisioner = $provisioner->filter($filter);
-
-        $traversable = (new \LORIS\Data\Table())
-            ->withDataFrom($provisioner)
-            ->getRows($user);
-
-        return iterator_to_array($traversable);
+        return $provisioner->execute($user);
     }
 
     /**
@@ -1096,18 +1097,19 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Gets the DicomTars of that session.
      *
-     * @param \User $user The requesting user
+     * @param \LORIS\LorisInstance $loris The LORIS instance to retrieve data
+     *                                    from.
+     * @param \User                $user  The requesting user.
      *
      * @return \LORIS\data\Models\DicomTarDTO[] A traversable of DicomTarDTO
      */
-    public function getDicomTars(\User $user): array
+    public function getDicomTars(\LORIS\LorisInstance $loris, \User $user): iterable
     {
-        $provisioner = new \LORIS\api\provisioners\VisitDicomsRowProvisioner($this);
-        $traversable = (new \LORIS\Data\Table())
-            ->withDataFrom($provisioner)
-            ->getRows($user);
-
-        return iterator_to_array($traversable);
+        $provisioner = new \LORIS\api\provisioners\VisitDicomsRowProvisioner(
+            $loris,
+            $this
+        );
+        return $provisioner->execute($user);
     }
 
     /**

--- a/src/Data/Provisioners/DBRowProvisioner.php
+++ b/src/Data/Provisioners/DBRowProvisioner.php
@@ -90,34 +90,8 @@ abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
         if ($results === false) {
             throw new \Exception("Invalid SQL statement: " . $this->query);
         }
-
-        // Wrap an \IteratorIterator to convert from a PDOStatement row to
-        // a DataInstance.
-        $iterator = new class($stmt, $this) extends \IteratorIterator {
-            protected $outer;
-            /**
-             * Constructor creates a closure over the PDO statement and outer class
-             * in order to have access to getInstance()
-             *
-             * @param \PDOStatement    $rows The PDOStatement being traversed.
-             * @param DBRowProvisioner $self The outer class being closed over.
-             */
-            public function __construct($rows, &$self)
-            {
-                parent::__construct($rows);
-                $this->outer = &$self;
-            }
-
-            /**
-             * Override IteratorIterator to call the closure's getInstance
-             *
-             * @return DataInstance
-             */
-            public function current() : DataInstance
-            {
-                return $this->outer->getInstance(parent::current());
-            }
-        };
-        return $iterator;
+        foreach ($results as $row) {
+            yield $this->getInstance($row);
+        }
     }
 }

--- a/src/Data/Provisioners/DBRowProvisioner.php
+++ b/src/Data/Provisioners/DBRowProvisioner.php
@@ -115,16 +115,7 @@ abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
              */
             public function current() : DataInstance
             {
-                $row    = parent::current();
-                $newrow = [];
-                foreach ($row as $key => $val) {
-                    if ($val === null) {
-                        $newrow[$key] = null;
-                    } else {
-                        $newrow[$key] = strval($val);
-                    }
-                }
-                return $this->outer->getInstance($newrow);
+                return $this->outer->getInstance(parent::current());
             }
         };
         return $iterator;

--- a/src/Data/Provisioners/TimepointImagesRowProvisioner.php
+++ b/src/Data/Provisioners/TimepointImagesRowProvisioner.php
@@ -34,9 +34,10 @@ class TimepointImagesRowProvisioner extends DBRowProvisioner
      *
      * @param \Timepoint $timepoint The requested timepoint
      */
-    public function __construct(\Timepoint $timepoint)
+    public function __construct(protected \LORIS\LorisInstance $loris, \Timepoint $timepoint)
     {
         parent::__construct(
+            $loris,
             '
              SELECT
                FileID as fileid

--- a/src/Data/Provisioners/TimepointRecordingsRowProvisioner.php
+++ b/src/Data/Provisioners/TimepointRecordingsRowProvisioner.php
@@ -32,9 +32,10 @@ class TimepointRecordingsRowProvisioner extends DBRowProvisioner
      *
      * @param \Timepoint $timepoint The requested timepoint
      */
-    public function __construct(\Timepoint $timepoint)
+    public function __construct(protected \LORIS\LorisInstance $loris, \Timepoint $timepoint)
     {
         parent::__construct(
+            $this->loris,
             '
              SELECT
                PhysiologicalFileID as fileid


### PR DESCRIPTION
This updates DBRowProvisioner to remove the strval (and fixes #9335).

After doing that, it became clear that the inner class could be replaced by a generator while still fulfilling the contract of returning a `\Traversable`. Doing this made it more obvious that since #9334, pselect could be used directly while maintaining the lazy evaluation instead of bypassing the Database object to use the PDO directly. However this required injecting a `LorisInstance` object to the constructor to get the database connection.

With access to the `LorisInstance` object, the `DBRowProvisioner` can also get a new database connection and disable query buffering to lazily retrieve rows since PR #9344. This may theoretically improve performance and memory usage on large provisioners but has not been tested. (Performance did not decrease in raisinbread but it is not a large dataset where it would be noticeable.)