### PR TITLE
[media] Fix download of filenames with commas

### DIFF
--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -113,7 +113,11 @@ class MediaIndex extends Component {
                             + encodeURIComponent(row['File Name']);
         result = (
           <td className={style}>
-            <a href={downloadURL} target="_blank" download={encodeURIComponent(row['File Name'])}>
+            <a 
+              href={downloadURL} 
+              target="_blank" 
+              download={encodeURIComponent(row['File Name'])}
+            >
               {cell}
             </a>
           </td>

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -113,7 +113,7 @@ class MediaIndex extends Component {
                             + encodeURIComponent(row['File Name']);
         result = (
           <td className={style}>
-            <a href={downloadURL} target="_blank" download={row['File Name']}>
+            <a href={downloadURL} target="_blank" download={encodeURIComponent(row['File Name'])}>
               {cell}
             </a>
           </td>

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -113,9 +113,9 @@ class MediaIndex extends Component {
                             + encodeURIComponent(row['File Name']);
         result = (
           <td className={style}>
-            <a 
-              href={downloadURL} 
-              target="_blank" 
+            <a
+              href={downloadURL}
+              target="_blank"
               download={encodeURIComponent(row['File Name'])}
             >
               {cell}

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -75,7 +75,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
         }
 
         assert(is_string($filename) || $filename instanceof \Stringable);
-        $filename = \Utility::resolvePath(strval($filename));
+        $filename = urldecode(\Utility::resolvePath(strval($filename)));
 
         $targetPath = \Utility::appendForwardSlash(
             $this->downloadDirectory->getPathname()

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -68,6 +68,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
         }
         //Use basename to remove path traversal characters.
         $filename = $request->getAttribute('filename');
+
         if (empty($filename)) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 self::ERROR_EMPTY_FILENAME


### PR DESCRIPTION
## Brief summary of changes
In the Media module, allows files with names containing commas to be downloaded (would previously result in an error)

#### Testing instructions (if applicable)

1. Upload a file containing a comma in its name to the Media module
2. Check that the file can be downloaded

#### Link(s) to related issue(s)
The same fix was made [here](https://github.com/aces/Loris/pull/9461) for the document repository
