### PR TITLE
[Core] Add support / fix PHP 8.4 support

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.3']
+        php: ['8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3']
+        php: ['8.3', '8.4']
         apiversion: ['v0.0.3', 'v0.0.4-dev']
     steps:
     - uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
         fail-fast: false
         matrix:
             testsuite: ['integration']
-            php: ['8.3']
+            php: ['8.3', '8.4']
             ci_node_index: [0,1,2,3]
 
             include:
@@ -221,6 +221,10 @@ jobs:
               php: '8.3'
             - testsuite: 'unit'
               php: '8.3'
+            - testsuite: 'static'
+              php: '8.4'
+            - testsuite: 'unit'
+              php: '8.4'
 
     steps:
     - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/http-server-handler" : "*",
         "psr/http-server-middleware" : "*",
         "psr/log": "*",
-        "laminas/laminas-diactoros" : "^2.5",
+        "laminas/laminas-diactoros" : "^3.5",
         "ext-json": "*",
         "bjeavons/zxcvbn-php": "^1.0",
         "aws/aws-sdk-php": "^3.209"

--- a/composer.lock
+++ b/composer.lock
@@ -2721,16 +2721,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.3",
+            "version": "1.12.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "709999b91448d4f2bb07daffffedc889b33e461c"
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/709999b91448d4f2bb07daffffedc889b33e461c",
-                "reference": "709999b91448d4f2bb07daffffedc889b33e461c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
                 "shasum": ""
             },
             "require": {
@@ -2759,8 +2759,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.3"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -2770,13 +2773,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2022-12-13T10:28:10+00:00"
+            "time": "2024-11-28T22:13:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -1965,16 +1965,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.1.1",
+            "version": "v0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/microsoft/tolerant-php-parser.git",
-                "reference": "6a965617cf484355048ac6d2d3de7b6ec93abb16"
+                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/6a965617cf484355048ac6d2d3de7b6ec93abb16",
-                "reference": "6a965617cf484355048ac6d2d3de7b6ec93abb16",
+                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/3eccfd273323aaf69513e2f1c888393f5947804b",
+                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b",
                 "shasum": ""
             },
             "require": {
@@ -2004,9 +2004,9 @@
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
             "support": {
                 "issues": "https://github.com/microsoft/tolerant-php-parser/issues",
-                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.1.1"
+                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.1.2"
             },
-            "time": "2021-07-16T21:28:12+00:00"
+            "time": "2022-10-05T17:30:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2176,16 +2176,16 @@
         },
         {
             "name": "phan/phan",
-            "version": "5.4.1",
+            "version": "5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "fef40178a952bcfcc3f69b76989dd613c3d5c759"
+                "reference": "2b15302175931a0629a85c57d0c1f91d68b26a4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/fef40178a952bcfcc3f69b76989dd613c3d5c759",
-                "reference": "fef40178a952bcfcc3f69b76989dd613c3d5c759",
+                "url": "https://api.github.com/repos/phan/phan/zipball/2b15302175931a0629a85c57d0c1f91d68b26a4d",
+                "reference": "2b15302175931a0629a85c57d0c1f91d68b26a4d",
                 "shasum": ""
             },
             "require": {
@@ -2195,11 +2195,11 @@
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.4",
-                "microsoft/tolerant-php-parser": "0.1.1",
+                "microsoft/tolerant-php-parser": "0.1.2",
                 "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0",
                 "php": "^7.2.0|^8.0.0",
                 "sabre/event": "^5.1.3",
-                "symfony/console": "^3.2|^4.0|^5.0|^6.0",
+                "symfony/console": "^3.2|^4.0|^5.0|^6.0|^7.0",
                 "symfony/polyfill-mbstring": "^1.11.0",
                 "symfony/polyfill-php80": "^1.20.0",
                 "tysonandre/var_representation_polyfill": "^0.0.2|^0.1.0"
@@ -2245,13 +2245,14 @@
             "keywords": [
                 "analyzer",
                 "php",
-                "static"
+                "static",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/phan/phan/issues",
-                "source": "https://github.com/phan/phan/tree/5.4.1"
+                "source": "https://github.com/phan/phan/tree/5.4.5"
             },
-            "time": "2022-08-26T00:49:07+00:00"
+            "time": "2024-08-13T21:41:35+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47b37af4379a5b81dffb3575b44bd2f4",
+    "content-hash": "bc7426640c6831e453da1519c701912e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -644,41 +644,41 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.26.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "6584d44eb8e477e89d453313b858daac6183cddc"
+                "reference": "143a16306602ce56b8b092a7914fef03c37f9ed2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6584d44eb8e477e89d453313b858daac6183cddc",
-                "reference": "6584d44eb8e477e89d453313b858daac6183cddc",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/143a16306602ce56b8b092a7914fef03c37f9ed2",
+                "reference": "143a16306602ce56b8b092a7914fef03c37f9ed2",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0"
             },
             "conflict": {
-                "zendframework/zend-diactoros": "*"
+                "amphp/amp": "<2.6.4"
             },
             "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message-implementation": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "ext-dom": "*",
                 "ext-gd": "*",
                 "ext-libxml": "*",
-                "http-interop/http-factory-tests": "^0.9.0",
-                "laminas/laminas-coding-standard": "^2.5",
-                "php-http/psr7-integration-tests": "^1.2",
-                "phpunit/phpunit": "^9.5.28",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.6"
+                "http-interop/http-factory-tests": "^2.2.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "php-http/psr7-integration-tests": "^1.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "extra": {
@@ -693,18 +693,9 @@
                     "src/functions/marshal_headers_from_sapi.php",
                     "src/functions/marshal_method_from_sapi.php",
                     "src/functions/marshal_protocol_version_from_sapi.php",
-                    "src/functions/marshal_uri_from_sapi.php",
                     "src/functions/normalize_server.php",
                     "src/functions/normalize_uploaded_files.php",
-                    "src/functions/parse_cookie_header.php",
-                    "src/functions/create_uploaded_file.legacy.php",
-                    "src/functions/marshal_headers_from_sapi.legacy.php",
-                    "src/functions/marshal_method_from_sapi.legacy.php",
-                    "src/functions/marshal_protocol_version_from_sapi.legacy.php",
-                    "src/functions/marshal_uri_from_sapi.legacy.php",
-                    "src/functions/normalize_server.legacy.php",
-                    "src/functions/normalize_uploaded_files.legacy.php",
-                    "src/functions/parse_cookie_header.legacy.php"
+                    "src/functions/parse_cookie_header.php"
                 ],
                 "psr-4": {
                     "Laminas\\Diactoros\\": "src/"
@@ -737,7 +728,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-29T16:17:44+00:00"
+            "time": "2024-10-14T11:59:49+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -1035,21 +1026,21 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -1069,10 +1060,10 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -1084,9 +1075,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2607,26 +2598,27 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.18.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c"
+                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d4f454f7e1193933f04e6500de3e79191648ed0c",
-                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/a0165c648cab6a80311c74ffc708a07bb53ecc93",
+                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
+                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0"
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.40",
                 "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
@@ -2670,9 +2662,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.18.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.20.0"
             },
-            "time": "2023-12-07T16:22:33+00:00"
+            "time": "2024-11-19T13:12:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -5246,6 +5238,6 @@
     "platform": {
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
@@ -24,14 +24,14 @@ try {
     header("HTTP/1.1 400 Bad Request");
     header("Content-Type: application/json");
     print json_encode(['error' => 'invalid candID']);
-    exit;
+    exit(0);
 }
 
 if (!isset($_POST['feedbackID'])) {
     header("HTTP/1.1 400 Bad Request");
     header("Content-Type: application/json");
     print json_encode(['error' => 'Missing FeedbackID']);
-    exit;
+    exit(0);
 }
 
 $feedbackid = $_POST['feedbackID'];
@@ -49,7 +49,7 @@ try {
     print json_encode(
         ['error' => 'The requested feedback thread can`t be found']
     );
-    exit;
+    exit(0);
 }
 
 if ($closethreadcount === 0) {
@@ -58,11 +58,11 @@ if ($closethreadcount === 0) {
     print json_encode(
         ['error' => 'No feedback thread updated']
     );
-    exit;
+    exit(0);
 }
 
 header("content-type:application/json");
 echo json_encode(['success' => true]);
-exit;
+exit(0);
 
 

--- a/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/delete_thread_comment_bvl_feedback.php
@@ -24,4 +24,4 @@ $db->delete('feedback_bvl_entry', ["ID" => $_POST['entryID']]);
 
 print json_encode('success');
 
-exit();
+exit(0);

--- a/modules/bvl_feedback/ajax/get_bvl_feedback_summary.php
+++ b/modules/bvl_feedback/ajax/get_bvl_feedback_summary.php
@@ -21,4 +21,4 @@ require "bvl_panel_ajax.php";
 $feedbackThreadSummary = $feedbackThread->getSummaryOfThreads();
 echo json_encode($feedbackThreadSummary);
 
-exit();
+exit(0);

--- a/modules/bvl_feedback/ajax/get_thread_entry_data.php
+++ b/modules/bvl_feedback/ajax/get_thread_entry_data.php
@@ -29,5 +29,5 @@ if (isset($_GET['feedbackID']) && !Empty($_GET['feedbackID'])) {
     print json_encode($threadEntries);
 }
 
-exit();
+exit(0);
 

--- a/modules/bvl_feedback/ajax/new_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/new_bvl_feedback.php
@@ -72,4 +72,4 @@ if (isset($data['comment']) && isset($data['candID'])
     print json_encode($newEntryValues);
 }
 
-    exit();
+    exit(0);

--- a/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
@@ -22,7 +22,7 @@ if (! \Utility::valueIsPositiveInteger($feedbackID)) {
     print json_encode(
         ['error' => 'feedbackId missing or invalid']
     );
-    exit;
+    exit(0);
 }
 
 // This is really powerful; it allows you to reopen any feedbackthread as long as the
@@ -36,7 +36,7 @@ if ($openedthreadcount === 0) {
     print json_encode(
         ['error' => 'No feedback thread updated']
     );
-    exit;
+    exit(0);
 }
 
 
@@ -45,5 +45,5 @@ print json_encode(
     ['status' => 'success']
 );
 
-exit;
+exit(0);
 

--- a/modules/bvl_feedback/ajax/react_get_bvl_threads.php
+++ b/modules/bvl_feedback/ajax/react_get_bvl_threads.php
@@ -50,5 +50,5 @@ if (isset($data['candID']) && !empty($data['candID'])) {
 $feedbackThreadList = $feedbackThread->getThreadList();
 echo json_encode($feedbackThreadList);
 
-exit();
+exit(0);
 

--- a/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
@@ -30,11 +30,11 @@ if (isset($_POST['comment']) && isset($_POST['feedbackID'])) {
     );
 } else {
     print json_encode('error');
-    exit();
+    exit(0);
 }
 
 print json_encode($newEntryValues);
 
-exit();
+exit(0);
 
 

--- a/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/update_thread_comment_bvl_feedback.php
@@ -32,7 +32,7 @@ if (isset($_POST['entryID']) && isset($_POST['newComment'])) {
     print json_encode('success');
 } else {
     print json_encode('error');
-    exit();
+    exit(0);
 }
 
-exit();
+exit(0);

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -18,7 +18,7 @@ use \LORIS\StudyEntities\Candidate\CandID;
 $tab = $_POST['tab'] ?? '';
 if ($tab === '') {
     header("HTTP/1.1 400 Bad Request");
-    exit;
+    exit(0);
 }
 
 $user = \User::singleton();
@@ -26,18 +26,18 @@ if (($tab == 'candidateDOB')
     && (!$user->hasPermission('candidate_dob_edit'))
 ) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 } elseif (($tab == 'candidateDOD')
     && (!$user->hasPermission('candidate_dod_edit'))
 ) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 } elseif (($tab != 'candidateDOB')
     && ($tab != 'candidateDOD')
     && !$user->hasPermission('candidate_parameter_edit')
 ) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 $db = \NDB_Factory::singleton()->database();
@@ -77,7 +77,7 @@ case 'candidateDOD':
 
 default:
     header("HTTP/1.1 404 Not Found");
-    exit;
+    exit(0);
 }
 
 /**

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -28,43 +28,43 @@ if (!$user->hasPermission('access_all_profiles')
     ) && $user->hasCenter($candidate->getCenterID()))
 ) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 $data = $_GET['data'] ?? '';
 if ($data == '') {
     header("HTTP/1.1 400 Bad Request");
-    exit;
+    exit(0);
 }
 
 switch ($data) {
 case 'candidateInfo':
     echo json_encode(getCandInfoFields());
-    exit;
+    exit(0);
 case 'probandInfo':
     echo json_encode(getProbandInfoFields());
-    exit;
+    exit(0);
 case 'familyInfo':
     echo json_encode(getFamilyInfoFields());
-    exit;
+    exit(0);
 case 'participantStatus':
     echo json_encode(getParticipantStatusFields());
-    exit;
+    exit(0);
 case 'consentStatus':
     echo json_encode(getConsentStatusFields());
-    exit;
+    exit(0);
 case 'candidateDOB':
     echo json_encode(getDOBFields());
-    exit;
+    exit(0);
 case 'candidateDOD':
     echo json_encode(getDODFields());
-    exit;
+    exit(0);
 case 'diagnosisEvolution':
     echo json_encode(getDiagnosisEvolutionFields());
-    exit;
+    exit(0);
 default:
     header("HTTP/1.1 404 Not Found");
-    exit;
+    exit(0);
 }
 /**
  * Handles the fetching of Candidate Info fields

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -95,7 +95,7 @@ foreach ($_POST as $key => $value) {
                     "Duplicate value submitted: "
                     . htmlspecialchars($value, ENT_QUOTES)
                 );
-                exit;
+                exit(0);
             }
             // Get all the IDs in ConfigSettings with the web_path data type.
             $pathIDs = getPathIDs('ConfigSettings');

--- a/modules/configuration/ajax/updateCohort.php
+++ b/modules/configuration/ajax/updateCohort.php
@@ -11,7 +11,7 @@ $factory = NDB_Factory::singleton();
 $user    = $factory->user();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 require_once __DIR__ . "/../../../vendor/autoload.php";
@@ -119,5 +119,5 @@ if (!Utility::valueIsPositiveInteger($recTarget)) {
     {
         http_response_code($code);
         print json_encode($msg);
-        exit;
+        exit(0);
     }

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -16,7 +16,7 @@
 $user = \User::singleton();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 $client = new NDB_Client();
@@ -42,7 +42,7 @@ if ($projectID == 'new') {
     if (in_array($_POST['Name'], $ProjectList, true)) {
         http_response_code(409);
         echo json_encode(['error' => 'Conflict']);
-        exit;
+        exit(0);
     }
 
     if (empty($_POST['Name'])
@@ -51,7 +51,7 @@ if ($projectID == 'new') {
     ) {
         http_response_code(400);
         echo json_encode(['error' => 'Bad Request']);
-        exit;
+        exit(0);
     }
 
     $project = \Project::createNew($projectName, $projectAlias, $recTarget);
@@ -66,7 +66,7 @@ if ($projectID == 'new') {
     ) {
         http_response_code(400);
         echo json_encode(['error' => 'Bad Request']);
-        exit;
+        exit(0);
     }
 
     // Update Project fields
@@ -99,5 +99,5 @@ if (!empty($cohortIDs)) {
 
 http_response_code(200);
 echo json_encode(['ok' => 'Success']);
-exit;
+exit(0);
 

--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -15,7 +15,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('data_dict_edit')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -313,7 +313,7 @@ class Files extends \NDB_Page
 
         if (! $user->hasPermission('document_repository_upload_edit')) {
             header("HTTP/1.1 403 Forbidden");
-            exit;
+            exit(0);
         }
 
         // Do some validation and fail early on bad inputs.
@@ -325,7 +325,7 @@ class Files extends \NDB_Page
 
         if (is_null($uploadedFiles)) {
             header("HTTP/1.1 413 Too_large");
-            exit;
+            exit(0);
         }
         $category = $body['category']; // required
         if (!\Utility::valueIsPositiveInteger(strval($category))) {

--- a/modules/dqt/ajax/GetDoc.php
+++ b/modules/dqt/ajax/GetDoc.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/datadictionary.php
+++ b/modules/dqt/ajax/datadictionary.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/getAllSessions.php
+++ b/modules/dqt/ajax/getAllSessions.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryContains.php
+++ b/modules/dqt/ajax/queryContains.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryEqual.php
+++ b/modules/dqt/ajax/queryEqual.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryGreaterThanEqual.php
+++ b/modules/dqt/ajax/queryGreaterThanEqual.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryLessThanEqual.php
+++ b/modules/dqt/ajax/queryLessThanEqual.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryNotEqual.php
+++ b/modules/dqt/ajax/queryNotEqual.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/queryStartsWith.php
+++ b/modules/dqt/ajax/queryStartsWith.php
@@ -14,7 +14,7 @@
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/retrieveCategoryDocs.php
+++ b/modules/dqt/ajax/retrieveCategoryDocs.php
@@ -17,7 +17,7 @@ ini_set("max_input_vars", '10000');
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();

--- a/modules/dqt/ajax/saveQuery.php
+++ b/modules/dqt/ajax/saveQuery.php
@@ -16,7 +16,7 @@ ini_set("max_input_vars", '4000');
 $user =& User::singleton();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
@@ -48,7 +48,7 @@ if ($_REQUEST['OverwriteQuery'] === "false") {
     if (!empty($results)) {
         error_log($_REQUEST['SharedQuery']);
         header("HTTP/1.1 409 Conflict");
-        exit;
+        exit(0);
     }
 }
 

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -33,7 +33,7 @@ try {
     if (ob_get_level() > 0) {
         ob_end_flush();
     }
-    exit;
+    exit(0);
 } catch (Exception $e) {
 
     // Wasn't a module, so fall back on the old style of DB lookup.

--- a/modules/help_editor/ajax/process.php
+++ b/modules/help_editor/ajax/process.php
@@ -26,7 +26,7 @@ if (!$user->hasPermission('context_help')) {
 
 if (empty($_POST)) {
     header("HTTP/1.1 400 Bad Request");
-    exit;
+    exit(0);
 }
 
 $DB = (\NDB_Factory::singleton())->database();

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -375,7 +375,7 @@ class Edit extends \NDB_Page implements ETagCalculator
      *
      * @return array
      */
-    function getIssueData(int $issueID=null, \User $user): array
+    function getIssueData(?int $issueID=null, \User $user): array
     {
         $db = $this->loris->getDatabaseConnection();
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -38,7 +38,7 @@ function editFile()
     $user =& User::singleton();
     if (!$user->hasPermission('media_write')) {
         showMediaError("Permission Denied", 403);
-        exit;
+        exit(0);
     }
 
     // Read JSON from STDIN
@@ -91,7 +91,7 @@ function uploadFile()
     $user   =& User::singleton();
     if (!$user->hasPermission('media_write')) {
         showMediaError("Permission Denied", 403);
-        exit;
+        exit(0);
     }
 
     // Validate media path and destination folder

--- a/modules/publication/ajax/FileDelete.php
+++ b/modules/publication/ajax/FileDelete.php
@@ -29,25 +29,36 @@ $message = ['message' => null];
 if (empty($uploadData)) {
     http_response_code(400);
     $message['message'] = 'Invalid Upload ID';
-    exit(json_encode($message));
+    print json_encode($message);
+    exit(0);
 }
 
 if (userCanDelete($uploadData, $db, $user)) {
+    $uploaddir = $config->getSetting('publication_uploads');
+    $deletedir = $config->getSetting('publication_deletions');
+
+    if (empty($uploaddir) || empty($deletedir)) {
+        throw new \Exception("Invalid config setting");
+    }
+    if (empty($uploadData['Filename'])) {
+        throw new \Exception("Invalid filename");
+    }
 
     $db->delete(
         'publication_upload',
         ['PublicationUploadID' => $uploadID]
     );
 
-    $src  = $config->getSetting('publication_uploads') . $uploadData['Filename'];
-    $dest = $config->getSetting('publication_deletions') . $uploadData['Filename'];
+    $src  = \Utility::pathJoin($uploaddir, $uploadData['Filename']);
+    $dest = \Utility::pathJoin($deletedir, $uploadData['Filename']);
 
     rename($src, $dest);
 
 } else {
     http_response_code(403);
     $message['message'] = 'You do not have permission to delete this file.';
-    exit(json_encode($message));
+    print json_encode($message);
+    exit(0);
 }
 
 /**

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -21,7 +21,7 @@ if (isset($_REQUEST['action'])) {
         editProject();
     } else {
         http_response_code(400);
-        exit;
+        exit(0);
     }
 }
 
@@ -948,5 +948,7 @@ function showPublicationError($message, $code = 500) : void
 
     http_response_code($code);
     header('Content-Type: application/json; charset=UTF-8');
-    exit(json_encode(['message' => $message]));
+
+    print(json_encode(['message' => $message]));
+    exit(0);
 }

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -43,7 +43,7 @@ if (isset($_REQUEST['action'])) {
         }
     } else {
         http_response_code(400);
-        exit;
+        exit(0);
     }
 }
 /**

--- a/modules/survey_accounts/ajax/GetEmailContent.php
+++ b/modules/survey_accounts/ajax/GetEmailContent.php
@@ -17,7 +17,7 @@
 $user = \User::singleton();
 if (!$user->hasPermission('survey_accounts_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -16,7 +16,7 @@
 $user = \User::singleton();
 if (!$user->hasPermission('survey_accounts_view')) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    exit(0);
 }
 
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
@@ -47,7 +47,7 @@ if ($numCandidates != 1) {
     echo json_encode(
         ['error_msg' => $error_msg]
     );
-    exit;
+    exit(0);
 }
 
 $numSessions = $db->pselectOne(
@@ -68,14 +68,14 @@ if ($numSessions != 1) {
                              " does not exist for given candidate",
         ]
     );
-    exit;
+    exit(0);
 }
 
 if (empty($_REQUEST['TN'])) {
     echo json_encode(
         ['error_msg' => 'Please choose an instrument']
     );
-    exit;
+    exit(0);
 }
 
 $instrument_list = $db->pselect(
@@ -98,7 +98,7 @@ foreach ($instrument_list as $instrument) {
                 " already exists for given candidate for visit ". $_REQUEST['VL'],
             ]
         );
-        exit;
+        exit(0);
     }
 }
 
@@ -107,7 +107,7 @@ if (!empty($_REQUEST['Email']) ) {
         echo json_encode(
             ['error_msg' => 'The email address is not valid.']
         );
-        exit;
+        exit(0);
     }
 }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -259,7 +259,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         ?string $edc,
         Sex $sex,
         ?string $PSCID = null,
-        ProjectID $registrationProjectID = null
+        ?ProjectID $registrationProjectID = null
     ): CandID {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -87,7 +87,7 @@ class FeedbackMRI
      *
      * @return bool true if operation succeeded
      */
-    function setPredefinedComments(array $predefinedCommentIDs=null): bool
+    function setPredefinedComments(?array $predefinedCommentIDs=null): bool
     {
         // choke if we are passed an empty array
         if (empty($predefinedCommentIDs)) {

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -67,15 +67,15 @@ class FilesDownloadHandler implements RequestHandlerInterface
             );
         }
         //Use basename to remove path traversal characters.
-        $filename = \Utility::resolvePath(
-            strval($request->getAttribute('filename'))
-        );
-
+        $filename = $request->getAttribute('filename');
         if (empty($filename)) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 self::ERROR_EMPTY_FILENAME
             );
         }
+
+        assert(is_string($filename) || $filename instanceof \Stringable);
+        $filename = \Utility::resolvePath(strval($filename));
 
         $targetPath = \Utility::appendForwardSlash(
             $this->downloadDirectory->getPathname()

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -503,7 +503,7 @@ class NDB_BVL_Feedback
         }
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query           .= " AND ft.CommentID = :ComID";
-            $qparams['ComID'] = $this->_feedbackCandidateProfileInfo['CommentID'];
+            $qparams['ComID'] = $this->_feedbackObjectInfo['CommentID'];
         }
 
         if (!$hasReadPermission) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -3329,7 +3329,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     static function getDDEInstrumentNamesList(
         \LORIS\LorisInstance $loris,
-        String $Visit_label=null
+        ?string $Visit_label=null
     ) : array {
         $DB = $loris->getDatabaseConnection();
 

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -417,7 +417,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
         // make sure user belongs to same site as timepoint
         if (!$user->hasPermission('data_entry')
             || !in_array(
-                $timePoint->getData('CenterID'),
+                $timePoint->getCenterID(),
                 $user->getCenterIDs()
             )
         ) {

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -79,7 +79,6 @@ class SiteIDGenerator extends IdentifierGenerator
             || empty($this->minValue)
             || empty($this->maxValue)
             || empty($this->prefix)
-            || !is_array($this->alphabet)
         ) {
             throw new \DomainException(
                 'Values not configured properly for ' . get_class($this) . '. '
@@ -309,7 +308,7 @@ class SiteIDGenerator extends IdentifierGenerator
      *                                                 for which we want the
      *                                                 value.
      *
-     * @return array<int,mixed> The value(s) corresponding to $setting.
+     * @return array<int,string> The value(s) corresponding to $setting.
      */
     private static function _getSeqAttribute(
         array $idStructure,
@@ -375,7 +374,13 @@ class SiteIDGenerator extends IdentifierGenerator
      */
     private function _getPrefix(): string
     {
-        return strval($this->_getIDSetting('prefix'));
+        $val = $this->_getIDSetting('prefix');
+        if (is_array($val)) {
+            throw new \ConfigurationException(
+                'Did not expect prefix to be an array'
+            );
+        }
+        return strval($val);
     }
     /**
      * Returns the minimum value for the identifier.
@@ -384,8 +389,14 @@ class SiteIDGenerator extends IdentifierGenerator
      */
     private function _getMinValue(): string
     {
+        $val = $this->_getIDSetting('min');
+        if (is_array($val)) {
+            throw new \ConfigurationException(
+                'Did not expect min to be an array'
+            );
+        }
         return strval(
-            $this->_getIDSetting('min') ??
+            $val ??
             str_repeat(strval($this->alphabet[0]), intval($this->length))
         );
     }
@@ -397,8 +408,14 @@ class SiteIDGenerator extends IdentifierGenerator
      */
     private function _getMaxValue(): string
     {
+        $val = $this->_getIDSetting('max');
+        if (is_array($val)) {
+            throw new \ConfigurationException(
+                'Did not expect max to be an array'
+            );
+        }
         return strval(
-            $this->_getIDSetting('max') ??
+            $val ??
             str_repeat(
                 strval($this->alphabet[count($this->alphabet) - 1]),
                 intval($this->length)

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  php = pkgs.php83.withExtensions ({ enabled, all }:
+  php = pkgs.php84.withExtensions ({ enabled, all }:
     enabled ++ [ all.ast ]);
 in
 pkgs.mkShell {
-  buildInputs = with pkgs; [ php git nodejs php83Packages.composer ];
+  buildInputs = with pkgs; [ php git nodejs php84Packages.composer ];
   shellHook =
     ''
        php -v;


### PR DESCRIPTION
Since PHP 8.4 is the most recently released version of PHP, this adds support for it (mostly by updating package dependencies) and adds it to the GitHub Actions test matrix.

Fixes #9512