### PR TITLE
[Core] Faster php syntax checking

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -29,7 +29,7 @@ fi
 find docs modules htdocs php src tools \
     -name '*.class.inc' \
     -print0 -o -name '*.php' -print0 \
-    |xargs -0 -n1 php -l \
+    |xargs -0 php -l \
     >/dev/null
 
 # Run PHPCS on all .php and .inc files in folders:


### PR DESCRIPTION
PHP 8.3 added the ability to pass more than one filename at a time to 'php -l'. As such, we no longer need to specify that xargs should only lint one file at a time and let it work on batches now that the minimum supported version of LORIS is PHP 8.3.

This improves the time of running 'make checkstatic'.
