### PR TITLE
[EEG Browser] Fix webpack and ts config

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/tsconfig.json
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "extends": "../../../../tsconfig",
-    "compilerOptions": {
-        "strict": false
-    }
-}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -171,10 +171,27 @@ const module: webpack.ModuleOptions = {
     },
     {
       test: /\.tsx?$/,
+      exclude: [/react-series-data-viewer/],
       use: [
         {
           loader: 'ts-loader',
-          options: {onlyCompileBundledFiles: true},
+          options: {
+            onlyCompileBundledFiles: true,
+          },
+        },
+      ],
+    },
+    {
+      test: /.*\/react-series-data-viewer\/.*\.tsx?$/,
+      use: [
+        {
+          loader: 'ts-loader',
+          options:{
+            onlyCompileBundledFiles: true,
+            compilerOptions: {
+              strict: false,
+            }
+          }
         },
       ],
     },
@@ -316,41 +333,5 @@ configs.push({
   module,
   stats: 'errors-warnings',
 });
-
-// HACK: For some reason, the electrophysiology session view only compiles if
-// it uses a separate (although possibly identical) configuration.
-if (!target || target === 'electrophysiology_browser') {
-  configs.push({
-    entry: {
-      electrophysiology_browser: {
-        import: './modules/electrophysiology_browser/'
-          + 'jsx/electrophysiologySessionView',
-        filename: './modules/electrophysiology_browser/'
-          + 'js/electrophysiologySessionView.js',
-        library: {
-          name: [
-            'lorisjs',
-            'electrophysiology_browser',
-            'electrophysiologySessionView',
-          ],
-          type: 'window',
-        },
-      },
-    },
-    output: {
-      path: __dirname,
-      filename: './htdocs/js/components/[name].js',
-      library: ['lorisjs', '[name]'],
-      libraryTarget: 'window',
-    },
-    externals: {'react': 'React', 'react-dom': 'ReactDOM'},
-    devtool: 'source-map',
-    plugins,
-    optimization,
-    resolve,
-    module,
-    stats: 'errors-warnings',
-  });
-}
 
 export default configs;


### PR DESCRIPTION
Fix the webpack and TS config for EEG Browser:
- disable TS strict mode for the EEG visualization module for successful compilation
- remove unecessary webpack hack with proper ts config