### PR TITLE
[dataquery] Add instrument flags to instruments query engine

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -84,15 +84,17 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                         $cardinality,
                         'Data_entry',
                     ),
-                    new DictionaryItem(
-                        $inst->testName.'_Validity',
-                        'Test validity for ' . $inst->getFullName(),
-                        $scope,
-                        $validityoptions,
-                        $cardinality,
-                        'Validity',
-                    ),
                 ];
+                if ($inst->ValidityEnabled) {
+                            $fields[] =    new DictionaryItem(
+                                $inst->testName.'_Validity',
+                                'Test validity for ' . $inst->getFullName(),
+                                $scope,
+                                $validityoptions,
+                                $cardinality,
+                                'Validity',
+                            );
+                }
                 $fields = array_merge($fields, $inst->getDataDictionary());
                 $dict[] = $cat->withItems($fields);
             } catch (\LorisException $e) {

--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
 namespace LORIS\instruments;
+use \LORIS\Data\Scope;
+use \LORIS\Data\Cardinality;
+
+use \LORIS\Data\Types\Enumeration;
 
 /**
  * InstrumentQueryEngine implements a LORIS QueryEngine for querying
@@ -41,19 +45,55 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $rows = $DB->pselectCol("SELECT Test_name FROM test_names", []);
 
         $dict = [];
+
+        // Use the same option enums for all instruments
+        $adminoptions     = new Enumeration('None', 'Partial', 'All');
+        $dataentryoptions = new Enumeration('In Progress', 'Complete');
+        $validityoptions  = new Enumeration('Questionable', 'Invalid', 'Valid');
+
+        $cardinality = new Cardinality(Cardinality::SINGLE);
+        $scope       = new Scope(Scope::SESSION);
+
         foreach ($rows as $testname) {
             try {
-                $inst   = \NDB_BVL_Instrument::factory(
+                $inst = \NDB_BVL_Instrument::factory(
                     $this->loris,
                     $testname,
                     "",
                     "",
                 );
-                $cat    = new \LORIS\Data\Dictionary\Category(
+                $cat  = new \LORIS\Data\Dictionary\Category(
                     $testname,
                     $inst->getFullName()
                 );
-                $fields = $inst->getDataDictionary();
+
+                $fields = [
+                    new DictionaryItem(
+                        $inst->testName.'_Administration',
+                        'Administration flag for ' . $inst->getFullName(),
+                        $scope,
+                        $adminoptions,
+                        $cardinality,
+                        'Administration',
+                    ),
+                    new DictionaryItem(
+                        $inst->testName.'_Data_entry',
+                        'Data entry status for ' . $inst->getFullName(),
+                        $scope,
+                        $dataentryoptions,
+                        $cardinality,
+                        'Data_entry',
+                    ),
+                    new DictionaryItem(
+                        $inst->testName.'_Validity',
+                        'Test validity for ' . $inst->getFullName(),
+                        $scope,
+                        $validityoptions,
+                        $cardinality,
+                        'Validity',
+                    ),
+                ];
+                $fields = array_merge($fields, $inst->getDataDictionary());
                 $dict[] = $cat->withItems($fields);
             } catch (\LorisException $e) {
                 error_log($e);
@@ -329,11 +369,25 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                         $candData[$dict->getName()] = [];
                     }
                     $sid = $loadedInstrument->getSessionID();
-                    $candData[$dict->getName()][$sid->__toString()] = [
-                        'VisitLabel' => $loadedInstrument->getVisitLabel(),
-                        'SessionID'  => $sid->__toString(),
-                        'value'      => $loadedInstrument->getDictionaryValue($dict),
-                    ];
+                    switch ($dict->fieldname) {
+                    case 'Administration':
+                    case 'Data_entry':
+                    case 'Validity':
+                        $flags = $loadedInstrument->getFlags()->toArray();
+                        $candData[$dict->getName()][$sid->__toString()] = [
+                            'VisitLabel' => $loadedInstrument->getVisitLabel(),
+                            'SessionID'  => $sid->__toString(),
+                            'value'      => $flags[$dict->fieldname],
+                        ];
+                        break;
+                    default:
+                        $candData[$dict->getName()][$sid->__toString()] = [
+                            'VisitLabel' => $loadedInstrument->getVisitLabel(),
+                            'SessionID'  => $sid->__toString(),
+                            'value'      => $loadedInstrument
+                        ->getDictionaryValue($dict),
+                        ];
+                    }
                 }
             }
             yield "$iCandID" => $candData;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2267,26 +2267,52 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 			    (SELECT CommentID FROM load_comment_ids)";
             }
             if ($condition !== null) {
-                $conditions[] = 'JSON_VALUE(Data, "$.'
-                . substr(
+                $fname = substr(
                     $condition->dictionary->getName(),
                     strlen($this->testName)+1
-                )
-                . '") '
-                . \LORIS\Data\Query\SQLQueryEngine::sqlOperator($condition->criteria)
-                . ' '
-                . \LORIS\Data\Query\SQLQueryEngine::sqlValue(
-                    $condition->dictionary,
-                    $condition->criteria,
-                    $params
-                )
-                . ' ';
+                );
+                if ($fname == 'Administration'
+                    || $name == 'Validity'
+                    || $fname == 'Data_entry'
+                ) {
+                    $conditions[] = "flag.$fname"
+                    . \LORIS\Data\Query\SQLQueryEngine::sqlOperator(
+                        $condition->criteria
+                    )
+                    . \LORIS\Data\Query\SQLQueryEngine::sqlValue(
+                        $condition->dictionary,
+                        $condition->criteria,
+                        $params
+                    )
+                                   . ' ';
+                } else {
+
+                    $conditions[] = 'JSON_VALUE(Data, "$.'
+                    . substr(
+                        $condition->dictionary->getName(),
+                        strlen($this->testName)+1
+                    )
+                    . '")'
+                    . \LORIS\Data\Query\SQLQueryEngine::sqlOperator(
+                        $condition->criteria
+                    )
+                    . \LORIS\Data\Query\SQLQueryEngine::sqlValue(
+                        $condition->dictionary,
+                        $condition->criteria,
+                        $params
+                    )
+                    . ' ';
+                }
+                $conditions[] ="t.CommentID NOT LIKE 'DDE_%'";
             }
             $where = 'WHERE ' . join(' AND ', $conditions);
             $query = "SELECT CandID,
 		    	SessionID,
                         CommentID,
                         session.Visit_Label as VisitLabel,
+			flag.Administration,
+			flag.Data_entry as DataEntry,
+			flag.Validity,
                         Data
                     FROM flag
                         JOIN session ON (session.ID=flag.SessionID)
@@ -2298,12 +2324,18 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             foreach ($jsondata as $row) {
                     $newinst = clone $this;
 
-                $newinst->candID           = new CandID(strval($row['CandID']));
-                    $newinst->commentID    = $row['CommentID'];
-                    $newinst->visitLabel   = $row['VisitLabel'];
-                $newinst->sessionID        = new SessionID(
-                    strval($row['SessionID'])
+                    $newinst->candID     = new CandID(strval($row['CandID']));
+                    $newinst->commentID  = $row['CommentID'];
+                    $newinst->visitLabel = $row['VisitLabel'];
+                    $newinst->sessionID  = new SessionID(
+                        strval($row['SessionID'])
+                    );
+                $newinst->flags          = new \InstrumentFlags(
+                    $row['Data_entry'],
+                    $row['Administration'],
+                    $row['Validity']
                 );
+                unset($row['Data_entry'], $row['Administration'], $row['Validity']);
                     $newinst->instanceData = json_decode(
                         $row['Data'] ?? '{}',
                         true,
@@ -2319,11 +2351,21 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 			    (SELECT CommentID FROM load_comment_ids)";
             }
             if ($condition !== null) {
-                $conditions[] = 't.'
-                . substr(
+                $fname = substr(
                     $condition->dictionary->getName(),
                     strlen($this->testName)+1
-                )
+                );
+                if ($fname == 'Administration'
+                    || $name == 'Validity'
+                    || $fname == 'Data_entry'
+                ) {
+                    $tname = 'f.';
+                } else {
+                    $tname = 't.';
+                }
+
+                $conditions[] = $tname
+                . $fname
                 . ' '
                 . \LORIS\Data\Query\SQLQueryEngine::sqlOperator(
                     $condition->criteria
@@ -2335,12 +2377,16 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     $params
                 )
                 . ' ';
+                $conditions[] ="t.CommentID NOT LIKE 'DDE_%'";
             }
             $where = 'WHERE ' . join(' AND ', $conditions);
             $query = "SELECT 
 		    session.CandID as CandID,
 		    t.CommentID as CommentID,
                     session.Visit_Label as VisitLabel,
+			f.Administration,
+			f.Data_entry,
+			f.Validity,
                     session.ID as SessionID, t.*
                  FROM $this->table t
                     JOIN flag f ON (t.CommentID=f.CommentID)
@@ -2356,6 +2402,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     $newinst->visitLabel = $row['VisitLabel'];
                     $newinst->sessionID  = new SessionID(strval($row['SessionID']));
                     unset($row['CommentID'], $row['VisitLabel'], $row['SessionID']);
+
+                $newinst->flags = new \InstrumentFlags(
+                    $row['Data_entry'],
+                    $row['Administration'],
+                    $row['Validity']
+                );
+                unset($row['Data_entry'], $row['Administration'], $row['Validity']);
 
                     $newinst->instanceData = $row;
 
@@ -3063,6 +3116,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         return $this->determineDataEntryAllowed();
     }
 
+    private ?\InstrumentFlags $flags = null;
     /**
      * Gets the flags of that instrument
      *
@@ -3070,6 +3124,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     public function getFlags(): \InstrumentFlags
     {
+        if ($this->flags !== null) {
+            return $this->flags;
+        }
         $row = \NDB_Factory::singleton()->database()->pselectRow(
             'SELECT
                Data_entry as dataentry,
@@ -3085,11 +3142,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $administration = $row['administration'] ?? null;
         $validity       = $row['validity'] ?? null;
 
-        return new \InstrumentFlags(
+        $this->flags = new \InstrumentFlags(
             $dataentry,
             $administration,
             $validity
         );
+        return $this->flags;
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2272,7 +2272,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     strlen($this->testName)+1
                 );
                 if ($fname == 'Administration'
-                    || $name == 'Validity'
+                    || $fname == 'Validity'
                     || $fname == 'Data_entry'
                 ) {
                     $conditions[] = "flag.$fname"
@@ -2356,7 +2356,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     strlen($this->testName)+1
                 );
                 if ($fname == 'Administration'
-                    || $name == 'Validity'
+                    || $fname == 'Validity'
                     || $fname == 'Data_entry'
                 ) {
                     $tname = 'f.';


### PR DESCRIPTION
This adds instrument flags to the data that is bulk loaded by bulkLoadInstanceData and uses that to address the low hanging fruit of #9372 of including administration flags in the data query tool.

It does not address the DDE and conflict related fields that are in the CouchDB import script because we should investigate if those make sense in the instruments query engine or if it's possible to have those provided by the conflict resolver module rather than the instruments module, as they are more related to that module.