### PR TITLE
Fix the 500 error when calling the PUT or PATCH method to update an instrument via the API

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -189,6 +189,8 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 'Could not update.'
             );
         }
+      
+        $data['Data']['candID'] = $data['Meta']['Candidate'];
 
         try {
             $this->_instrument->clearInstrument();
@@ -236,6 +238,8 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 'Could not update.'
             );
         }
+
+        $data['Data']['candID'] = $data['Meta']['Candidate'];
 
         try {
             $version = $request->getAttribute('LORIS-API-Version');

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -189,7 +189,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 'Could not update.'
             );
         }
-      
+
         $data['Data']['candID'] = $data['Meta']['Candidate'];
 
         try {


### PR DESCRIPTION
Fix the candID is always empty when API calls. 
test:   using https://???????.loris.ca/api/v0.0.3/candidates/{id}/{visit}/instruments/{instrument} 
send the test data using put and patch methods.