### PR TITLE
[Core] fix timeout redirect location

### DIFF
--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -44,8 +44,10 @@ class Error extends HtmlResponse
         int $status,
         string $message = ''
     ) {
-        $uri     = $request->getURI();
-        $baseurl = $uri->getScheme() .'://'. $uri->getAuthority();
+        $uri          = $request->getURI();
+        $serverParams = $request->getServerParams();
+        $redirectUrl  = $serverParams['REDIRECT_URL'] ?? null;
+        $baseurl      = $uri->getScheme() .'://'. $uri->getAuthority();
 
         $tpl_data = [
                      'message' => $message,
@@ -58,7 +60,7 @@ class Error extends HtmlResponse
         // Variables used to suggest the user to login and later redirect them if they
         // are not authenticated in a 403.
         $tpl_data['anonymous'] = $user instanceof \LORIS\AnonymousUser;
-        $tpl_data['url']       = urlencode($uri->__toString());
+        $tpl_data['url']       = urlencode($baseurl.$redirectUrl);
 
         // Add a link to the issue tracker as long as a LORIS Instance object
         // is present in the request.


### PR DESCRIPTION
## Brief summary of changes
The feature introduced in https://github.com/aces/Loris/pull/9041 seems to be broken on 26. The changes I'm proposing are the hack that i'm temporarily using on CBIG but there might be a better way of doing it.

One cause of the bug might actually be another PR submitted by maxime and merged https://github.com/aces/Loris/pull/9055. not sure if the changes in that PR broke the chnages in #9041

Below are a couple examples of the existing redirect for URLs
```
http://localhost:8083/user_accounts/edit_user/rida
<a href="/login?redirect=http%3A%2F%2Flocalhost%3A8083%2Fedit_user%2Frida">Try logging in</a>

http://localhost:8083/configuration/
<a href="/login?redirect=http%3A%2F%2Flocalhost%3A8083">Try logging in</a>
```
#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
