### PR TITLE
Fixing the display of the Entity Type options in the Imaging Browser

### DIFF
--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -170,7 +170,7 @@ class ImagingBrowserIndex extends Component {
       {label: 'Entity Type', show: false, filter: {
        name: 'entityType',
        type: 'multiselect',
-       option: options.entityType,
+       options: options.entityType,
       }},
     ];
     /**


### PR DESCRIPTION
- There was a typo in the `ImagingBrowserIndex` options for the entityType.

#### Testing instructions (if applicable)
1. Go to the imaging browser and check the Entity Type to see the two options (Humen, Scanner).

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/8962#event-16018789519