### PR TITLE
Add the MRI variables in the imaging_browser's query engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ VERSION
 .DS_Store
 .eslintcache
 tools/logs
+*.mo

--- a/Dockerfile.test.php8
+++ b/Dockerfile.test.php8
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y mariadb-client libzip-dev
 
 # Install PHP extensions
-RUN docker-php-ext-install pdo_mysql zip
+RUN docker-php-ext-install pdo_mysql zip gettext
 
 # Ensure the logs directory exists
 RUN mkdir -p /app/logs

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ clean:
 	rm -rf vendor
 	rm -rf node_modules
 	rm -rf modules/electrophysiology_browser/jsx/react-series-data-viewer/node_modules
+	rm -f modules/*/locale/*/LC_MESSAGES/*.mo
 
 # Perform static analysis checks
 checkstatic: phpdev
@@ -56,7 +57,59 @@ check: checkstatic unittests
 testdata:
 	php tools/raisinbread_refresh.php
 
-data_release:
+locales: 
+	msgfmt -o locale/ja/LC_MESSAGES/loris.mo locale/ja/LC_MESSAGES/loris.po
+	msgfmt -o modules/new_profile/locale/ja/LC_MESSAGES/new_profile.mo modules/new_profile/locale/ja/LC_MESSAGES/new_profile.po
+	msgfmt -o modules/acknowledgements/locale/ja/LC_MESSAGES/acknowledgements.mo modules/acknowledgements/locale/ja/LC_MESSAGES/acknowledgements.po
+	msgfmt -o modules/api_docs/locale/ja/LC_MESSAGES/api_docs.mo modules/api_docs/locale/ja/LC_MESSAGES/api_docs.po
+	msgfmt -o modules/battery_manager/locale/ja/LC_MESSAGES/battery_manager.mo modules/battery_manager/locale/ja/LC_MESSAGES/battery_manager.po
+	msgfmt -o modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.mo modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
+	msgfmt -o modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.mo modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po
+	msgfmt -o modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.mo modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
+	msgfmt -o modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+	msgfmt -o modules/candidate_parameters/locale/ja/LC_MESSAGES/candidate_parameters.mo modules/candidate_parameters/locale/ja/LC_MESSAGES/candidate_parameters.po
+	msgfmt -o modules/candidate_profile/locale/ja/LC_MESSAGES/candidate_profile.mo modules/candidate_profile/locale/ja/LC_MESSAGES/candidate_profile.po
+	msgfmt -o modules/configuration/locale/ja/LC_MESSAGES/configuration.mo modules/configuration/locale/ja/LC_MESSAGES/configuration.po
+	msgfmt -o modules/configuration/locale/ja/LC_MESSAGES/configuration.mo modules/configuration/locale/ja/LC_MESSAGES/configuration.po
+	msgfmt -o modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.mo modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.po
+	msgfmt -o modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.mo modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po
+	msgfmt -o modules/dashboard/locale/ja/LC_MESSAGES/dashboard.mo modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
+	msgfmt -o modules/datadict/locale/ja/LC_MESSAGES/datadict.mo modules/datadict/locale/ja/LC_MESSAGES/datadict.po
+	msgfmt -o modules/dataquery/locale/ja/LC_MESSAGES/dataquery.mo modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+	msgfmt -o modules/data_release/locale/ja/LC_MESSAGES/data_release.mo modules/data_release/locale/ja/LC_MESSAGES/data_release.po
+	msgfmt -o modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.mo modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.po
+	msgfmt -o modules/dictionary/locale/ja/LC_MESSAGES/dictionary.mo modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
+	msgfmt -o modules/document_repository/locale/ja/LC_MESSAGES/document_repository.mo modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+	msgfmt -o modules/dqt/locale/ja/LC_MESSAGES/dqt.mo modules/dqt/locale/ja/LC_MESSAGES/dqt.po
+	msgfmt -o modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.mo modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
+	msgfmt -o modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.mo modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
+	msgfmt -o modules/examiner/locale/ja/LC_MESSAGES/examiner.mo modules/examiner/locale/ja/LC_MESSAGES/examiner.po
+	msgfmt -o modules/genomic_browser/locale/ja/LC_MESSAGES/genomic_browser.mo modules/genomic_browser/locale/ja/LC_MESSAGES/genomic_browser.po
+	msgfmt -o modules/help_editor/locale/ja/LC_MESSAGES/help_editor.mo modules/help_editor/locale/ja/LC_MESSAGES/help_editor.po
+	msgfmt -o modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.mo modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+	msgfmt -o modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.mo modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.po
+	msgfmt -o modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.mo modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+	msgfmt -o modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.mo modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
+	msgfmt -o modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.mo modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
+	msgfmt -o modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.mo modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.po
+	msgfmt -o modules/instruments/locale/ja/LC_MESSAGES/instruments.mo modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+	msgfmt -o modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.mo modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
+	msgfmt -o modules/login/locale/ja/LC_MESSAGES/login.mo modules/login/locale/ja/LC_MESSAGES/login.po
+	msgfmt -o modules/media/locale/ja/LC_MESSAGES/media.mo modules/media/locale/ja/LC_MESSAGES/media.po
+	msgfmt -o modules/module_manager/locale/ja/LC_MESSAGES/module_manager.mo modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
+	msgfmt -o modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.mo modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+	msgfmt -o modules/next_stage/locale/ja/LC_MESSAGES/next_stage.mo modules/next_stage/locale/ja/LC_MESSAGES/next_stage.po
+	msgfmt -o modules/oidc/locale/ja/LC_MESSAGES/oidc.mo modules/oidc/locale/ja/LC_MESSAGES/oidc.po
+	msgfmt -o modules/publication/locale/ja/LC_MESSAGES/publication.mo modules/publication/locale/ja/LC_MESSAGES/publication.po
+	msgfmt -o modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.mo modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
+	msgfmt -o modules/server_processes_manager/locale/ja/LC_MESSAGES/server_processes_manager.mo modules/server_processes_manager/locale/ja/LC_MESSAGES/server_processes_manager.po
+	msgfmt -o modules/statistics/locale/ja/LC_MESSAGES/statistics.mo modules/statistics/locale/ja/LC_MESSAGES/statistics.po
+	msgfmt -o modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.mo modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
+	msgfmt -o modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.mo modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
+	msgfmt -o modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.mo modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
+
+
+data_release: 
 	target=data_release npm run compile
 
 instrument_manager:

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -67,7 +67,8 @@ Profiler::checkpoint("Profiler started");
 // Middleware that happens on every request. This doesn't include
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.
-$middlewarechain = (new \LORIS\Middleware\ContentLength())
+$middlewarechain = (new \LORIS\Middleware\Language())
+    ->withMiddleware(new \LORIS\Middleware\ContentLength())
     ->withMiddleware(new \LORIS\Middleware\AWS())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 
@@ -111,7 +112,6 @@ $serverrequest = $serverrequest->withAttribute("user", $user)
     ->withAttribute("loris", $lorisInstance);
 
 // Now handle the request.
-//
 $response = $middlewarechain->process($serverrequest, $entrypoint);
 
 // Add the HTTP header line.

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -1,0 +1,118 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Smarty template main.tpl strings
+msgid "LORIS"
+msgstr "ロリス"
+
+msgid "DEV"
+msgstr "開発環境"
+
+msgid "Affiliations"
+msgstr "所属"
+
+msgid "Site Affiliation"
+msgstr "サイトの所属"
+
+msgid "Site Affiliations"
+msgstr "サイトの所属"
+
+msgid "Project Affiliation"
+msgstr "プロジェクトの所属"
+
+msgid "Project Affiliations"
+msgstr "プロジェクトの所属"
+
+msgid "Log Out"
+msgstr "ログアウト"
+
+msgid "My Preferences"
+msgstr "私の好み"
+
+# Auto extracted strings from PHP
+# Menu categories
+#: modules/configuration/php/module.class.inc:50
+#: modules/help_editor/php/module.class.inc:47
+#: modules/instrument_manager/php/module.class.inc:53
+#: modules/module_manager/php/module.class.inc:50
+#: modules/server_processes_manager/php/module.class.inc:104
+#: modules/survey_accounts/php/module.class.inc:48
+#: modules/user_accounts/php/module.class.inc:53
+msgid "Admin"
+msgstr "行政上の"
+#: modules/acknowledgements/php/module.class.inc:54
+#: modules/api_docs/php/module.class.inc:66
+#: modules/battery_manager/php/module.class.inc:55
+#: modules/datadict/php/module.class.inc:49
+#: modules/data_release/php/module.class.inc:56
+#: modules/dictionary/php/module.class.inc:49
+#: modules/document_repository/php/module.class.inc:56
+#: modules/instrument_builder/php/module.class.inc:48
+#: modules/issue_tracker/php/module.class.inc:54
+#: modules/schedule_module/php/module.class.inc:49
+msgid "Tools"
+msgstr "ツール"
+
+#: modules/behavioural_qc/php/module.class.inc:51
+#: modules/conflict_resolver/php/module.class.inc:83
+#: modules/examiner/php/module.class.inc:50
+#: modules/media/php/module.class.inc:33
+msgid "Clinical"
+msgstr "臨床的"
+
+#: modules/dicom_archive/php/module.class.inc:115
+#: modules/imaging_browser/php/module.class.inc:40
+#: modules/imaging_qc/php/module.class.inc:50
+#: modules/imaging_uploader/php/module.class.inc:54
+#: modules/mri_violations/php/module.class.inc:53
+msgid "Imaging"
+msgstr "イメージング"
+
+#: modules/candidate_list/php/module.class.inc:76
+#: modules/new_profile/php/module.class.inc:50
+msgid "Candidate"
+msgstr "為り手"
+
+#: modules/genomic_browser/php/module.class.inc:53
+msgid "Genomics"
+msgstr "ゲノミクス"
+
+#: modules/electrophysiology_browser/php/module.class.inc:54
+msgid "Electrophysiology"
+msgstr "電気生理学"
+
+#: modules/dataquery/php/module.class.inc:33
+#: modules/dqt/php/module.class.inc:49
+#: modules/publication/php/module.class.inc:55
+#: modules/statistics/php/module.class.inc:49
+msgid "Reports"
+msgstr "レポート"
+
+# Common loris terms. Consider moving these to their own textdomain?
+msgid "TimePoint"
+msgstr "タイムポイント"
+
+# Common select option labels
+msgid "Yes"
+msgstr "はい"
+
+msgid "No"
+msgstr "いいえ"
+

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -1,0 +1,118 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Smarty template main.tpl strings
+msgid "LORIS"
+msgstr ""
+
+msgid "DEV"
+msgstr ""
+
+msgid "Affiliations"
+msgstr ""
+
+msgid "Site Affiliation"
+msgstr ""
+
+msgid "Site Affiliations"
+msgstr ""
+
+msgid "Project Affiliation"
+msgstr ""
+
+msgid "Project Affiliations"
+msgstr ""
+
+msgid "Log Out"
+msgstr ""
+
+msgid "My Preferences"
+msgstr ""
+
+# Auto extracted strings from PHP
+# Menu categories
+#: modules/configuration/php/module.class.inc:50
+#: modules/help_editor/php/module.class.inc:47
+#: modules/instrument_manager/php/module.class.inc:53
+#: modules/module_manager/php/module.class.inc:50
+#: modules/server_processes_manager/php/module.class.inc:104
+#: modules/survey_accounts/php/module.class.inc:48
+#: modules/user_accounts/php/module.class.inc:53
+msgid "Admin"
+msgstr ""
+#: modules/acknowledgements/php/module.class.inc:54
+#: modules/api_docs/php/module.class.inc:66
+#: modules/battery_manager/php/module.class.inc:55
+#: modules/datadict/php/module.class.inc:49
+#: modules/data_release/php/module.class.inc:56
+#: modules/dictionary/php/module.class.inc:49
+#: modules/document_repository/php/module.class.inc:56
+#: modules/instrument_builder/php/module.class.inc:48
+#: modules/issue_tracker/php/module.class.inc:54
+#: modules/schedule_module/php/module.class.inc:49
+msgid "Tools"
+msgstr ""
+
+#: modules/behavioural_qc/php/module.class.inc:51
+#: modules/conflict_resolver/php/module.class.inc:83
+#: modules/examiner/php/module.class.inc:50
+#: modules/media/php/module.class.inc:33
+msgid "Clinical"
+msgstr ""
+
+#: modules/dicom_archive/php/module.class.inc:115
+#: modules/imaging_browser/php/module.class.inc:40
+#: modules/imaging_qc/php/module.class.inc:50
+#: modules/imaging_uploader/php/module.class.inc:54
+#: modules/mri_violations/php/module.class.inc:53
+msgid "Imaging"
+msgstr ""
+
+#: modules/candidate_list/php/module.class.inc:76
+#: modules/new_profile/php/module.class.inc:50
+msgid "Candidate"
+msgstr ""
+
+#: modules/genomic_browser/php/module.class.inc:53
+msgid "Genomics"
+msgstr ""
+
+#: modules/electrophysiology_browser/php/module.class.inc:54
+msgid "Electrophysiology"
+msgstr ""
+
+#: modules/dataquery/php/module.class.inc:33
+#: modules/dqt/php/module.class.inc:49
+#: modules/publication/php/module.class.inc:55
+#: modules/statistics/php/module.class.inc:49
+msgid "Reports"
+msgstr ""
+
+# Common loris terms. Consider moving these to their own textdomain?
+msgid "TimePoint"
+msgstr ""
+
+# Common select option labels
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+

--- a/modules/acknowledgements/locale/acknowledgements.pot
+++ b/modules/acknowledgements/locale/acknowledgements.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Acknowledgements"
+msgstr ""
+

--- a/modules/acknowledgements/locale/ja/LC_MESSAGES/acknowledgements.po
+++ b/modules/acknowledgements/locale/ja/LC_MESSAGES/acknowledgements.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Acknowledgements"
+msgstr "感謝"
+

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -56,8 +56,8 @@ class Acknowledgements extends \DataFrameworkMenu
     protected function getFieldOptions() : array
     {
         $yesNoOptions = [
-            'Yes' => 'Yes',
-            'No'  => 'No',
+            'Yes' => dgettext("loris", 'Yes'),
+            'No'  => dgettext("loris", 'No'),
         ];
 
         return [

--- a/modules/acknowledgements/php/module.class.inc
+++ b/modules/acknowledgements/php/module.class.inc
@@ -51,7 +51,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -61,6 +61,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Acknowledgements";
+        return dgettext("acknowledgements", "Acknowledgements");
     }
 }

--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -131,7 +131,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "API";
+        return dgettext("api", "API");
     }
 
     /**

--- a/modules/api_docs/locale/api_docs.pot
+++ b/modules/api_docs/locale/api_docs.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "API Documentation"
+msgstr ""
+

--- a/modules/api_docs/locale/ja/LC_MESSAGES/api_docs.po
+++ b/modules/api_docs/locale/ja/LC_MESSAGES/api_docs.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "API Documentation"
+msgstr "APIのドキュメント"
+

--- a/modules/api_docs/php/module.class.inc
+++ b/modules/api_docs/php/module.class.inc
@@ -48,7 +48,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "API Documentation";
+        return dgettext("api_docs", "API Documentation");
     }
 
     /**
@@ -63,7 +63,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
 }

--- a/modules/battery_manager/locale/battery_manager.pot
+++ b/modules/battery_manager/locale/battery_manager.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Battery Manager"
+msgstr ""
+

--- a/modules/battery_manager/locale/ja/LC_MESSAGES/battery_manager.po
+++ b/modules/battery_manager/locale/ja/LC_MESSAGES/battery_manager.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Battery Manager"
+msgstr "バッテリーマネージャー"
+

--- a/modules/battery_manager/php/module.class.inc
+++ b/modules/battery_manager/php/module.class.inc
@@ -52,7 +52,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -62,6 +62,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Battery Manager";
+        return dgettext("battery_manager", "Battery Manager");
     }
 }

--- a/modules/behavioural_qc/locale/behavioural_qc.pot
+++ b/modules/behavioural_qc/locale/behavioural_qc.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Behavioural Quality Control"
+msgstr ""
+

--- a/modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
+++ b/modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Behavioural Quality Control"
+msgstr "行動品質管理"
+

--- a/modules/behavioural_qc/php/module.class.inc
+++ b/modules/behavioural_qc/php/module.class.inc
@@ -48,7 +48,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Clinical";
+        return dgettext("loris", "Clinical");
     }
 
     /**
@@ -58,6 +58,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Behavioural Quality Control";
+        return dgettext("behavioural_qc", "Behavioural Quality Control");
     }
 }

--- a/modules/brainbrowser/locale/brainbrowser.pot
+++ b/modules/brainbrowser/locale/brainbrowser.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Brainbrowser"
+msgstr ""
+

--- a/modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po
+++ b/modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Brainbrowser"
+msgstr "ブレインブラウザ"
+

--- a/modules/brainbrowser/php/module.class.inc
+++ b/modules/brainbrowser/php/module.class.inc
@@ -34,6 +34,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Brainbrowser";
+        return dgettext("brainbrowser", "Brainbrowser");
     }
 }

--- a/modules/bvl_feedback/locale/bvl_feedback.pot
+++ b/modules/bvl_feedback/locale/bvl_feedback.pot
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Behavioural Feedback"
+msgstr ""
+
+msgid "Behavioural Feedback Notifications"
+msgstr ""
+

--- a/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Behavioural Feedback"
+msgstr "行動フィードバック"
+
+msgid "Behavioural Feedback Notifications"
+msgstr "行動フィードバック通知"
+

--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Behavioural Feedback";
+        return dgettext("bvl_feedback", "Behavioural Feedback");
     }
 
     /**
@@ -134,7 +134,10 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\Widget(
                     new \LORIS\dashboard\WidgetContent(
-                        "Behavioural Feedback Notifications",
+                        dgettext(
+                            "bvl_feedback",
+                            "Behavioural Feedback Notifications"
+                        ),
                         $this->renderTemplate(
                             "dashboardwidget.tpl",
                             [

--- a/modules/candidate_list/locale/candidate_list.pot
+++ b/modules/candidate_list/locale/candidate_list.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Access Profile"
+msgstr ""
+

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
@@ -1,0 +1,24 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Access Profile"
+msgstr "アクセスプロファイル"
+
+

--- a/modules/candidate_list/php/module.class.inc
+++ b/modules/candidate_list/php/module.class.inc
@@ -73,7 +73,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Candidate";
+        return dgettext("loris", "Candidate");
     }
 
     /**
@@ -83,7 +83,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Access Profile";
+        return dgettext("candidate_list", "Access Profile");
     }
 
     /**

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Candidate Parameters"
+msgstr ""
+

--- a/modules/candidate_parameters/locale/ja/LC_MESSAGES/candidate_parameters.po
+++ b/modules/candidate_parameters/locale/ja/LC_MESSAGES/candidate_parameters.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Candidate Parameters"
+msgstr "候補パラメータ"
+

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -94,7 +94,7 @@ class Candidate_Parameters extends \NDB_Form
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Candidate Parameters',
+                dgettext("candidate_parameters", 'Candidate Parameters'),
                 "/candidate_parameters/?candID=$candID&identifier=$candID"
             )
         );

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -18,7 +18,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Candidate Parameters";
+        return dgettext("candidate_parameters", "Candidate Parameters");
     }
 
     /**

--- a/modules/candidate_profile/locale/candidate_profile.pot
+++ b/modules/candidate_profile/locale/candidate_profile.pot
@@ -1,0 +1,28 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Candidate Profile"
+msgstr ""
+
+msgid "Candidate Info"
+msgstr ""
+
+msgid "Candidate Dashboard"
+msgstr ""

--- a/modules/candidate_profile/locale/ja/LC_MESSAGES/candidate_profile.po
+++ b/modules/candidate_profile/locale/ja/LC_MESSAGES/candidate_profile.po
@@ -1,0 +1,28 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Candidate Profile"
+msgstr "候補者プロフィール"
+
+msgid "Candidate Info"
+msgstr "候補者情報"
+
+msgid "Candidate Dashboard"
+msgstr "候補者ダッシュボード"

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -129,7 +129,7 @@ class Candidate_Profile extends \NDB_Page
         if ($this->candidate === null) {
             return new \LORIS\BreadcrumbTrail(
                 new \LORIS\Breadcrumb(
-                    'Access Profile',
+                    dgettext("candidate_list", 'Access Profile'),
                     '/candidate_list/?betaprofile=1'
                 ),
             );
@@ -139,11 +139,12 @@ class Candidate_Profile extends \NDB_Page
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Access Profile',
+                dgettext("candidate_list", 'Access Profile'),
                 '/candidate_list/?betaprofile=1'
             ),
             new \LORIS\Breadcrumb(
-                "Candidate Dashboard $candid / $pscid",
+                dgettext("candidate_profile", 'Candidate Dashboard')
+                . " $candid / $pscid",
                 "/candidate_profile/$candid"
             )
         );

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -52,7 +52,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Candidate Profile";
+        return dgettext("candidate_profile", "Candidate Profile");
     }
 
     /**
@@ -91,7 +91,7 @@ class Module extends \Module
 
             return [
                 new CandidateWidget(
-                    "Candidate Info",
+                    dgettext("candidate_profile", "Candidate Info"),
                     $baseurl . "/candidate_profile/js/CandidateInfo.js",
                     "lorisjs.candidate_profile.CandidateInfo.CandidateInfo",
                     ['ExtraCandidateInfo' => $params],

--- a/modules/configuration/locale/configuration.pot
+++ b/modules/configuration/locale/configuration.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Configuration"
+msgstr ""
+

--- a/modules/configuration/locale/ja/LC_MESSAGES/configuration.po
+++ b/modules/configuration/locale/ja/LC_MESSAGES/configuration.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Configuration"
+msgstr "構成"
+

--- a/modules/configuration/php/module.class.inc
+++ b/modules/configuration/php/module.class.inc
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -57,6 +57,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Configuration";
+        return dgettext("configuration", "Configuration");
     }
 }

--- a/modules/conflict_resolver/locale/conflict_resolver.pot
+++ b/modules/conflict_resolver/locale/conflict_resolver.pot
@@ -1,0 +1,29 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Conflict Resolver"
+msgstr ""
+
+msgid "Data entry conflict"
+msgstr ""
+
+msgid "Unresolved Conflicts"
+msgstr ""
+

--- a/modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.po
+++ b/modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.po
@@ -1,0 +1,29 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Conflict Resolver"
+msgstr "紛争解決者"
+
+msgid "Data entry conflict"
+msgstr "データ入力の競合"
+
+msgid "Unresolved Conflicts"
+msgstr "未解決の紛争"
+

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -80,7 +80,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Clinical";
+        return dgettext("loris", "Clinical");
     }
 
     /**
@@ -90,7 +90,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Conflict Resolver";
+        return dgettext("conflict_resolver", "Conflict Resolver");
     }
 
     /**
@@ -113,7 +113,7 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "Data entry conflict",
+                    dgettext("conflict_resolver", "Data entry conflict"),
                     $DB,
                     "SELECT COUNT(*) FROM conflicts_unresolved cu
                          LEFT JOIN flag ON (cu.CommentId1=flag.CommentID)
@@ -165,7 +165,7 @@ class Module extends \Module
             }
             return [
                 new \LORIS\candidate_profile\CandidateWidget(
-                    "Unresolved Conflicts",
+                    dgettext("conflict_resolver", "Unresolved Conflicts"),
                     $baseURL . "/conflict_resolver/js/CandidateConflictsWidget.js",
                     "lorisjs.conflict_resolver.CandidateConflictsWidget.default",
                     [

--- a/modules/create_timepoint/locale/create_timepoint.pot
+++ b/modules/create_timepoint/locale/create_timepoint.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Create Timepoint"
+msgstr ""
+

--- a/modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po
+++ b/modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Create Timepoint"
+msgstr "タイムポイントを作成"
+

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -65,15 +65,16 @@ class Create_Timepoint extends \NDB_Form
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Access Profile',
+                dgettext("candidate_list", 'Access Profile'),
                 '/candidate_list'
             ),
             new \LORIS\Breadcrumb(
-                "Candidate Profile $candid / $pscid",
+                dgettext("candidate_profile", "Candidate Profile")
+                .  " $candid / $pscid",
                 "/$candid"
             ),
             new \LORIS\Breadcrumb(
-                'Create Time Point',
+                dgettext("create_timepoint", 'Create Timepoint'),
                 "/create_timepoint/?candID=$candid&identifier=$candid"
             )
         );

--- a/modules/create_timepoint/php/module.class.inc
+++ b/modules/create_timepoint/php/module.class.inc
@@ -32,6 +32,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Create Timepoint";
+        return dgettext("create_timepoint", "Create Timepoint");
     }
 }

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -66,7 +66,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Create Time Point", $bodyText);
+        $this->assertStringContainsString("Create Timepoint", $bodyText);
         $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
@@ -94,7 +94,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Create Time Point", $bodyText);
+        $this->assertStringContainsString("Create Timepoint", $bodyText);
         $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText

--- a/modules/dashboard/locale/dashboard.pot
+++ b/modules/dashboard/locale/dashboard.pot
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "My Tasks"
+msgstr ""
+

--- a/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+msgid "My Tasks"
+msgstr "私のタスク"
+

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -34,7 +34,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Dashboard";
+        return dgettext("dashboard", "Dashboard");
     }
 
     /**
@@ -151,7 +151,7 @@ class Module extends \Module
         }
         return new Widget(
             new WidgetContent(
-                "My Tasks",
+                dgettext("dashboard", "My Tasks"),
                 $this->renderTemplate(
                     "mytasks.tpl",
                     [

--- a/modules/data_release/locale/data_release.pot
+++ b/modules/data_release/locale/data_release.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Release"
+msgstr ""
+

--- a/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Release"
+msgstr "データリリース"
+

--- a/modules/data_release/php/module.class.inc
+++ b/modules/data_release/php/module.class.inc
@@ -53,7 +53,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -63,6 +63,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Release";
+        return dgettext("data_release", "Data Release");
     }
 }

--- a/modules/datadict/locale/datadict.pot
+++ b/modules/datadict/locale/datadict.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Dictionary (Legacy)"
+msgstr ""
+

--- a/modules/datadict/locale/ja/LC_MESSAGES/datadict.po
+++ b/modules/datadict/locale/ja/LC_MESSAGES/datadict.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Dictionary (Legacy)"
+msgstr "データ辞書（レガシー）"
+

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -134,18 +134,6 @@ class Datadict extends \DataFrameworkMenu
     }
 
     /**
-     * Generate a breadcrumb trail for this page.
-     *
-     * @return \LORIS\BreadcrumbTrail
-     */
-    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
-    {
-        return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb('Data Dictionary', "/$this->name")
-        );
-    }
-
-    /**
      * The datadict module does not have any concept of a project.
      *
      * @return bool

--- a/modules/datadict/php/module.class.inc
+++ b/modules/datadict/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -56,6 +56,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Dictionary (Legacy)";
+        return dgettext("datadict", "Data Dictionary (Legacy)");
     }
 }

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Query Tool (Beta)"
+msgstr ""
+

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Query Tool (Beta)"
+msgstr "データ辞書（レガシー）"
+

--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -30,7 +30,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Reports";
+        return dgettext("loris", "Reports");
     }
 
     /**
@@ -40,7 +40,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Query Tool (Beta)";
+        return dgettext("dataquery", "Data Query Tool (Beta)");
     }
 
     /**

--- a/modules/dicom_archive/locale/dicom_archive.pot
+++ b/modules/dicom_archive/locale/dicom_archive.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "DICOM Archive"
+msgstr ""
+

--- a/modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.po
+++ b/modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "DICOM Archive"
+msgstr "DICOMアーカイブ"
+

--- a/modules/dicom_archive/php/module.class.inc
+++ b/modules/dicom_archive/php/module.class.inc
@@ -117,7 +117,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Imaging";
+        return dgettext("loris", "Imaging");
     }
 
     /**
@@ -127,6 +127,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "DICOM Archive";
+        return dgettext("dicom_archive", "DICOM Archive");
     }
 }

--- a/modules/dictionary/locale/dictionary.pot
+++ b/modules/dictionary/locale/dictionary.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Dictionary"
+msgstr ""
+

--- a/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
+++ b/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Dictionary"
+msgstr "データ辞書"
+

--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -56,7 +56,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Dictionary";
+        return dgettext("dictionary", "Data Dictionary");
     }
 
     /**

--- a/modules/document_repository/locale/document_repository.pot
+++ b/modules/document_repository/locale/document_repository.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Document Repository"
+msgstr ""
+

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Document Repository"
+msgstr "ドキュメントリポジトリ"
+

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -53,7 +53,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -63,7 +63,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Document Repository";
+        return dgettext("document_repository", "Document Repository");
     }
 
     /**

--- a/modules/dqt/locale/dqt.pot
+++ b/modules/dqt/locale/dqt.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Query Tool"
+msgstr ""
+

--- a/modules/dqt/locale/ja/LC_MESSAGES/dqt.po
+++ b/modules/dqt/locale/ja/LC_MESSAGES/dqt.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Query Tool"
+msgstr "データクエリツール"
+

--- a/modules/dqt/php/module.class.inc
+++ b/modules/dqt/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Reports";
+        return dgettext("loris", "Reports");
     }
 
     /**
@@ -56,6 +56,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Data Query Tool";
+        return dgettext("dqt", "Data Query Tool");
     }
 }

--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Electrophysiology Browser"
+msgstr ""
+

--- a/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Electrophysiology Browser"
+msgstr "電気生理学ブラウザ"
+

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -51,7 +51,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Electrophysiology";
+        return dgettext("loris", "Electrophysiology");
     }
 
     /**
@@ -61,6 +61,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Electrophysiology Browser";
+        return dgettext("electrophysiology_browser", "Electrophysiology Browser");
     }
 }

--- a/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
+++ b/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Electrophysiology Uploader"
+msgstr ""
+

--- a/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Electrophysiology Uploader"
+msgstr "電気生理学アップローダー"
+

--- a/modules/electrophysiology_uploader/php/module.class.inc
+++ b/modules/electrophysiology_uploader/php/module.class.inc
@@ -51,7 +51,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Electrophysiology";
+        return dgettext("loris", "Electrophysiology");
     }
 
     /**
@@ -61,6 +61,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Electrophysiology Uploader";
+        return dgettext("electrophysiology_uploader", "Electrophysiology Uploader");
     }
 }

--- a/modules/examiner/locale/examiner.pot
+++ b/modules/examiner/locale/examiner.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Examiner"
+msgstr ""
+

--- a/modules/examiner/locale/ja/LC_MESSAGES/examiner.po
+++ b/modules/examiner/locale/ja/LC_MESSAGES/examiner.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Examiner"
+msgstr "審査官"
+

--- a/modules/examiner/php/module.class.inc
+++ b/modules/examiner/php/module.class.inc
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Clinical";
+        return dgettext("loris", "Clinical");
     }
 
     /**
@@ -57,6 +57,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Examiner";
+        return dgettext("examiner", "Examiner");
     }
 }

--- a/modules/genomic_browser/locale/genomic_browser.pot
+++ b/modules/genomic_browser/locale/genomic_browser.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Genomic Browser"
+msgstr ""
+

--- a/modules/genomic_browser/locale/ja/LC_MESSAGES/genomic_browser.po
+++ b/modules/genomic_browser/locale/ja/LC_MESSAGES/genomic_browser.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Genomic Browser"
+msgstr "ゲノムブラウザ"
+

--- a/modules/genomic_browser/php/module.class.inc
+++ b/modules/genomic_browser/php/module.class.inc
@@ -50,7 +50,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Genomics";
+        return dgettext("loris", "Genomics");
     }
 
     /**
@@ -60,6 +60,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Genomic Browser";
+        return dgettext("genomic_browser", "Genomic Browser");
     }
 }

--- a/modules/help_editor/locale/help_editor.pot
+++ b/modules/help_editor/locale/help_editor.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Help Editor"
+msgstr ""
+

--- a/modules/help_editor/locale/ja/LC_MESSAGES/help_editor.po
+++ b/modules/help_editor/locale/ja/LC_MESSAGES/help_editor.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Help Editor"
+msgstr "ヘルプエディター"
+

--- a/modules/help_editor/php/module.class.inc
+++ b/modules/help_editor/php/module.class.inc
@@ -44,7 +44,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -54,6 +54,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Help Editor";
+        return dgettext("help_editor", "Help Editor");
     }
 }

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -1,0 +1,25 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Browser"
+msgstr ""
+
+msgid "View Session"
+msgstr ""

--- a/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
@@ -1,0 +1,25 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Browser"
+msgstr "イメージングブラウザ"
+
+msgid "View Session"
+msgstr "セッションを見る"

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -37,7 +37,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Imaging";
+        return dgettext("loris", "Imaging");
     }
 
     /**
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Imaging Browser";
+        return dgettext("imaging_browser", "Imaging Browser");
     }
 
     /**

--- a/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
@@ -15,6 +15,7 @@ use \LORIS\Data\Cardinality;
  */
 class MRICommentDictionaryItem extends ImagingDictionaryItem
 {
+    // Name of the comment associated to this record
     private $commentName;
 
     /**
@@ -26,8 +27,8 @@ class MRICommentDictionaryItem extends ImagingDictionaryItem
      * @param Type        $t           The data type of this dictionary item
      * @param Cardinality $c           The data cardinality
      * @param string      $modality    The imaging modality that this item is for
-     * @param string      $commentName Name of the comment (as per table
-     *                                 feedback_mri_comment_types).
+     * @param string      $commentName Name of the comment (i.e. value of column
+     *                                 CommentName in table feedback_mri_comment_types).
      */
     public function __construct(
         string $name,
@@ -42,6 +43,11 @@ class MRICommentDictionaryItem extends ImagingDictionaryItem
         $this->commentName = $commentName;
     }
 
+    /**
+     * Accessor for field $commentName.
+     *
+     * @return string Value of field $commentName.
+     */
     public function getCommentName() : string
     {
         return $this->commentName;

--- a/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
@@ -28,7 +28,8 @@ class MRICommentDictionaryItem extends ImagingDictionaryItem
      * @param Cardinality $c           The data cardinality
      * @param string      $modality    The imaging modality that this item is for
      * @param string      $commentName Name of the comment (i.e. value of column
-     *                                 CommentName in table feedback_mri_comment_types).
+     *                                 CommentName in table
+     *                                 feedback_mri_comment_types).
      */
     public function __construct(
         string $name,

--- a/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRICommentDictionaryItem extends ImagingDictionaryItem
+{
+    private $commentName;
+
+    /**
+     * Construct an ImagingDictionaryItem
+     *
+     * @param string      $name        The field name of the dictionary item
+     * @param string      $desc        The dictionary item's description
+     * @param Scope       $scope       The scope to which this DictionaryItem applies
+     * @param Type        $t           The data type of this dictionary item
+     * @param Cardinality $c           The data cardinality
+     * @param string      $modality    The imaging modality that this item is for
+     * @param string      $commentName Name of the comment (as per table
+     *                                 feedback_mri_comment_types).
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        string $commentName
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->commentName = $commentName;
+    }
+
+    public function getCommentName() : string
+    {
+        return $this->commentName;
+    }
+}

--- a/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
@@ -22,11 +22,11 @@ class MRIFeedbackDictionaryItem extends ImagingDictionaryItem
      *
      * @param string      $name              The field name of the dictionary item
      * @param string      $desc              The dictionary item's description
-     * @param Scope       $scope             Scope to which this DictionaryItem applies
+     * @param Scope       $scope             Scope to which this item applies
      * @param Type        $t                 The data type of this dictionary item
      * @param Cardinality $c                 The data cardinality
      * @param string      $modality          The modality that this item is for
-     * @param string      $parameterTypeName Name of the parameter in table 
+     * @param string      $parameterTypeName Name of the parameter in table
      *                                       parameter_type associated with this MRI
      *                                       feedback object.
      */

--- a/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
@@ -22,12 +22,13 @@ class MRIFeedbackDictionaryItem extends ImagingDictionaryItem
      *
      * @param string      $name              The field name of the dictionary item
      * @param string      $desc              The dictionary item's description
-     * @param Scope       $scope             The scope to which this DictionaryItem applies
+     * @param Scope       $scope             Scope to which this DictionaryItem applies
      * @param Type        $t                 The data type of this dictionary item
      * @param Cardinality $c                 The data cardinality
-     * @param string      $modality          The imaging modality that this item is for
-     * @param string      $parameterTypeName Name of the parameter in table parameter_type
-     *                                       associated with this feedback object.
+     * @param string      $modality          The modality that this item is for
+     * @param string      $parameterTypeName Name of the parameter in table 
+     *                                       parameter_type associated with this MRI
+     *                                       feedback object.
      */
     public function __construct(
         string $name,
@@ -42,6 +43,11 @@ class MRIFeedbackDictionaryItem extends ImagingDictionaryItem
         $this->parameterTypeName = $parameterTypeName;
     }
 
+    /**
+     * Accessor method for field $parameterTypeName.
+     *
+     * @return string Value of field $parameterTypeName.
+     */
     public function getParameterTypeName() : string
     {
         return $this->parameterTypeName;

--- a/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRIFeedbackDictionaryItem extends ImagingDictionaryItem
+{
+    private $parameterTypeName;
+
+    /**
+     * Construct an ImagingDictionaryItem
+     *
+     * @param string      $name              The field name of the dictionary item
+     * @param string      $desc              The dictionary item's description
+     * @param Scope       $scope             The scope to which this DictionaryItem applies
+     * @param Type        $t                 The data type of this dictionary item
+     * @param Cardinality $c                 The data cardinality
+     * @param string      $modality          The imaging modality that this item is for
+     * @param string      $parameterTypeName Name of the parameter in table parameter_type
+     *                                       associated with this feedback object.
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        string $parameterTypeName
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->parameterTypeName = $parameterTypeName;
+    }
+
+    public function getParameterTypeName() : string
+    {
+        return $this->parameterTypeName;
+    }
+}

--- a/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRIPredefinedCommentDictionaryItem extends ImagingDictionaryItem
+{
+    // Value of column PredefinedCommentID in table feedback_mri_predefined_comments
+    // this record.
+    private $predefinedCommentID;
+
+    /**
+     * Construct an MRIPredefinedCommentDictionaryItem
+     *
+     * @param string      $name                The field name of the dictionary item
+     * @param string      $desc                The dictionary item's
+     *                                         description
+     * @param Scope       $scope               The scope to which this
+     *                                         DictionaryItem applies
+     * @param Type        $t                   The data type of this dictionary item
+     * @param Cardinality $c                   The data cardinality
+     * @param string      $modality            The imaging modality that this item is for
+     * @param string      $predefinedCommentID Value of column PredefinedCommentID
+     *                                         in table
+     *                                         feedback_mri_predefined_comments
+     *                                         for this record
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        int $predefinedCommentID
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->predefinedCommentID = $predefinedCommentID;
+    }
+
+    /**
+     * Accessor for field $predefinedCommentID.
+     *
+     * @return int Value of field $predefinedCommentID.
+     */
+    public function getPredefinedCommentID() : int
+    {
+        return $this->predefinedCommentID;
+    }
+}

--- a/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
@@ -31,7 +31,7 @@ class MRIPredefinedCommentDictionaryItem extends ImagingDictionaryItem
      * @param Cardinality $c                   The data cardinality
      * @param string      $modality            The imaging modality that this item
      *                                         is for
-     * @param string      $predefinedCommentID Value of column PredefinedCommentID
+     * @param int         $predefinedCommentID Value of column PredefinedCommentID
      *                                         in table
      *                                         feedback_mri_predefined_comments
      *                                         for this record

--- a/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
@@ -29,7 +29,8 @@ class MRIPredefinedCommentDictionaryItem extends ImagingDictionaryItem
      *                                         DictionaryItem applies
      * @param Type        $t                   The data type of this dictionary item
      * @param Cardinality $c                   The data cardinality
-     * @param string      $modality            The imaging modality that this item is for
+     * @param string      $modality            The imaging modality that this item
+     *                                         is for
      * @param string      $predefinedCommentID Value of column PredefinedCommentID
      *                                         in table
      *                                         feedback_mri_predefined_comments

--- a/modules/imaging_browser/php/parameterdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/parameterdictionaryitem.class.inc
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class ParameterDictionaryItem extends ImagingDictionaryItem
+{
+}

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -277,7 +277,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                         $ScanType,
                         $commentProperties['field']
                     );
-           
+
                     //--------------------------------------------------------//
                     // Values of all the predefined comments for this comment //
                     // type.                                                  //
@@ -287,8 +287,8 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                     foreach ($predefinedComments as $ID => $predefinedComment) {
                         $items[] = new MRIPredefinedCommentDictionaryItem(
                             "{$ScanType}_{$predefinedComment['Comment']}",
-                            "'{$predefinedComment['FullComment']}' in the MRI feedback form"
-                            . " is checked for $ScanType acquisitions",
+                            "'{$predefinedComment['FullComment']}' in the MRI "
+                            . "feedback form is checked for $ScanType acquisitions",
                             $scope,
                             new \LORIS\Data\Types\Enumeration('Yes', 'No'),
                             new Cardinality(Cardinality::MANY),

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -13,11 +13,16 @@ use \LORIS\Data\Cardinality;
  */
 class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 {
-    const FDI_DATA_TYPE_IDX   = 0;
-    const FDI_SELECT_IDX      = 1;
+    // Index of the data type in the arrays contained in $FILE_DICTIONARY_ITEMS
+    const FDI_DATA_TYPE_IDX = 0;
+    // Index of the info to select in the arrays contained in $FILE_DICTIONARY_ITEMS
+    const FDI_SELECT_IDX = 1;
+    // Index of the description in the arrays contained in $FILE_DICTIONARY_ITEMS
     const FDI_DESCRIPTION_IDX = 2;
 
-    // All the fields that get their info directly from table files
+    // Properties of all fields that are stored in the data dictionary as
+    // LocationDictionaryItem. The information in this array is used to create the
+    // item and to build the SQL query used to fetch the field value in the DB.
     const FILE_DICTIONARY_ITEMS = [
         'file'            => [
             'StringType', 'File', 'acquisition file path'
@@ -31,6 +36,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         'ScannerID'       => [
             'IntegerType', 'ScannerID', 'acquisition scanner ID'
         ],
+        'FileInsertDate'  => [
+            'DateType',
+            'FROM_UNIXTIME(InsertTime,"%Y-%m-%d")',
+            'acquisition file insert date'
+        ],
         'Caveat'          => [
             'StringType', 'Caveat', 'acquisition caveat'
         ],
@@ -39,20 +49,25 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         ],
         'CoordinateSpace' => [
             'StringType', 'CoordinateSpace', 'acquisition coordinate space'
-        ],
-        'FileInsertDate'  => [
-            'DateType',
-            'FROM_UNIXTIME(InsertTime,"%Y-%m-%d")',
-            'acquisition file insert date'
         ]
     ];
 
-    const PDI_DATA_TYPE_IDX      = 0;
+    // Index of the data type in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_DATA_TYPE_IDX = 0;
+    // Index of the parameter name in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
     const PDI_PARAMETER_NAME_IDX = 1;
-    const PDI_SELECT_IDX         = 2;
-    const PDI_DESCRIPTION_IDX    = 3;
+    // Index of the info to select in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_SELECT_IDX = 2;
+    // Index of the description in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_DESCRIPTION_IDX = 3;
 
-    // All the fields that get their info directly from table parameter_files
+    // Properties of all fields that are stored in the data dictionary as
+    // ParameterDictionaryItem. The information in this array is used to create the
+    // item and to build the SQL query used to fetch the field value in the DB.
     const PARAMETER_DICTIONARY_ITEMS = [
         'AcquisitionDate'       => [
             'StringType',

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -13,6 +13,131 @@ use \LORIS\Data\Cardinality;
  */
 class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 {
+    const FDI_DATA_TYPE_IDX   = 0;
+    const FDI_SELECT_IDX      = 1;
+    const FDI_DESCRIPTION_IDX = 2;
+
+    // All the fields that get their info directly from table files
+    const FILE_DICTIONARY_ITEMS = [
+        'file'            => [
+            'StringType', 'File', 'acquisition file path'
+        ],
+        'OutputType'      => [
+            'StringType', 'OutputType', 'acquisition output type'
+        ],
+        'Pipeline'        => [
+            'StringType', 'SourcePipeline', 'acquisition source pipeline'
+        ],
+        'ScannerID'       => [
+            'IntegerType', 'ScannerID', 'acquisition scanner ID'
+        ],
+        'Caveat'          => [
+            'StringType', 'Caveat', 'acquisition caveat'
+        ],
+        'url'             => [
+            'URI', 'File', 'acquisition file URL'
+        ],
+        'CoordinateSpace' => [
+            'StringType', 'CoordinateSpace', 'acquisition coordinate space'
+        ],
+        'FileInsertDate'  => [
+            'DateType',
+            'FROM_UNIXTIME(InsertTime,"%Y-%m-%d")',
+            'acquisition file insert date'
+        ]
+    ];
+
+    const PDI_DATA_TYPE_IDX      = 0;
+    const PDI_PARAMETER_NAME_IDX = 1;
+    const PDI_SELECT_IDX         = 2;
+    const PDI_DESCRIPTION_IDX    = 3;
+
+    // All the fields that get their info directly from table parameter_files
+    const PARAMETER_DICTIONARY_ITEMS = [
+        'AcquisitionDate'       => [
+            'StringType',
+            'acquisition_date',
+            'DATE_FORMAT(pf.value, "%Y-%m-%d")',
+            'acquisition date'
+        ],
+        // CouchDB_MRI_Importer gets this from table files but I think
+        // it's better to get it from table parameter_file
+        'AcquisitionProtocol'   => [
+            'StringType', 'acquisition:protocol', 'pf.value', 'acquisition protocol'
+        ],
+        'Algorithm'             => [
+            'StringType', 'Algorithm', 'pf.value', 'algorithm'
+        ],
+        'SeriesDescription'     => [
+            'StringType', 'series_description', 'pf.value', 'series description'
+        ],
+        'SeriesNumber'          => [
+            'IntegerType', 'series_number', 'pf.value', 'series number'
+        ],
+        'EchoTime'              => [
+            'DecimalType', 'echo_time', 'ROUND(1000 * pf.value, 2)', 'echo time'
+        ],
+        'RepetitionTime'        => [
+            'DecimalType',
+            'repetition_time',
+            'ROUND(1000 * pf.value, 2)',
+            'repetition time (TR)'
+        ],
+        'SliceThickness'        => [
+            'DecimalType',
+            'slice_thickness',
+            'ROUND(1000 * pf.value, 2)',
+            'slice thickness'
+        ],
+        'Time'                  => [
+            'DecimalType',
+            'time',
+            'ROUND(1000 * pf.value, 2)',
+            'time (No of volumes)'
+        ],
+        // I put 'acquisition:comment' as the parameter name but
+        // CouchDB_MRI_Importer has 'Comment' which does not seem to exist
+        // anywhere...
+        'Comment'               => [
+            'StringType', 'acquisition:comment', 'pf.value', 'acquisition comment'
+        ],
+        // List of directions obtained for SlicewiseRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'SlicewiseRejected'     => [
+            'StringType',
+            'processing:slicewise_rejected',
+            'regexp_replace(pf.value, "\\(.*", "")',
+            'slicewise rejected'
+        ],
+        // List of directions obtained for InterlaceRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'InterlaceRejected'     => [
+            'StringType',
+            'processing:interlace_rejected',
+            'regexp_replace(pf.value, "\\(.*", "")',
+            'interlace rejected'
+        ],
+        // List of directions obtained for IntergradientRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'IntergradientRejected' => [
+            'StringType',
+            'processing:intergradient_rejected',
+            'regexp_replace(pf.value, "\\(.*", "")',
+            'intergradient rejected'
+        ],
+        // List of directions obtained for TotalRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'TotalRejected'         => [
+            'StringType',
+            'processing:total_rejected',
+            'regexp_replace(pf.value, "\\(.*", "")',
+            'total rejected'
+        ],
+        'ProcessingPipeline'    => [
+            'StringType', 'processing:pipeline', 'pf.value', 'processing pipeline'
+        ]
+    ];
+
     protected $baseURL;
     /**
      * {@inheritDoc}
@@ -49,22 +174,39 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $scantypes = \Utility::getScanTypeList();
         foreach ($scantypes as $ScanType) {
-            $items[] = new LocationDictionaryItem(
-                $ScanType . "_file",
-                "$ScanType acquisition file path",
-                $scope,
-                new \LORIS\Data\Types\StringType(),
-                new Cardinality(Cardinality::MANY),
-                $ScanType,
-            );
-            $items[] = new LocationDictionaryItem(
-                $ScanType . "_url",
-                "$ScanType acquisition file URL",
-                $scope,
-                new \LORIS\Data\Types\URI(),
-                new Cardinality(Cardinality::MANY),
-                $ScanType,
-            );
+            foreach (self::FILE_DICTIONARY_ITEMS as $field => $properties) {
+                $fullyQualifiedType
+                    = '\LORIS\Data\Types\\' . $properties[self::FDI_DATA_TYPE_IDX];
+                $items[]            = new LocationDictionaryItem(
+                    sprintf("%s_%s", $ScanType, $field),
+                    sprintf(
+                        "%s %s",
+                        $ScanType,
+                        $properties[self::FDI_DESCRIPTION_IDX]
+                    ),
+                    $scope,
+                    new $fullyQualifiedType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                );
+            }
+
+            foreach (self::PARAMETER_DICTIONARY_ITEMS as $fieldName => $properties) {
+                $fullyQualifiedType
+                    = '\LORIS\Data\Types\\' . $properties[self::PDI_DATA_TYPE_IDX];
+                $items[]            = new ParameterDictionaryItem(
+                    sprintf('%s_%s', $ScanType, $fieldName),
+                    sprintf(
+                        '%s %s',
+                        $ScanType,
+                        $properties[self::PDI_DESCRIPTION_IDX]
+                    ),
+                    $scope,
+                    new $fullyQualifiedType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                );
+            }
             // TODO: Investigate adding a file scope instead of having this apply
             // on a session scope with a Many cardinality.
             $items[] = new QCDictionaryItem(
@@ -72,6 +214,14 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 "Quality control status for $ScanType acquisition",
                 $scope,
                 new \LORIS\Data\Types\Enumeration("Pass", "Fail"),
+                new Cardinality(Cardinality::MANY),
+                $ScanType,
+            );
+            $items[] = new QCDictionaryItem(
+                $ScanType . "_Selected",
+                "Selected file for $ScanType for session",
+                $scope,
+                new \LORIS\Data\Types\BooleanType(),
                 new Cardinality(Cardinality::MANY),
                 $ScanType,
             );
@@ -137,26 +287,25 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                              WHEN s.Scan_Done='N' THEN false
                              ELSE NULL END";
         }
+
+        if (!($item instanceof ImagingDictionaryItem)) {
+            throw new \DomainException(
+                "Item is not an instance of ImagingDictionaryItem"
+            );
+        }
+
+        $modality = $item->getModality();
+        $exploded = explode("_", $item->getName());
+        $field    = $exploded[count($exploded)-1];
+        $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
+        $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
+
         if ($item instanceof LocationDictionaryItem) {
-            $modality = $item->getModality();
-
-            $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
-            $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
-
-            // Because of complex interactions between joins that get
-            // out of hand when a scan type that doesn't exist is selected
-            // alongside one that does, we use a subselect here.
-            if (str_ends_with($item->getName(), "_file")) {
-                return "(SELECT File FROM files as files2
-                            JOIN mri_scan_type mst
-                                ON (files2.MriScanTypeID=mst.MriScanTypeID)
-                            WHERE files2.FileID=files.FileID
-                                AND mst.MriScanTypeName='{$modality}')";
-            } else if (str_ends_with($item->getName(), "_url")) {
+            if ($field == 'url') {
                 return "(SELECT CONCAT(
                             \"$this->baseURL\",
                             \"/api/v0.0.3/candidates/\",
-                            c.CandID,
+                            c.ID,
                             \"/\",
                             s.Visit_label,
                             \"/images/\",
@@ -166,20 +315,51 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                                 ON (files2.MriScanTypeID=mst.MriScanTypeID)
                             WHERE files2.FileID=files.FileID
                                 AND mst.MriScanTypeName='{$modality}')";
+            } else {
+                $fdi = self::FILE_DICTIONARY_ITEMS[$field];
+                // Because of complex interactions between joins that get
+                // out of hand when a scan type that doesn't exist is selected
+                // alongside one that does, we use a subselect here.
+                return sprintf(
+                    "(SELECT %s FROM files as files2
+                      JOIN mri_scan_type mst
+                          ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                      WHERE files2.FileID=files.FileID
+                          AND mst.MriScanTypeName='%s')
+                    ",
+                    $fdi[self::FDI_SELECT_IDX],
+                    $modality
+                );
             }
         }
-        if ($item instanceof QCDictionaryItem) {
-            $modality = $item->getModality();
 
-            $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
-            $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
-            return "(SELECT QCStatus FROM files_qcstatus
+        if ($item instanceof QCDictionaryItem) {
+            return "(SELECT $field FROM files_qcstatus
                         JOIN files as files2
                         JOIN mri_scan_type mst
                             ON (files2.MriScanTypeID=mst.MriScanTypeID)
                         WHERE files_qcstatus.FileID=files.FileID
                             AND files2.FileID=files.FileID
                             AND mst.MriScanTypeName='{$modality}')";
+        }
+
+        if ($item instanceof ParameterDictionaryItem) {
+            $pdi = self::PARAMETER_DICTIONARY_ITEMS[$field];
+            return sprintf(
+                "(SELECT %s FROM files as files2
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  JOIN parameter_file pf
+                      ON (pf.FileID=files2.FileID)
+                  JOIN parameter_type pt
+                      ON (pt.ParameterTypeID=pf.ParameterTypeID AND pt.name='%s')
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                )",
+                $pdi[self::PDI_SELECT_IDX],
+                $pdi[self::PDI_PARAMETER_NAME_IDX],
+                $modality,
+            );
         }
 
         throw new \DomainException("Invalid field " . $item->getName());
@@ -210,6 +390,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
     ) {
         if ($item instanceof LocationDictionaryItem
             || $item instanceof QCDictionaryItem
+            || $item instanceof ParameterDictionaryItem
         ) {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
             $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -42,7 +42,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             'acquisition file insert date'
         ],
         'Caveat'          => [
-            'StringType', 'Caveat', 'acquisition caveat'
+            'IntegerType', 'Caveat', 'acquisition caveat'
         ],
         'url'             => [
             'URI', 'File', 'acquisition file URL'
@@ -296,6 +296,12 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
     protected function getFieldNameFromDict(
         \LORIS\Data\Dictionary\DictionaryItem $item
     ): string {
+        if (!($item instanceof ImagingDictionaryItem)) {
+            throw new \DomainException(
+                "Item is not an instance of ImagingDictionaryItem"
+            );
+        }
+
         if ($item->getName() == 'ScanDone') {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
                 return "CASE WHEN s.Scan_Done='Y' THEN true
@@ -373,6 +379,26 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 )",
                 $pdi[self::PDI_SELECT_IDX],
                 $pdi[self::PDI_PARAMETER_NAME_IDX],
+                $modality,
+            );
+        }
+
+        if ($item instanceof CommentDictionaryItem) {
+            $pcdi = self::PREDEFINED_COMMENT_DICTIONARY_ITEMS[$field];
+            return sprintf(
+                "(SELECT %s FROM files as files2
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  JOIN feedback_mri_comments fmc
+                      ON (fmc.FileID=files2.FileID)
+                  LEFT JOIN feedback_mri_predefined_comments fmpc
+                      ON (fmpc.PredefinedCommentID=fmc.PredefinedCommentID)
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                      AND fmpc.Comment='%s'
+                )",
+                $pcdi[self::PDI_SELECT_IDX],
+                $pcdi[self::PDI_COMMENT_TEXT_IDX],
                 $modality,
             );
         }

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -121,7 +121,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         'SlicewiseRejected'     => [
             'StringType',
             'processing:slicewise_rejected',
-            'regexp_replace(pf.value, "\\(.*", "")',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
             'slicewise rejected'
         ],
         // List of directions obtained for InterlaceRejected is not sorted as in
@@ -129,7 +133,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         'InterlaceRejected'     => [
             'StringType',
             'processing:interlace_rejected',
-            'regexp_replace(pf.value, "\\(.*", "")',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
             'interlace rejected'
         ],
         // List of directions obtained for IntergradientRejected is not sorted as in
@@ -137,7 +145,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         'IntergradientRejected' => [
             'StringType',
             'processing:intergradient_rejected',
-            'regexp_replace(pf.value, "\\(.*", "")',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
             'intergradient rejected'
         ],
         // List of directions obtained for TotalRejected is not sorted as in

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -260,7 +260,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             // All MRI comment types
             $allCommentTypes
                 = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
-            foreach ($allCommentTypes as $commentTypeID => $commentProperties) {
+            foreach (array_values($allCommentTypes) as $commentProperties) {
                 if ($commentProperties['name'] != 'Overall') {
                     $items[] = new MRIFeedbackDictionaryItem(
                         "{$ScanType}_feedback_{$commentProperties['field']}",
@@ -359,7 +359,6 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         }
 
         $modality = $item->getModality();
-        $exploded = explode("_", $item->getName());
 
         // $field = whatever's after the first underscore
         $field = substr($item->getName(), strpos($item->getName(), '_') + 1);

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -296,12 +296,6 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
     protected function getFieldNameFromDict(
         \LORIS\Data\Dictionary\DictionaryItem $item
     ): string {
-        if (!($item instanceof ImagingDictionaryItem)) {
-            throw new \DomainException(
-                "Item is not an instance of ImagingDictionaryItem"
-            );
-        }
-
         if ($item->getName() == 'ScanDone') {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
                 return "CASE WHEN s.Scan_Done='Y' THEN true

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -157,7 +157,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         'TotalRejected'         => [
             'StringType',
             'processing:total_rejected',
-            'regexp_replace(pf.value, "\\(.*", "")',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
             'total rejected'
         ],
         'ProcessingPipeline'    => [

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -258,25 +258,29 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             );
 
             // All MRI comment types
-            $allCommentTypes = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
-            foreach($allCommentTypes as $commentTypeID => $commentProperties) {
+            $allCommentTypes
+                = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
+            foreach ($allCommentTypes as $commentTypeID => $commentProperties) {
                 if ($commentProperties['name'] != 'Overall') {
                     $items[] = new MRIFeedbackDictionaryItem(
-                        implode('_', [$ScanType, 'feedback', $commentProperties['field']]),
-                        "Value for {$commentProperties['name']} in the MRI feedback form for $ScanType acquisitions",
+                        "{$ScanType}_feedback_{$commentProperties['field']}",
+                        "Value for {$commentProperties['name']} in the MRI"
+                        . " feedback form for $ScanType acquisitions",
                         $scope,
-                        new \LORIS\Data\Types\Enumeration(...$commentProperties['values']),
+                        new \LORIS\Data\Types\Enumeration(
+                            ...$commentProperties['values']
+                        ),
                         new Cardinality(Cardinality::MANY),
                         $ScanType,
                         $commentProperties['field']
                     );
                 }
 
-                $itemDescription = "Comment in section '{$commentProperties['name']}'"
-                                 . " of the MRI feedback form for $ScanType"
-                                 . " acquisitions";
-                $items[] = new MRICommentDictionaryItem(
-                    implode('_', [$ScanType, 'comment', $commentProperties['field']]),
+                $itemDescription = "Comment in section"
+                                 . "'{$commentProperties['name']}' of the MRI"
+                                 . " feedback form for $ScanType acquisitions";
+                $items[]         = new MRICommentDictionaryItem(
+                    "{$ScanType}_comment_{$commentProperties['field']}",
                     $itemDescription,
                     $scope,
                     new \LORIS\Data\Types\StringType(),
@@ -358,7 +362,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         $exploded = explode("_", $item->getName());
 
         // $field = whatever's after the first underscore
-        $field    = substr($item->getName(), strpos($item->getName(), '_') + 1);
+        $field = substr($item->getName(), strpos($item->getName(), '_') + 1);
 
         $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
         $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -260,8 +260,11 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             // All MRI comment types
             $allCommentTypes
                 = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
-            foreach (array_values($allCommentTypes) as $commentProperties) {
+            foreach ($allCommentTypes as $commentTypeID => $commentProperties) {
                 if ($commentProperties['name'] != 'Overall') {
+                    //--------------------------------------------------//
+                    // Value of feedback for that specific comment type //
+                    //--------------------------------------------------//
                     $items[] = new MRIFeedbackDictionaryItem(
                         "{$ScanType}_feedback_{$commentProperties['field']}",
                         "Value for {$commentProperties['name']} in the MRI"
@@ -274,8 +277,30 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                         $ScanType,
                         $commentProperties['field']
                     );
+           
+                    //--------------------------------------------------------//
+                    // Values of all the predefined comments for this comment //
+                    // type.                                                  //
+                    //--------------------------------------------------------//
+                    $predefinedComments
+                        = \FeedbackMRI::getAllPredefinedComments($commentTypeID);
+                    foreach ($predefinedComments as $ID => $predefinedComment) {
+                        $items[] = new MRIPredefinedCommentDictionaryItem(
+                            "{$ScanType}_{$predefinedComment['Comment']}",
+                            "'{$predefinedComment['FullComment']}' in the MRI feedback form"
+                            . " is checked for $ScanType acquisitions",
+                            $scope,
+                            new \LORIS\Data\Types\Enumeration('Yes', 'No'),
+                            new Cardinality(Cardinality::MANY),
+                            $ScanType,
+                            $ID
+                        );
+                    }
                 }
 
+                //------------------------------------------------//
+                // Free form text comment for  this comment type  //
+                //------------------------------------------------//
                 $itemDescription = "Comment in section"
                                  . "'{$commentProperties['name']}' of the MRI"
                                  . " feedback form for $ScanType acquisitions";
@@ -290,6 +315,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 );
             }
         }
+
         $images = $images->withItems($items);
 
         return [$images];
@@ -463,6 +489,24 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             );
         }
 
+        if ($item instanceof MRIPredefinedCommentDictionaryItem) {
+            return sprintf(
+                "(SELECT 'Yes' FROM files AS files2
+                  JOIN feedback_mri_comments fmc
+                      ON (fmc.FileID=files2.FileID)
+                  JOIN feedback_mri_predefined_comments fmpc
+                      ON (fmc.PredefinedCommentID=fmpc.PredefinedCommentID)
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                      AND fmpc.PredefinedCommentID=%d
+                )",
+                $modality,
+                $item->getPredefinedCommentID()
+            );
+        }
+
         throw new \DomainException("Invalid field " . $item->getName());
     }
 
@@ -494,6 +538,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             || $item instanceof ParameterDictionaryItem
             || $item instanceof MRIFeedbackDictionaryItem
             || $item instanceof MRICommentDictionaryItem
+            || $item instanceof MRIPredefinedCommentDictionaryItem
         ) {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
             $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -256,6 +256,35 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new Cardinality(Cardinality::MANY),
                 $ScanType,
             );
+
+            // All MRI comment types
+            $allCommentTypes = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
+            foreach($allCommentTypes as $commentTypeID => $commentProperties) {
+                if ($commentProperties['name'] != 'Overall') {
+                    $items[] = new MRIFeedbackDictionaryItem(
+                        implode('_', [$ScanType, 'feedback', $commentProperties['field']]),
+                        "Value for {$commentProperties['name']} in the MRI feedback form for $ScanType acquisitions",
+                        $scope,
+                        new \LORIS\Data\Types\Enumeration(...$commentProperties['values']),
+                        new Cardinality(Cardinality::MANY),
+                        $ScanType,
+                        $commentProperties['field']
+                    );
+                }
+
+                $itemDescription = "Comment in section '{$commentProperties['name']}'"
+                                 . " of the MRI feedback form for $ScanType"
+                                 . " acquisitions";
+                $items[] = new MRICommentDictionaryItem(
+                    implode('_', [$ScanType, 'comment', $commentProperties['field']]),
+                    $itemDescription,
+                    $scope,
+                    new \LORIS\Data\Types\StringType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                    $commentProperties['name']
+                );
+            }
         }
         $images = $images->withItems($items);
 
@@ -327,7 +356,10 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $modality = $item->getModality();
         $exploded = explode("_", $item->getName());
-        $field    = $exploded[count($exploded)-1];
+
+        // $field = whatever's after the first underscore
+        $field    = substr($item->getName(), strpos($item->getName(), '_') + 1);
+
         $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
         $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
 
@@ -336,7 +368,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 return "(SELECT CONCAT(
                             \"$this->baseURL\",
                             \"/api/v0.0.3/candidates/\",
-                            c.ID,
+                            c.CandID,
                             \"/\",
                             s.Visit_label,
                             \"/images/\",
@@ -393,6 +425,41 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             );
         }
 
+        if ($item instanceof MRIFeedbackDictionaryItem) {
+            return sprintf(
+                "(SELECT pf.Value FROM files AS files2
+                  JOIN parameter_file pf
+                      ON (pf.FileID=files2.FileID)
+                  JOIN parameter_type pt
+                      ON (pt.ParameterTypeID=pf.ParameterTypeID AND pt.Name='%s')
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                )",
+                $modality
+            );
+        }
+
+        if ($item instanceof MRICommentDictionaryItem) {
+            return sprintf(
+                "(SELECT fmc.Comment FROM files AS files2
+                  JOIN feedback_mri_comments fmc
+                      ON (fmc.FileID=files2.FileID)
+                  JOIN feedback_mri_comment_types fmct
+                      ON (fmc.CommentTypeID=fmct.CommentTypeID)
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND fmct.CommentName='%s'
+                      AND mst.MriScanTypeName='%s'
+                      AND fmc.Comment IS NOT NULL
+                )",
+                $item->getCommentName(),
+                $modality
+            );
+        }
+
         throw new \DomainException("Invalid field " . $item->getName());
     }
 
@@ -422,6 +489,8 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         if ($item instanceof LocationDictionaryItem
             || $item instanceof QCDictionaryItem
             || $item instanceof ParameterDictionaryItem
+            || $item instanceof MRIFeedbackDictionaryItem
+            || $item instanceof MRICommentDictionaryItem
         ) {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
             $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -236,7 +236,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 $ScanType . "_Selected",
                 "Selected file for $ScanType for session",
                 $scope,
-                new \LORIS\Data\Types\BooleanType(),
+                new \LORIS\Data\Types\Enumeration("true", "false"),
                 new Cardinality(Cardinality::MANY),
                 $ScanType,
             );
@@ -349,13 +349,13 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         }
 
         if ($item instanceof QCDictionaryItem) {
-            return "(SELECT $field FROM files_qcstatus
-                        JOIN files as files2
-                        JOIN mri_scan_type mst
-                            ON (files2.MriScanTypeID=mst.MriScanTypeID)
-                        WHERE files_qcstatus.FileID=files.FileID
-                            AND files2.FileID=files.FileID
-                            AND mst.MriScanTypeName='{$modality}')";
+            return "(SELECT $field FROM files_qcstatus fqs
+                     JOIN files as files2
+                         ON (fqs.FileID=files2.FileID)
+                     JOIN mri_scan_type mst
+                         ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                     WHERE files2.FileID=files.FileID
+                         AND mst.MriScanTypeName='{$modality}')";
         }
 
         if ($item instanceof ParameterDictionaryItem) {

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -377,26 +377,6 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             );
         }
 
-        if ($item instanceof CommentDictionaryItem) {
-            $pcdi = self::PREDEFINED_COMMENT_DICTIONARY_ITEMS[$field];
-            return sprintf(
-                "(SELECT %s FROM files as files2
-                  JOIN mri_scan_type mst
-                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
-                  JOIN feedback_mri_comments fmc
-                      ON (fmc.FileID=files2.FileID)
-                  LEFT JOIN feedback_mri_predefined_comments fmpc
-                      ON (fmpc.PredefinedCommentID=fmc.PredefinedCommentID)
-                  WHERE files2.FileID=files.FileID
-                      AND mst.MriScanTypeName='%s'
-                      AND fmpc.Comment='%s'
-                )",
-                $pcdi[self::PDI_SELECT_IDX],
-                $pcdi[self::PDI_COMMENT_TEXT_IDX],
-                $modality,
-            );
-        }
-
         throw new \DomainException("Invalid field " . $item->getName());
     }
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -1032,9 +1032,12 @@ class ViewSession extends \NDB_Form
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
         return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb('Imaging Browser', '/imaging_browser'),
             new \LORIS\Breadcrumb(
-                'View Session',
+                dgettext("imaging_browser", 'Imaging Browser'),
+                '/imaging_browser'
+            ),
+            new \LORIS\Breadcrumb(
+                dgettext("imaging_browser", 'View Session'),
                 "/imaging_browser/viewSession/?sessionID=$this->sessionID"
             )
         );

--- a/modules/imaging_qc/locale/imaging_qc.pot
+++ b/modules/imaging_qc/locale/imaging_qc.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Quality Control"
+msgstr ""

--- a/modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.po
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Quality Control"
+msgstr "画像品質管理"

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -382,21 +382,6 @@ class Imaging_QC extends \NDB_Menu_Filter
     }
 
     /**
-     * Generate a breadcrumb trail for this page.
-     *
-     * @return \LORIS\BreadcrumbTrail
-     */
-    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
-    {
-        return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb(
-                'Imaging Quality Control',
-                '/imaging_qc'
-            )
-        );
-    }
-
-    /**
      * This method overrides the NBD_Page handle function.
      * It checks if the MRI Parameter Form table exists
      * before calling the parent handle function.

--- a/modules/imaging_qc/php/module.class.inc
+++ b/modules/imaging_qc/php/module.class.inc
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Imaging";
+        return dgettext("loris", "Imaging");
     }
 
     /**
@@ -57,6 +57,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Imaging Quality Control";
+        return dgettext("imaging_qc", "Imaging Quality Control");
     }
 }

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Uploader"
+msgstr ""
+

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Imaging Uploader"
+msgstr "画像アップローダー"
+

--- a/modules/imaging_uploader/php/module.class.inc
+++ b/modules/imaging_uploader/php/module.class.inc
@@ -51,7 +51,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Imaging";
+        return dgettext("loris", "Imaging");
     }
 
     /**
@@ -61,7 +61,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Imaging Uploader";
+        return dgettext("imaging_uploader", "Imaging Uploader");
     }
 
     /**

--- a/modules/instrument_builder/locale/instrument_builder.pot
+++ b/modules/instrument_builder/locale/instrument_builder.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument Builder"
+msgstr ""
+

--- a/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument Builder"
+msgstr "楽器ビルダー"
+

--- a/modules/instrument_builder/php/module.class.inc
+++ b/modules/instrument_builder/php/module.class.inc
@@ -45,7 +45,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -55,6 +55,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Instrument Builder";
+        return dgettext("instrument_builder", "Instrument Builder");
     }
 }

--- a/modules/instrument_list/locale/instrument_list.po
+++ b/modules/instrument_list/locale/instrument_list.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument List"
+msgstr ""
+

--- a/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument List"
+msgstr "楽器リスト"
+

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -370,15 +370,16 @@ class Instrument_List extends \NDB_Menu_Filter
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Access Profile',
+                dgettext("candidate_list", 'Access Profile'),
                 '/candidate_list'
             ),
             new \LORIS\Breadcrumb(
-                "Candidate Profile $candid / $pscid",
+                dgettext("candidate_profile", "Candidate Profile")
+                . " $candid / $pscid",
                 "/$candid"
             ),
             new \LORIS\Breadcrumb(
-                "TimePoint $visitlabel Details",
+                dgettext("loris", "TimePoint") . " $visitlabel",
                 "/instrument_list/?candID=$candid&sessionID=$sessionid"
             )
         );

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -130,6 +130,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Instrument List";
+        return dgettext("instrument_list", "Instrument List");
     }
 }

--- a/modules/instrument_manager/locale/instrument_manager.pot
+++ b/modules/instrument_manager/locale/instrument_manager.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument Manager"
+msgstr ""
+

--- a/modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.po
+++ b/modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument Manager"
+msgstr "機器マネージャー"
+

--- a/modules/instrument_manager/php/module.class.inc
+++ b/modules/instrument_manager/php/module.class.inc
@@ -50,7 +50,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -60,6 +60,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Instrument Manager";
+        return dgettext("instrument_manager", "Instrument Manager");
     }
 }

--- a/modules/instruments/locale/instruments.pot
+++ b/modules/instruments/locale/instruments.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instruments"
+msgstr ""
+

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instruments"
+msgstr "機器"
+

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -104,7 +104,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Instruments";
+        return dgettext("instruments", "Instruments");
     }
 
     /**

--- a/modules/issue_tracker/locale/issue_tracker.pot
+++ b/modules/issue_tracker/locale/issue_tracker.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Issue Tracker"
+msgstr ""
+

--- a/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Issue Tracker"
+msgstr "問題トラッカー"
+

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -51,7 +51,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -61,7 +61,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Issue Tracker";
+        return dgettext("issue_tracker", "Issue Tracker");
     }
 
     /**

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Login"
+msgstr "ログイン"
+

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Login"
+msgstr ""
+

--- a/modules/login/php/module.class.inc
+++ b/modules/login/php/module.class.inc
@@ -31,6 +31,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return 'Login';
+        return dgettext('login', 'Login');
     }
 }

--- a/modules/media/locale/ja/LC_MESSAGES/media.po
+++ b/modules/media/locale/ja/LC_MESSAGES/media.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Media"
+msgstr "メディア"
+

--- a/modules/media/locale/media.pot
+++ b/modules/media/locale/media.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Media"
+msgstr ""
+

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -30,7 +30,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Clinical";
+        return dgettext("loris", "Clinical");
     }
 
     /**
@@ -40,7 +40,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Media";
+        return dgettext("media", "Media");
     }
 
     /**

--- a/modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
+++ b/modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Module Manager"
+msgstr "モジュールマネージャー"
+

--- a/modules/module_manager/locale/module_manager.pot
+++ b/modules/module_manager/locale/module_manager.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Module Manager"
+msgstr ""
+

--- a/modules/module_manager/php/module.class.inc
+++ b/modules/module_manager/php/module.class.inc
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -57,6 +57,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Module Manager";
+        return dgettext("module_manager", "Module Manager");
     }
 }

--- a/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "MRI Violated Scans"
+msgstr "MRI違反スキャン"
+

--- a/modules/mri_violations/locale/mri_violations.pot
+++ b/modules/mri_violations/locale/mri_violations.pot
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "MRI Violated Scans"
+msgstr ""
+

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -50,7 +50,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Imaging";
+        return dgettext("loris", "Imaging");
     }
 
     /**
@@ -60,7 +60,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "MRI Violated Scans";
+        return dgettext("mri_violations", "MRI Violated Scans");
     }
 
     /**

--- a/modules/my_preferences/php/module.class.inc
+++ b/modules/my_preferences/php/module.class.inc
@@ -15,6 +15,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "My Preferences";
+        return _("My Preferences");
     }
 }

--- a/modules/new_profile/locale/ja/LC_MESSAGES/new_profile.po
+++ b/modules/new_profile/locale/ja/LC_MESSAGES/new_profile.po
@@ -1,0 +1,24 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/new_profile/php/module.class.inc:60
+msgid "New Profile"
+msgstr "新しいプロフィール"
+

--- a/modules/new_profile/locale/new_profile.pot
+++ b/modules/new_profile/locale/new_profile.pot
@@ -1,0 +1,24 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/new_profile/php/module.class.inc:60
+msgid "New Profile"
+msgstr ""
+

--- a/modules/new_profile/php/module.class.inc
+++ b/modules/new_profile/php/module.class.inc
@@ -47,7 +47,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Candidate";
+        return dgettext("loris", "Candidate");
     }
 
     /**
@@ -57,6 +57,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "New Profile";
+        return dgettext("new_profile", "New Profile");
     }
 }

--- a/modules/next_stage/locale/ja/LC_MESSAGES/next_stage.po
+++ b/modules/next_stage/locale/ja/LC_MESSAGES/next_stage.po
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/new_profile/php/module.class.inc:60
+msgid "Next Stage"
+msgstr "次のステージ"
+
+msgid "Start Next Stage"
+msgstr "次のステージを開始"

--- a/modules/next_stage/locale/next_stage.pot
+++ b/modules/next_stage/locale/next_stage.pot
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/new_profile/php/module.class.inc:60
+msgid "Next Stage"
+msgstr ""
+
+msgid "Start Next Stage"
+msgstr ""

--- a/modules/next_stage/php/module.class.inc
+++ b/modules/next_stage/php/module.class.inc
@@ -34,6 +34,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Next Stage";
+        return dgettext("next_stage", "Next Stage");
     }
 }

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -266,19 +266,20 @@ class Next_Stage extends \NDB_Form
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Access Profile',
+                dgettext("candidate_list", 'Access Profile'),
                 '/candidate_list'
             ),
             new \LORIS\Breadcrumb(
-                'Candidate Profile ' . $candid . ' / ' . $pscid,
+                dgettext("candidate_profile", 'Candidate Profile')
+                . " " .$candid . ' / ' . $pscid,
                 "/$candid"
             ),
             new \LORIS\Breadcrumb(
-                "TimePoint $visitlabel Details",
+                dgettext("loris", "TimePoint") . " $visitlabel",
                 "/instrument_list/?candID=$candid&sessionID=$sessionid"
             ),
             new \LORIS\Breadcrumb(
-                'Start Next Stage',
+                dgettext('next_stage', 'Start Next Stage'),
                 "/next_stage/?candID=$candid&sessionID=$sessionid" .
                 "&identifier=$sessionid"
             )

--- a/modules/oidc/locale/ja/LC_MESSAGES/oidc.po
+++ b/modules/oidc/locale/ja/LC_MESSAGES/oidc.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Seems to use the English name at https://www.openid.or.jp/document/ 
+msgid "OpenID Connect"
+msgstr "OpenID Connect"

--- a/modules/oidc/locale/oidc.pot
+++ b/modules/oidc/locale/oidc.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "OpenID Connect"
+msgstr ""

--- a/modules/oidc/php/module.class.inc
+++ b/modules/oidc/php/module.class.inc
@@ -26,6 +26,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return 'OpenID Connect';
+        return dgettext("oidc", 'OpenID Connect');
     }
 }

--- a/modules/publication/locale/ja/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/ja/LC_MESSAGES/publication.po
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Publications"
+msgstr "出版物"

--- a/modules/publication/locale/publication.pot
+++ b/modules/publication/locale/publication.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Publications"
+msgstr ""

--- a/modules/publication/php/module.class.inc
+++ b/modules/publication/php/module.class.inc
@@ -52,7 +52,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Reports";
+        return dgettext("loris", "Reports");
     }
 
     /**
@@ -62,6 +62,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Publications";
+        return dgettext("publication", "Publications");
     }
 }

--- a/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Schedule Appointment"
+msgstr "予約する"

--- a/modules/schedule_module/locale/schedule_module.pot
+++ b/modules/schedule_module/locale/schedule_module.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Schedule Appointment"
+msgstr ""

--- a/modules/schedule_module/php/module.class.inc
+++ b/modules/schedule_module/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Tools";
+        return dgettext("loris", "Tools");
     }
 
     /**
@@ -56,6 +56,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Schedule Appointment";
+        return dgettext("schedule_module", "Schedule Appointment");
     }
 }

--- a/modules/server_processes_manager/locale/ja/LC_MESSAGES/server_processes_manager.po
+++ b/modules/server_processes_manager/locale/ja/LC_MESSAGES/server_processes_manager.po
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Server Processes Manager"
+msgstr "サーバープロセスマネージャー"

--- a/modules/server_processes_manager/locale/server_processes_manager.pot
+++ b/modules/server_processes_manager/locale/server_processes_manager.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Server Processes Manager"
+msgstr ""

--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -101,7 +101,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -111,6 +111,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Server Processes Manager";
+        return dgettext("server_processes_manager", "Server Processes Manager");
     }
 }

--- a/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Statistics"
+msgstr "統計"

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Statistics"
+msgstr ""

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -46,7 +46,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Reports";
+        return dgettext("loris", "Reports");
     }
 
     /**
@@ -56,7 +56,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Statistics";
+        return dgettext("statistics", "Statistics");
     }
 
     /**

--- a/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# I am not sure if this is the right kanji for "survey" 
+msgid "Survey Accounts"
+msgstr "視察アカウント"

--- a/modules/survey_accounts/locale/survey_accounts.pot
+++ b/modules/survey_accounts/locale/survey_accounts.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Survey Accounts"
+msgstr ""

--- a/modules/survey_accounts/php/module.class.inc
+++ b/modules/survey_accounts/php/module.class.inc
@@ -45,7 +45,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -55,6 +55,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Survey Accounts";
+        return dgettext("survey_accounts", "Survey Accounts");
     }
 }

--- a/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# I am not sure if this is the right kanji for "survey" 
+msgid "Timepoint List"
+msgstr "タイムポイントリスト"

--- a/modules/timepoint_list/locale/timepoint_list.pot
+++ b/modules/timepoint_list/locale/timepoint_list.pot
@@ -1,0 +1,22 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Timepoint List"
+msgstr ""

--- a/modules/timepoint_list/php/module.class.inc
+++ b/modules/timepoint_list/php/module.class.inc
@@ -61,7 +61,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Timepoint List";
+        return dgettext("timepoint_list", "Timepoint List");
     }
 
     /**

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -292,11 +292,12 @@ class Timepoint_List extends \NDB_Menu
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                'Access Profile',
+                dgettext("candidate_list", 'Access Profile'),
                 '/candidate_list'
             ),
             new \LORIS\Breadcrumb(
-                "Candidate Profile $candid / $pscid",
+                dgettext("candidate_profile", "Candidate Profile")
+                . " $candid / $pscid",
                 "/$candid"
             )
         );

--- a/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
+++ b/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "User Accounts"
+msgstr "ユーザーアカウント"
+
+msgid "Edit User"
+msgstr "ユーザーを編集"
+

--- a/modules/user_accounts/locale/user_accounts.pot
+++ b/modules/user_accounts/locale/user_accounts.pot
@@ -1,0 +1,26 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "User Accounts"
+msgstr ""
+
+msgid "Edit User"
+msgstr ""
+

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -50,7 +50,7 @@ class Module extends \Module
      */
     public function getMenuCategory() : string
     {
-        return "Admin";
+        return dgettext("loris", "Admin");
     }
 
     /**
@@ -60,7 +60,7 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "User Accounts";
+        return dgettext("user_accounts", "User Accounts");
     }
 
     /**

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -177,7 +177,7 @@ class FeedbackMRI
      * @return array A two-dimensional array with key (int) PredefinedCommentID
      *               and one-element array ('Comment'=> string CommentName)
      */
-    function getAllPredefinedComments(int $commentTypeID): array
+    public static function getAllPredefinedComments(int $commentTypeID): array
     {
         // create DB object
         $DB = \NDB_Factory::singleton()->database();
@@ -323,6 +323,23 @@ class FeedbackMRI
      */
     function getAllCommentTypes(): array
     {
+        return self::getAllCommentTypesForObjectType($this->objectType);
+    }
+
+    /**
+     * Gets the list of all comment types
+     *
+     * @return array A two-dimensional array of ints (CommentTypeID) and
+     *               three-element arrays ('name'=>string CommentName,
+     *               'field'=>string name of column in mri table for status,
+     *               'values'=>array of possible enum values for field)
+     */
+    public static function getAllCommentTypesForObjectType(string $objectType): array
+    {
+        if ($objectType != 'volume' && $objectType != 'visit') {
+            throw new \LorisException("Invalid object type $objectType");
+        }
+
         // create DB object
         $DB = \NDB_Factory::singleton()->database();
 
@@ -331,7 +348,7 @@ class FeedbackMRI
                     FROM feedback_mri_comment_types
                   WHERE CommentType=:CT";
 
-        $result = $DB->pselect($query, ['CT' => $this->objectType]);
+        $result = $DB->pselect($query, ['CT' => $objectType]);
 
         // build the output array and keep overall section at the end of the array
         $commentNames = [];

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -332,7 +332,6 @@ class FeedbackMRI
      * @param string $objectType Type of object (i.e value of column ComentType
      *                           in table feedback_mri_comment_types).
      *
-     *
      * @return array A two-dimensional array of ints (CommentTypeID) and
      *               three-element arrays ('name'=>string CommentName,
      *               'field'=>string name of column in mri table for status,

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -194,8 +194,9 @@ class FeedbackMRI
         foreach ($result as $row) {
             $PredefinedID       = $row['PredefinedCommentID'];
             $preDefinedComments = [];
-            $preDefinedComments['Comment'] = stripslashes($row['Comment']);
-            $comments[$PredefinedID]       = $preDefinedComments;
+            $preDefinedComments['Comment']     = stripslashes($row['Comment']);
+            $preDefinedComments['FullComment'] = $row['Comment'];
+            $comments[$PredefinedID]           = $preDefinedComments;
         }
 
         // return the output array

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -327,7 +327,11 @@ class FeedbackMRI
     }
 
     /**
-     * Gets the list of all comment types
+     * Gets the list of all comment types for a given object type.
+     *
+     * @param string $objectType Type of object (i.e value of column ComentType
+     *                           in table feedback_mri_comment_types).
+     *
      *
      * @return array A two-dimensional array of ints (CommentTypeID) and
      *               three-element arrays ('name'=>string CommentName,

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -78,7 +78,14 @@ class User extends UserPermissions implements
         }
 
         //Change 'language_preference' to number rather than a string
-        $row['language_preference'] = (int)$row['language_preference'];
+        if ($row['language_preference'] !== null) {
+            $row['language_preference'] = (int)$row['language_preference'];
+            $language_code        = $DB->pselectOne(
+                "SELECT language_code FROM language WHERE language_id=:langid",
+                ['langid' => $row['language_preference']]
+            );
+            $row['language_code'] = $language_code;
+        }
 
         // get user sites
         $user_centerID_query =  $DB->pselect(
@@ -376,6 +383,17 @@ class User extends UserPermissions implements
     function getLanguagePreference(): ?int
     {
         return $this->userInfo['language_preference'] ?? null;
+    }
+
+    /**
+     * Return the ISO 639 language code for the language
+     * this user prefers to use.
+     *
+     * @return string
+     */
+    function getLanguageCode() : string
+    {
+        return $this->userInfo['language_code'] ?? 'en_CA';
     }
 
     /**

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
     enabled ++ [ all.ast ]);
 in
 pkgs.mkShell {
-  buildInputs = with pkgs; [ php git nodejs php84Packages.composer ];
+  buildInputs = with pkgs; [ php git nodejs php84Packages.composer gettext ];
   shellHook =
     ''
        php -v;

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -120,7 +120,7 @@
                        <!-- toggle feedback in mobile view -->
 
 
-                        <a class="navbar-brand" href="{$baseurl}/">LORIS{if $sandbox}: DEV{/if}</a>
+                        <a class="navbar-brand" href="{$baseurl}/">{dgettext("loris", "LORIS")}{if $sandbox}: {dgettext("loris", "DEV")}{/if}</a>
                    </div>
                    <div class="collapse navbar-collapse" id="example-navbar-collapse">
                         <ul class="nav navbar-nav">
@@ -149,11 +149,11 @@
                             <!-- Affiliations Dropdown Menu -->
                             <li class="nav dropdown nav-affiliations">
                                 <a href="#" class="css-tooltip dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                    Affiliations
+                                    {dgettext("loris", "Affiliations")}
                                     <span class="caret"></span>
                                 </a>
                                 <ul class="dropdown-menu affiliations-dropdown">
-                                    <li class="dropdown-header">Site Affiliations: {$userNumSites}</li>
+                                    <li class="dropdown-header">{dngettext("loris", "Site Affiliation", "Site Affiliations", $userNumSites)}: {$userNumSites}</li>
                                     <li>
                                         <a href="#">
                                             <span class="tooltip-text">{$user.SitesTooltip}</span>
@@ -162,7 +162,7 @@
 
                                     <li role="separator" class="divider"></li>
 
-                                    <li class="dropdown-header">Project Affiliations: {$userNumProjects}</li>
+                                    <li class="dropdown-header">{dngettext("loris", "Project Affiliation", "Project Affiliations", $userNumProjects)}: {$userNumProjects}</li>
                                     <li>
                                         <a href="#">
                                             <span class="tooltip-text">{$user.ProjectsTooltip}</span>
@@ -180,13 +180,13 @@
                                     {if $my_preferences|default}
                                     <li>
                                         <a href="{$baseurl}/my_preferences/">
-                                            My Preferences
+                                            {dgettext("loris", "My Preferences")}
                                         </a>
                                     </li>
                                     {/if}
                                     <li>
                                         <a href="{$baseurl}/?logout=true">
-                                            Log Out
+                                            {dgettext("loris", "Log Out")}
                                         </a>
                                     </li>
                                 </ul>

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -171,6 +171,13 @@ class LorisInstance
                 $cls       = new $className($this, $name, $mpath);
                 $this->moduleInstances[$name] = $cls;
                 $cls->registerAutoloader();
+
+        // NB: This gets overridden by the BaseRouter if a project/locale/
+        //     override exists for the user's language
+                if (is_dir("$mpath/locale/")) {
+                    \bind_textdomain_codeset($name, 'UTF-8');
+                    \bindtextdomain($name, "$mpath/locale");
+                }
                 return $cls;
             }
         }

--- a/src/Middleware/Language.php
+++ b/src/Middleware/Language.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\Middleware;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\MiddlewareInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * The language middleware tries to get the most appropriate locale for
+ * a user.
+ *
+ * By priority:
+ *  1. First it will check if a "lang" get attribute is passed so
+ *         that it can be overridden on a page dropdown
+ *      2. Next, it will check the user's preference and use their preferred
+ *         language if they haven't chosen another for this page load
+ *      3. Finally, a best attempt based on the request Accept-Language header
+ *         is made
+ *
+ * Otherwise, the request will fall back on the default locale.
+ *
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Language implements MiddlewareInterface, MiddlewareChainer
+{
+    use MiddlewareChainerMixin;
+
+    public static function detectLocale(\LORIS\LorisInstance $loris, ServerRequestInterface $request) : ?string
+    {
+        $DB = $request->getAttribute("loris")->getDatabaseConnection();
+
+        $validLocales = $DB->pselectCol(
+            "SELECT language_code FROM language",
+            [],
+        );
+
+        $params = $request->getQueryParams();
+        if (isset($params['lang'])
+            && in_array($params['lang'], $validLocales)) {
+            return $params['lang'];
+        }
+
+        $user     = $request->getAttribute("user");
+        $userpref = $user->getLanguageCode();
+        if ($userpref !== ""
+            && in_array($userpref, $validLocales)) {
+            return $userpref;
+        }
+
+        // This doesn't necessarily work if the user has multiple languages
+        // accepted because the potential match is based on the system's
+    // locales, not the LORIS language table. It also may not be available
+    // depending on PHP versions
+        if (function_exists('\locale_accept_from_http')) {
+            $fromheader = \locale_accept_from_http($request->getHeaderLine('Accept-Language'));
+            if ($fromheader !== false
+            && in_array($fromheader, $validLocales)) {
+                return $fromheader;
+            }
+        }
+        return null;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface  $request The incoming PSR7 request.
+     * @param RequestHandlerInterface $handler The PSR15 handler to delegate
+     *                                         content generation to.
+     *
+     * @return ResponseInterface the PSR15 response
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+        $loris = $request->getAttribute("loris");
+        $lang  = self::detectLocale($loris, $request);
+        if ($lang !== null) {
+            \setlocale(LC_MESSAGES, $lang . '.utf8');
+            return $this->next->process(
+                $request->withAttribute("locale", $lang),
+                $handler
+            );
+        }
+        return $this->next->process($request, $handler);
+    }
+}

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -56,6 +56,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
     {
         $uri  = $request->getUri();
         $path = $uri->getPath();
+
         // Replace multiple slashes in the URL with a single slash
         $path = preg_replace("/\/+/", "/", $path);
         // Remove any trailing slash remaining, so that foo/ and foo are the same
@@ -114,6 +115,39 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $module = $this->loris->getModule($modulename);
             $module->registerAutoloader();
+
+            if (file_exists(__DIR__ . "/../../project/locale/")) {
+                $lang = \LORIS\Middleware\Language::detectLocale($this->loris, $request);
+                if ($lang !== null) {
+                    /* detectLanguage should have validated that it's a valid locale, but
+                     * ensure that there are no unsafe characters just in case since we
+                     * might be dealing with user input */
+                    if (preg_match("/([a-zA-Z])+(_)?(a-zA-Z)*/", $lang)) {
+                        $overrides = glob(__DIR__ . "/../../project/locale/$lang/LC_MESSAGES/*.mo");
+                        // Requires pecl intl extension
+                        if (function_exists('locale_get_primary_language')) {
+                            $overrides = array_merge(
+                                $overrides,
+                                glob(
+                                    __DIR__ . "/../../project/locale/"
+                                    . locale_get_primary_language($lang)
+                                    . "/LC_MESSAGES/*.mo"
+                                )
+                            );
+                        }
+
+                        // We need to override the textdomain binding for every module
+                        // that has a translation override for the menu to be able
+                        // to look up the right project-specific translation even though we're
+                        // in the module.
+                        // Otherwise, fall back on the module's textdomain set from getModule()
+                        foreach ($overrides as $file) {
+                            $textdomain = basename($file, ".mo");
+                            bindtextdomain($textdomain, __DIR__ . "/../../project/locale/");
+                        }
+                    }
+                }
+            }
             $requestloglevel = $logSettings->getRequestLogLevel();
             if ($requestloglevel != "none") {
                 $module->setLogger(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -171,6 +171,8 @@ abstract class LorisIntegrationTest extends TestCase
     protected function login($username, $password)
     {
         $this->safeGet($this->url);
+        // It is sometimes useful to uncomment this to debug GitHub Actions
+        // var_dump($this->webDriver->getPageSource());
         /*
         $this->webDriver->wait(120, 1000)->until(
             WebDriverExpectedCondition::presenceOfElementLocated(

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -295,9 +295,9 @@ class UserTest extends TestCase
         $this->_mockConfig = $mockconfig;
 
         $this->_userInfoComplete       = $this->_userInfo;
-        $this->_userInfoComplete['ID'] = '1';
-        $this->_userInfoComplete['Privilege']           = '1';
-        $this->_userInfoComplete['language_preference'] = '2';
+        $this->_userInfoComplete['ID'] = 1;
+        $this->_userInfoComplete['Privilege']           = 1;
+        $this->_userInfoComplete['language_preference'] = 2;
         $this->_userInfoComplete['Sites']      = 'psc_test;psc_test2';
         $this->_userInfoComplete['examiner']   = ['pending' => 'N',
             '1'       => ['Y',
@@ -313,6 +313,7 @@ class UserTest extends TestCase
         $passwordHash = (new \Password(
             $this->_userInfo['Password']
         ))->__toString();
+        $this->_userInfoComplete['language_code'] = null;
         $this->_userInfo['Password_hash']         = $passwordHash;
         $this->_userInfoComplete['Password_hash'] = $passwordHash;
 


### PR DESCRIPTION
First draft for the PR that adds the MRI variables in the imaging_browser's query engine. All vars are added, except those associated to the predefined comments. The information used to set the variable values sometimes differs from those used in `CouchDB_MRI_Importer` but I put comments in the code for those cases.


Fixes #9374 (partially)