### PR TITLE
[issue_tracker] Fixes but in permission when own user editing.

### DIFF
--- a/SQL/0000-00-02-Permission.sql
+++ b/SQL/0000-00-02-Permission.sql
@@ -105,7 +105,7 @@ INSERT INTO `permissions` VALUES
     (33,'genomic_data_manager','Genomic Files',(SELECT ID FROM modules WHERE Name='genomic_browser'),'Upload','2'),
     (34,'media_write','Candidate Media Files',(SELECT ID FROM modules WHERE Name='media'),'Edit/Upload/Hide','2'),
     (35,'media_read','Candidate Media Files',(SELECT ID FROM modules WHERE Name='media'),'View/Download','2'),
-    (36,'issue_tracker_reporter', 'Create/Edit Own Issues and Comment on All Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
+    (36,'issue_tracker_reporter', 'Create/Edit/Close Own Issues and Comment on All Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
     (37,'issue_tracker_developer', 'Close/Edit/Re-assign/Comment on All Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
     (38,'imaging_browser_phantom_allsites', 'Phantom Scans - All Sites',(SELECT ID FROM modules WHERE Name='imaging_browser'),'View', 2),
     (39,'imaging_browser_phantom_ownsite', 'Phantom Scans - Own Sites',(SELECT ID FROM modules WHERE Name='imaging_browser'),'View', 2),

--- a/SQL/New_patches/2025_02_03_permissions_Modifies_issue_tracker_reporter_description.sql
+++ b/SQL/New_patches/2025_02_03_permissions_Modifies_issue_tracker_reporter_description.sql
@@ -1,0 +1,3 @@
+UPDATE permissions
+    SET description = 'Create/Edit/Close Own Issues and Comment on All Issues'
+    WHERE code = 'issue_tracker_reporter';

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -263,7 +263,8 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
         $issueData['comment'] = null;
 
-        $isOwnIssue = $issueData['reporter'] == $user->getUsername();
+        $isOwnIssue = $issueData['reporter']
+            == $this->formatUserInformation($user->getUsername());
 
         $result = [
             'assignees'         => $assignees,

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -36,7 +36,7 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (42,'genomic_data_manager','Genomic Files',18,'Upload',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (43,'media_write','Candidate Media Files',29,'Edit/Upload/Delete',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (44,'media_read','Candidate Media Files',29,'View/Download',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (45,'issue_tracker_reporter','Create/Edit Own Issues and Comment on All Issues',27,NULL,2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (45,'issue_tracker_reporter','Create/Edit/Close Own Issues and Comment on All Issues',27,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (46,'issue_tracker_developer','Close/Edit/Re-assign/Comment on All Issues',27,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (47,'imaging_browser_phantom_allsites','Phantom Scans - All Sites',20,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (48,'imaging_browser_phantom_ownsite','Phantom Scans - Own Sites',20,'View',2);


### PR DESCRIPTION
## Brief summary of changes
- There were a bug - possible do to an upgrade - that was making the `issue tracker reporter username` been compared with the "formatted" username of the user logged. Now the comparison is properly done.
- The permission's description for `issue_tracker_reporter` was updated thus now it properly reflect that the user is indeed able to close the issues created by himself.
 
#### Testing instructions (if applicable)

1. Please log into LORIS with and admin account and notice that for the `issue_tracker_reporter ` the permission's description was changed from `Issue Tracker: Create/Edit Own Issues and Comment on All Issues`  to `Issue Tracker: Create/Edit/Close Own Issues and Comment on All Issues` 
![image](https://github.com/user-attachments/assets/1f8a584e-4d43-4a5a-96aa-2d728b62d1d9)
2. Please log into LORIS now with a user having only the `Issue Tracker: Create/Edit/Close Own Issues and Comment on All Issues` but not the `Issue Tracker: Close/Edit/Re-assign/Comment on All Issues` (and not super admin user neither).
3.  Go the issue tracker module ( MainMenu->Tools->Issue Tracker) and create a new issue.
4.  Then save the new issue and go to the previous page and try to edit the issue again.  You should be able to properly edit the issue now.
![image](https://github.com/user-attachments/assets/f1221a2d-054e-409c-ac7a-afa932a43c03)

#### Link(s) to related issue(s)

* Resolves #9540 