### PR TITLE
[dicom_archive] Dicom archive siteproject main

### DIFF
--- a/SQL/0000-00-02-Permission.sql
+++ b/SQL/0000-00-02-Permission.sql
@@ -144,7 +144,9 @@ INSERT INTO `permissions` (code, description, moduleID, action, categoryID) VALU
     ('issue_tracker_close_site_issue','Issues - Own Sites',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),'Close',2),
     ('issue_tracker_close_all_issue','Issues - All Sites',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),'Close',2),
     ('imaging_uploader_ownsites', 'Imaging Scans - Own Sites', (SELECT ID FROM modules WHERE Name='imaging_uploader'), 'View', '2'),
-    ('imaging_uploader_nosessionid', 'Imaging Scans with no session ID', (SELECT ID FROM modules WHERE Name='imaging_uploader'), 'View', '2')
+    ('imaging_uploader_nosessionid', 'Imaging Scans with no session ID', (SELECT ID FROM modules WHERE Name='imaging_uploader'), 'View', '2'),
+    ('dicom_archive_nosessionid', 'DICOMs with no session ID', (SELECT ID FROM modules WHERE Name='dicom_archive'), 'View', '2'),
+    ('dicom_archive_view_ownsites', 'DICOMs - Own Sites', (SELECT ID FROM modules WHERE Name='dicom_archive'), 'View', '2')
     ;
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -101,7 +101,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'tblScanTypes', 'Scan types from the mri_scan_type table that the project wants to see displayed in Imaging Browser table', 1, 1, 'scan_type', ID, 'Imaging Browser Tabulated Scan Types', 7 FROM ConfigSettings WHERE Name="imaging_modules";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingBrowserLinkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 8 FROM ConfigSettings WHERE Name="imaging_modules";
 
-
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('statistics', 'Statistics module settings', 1, 0, 'Statistics', 7);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'excludedMeasures', 'Instruments to be excluded from Statistics calculations', 1, 1, 'instrument', ID, 'Excluded instruments', 1 FROM ConfigSettings WHERE Name="statistics";
 

--- a/SQL/New_patches/2025-01-31-dicom_archive_permissions.sql
+++ b/SQL/New_patches/2025-01-31-dicom_archive_permissions.sql
@@ -1,0 +1,5 @@
+INSERT INTO permissions (code, description, moduleID, `action`, categoryID)
+SELECT 'dicom_archive_nosessionid', 'DICOMs with no session ID', ID, 'View', 2 FROM modules WHERE Name='dicom_archive';
+
+INSERT INTO permissions (code, description, moduleID, `action`, categoryID)
+SELECT 'dicom_archive_view_ownsites', 'DICOMs - Own Sites', ID, 'View', 2 FROM modules WHERE Name='dicom_archive';

--- a/modules/dicom_archive/README.md
+++ b/modules/dicom_archive/README.md
@@ -25,8 +25,35 @@ user's system.
 
 ## Permissions
 
-The permission `dicom_archive_view_allsites` is required to access
-the DICOM Archive module.
+*In the interest of backward compatibility, permission behaviour varies slightly 
+based on the `useAdvancedPermissions` configuration*
+
+Any of the following permissions grants access to the module.
+
+`dicom_archive_view_allsites`: 
+ - If `useAdvancedPermissions` is disabled, this permission gives access 
+ to all DICOMs in the database (backward compatible with projects not requiring a 
+ session ID to be defined).
+ - If `useAdvancedPermissions` is enabled, this permission gives access to 
+ all DICOMs as long as they are associated to a session and the session is affiliated
+ to a project that the user is affiliated with. When combined with 
+ `dicom_archive_nosessionid`, user gets access to their projects' data as well as 
+ DICOMs with no session ID associated.
+
+`dicom_archive_view_ownsites`: 
+ - If `useAdvancedPermissions` is disabled, this permission gives access 
+ to all DICOMs as long as they are associated to a session and the session is affiliated
+ to a site that the user is affiliated with. When combined with 
+ `dicom_archive_nosessionid`, user gets access to their sites' data as well as 
+ DICOMs with no session ID associated.
+ - If `useAdvancedPermissions` is enabled, this permission gives access to 
+ all DICOMs as long as they are associated to a session and the session is affiliated
+ to both a site and a project that the user is affiliated with. When combined with 
+ `dicom_archive_nosessionid`, user gets access to their sites' and projects' data as well as 
+ DICOMs with no session ID associated.
+
+Note that if you have access to the module, you will always see DICOMS uploaded by 
+your own user regardless of their site and project affiliation.
 
 ## Configurations
 
@@ -45,6 +72,14 @@ Patient ID column.
 The `showTransferStatus` configuration option is obsolete and should
 not be used, but determines if a first "Transfer Status" column
 appears in the menu table.
+
+The `useAdvancedPermissions` configuration enables more advanced Site and 
+Project access control (Although Site permissions are enabled without this 
+configuration, "all sites" gives access to DICOMS with no Session ID if this 
+configuration is turned off). If enabled, users accessing the module can only see 
+DICOMs where a session ID has been found and are thus linked to the site and project 
+of the session AND the site and project match the user's. Access to DICOMs with no 
+session is granted by the `dicom_archive_nosessionid` permission (see permissions section)
 
 #### Install Configurations
 

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -15,6 +15,14 @@
  */
 namespace LORIS\dicom_archive;
 
+use LORIS\Data\Filters\CompositeORFilter;
+use LORIS\Data\Filters\CompositeANDFilter;
+use LORIS\Data\Filters\UserSiteMatch;
+use LORIS\Data\Filters\UserHasAnyPermission;
+use LORIS\Data\Filters\UserProjectMatch;
+use LORIS\Data\Filters\ResourceHasNoSession;
+use LORIS\Data\Filters\UserIsCreator;
+
 /**
  * Provides the PHP code for the menu filter for the dicom archive
  *
@@ -27,6 +35,7 @@ namespace LORIS\dicom_archive;
  */
 class Dicom_Archive extends \DataFrameworkMenu
 {
+    protected $dataSessionCanBeNull = true;
 
     /**
      * Determine whether the user has permission to view this page
@@ -37,7 +46,12 @@ class Dicom_Archive extends \DataFrameworkMenu
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('dicom_archive_view_allsites');
+        return $user->hasAnyPermission(
+            [
+                'dicom_archive_view_allsites',
+                'dicom_archive_view_ownsites',
+            ]
+        );
     }
 
     /**
@@ -59,7 +73,24 @@ class Dicom_Archive extends \DataFrameworkMenu
      */
     public function useProjectFilter() : bool
     {
-        return false;
+        // Only enable project filtering if the site project permissions are enabled
+        // to be compatible with projects not requiring a session ID for all DICOMS
+        $config           = \NDB_Factory::singleton()->config();
+        $siteprojectperms = $config->getSetting(
+            'useAdvancedPermissions'
+        );
+        return $siteprojectperms === 'true';
+    }
+
+    /**
+     * Determines which permissions (if any) allows the user access to resources
+     * where the project is null.
+     *
+     * @return ?array
+     */
+    public function nullSessionPermissionNames() : ?array
+    {
+        return ['dicom_archive_nosessionid'];
     }
 
     /**
@@ -89,6 +120,75 @@ class Dicom_Archive extends \DataFrameworkMenu
 
         $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
 
+        return $provisioner;
+    }
+
+    /**
+     * Return a data provisioner of the same type as BaseDataProvisioner, with
+     * default LORIS filters applied. A subclass may override this to remove (or
+     * change) filters.
+     *
+     * @return \LORIS\Data\Provisioner a provisioner with default filters added
+     */
+    public function getDataProvisionerWithFilters() : \LORIS\Data\Provisioner
+    {
+        $provisioner      = $this->getBaseDataProvisioner();
+        $allSitePerms     = $this->allSitePermissionNames();
+        $nullSessionPerms = $this->nullSessionPermissionNames();
+
+        // Set filter default returns based on if the data loaded by this module can
+        // have or not a null session
+        $defaultReturn = $this->dataSessionCanBeNull ? false : null;
+
+        //Default filter to User Site Match
+        $filter = new UserSiteMatch($defaultReturn);
+
+        //Combine filter with Null session permissions if data can have null sessions
+        if ($this->dataSessionCanBeNull) {
+            $filter = new CompositeORFilter(
+                $filter,
+                new CompositeANDFilter(
+                    new UserHasAnyPermission($nullSessionPerms),
+                    new ResourceHasNoSession(),
+                ),
+            );
+        }
+
+        // If the user has any of the All Site permissions, combine as an OR filter
+        if (!empty($allSitePerms)) {
+            $filter = new CompositeORFilter(
+                $filter,
+                new UserHasAnyPermission($allSitePerms),
+            );
+        }
+
+        // Check if module uses Project filters
+        if ($this->useProjectFilter()) {
+            //Default project filter to User Project Match
+            $projectFilter = new UserProjectMatch($defaultReturn);
+
+            // Check if resources with null project should be included in the results
+            if (!empty($nullSessionPerms)) {
+                $projectFilter = new CompositeORFilter(
+                    new CompositeANDFilter(
+                        new ResourceHasNoSession(),
+                        new UserHasAnyPermission($nullSessionPerms)
+                    ),
+                    new UserProjectMatch($defaultReturn)
+                );
+            }
+
+            $filter = new CompositeANDFilter($filter, $projectFilter);
+        }
+
+        // Final filter, check if the user looking at the data is the user that
+        // uploaded the data
+        $filter = new CompositeORFilter(
+            $filter,
+            new UserIsCreator(),
+        );
+
+        $provisioner = $provisioner->filter($filter);
         return $provisioner;
     }
 

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -99,10 +99,20 @@ class DICOMArchiveAnonymizer implements Mapper
         }
 
         if (!$resource instanceof \LORIS\StudyEntities\SiteHaver) {
-            return new DICOMArchiveRowWithoutSession($newrow);
+            '@phan-var object $resource';
+            return new DICOMArchiveRowWithoutSession(
+                $newrow,
+                $resource->CreatedBy()
+            );
         } else {
-            $cid = $resource->getCenterID();
-            return new DICOMArchiveRowWithSession($newrow, $cid);
+            '@phan-var object $resource';
+            return new DICOMArchiveRowWithSession(
+                $newrow,
+                $resource->getCenterID(),
+                $resource->getProjectID(),
+                $resource->getSessionID(),
+                $resource->CreatedBy()
+            );
         }
     }
 }

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -56,7 +56,9 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
             t.TarchiveID AS TarchiveID,
             s.ID AS SessionID,
             s.CenterID AS CenterID,
-            m.IsPhantom AS IsPhantom
+            s.ProjectID AS ProjectID,
+            m.IsPhantom AS IsPhantom,
+            t.CreatingUser
             FROM tarchive t
                   LEFT JOIN session s ON (s.ID=t.SessionID)
                   LEFT JOIN candidate c ON (c.ID=s.CandidateID)
@@ -77,12 +79,23 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-        if ($row['CenterID'] !== null) {
+        $creator = \User::factory($row['CreatingUser']);
+
+        if ($row['CenterID'] !== null
+            && $row['ProjectID'] !== null
+            && $row['SessionID'] !== null
+        ) {
             $cid = \CenterID::singleton(intval($row['CenterID']));
+            $pid = \ProjectID::singleton(intval($row['ProjectID']));
+            $sid = new \SessionID(strval($row['SessionID']));
             unset($row['CenterID']);
-            return new DICOMArchiveRowWithSession($row, $cid);
+            unset($row['ProjectID']);
+            unset($row['CreatingUser']);
+            return new DICOMArchiveRowWithSession($row, $cid, $pid, $sid, $creator);
         }
         unset($row['CenterID']);
-        return new DICOMArchiveRowWithoutSession($row);
+        unset($row['ProjectID']);
+        unset($row['CreatingUser']);
+        return new DICOMArchiveRowWithoutSession($row, $creator);
     }
 }

--- a/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
@@ -29,6 +29,8 @@ namespace LORIS\dicom_archive;
 class DICOMArchiveRowWithoutSession implements \LORIS\Data\DataInstance
 {
     protected $DBRow;
+    protected $CreatedBy;
+
 
     /**
      * Create a new DICOMArchiveRow without a session.
@@ -36,12 +38,34 @@ class DICOMArchiveRowWithoutSession implements \LORIS\Data\DataInstance
      * Session-less DICOMArchiveRows do not have CenterIDs to be filtered
      * by.
      *
-     * @param array $row The row (in the same format as \Database::pselectRow
-     *                   returns)
+     * @param array $row     The row (in the same format as \Database::pselectRow
+     *                       returns)
+     * @param \User $creator The user who created this row
      */
-    public function __construct(array $row)
+    public function __construct(array $row, \User $creator)
     {
-        $this->DBRow = $row;
+        $this->DBRow     = $row;
+        $this->CreatedBy = $creator;
+    }
+
+    /**
+     * Returns Null always since this class is specifically for no session IDs.
+     *
+     * @return ?\SessionID The SessionID
+     */
+    public function getSessionID(): ?\SessionID
+    {
+        return null;
+    }
+
+    /**
+     * Return the User who created this row.
+     *
+     * @return \User The user who created this row
+     */
+    public function createdBy() : \User
+    {
+        return $this->CreatedBy;
     }
 
     /**
@@ -53,4 +77,6 @@ class DICOMArchiveRowWithoutSession implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+
 }

--- a/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
@@ -31,6 +31,9 @@ class DICOMArchiveRowWithSession implements \LORIS\Data\DataInstance,
 {
     protected $DBRow;
     protected $CenterID;
+    protected $ProjectID;
+    protected $SessionID;
+    protected $CreatedBy;
 
     /**
      * Create a new DICOMArchiveRowWithSession.
@@ -38,14 +41,25 @@ class DICOMArchiveRowWithSession implements \LORIS\Data\DataInstance,
      * This DataInstance type represents rows that have a session associated
      * with them (and hence are able to return a CenterID for the row.)
      *
-     * @param array     $row The row (in the same format as \Database::pselectRow
-     *                       returns)
-     * @param \CenterID $cid The centerID affiliated with this row.
+     * @param array      $row     The row (in the same format as
+     *                            \Database::pselectRow returns)
+     * @param \CenterID  $cid     The centerID affiliated with this row.
+     * @param \ProjectID $pid     The ProjectID affiliated with this row.
+     * @param \SessionID $sid     The SessionID affiliated with this row.
+     * @param \User      $creator The user who created this row
      */
-    public function __construct(array $row, \CenterID $cid)
-    {
-        $this->DBRow    = $row;
-        $this->CenterID = $cid;
+    public function __construct(
+        array $row,
+        \CenterID $cid,
+        \ProjectID $pid,
+        \SessionID $sid,
+        \User $creator,
+    ) {
+        $this->DBRow     = $row;
+        $this->CenterID  = $cid;
+        $this->ProjectID = $pid;
+        $this->SessionID = $sid;
+        $this->CreatedBy = $creator;
     }
 
     /**
@@ -67,5 +81,36 @@ class DICOMArchiveRowWithSession implements \LORIS\Data\DataInstance,
     public function getCenterID() : \CenterID
     {
         return $this->CenterID;
+    }
+
+    /**
+     * Returns the ProjectID for this row, for filters such as
+     * \LORIS\Data\Filters\UserProjectMatch to match again.
+     *
+     * @return \ProjectID The ProjectID
+     */
+    public function getProjectID(): \ProjectID
+    {
+        return $this->ProjectID;
+    }
+
+    /**
+     * Returns the SessionID for this row.
+     *
+     * @return \SessionID The SessionID
+     */
+    public function getSessionID(): \SessionID
+    {
+        return $this->SessionID;
+    }
+
+    /**
+     * Return the User who created this row.
+     *
+     * @return \User The user who created this row
+     */
+    public function createdBy() : \User
+    {
+        return $this->CreatedBy;
     }
 }

--- a/modules/dicom_archive/php/module.class.inc
+++ b/modules/dicom_archive/php/module.class.inc
@@ -39,7 +39,12 @@ class Module extends \Module
     public function hasAccess(\User $user) : bool
     {
         return parent::hasAccess($user) &&
-            $user->hasPermission('dicom_archive_view_allsites');
+            $user->hasAnyPermission(
+                [
+                    'dicom_archive_view_allsites',
+                    'dicom_archive_view_ownsites',
+                ]
+            );
     }
 
     /**

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -14,8 +14,6 @@
  */
 namespace LORIS\dicom_archive;
 
-use \Psr\Http\Message\ServerRequestInterface;
-
 /**
  * Implements the ViewDetails subpage of the dicom_archive module.
  *
@@ -54,63 +52,62 @@ class ViewDetails extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        // remove the possibility to have no tarchive ID in this page
-        if (is_null($this->tarchiveID)) {
-            // defaults to permission denied
-            return false;
-        }
-
-        // get project ID from Tarchive ID.
-        $projectID = $this->_getProjectFromTarchiveID();
-        if (is_null($projectID)) {
-            return false;
-        }
-
-        // check permissions
-        return $user->hasPermission('dicom_archive_view_allsites')
-            && $user->hasProject($projectID);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param \User                  $user    The user this request is for
-     * @param ServerRequestInterface $request The PSR7 request
-     *
-     * @return void
-     */
-    public function loadResources(
-        \User $user, ServerRequestInterface $request
-    ) : void {
-        $gets = $request->getQueryParams();
-        if (is_null($gets['tarchiveID'])) {
-            $this->tarchiveID = null;
-        } else {
-            $this->tarchiveID = intval($gets['tarchiveID']);
-        }
-    }
-
-    /**
-     * Get the ProjectID attached to a given tarchive ID.
-     *
-     * @return \ProjectID|null a ProjectID if found, else null
-     */
-    private function _getProjectFromTarchiveID(): ?\ProjectID
-    {
-        $db  = $this->loris->getDatabaseConnection();
-        $pid = $db->pselectOne(
-            "SELECT p.ProjectID
-            FROM tarchive t
-                JOIN session s ON (t.SessionID = s.ID)
-                JOIN Project p ON (p.ProjectID = s.ProjectID)
-            WHERE t.TarchiveID = :tar",
-            ['tar' => $this->tarchiveID]
+        // Permission of access to this page needs to match the module's filters
+        $config           = \NDB_Factory::singleton()->config();
+        $siteprojectperms = $config->getSetting(
+            'useAdvancedPermissions'
         );
-        //
-        if (is_null($pid)) {
-            return null;
+        $DB  = $this->loris->getDatabaseConnection();
+        $row = $DB->pselectRow(
+            "SELECT CenterID, ProjectID, SessionID, CreatingUser
+            FROM tarchive t 
+                JOIN session s ON s.ID = t.SessionID 
+            WHERE TarchiveID = :ID",
+            ['ID' => $_REQUEST['tarchiveID']]
+        );
+
+        $hasCenterAccess    = false;
+        $hasNoSessionAccess = false;
+        $hasProjectAccess   = false;
+        $isCreator          = false;
+
+        if (isset($row['CenterID'])) {
+            $hasCenterAccess = $user->hasCenter(
+                \CenterID::singleton(intval($row['CenterID']))
+            );
         }
-        return \ProjectID::singleton(intval($pid));
+        if (!isset($row['SessionID'])) {
+            $hasNoSessionAccess = $user->hasPermission("dicom_archive_nosessionid");
+        }
+        if (isset($row['ProjectID'])) {
+            $hasProjectAccess = $user->hasProject(
+                \ProjectID::singleton(intval($row['ProjectID']))
+            );
+        }
+        if (isset($row['CreatingUser'])) {
+            $isCreator = $row['CreatingUser'] === $user->getUsername();
+        }
+
+        // Assume project match is turned off first (as module filter does)
+        // User site match
+        // OR resource has no session but user has the no session permission
+        // OR user has access to all sites data
+        $access = $hasCenterAccess || $hasNoSessionAccess
+            || ($user->hasPermission('dicom_archive_view_allsites'));
+
+        // If the site project permissions are enabled
+        if ($siteprojectperms === 'true') {
+            // User has basic center access
+            // AND
+            // Either User has the project
+            // OR resource has no session but user has the no session permission
+            $access = $access && ($hasProjectAccess || $hasNoSessionAccess);
+        }
+
+        // User is the creator of the data
+        $access = $access || $isCreator;
+
+        return $access;
     }
 
     /**

--- a/modules/dicom_archive/test/TestPlan.md
+++ b/modules/dicom_archive/test/TestPlan.md
@@ -1,6 +1,43 @@
 # DICOM Archive - Test Plan
 
-1.  Access the 'DICOM Archive' under 'Imaging' Tab and check to see if the user has permission
+## Testing Access
+*For every step below, make sure the user has access to the 'View Details' page for any row returned, the permissions to 'View details' shoudld reflect the data table entries access. Note also that it is preferable to use a user that doesn not own the data in the DICOM Archive module s ownership of the DICOMS influences their access (see value in CreatingUser column in the database)*
+1. Remove All DICOM Archive permissions from user and make sure user is not a superuser
+   [Manual Testing]
+2. Disable the `useAdvancedPermissions` (Use Advanced Site Project Permissions) configuration under the Imaging Modules tab of the Configuration module.
+   [Manual Testing]
+3. Check to see that the user can not access the module (403 Forbidden).
+4. Give the user the `dicom_archive_view_allsites` (DICOM Archive: View DICOMs - All Sites) permission alone.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees ALL entries from the database (including entries at sites the user is not affiliated with and entries with no site/no session affiliated).
+   [Manual Testing]
+5. Give the user the `dicom_archive_view_ownsites` (DICOM Archive: View DICOMs - Own Sites) permission alone.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees only entries from the database at the user's sites (user should not be able to see entries with no site/no session affiliated).
+   [Manual Testing]
+6. Give the user the `dicom_archive_view_ownsites` (DICOM Archive: View DICOMs - Own Sites) and `dicom_archive_nosessionid` (DICOM Archive: View DICOMs with no session ID) permissions together.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees entries from the database at the user's sites and entries with no site/no session affiliated.
+   [Manual Testing]
+7. Reset the users permissions to no DICOM Archive permission and enable the `useAdvancedPermissions` (Use Advanced Site Project Permissions) Configuration option
+8. Give the user the `dicom_archive_view_allsites` (DICOM Archive: View DICOMs - All Sites) permission alone.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees entries from all sites but only from the user's projects (user should not be able to see entries with no site/no session affiliated as they are not affiliated to a project either).
+   [Manual Testing]
+9. Give the user the `dicom_archive_view_ownsites` (DICOM Archive: View DICOMs - Own Sites) permission alone.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees only entries from the database at the user's sites and projects (user should not be able to see entries with no site/no session affiliated as they are not affiliated to a project either).
+   [Manual Testing]
+10. Give the user the `dicom_archive_view_ownsites` (DICOM Archive: View DICOMs - Own Sites) and `dicom_archive_nosessionid` (DICOM Archive: View DICOMs with no session ID) permissions together.
+    a. Make sure user can access the DICOM archive module
+    b. Make sure user sees entries from the database at the user's sites and projects as well as entries with no site/no session/no project affiliated.
+   [Manual Testing]
+11. Make sure the user is the creator of at least one of the file entries in the tarchive table.
+    - Make sure that regardless of the permissions, as long as the user has access to the module, they can see their own DICOMs
+   [Manual Testing]
+
+## Testing Functionality
+1.  Access the 'DICOM Archive' under 'Imaging' Tab
     [Automation Testing]
 2.  Under 'Selection Filter' section, verfiy that the following Filter options exist: Patient ID, Patient Name, Sex, Date of Birth, Acquisition Date, Archive Location, Series UID, Site.
     [Manual Testing]

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -74,5 +74,7 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (80,'dataquery_admin','Admin dataquery queries',44,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (81,'imaging_uploader_ownsites','Imaging Scans - Own Sites',22,'View/Upload',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (82,'imaging_uploader_nosessionid', 'Imaging Scans with no session ID',22,'View',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (83,'dicom_archive_nosessionid','DICOMs with no session ID',15,'View',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (84,'dicom_archive_view_ownsites','DICOMs - Own Sites',15,'View',2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_user_perm_rel.sql
+++ b/raisinbread/RB_files/RB_user_perm_rel.sql
@@ -76,5 +76,7 @@ INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,79);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,80);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,81);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,82);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,83);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,84);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

This PR adds advanced site and project permissions to the dicom archive. It is designed to be fully backwards compatible based on the `useImagingSiteProjectPermissions` configuration setting. Here is how the permissions are designed to work

- If useImagingSiteProjectPermissions is disabled (status-quo)
  - A user with dicom_archive_allsites can see all the data (DEFAULT)
  - A user with own sites can only see data at their own sites (can not see data with no session ID)
  - A user with own sites and nosessionid permission can see their site data + dicoms not associated to a session
  - A user can always see DICOMS of scans they uploaded
- If useImagingSiteProjectPermissions is enabled
  - A user with all sites permissions can see all the data from all sites as long as the projectID is defined and they are affiliated with that project (null sessions WILL NOT SHOW)
  - A user with own sites, same logic, only projects they are affiliated with (NO NULL sessions)
  - A user with either site permissions + nosessionID permission can see respectively the same as above + DICOMS not affiliated to a sessions
  - A user can always see DICOMS they have uploaded


TO BE NOTED: The core of this PR is the work done in the `dicom_archive::getDataProvisionerWithFilters()` function. The code there could have been made slightly more concise but I wrote it in that way because I would like it to eventually become the DEFAULT dataframework filtering logic since it accounts for most if not all usecases (replacing the current UserSiteMAtchOrHasAnyPermissions). It defines flags that I would like to make standard going forward like `dataSessionCanBeNull` where multiple module seem to lack a session related to the resource.


TODO:
- [x] Expand Readme
- [x] complete test plan
- [x] add SQL patch 
#### Testing instructions (if applicable)

1. Follow test plan

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
