### PR TITLE
[issue_tracker] Add more granular permissions for Issue Tracker

### DIFF
--- a/SQL/0000-00-02-Permission.sql
+++ b/SQL/0000-00-02-Permission.sql
@@ -105,8 +105,8 @@ INSERT INTO `permissions` VALUES
     (33,'genomic_data_manager','Genomic Files',(SELECT ID FROM modules WHERE Name='genomic_browser'),'Upload','2'),
     (34,'media_write','Candidate Media Files',(SELECT ID FROM modules WHERE Name='media'),'Edit/Upload/Hide','2'),
     (35,'media_read','Candidate Media Files',(SELECT ID FROM modules WHERE Name='media'),'View/Download','2'),
-    (36,'issue_tracker_reporter', 'Create/Edit/Close Own Issues and Comment on All Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
-    (37,'issue_tracker_developer', 'Close/Edit/Re-assign/Comment on All Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
+    (36,'issue_tracker_own_issue', 'See/Edit/Comment and Close on Own Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
+    (37,'issue_tracker_all_issue', 'See/Edit/Comment on all Issues',(SELECT ID FROM modules WHERE Name='issue_tracker'),NULL, 2),
     (38,'imaging_browser_phantom_allsites', 'Phantom Scans - All Sites',(SELECT ID FROM modules WHERE Name='imaging_browser'),'View', 2),
     (39,'imaging_browser_phantom_ownsite', 'Phantom Scans - Own Sites',(SELECT ID FROM modules WHERE Name='imaging_browser'),'View', 2),
     (40,'data_release_view', 'Release Files',(SELECT ID FROM modules WHERE Name='data_release'),'View', 2),
@@ -136,7 +136,11 @@ INSERT INTO `permissions` VALUES
     (64,'dataquery_admin','Admin dataquery queries',(SELECT ID FROM modules WHERE Name='dataquery'),NULL,'2'),
     (65,'schedule_module','Schedule Module - edit and delete the appointment',(SELECT ID FROM modules WHERE Name='schedule_module'),'View/Create/Edit','2'),
     (66,'document_repository_categories','Categories',(SELECT ID FROM modules WHERE Name='document_repository'), 'Edit/Upload/Delete', '2'),
-    (67,'document_repository_hidden','Restricted files',(SELECT ID FROM modules WHERE Name='document_repository'), 'View', '2');
+    (67,'document_repository_hidden','Restricted files',(SELECT ID FROM modules WHERE Name='document_repository'), 'View', '2'),
+    (68,'issue_tracker_site_issue','See/Edit/Comment on Own Site Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),NULL,2),
+    (69,'issue_tracker_close_site_issue','Close Own Site Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),NULL,2),
+    (70,'issue_tracker_close_all_issue','Close all Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),NULL,2);
+
 
 INSERT INTO `user_perm_rel` (userID, permID)
   SELECT u.ID, p.permID

--- a/SQL/New_patches/2025-02-07_update_add_issue_tracker_permissions.sql
+++ b/SQL/New_patches/2025-02-07_update_add_issue_tracker_permissions.sql
@@ -1,0 +1,9 @@
+UPDATE permissions SET code = 'issue_tracker_own_issue', description = 'See/Edit/Comment and Close on Own Issues' 
+WHERE code = 'issue_tracker_reporter';
+UPDATE permissions SET code = 'issue_tracker_all_issue', description = 'See/Edit/Comment on all Issues' 
+WHERE code = 'issue_tracker_developer';
+
+INSERT INTO permissions (code, description, moduleID, categoryID) VALUES
+('issue_tracker_site_issue','See/Edit/Comment on Own Site Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),2),
+('issue_tracker_close_site_issue','Close Own Site Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),2),
+('issue_tracker_close_all_issue','Close all Issues',(SELECT ID FROM modules WHERE Name = 'issue_tracker'),2);

--- a/modules/issue_tracker/README.md
+++ b/modules/issue_tracker/README.md
@@ -4,13 +4,13 @@
 The Issues Module allows users to track issues they have with data, or with their LORIS instance itself. A form with pre-defined fields is provided for users to submit issues, upload attachments and a filter-form gives a sortable and filterable table view of issues viewable by the user.
 
 ## Permissions
-- `issue_tracker_reporter` permission allows adding an issue, editing issues created by the user, download issue attachments and commenting on all issues for the site.
-- `issue_tracker_developer` permission allows to do the same, as well as closing an issue or editing any field of a submitted issue for the site.
+- `issue_tracker_own_issue` permission allows seeing, editing, adding an issue, closing and commenting on issues created by the user.
+- `issue_tracker_site_issue` permission allows to do the same except closing an issue, as well as editing any field of a submitted issue for the user site(s).
+- `issue_tracker_all_issue` permission allows to do the same except closing an issue, as well as editing any field of a submitted issue for all site.
+- `issue_tracker_close_site_issue` permission allows closing issue created by the user site(s)
+- `issue_tracker_close_all_issue` permission allows closing issue for all sites
 - Permissions are in accordance with the data permissions granted to that user - if a user can not see data outside of their site, they will only be able to view issues relevant to their site.
 - If a user has DCC permission they will be able to see issues relevant to all sites.
-- Additionally, users can be designated reporters or developers.
-- Reporters can add issues, edit their own issues, and comment on all issues.
-- Developers can additionally edit all issues, and mark them as resolved.
 - Most users of Loris should be designated as reporters.
 - Users can also enable issue tracker notifications in `My Preferences` to 	be notified for all issues created or edited.
 

--- a/modules/issue_tracker/jsx/index.js
+++ b/modules/issue_tracker/jsx/index.js
@@ -19,7 +19,7 @@ window.addEventListener('load', () => {
         + '/issue_tracker/Edit/'}
       issue={id}
       baseURL={loris.BaseURL}
-      userHasPermission={loris.userHasPermission('issue_tracker_developer')}
+      userHasPermission={loris.userHasPermission}
     />
   );
 });

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -305,7 +305,7 @@ class IssueTrackerIndex extends Component {
     ];
 
     // Only display the Batch mode tab if user has the required permission
-    if (this.props.hasPermission('issue_tracker_developer')) {
+    if (this.props.hasPermission('issue_tracker_all_issue')) {
       tabList.push({
         id: 'batch',
         label: 'Batch Edit',

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -241,8 +241,9 @@ class Attachment extends \NDB_Page implements ETagCalculator
     {
         return $user->hasAnyPermission(
             [
-                'issue_tracker_reporter',
-                'issue_tracker_developer'
+                'issue_tracker_all_issue',
+                'issue_tracker_own_issue',
+                'issue_tracker_site_issue',
             ]
         );
     }

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -73,7 +73,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         //not yet ideal permissions
         $assignees      = [];
         $inactive_users = [];
-        if ($user->hasPermission('access_all_profiles')) {
+        if ($user->hasPermission('issue_tracker_all_issue')) {
             $assignee_expanded = $db->pselect(
                 "SELECT Real_name, UserID FROM users 
                     WHERE Active='Y' AND Pending_approval='N'",
@@ -142,8 +142,18 @@ class Edit extends \NDB_Page implements ETagCalculator
             }
         }
 
-        // can't set to closed if not developer.
-        if ($user->hasPermission('issue_tracker_developer')) {
+        // can't set to closed if no any of the persmissions.
+        $reporter = $db->pselectOne(
+            "SELECT reporter FROM issues WHERE IssueID=:issueID", 
+            ['issueID' => $values['issueID']]
+        );
+        $hasPartialAccess = $user->hasAnyPermission(
+            [
+                'issue_tracker_close_site_issue',
+                'issue_tracker_close_all_issue',
+            ]
+        ) || $reporter == $user->getUsername();
+        if ($hasPartialAccess) {
             $statuses = [
                 'new'          => 'New',
                 'acknowledged' => 'Acknowledged',
@@ -277,8 +287,11 @@ class Edit extends \NDB_Page implements ETagCalculator
             'instruments'       => $instruments,
             'otherWatchers'     => $otherWatchers,
             'issueData'         => $issueData,
-            'hasEditPermission' => $user->hasPermission(
-                'issue_tracker_developer'
+            'hasEditPermission' => $user->hasAnyPermission(
+                [
+                    'issue_tracker_all_issue',
+                    'issue_tracker_site_issue',
+                ]
             ),
             'isOwnIssue'        => $isOwnIssue,
         ];
@@ -305,7 +318,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         $centerPlaceholders = '';
 
         // Initialize variables based on permissions
-        if (!$user->hasPermission('access_all_profiles')) {
+        if (!$user->hasPermission('issue_tracker_all_issue')) {
             $centerIDsArray = array_map(
                 fn($centerID) => (int)$centerID->__toString(),
                 $user->getCenterIDs()
@@ -334,7 +347,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
 
         // Prepare assignee query
-        if ($user->hasPermission('access_all_profiles')) {
+        if ($user->hasPermission('issue_tracker_all_issue')) {
             $assigneeQuery  = "
                 SELECT Real_name, UserID, Active
                 FROM users
@@ -394,7 +407,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         ";
 
         $issueParams = [];
-        if (!$user->hasPermission('access_all_profiles')) {
+        if (!$user->hasPermission('issue_tracker_all_issue')) {
             $baseQuery  .= " WHERE i.centerID IN ($centerPlaceholders)";
             $issueParams = $centerIDsArray;
         }
@@ -1170,7 +1183,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
             $params = ['PSCID' => $result['PSCID']];
 
-            if (!$user->hasPermission('access_all_profiles')) {
+            if (!$user->hasPermission('issue_tracker_all_issue')) {
                 $params['CenterID'] = implode(',', $user->getCenterIDs());
                 $query .= " AND FIND_IN_SET(RegistrationCenterID,:CenterID)";
             }
@@ -1313,8 +1326,13 @@ class Edit extends \NDB_Page implements ETagCalculator
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('issue_tracker_reporter')
-            || $user->hasPermission('issue_tracker_developer');
+        return $user->hasAnyPermission(
+            [
+                'issue_tracker_all_issue',
+                'issue_tracker_own_issue',
+                'issue_tracker_site_issue',
+            ]
+        );
     }
 
     /**

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -46,8 +46,9 @@ class Issue extends \NDB_Form
             || !isset($issueID))
             && !$user->hasAnyPermission(
                 [
-                    'issue_tracker_reporter',
-                    'issue_tracker_developer',
+                    'issue_tracker_all_issue',
+                    'issue_tracker_own_issue',
+                    'issue_tracker_site_issue',
                 ]
             )
         ) {
@@ -107,9 +108,12 @@ class Issue extends \NDB_Form
             "SELECT centerID FROM issues WHERE issueID=:issueID",
             ['issueID' => $issueID]
         );
+        $centerIDs   = $user->getCenterIDs();
+        $centerList  = implode(",", $centerIDs);
+        $centerList  = explode(',', $centerList);
         return (is_null($issueData)
-            || in_array($issueData['centerID'], $user->getCenterIDs())
-            || ($user->hasPermission('access_all_profiles'))
+            || in_array($issueData['centerID'], $centerList)
+            || ($user->hasPermission('issue_tracker_all_issue'))
             || (empty($issueData['centerID']))
         );
     }

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -41,8 +41,9 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     {
         return $user->hasAnyPermission(
             [
-                'issue_tracker_reporter',
-                'issue_tracker_developer',
+                'issue_tracker_all_issue',
+                'issue_tracker_own_issue',
+                'issue_tracker_site_issue',
             ]
         );
     }
@@ -59,7 +60,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
 
-        if ($user->hasPermission('access_all_profiles') === false) {
+        if ($user->hasPermission('issue_tracker_all_issue') === false) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\UserSiteMatch()
             );
@@ -82,7 +83,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         bool $DCC = true
     ): array {
         $user = \User::singleton();
-        if ($user->hasPermission('access_all_profiles')) {
+        if ($user->hasPermission('issue_tracker_all_issue')) {
             // get the list of study sites - to be replaced by the Site object
             $sites = \Utility::getSiteList($study_site, $DCC);
         } else {
@@ -104,8 +105,15 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $user    = $factory->user();
         $db      = $factory->database();
 
+        $hasPartialAcess = !$user->hasAnyPermission(
+            [
+                'issue_tracker_all_issue',
+                'issue_tracker_site_issue',
+            ]
+        ) && $user->hasPermission('issue_tracker_own_issue');  
+
         //sites
-        if ($user->hasPermission('access_all_profiles')) {
+        if ($user->hasPermission('issue_tracker_all_issue')) {
             $sites = \Utility::getSiteList();
         } else {
             // allow only to view own site data
@@ -122,6 +130,16 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
                ON(i.reporter=u.UserID)",
             []
         );
+        if ($hasPartialAcess) {
+            $reporter_expanded = $db->pselect(
+                "SELECT DISTINCT u.UserID,
+                        u.Real_name
+                 FROM issues i
+                 INNER JOIN users u
+                   ON(i.reporter=u.UserID AND i.reporter=:username)",
+                ['username' => $user->getUsername()]
+            );
+        }
         foreach ($reporter_expanded as $r_row) {
             $reporters[$r_row['Real_name']] = $r_row['Real_name'];
         }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -50,10 +50,17 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         );
         $userID = $user->getUsername();
 
-        //note that this needs to be in the same order as the headers array
-        parent::__construct(
-            $loris,
-            "SELECT i.issueID,
+        $hasPartialAcess = !$user->hasAnyPermission(
+            [
+              'issue_tracker_all_issue',
+              'issue_tracker_site_issue',
+            ]
+        ) && $user->hasPermission('issue_tracker_own_issue');
+        if (!$hasPartialAcess) {
+            //note that this needs to be in the same order as the headers array
+            parent::__construct(
+                $loris,
+                "SELECT i.issueID,
                     i.title,
                     m.name as module,
                     i.category,
@@ -86,8 +93,49 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
               ON (i.assignee = uAssignee.UserID)
             GROUP BY i.issueID, w.userID
             ORDER BY i.issueID DESC",
-            ['username' => $userID]
-        );
+                ['username' => $userID]
+            );
+        }
+        if ($hasPartialAcess) {
+            parent::__construct(
+                $loris,
+                "SELECT i.issueID,
+                i.title,
+                m.name as module,
+                i.category,
+                CONCAT(uReporter.First_name, ' ', uReporter.Last_name),
+                CONCAT(uAssignee.First_name, ' ', uAssignee.Last_name),
+                i.status,
+                i.priority,
+                i.centerID as centerId,
+                c.PSCID as pscid,
+                s.Visit_label as visitLabel,
+                i.dateCreated,
+                i.lastUpdate,
+                s.ID as sessionId,
+                c.CandID as candidateId,
+                w.userID as userId
+        FROM issues as i
+        LEFT JOIN modules m
+          ON (m.ID=i.module)
+        LEFT JOIN candidate c
+          ON (i.candID=c.CandID)
+        LEFT JOIN session s
+          ON (i.sessionID = s.ID)
+        LEFT JOIN issues_watching w
+          ON (i.issueID = w.issueID AND w.userID=:username)
+        LEFT JOIN issues_comments ic
+          ON (i.issueID = ic.issueID)
+        JOIN users uReporter
+          ON (i.reporter = uReporter.UserID AND i.reporter=:username)
+        LEFT JOIN users uAssignee
+          ON (i.assignee = uAssignee.UserID)
+        GROUP BY i.issueID, w.userID
+        ORDER BY i.issueID DESC",
+                ['username' => $userID]
+            );
+        }
+
     }
 
     /**

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -37,8 +37,9 @@ class Module extends \Module
         return parent::hasAccess($user) &&
             $user->hasAnyPermission(
                 [
-                    'issue_tracker_reporter',
-                    'issue_tracker_developer'
+                    'issue_tracker_all_issue',
+                    'issue_tracker_own_issue',
+                    'issue_tracker_site_issue',
                 ]
             );
     }

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -113,7 +113,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
      */
     function testIssueTrackerDoespageLoadWithPermission()
     {
-        $this->setupPermissions(["issue_tracker_reporter"]);
+        $this->setupPermissions(["issue_tracker_all_issue"]);
         $this->safeGet($this->url . "/issue_tracker/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("#bc2 > a:nth-child(2) > div")

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -36,8 +36,8 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (42,'genomic_data_manager','Genomic Files',18,'Upload',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (43,'media_write','Candidate Media Files',29,'Edit/Upload/Delete',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (44,'media_read','Candidate Media Files',29,'View/Download',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (45,'issue_tracker_reporter','Create/Edit/Close Own Issues and Comment on All Issues',27,NULL,2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (46,'issue_tracker_developer','Close/Edit/Re-assign/Comment on All Issues',27,NULL,2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (45,'issue_tracker_own_issue','See/Edit/Comment and Close on Own Issues',27,NULL,2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (46,'issue_tracker_all_issue','See/Edit/Comment on all Issues',27,NULL,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (47,'imaging_browser_phantom_allsites','Phantom Scans - All Sites',20,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (48,'imaging_browser_phantom_ownsite','Phantom Scans - Own Sites',20,'View',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (49,'instrument_manager_read','Installed Instruments',25,'View',2);
@@ -67,7 +67,11 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (73,'schedule_module','Schedule Module: edit and delete appointment',48,'View/Create/Edit',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (74,'document_repository_categories','Categories',16,'Edit/Upload/Delete',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (75,'document_repository_hidden','Restricted files',16,'View',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (76,'media_upload_digest','Media files: Access to recently uploaded media notifications digest.',29,'Edit',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (76,'media_upload_digest','Media files: Access to recently uploaded media notifications digest.',29,'Edit',2),
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (77,'issue_tracker_site_issue','See/Edit/Comment on Own Site Issues',27,NULL,2),
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (78,'issue_tracker_close_site_issue','Close Own Site Issues',27,NULL,2),
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `action`, `categoryID`) VALUES (79,'issue_tracker_close_all_issue','Close all Issues',27,NULL,2);
+
 
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -54,9 +54,10 @@ class Error extends HtmlResponse
                     ];
 
         $lorisInstance = $request->getAttribute('loris');
-        $user          = $request->getAttribute('user') ?? new \LORIS\AnonymousUser();
+        $user          = $request->getAttribute('user') ?? new \LORIS\AnonymousUser()
+        ;
 
-        // Variables used to suggest the user to login and later redirect them if they
+        //Variables used to suggest the user to login and later redirect them if they
         // are not authenticated in a 403.
         $tpl_data['anonymous'] = $user instanceof \LORIS\AnonymousUser;
         $tpl_data['url']       = urlencode($uri->__toString());
@@ -75,8 +76,11 @@ class Error extends HtmlResponse
             // the correct permissions.
             $canReport = $user->hasAnyPermission(
                 [
-                 'issue_tracker_reporter',
-                 'issue_tracker_developer',
+                    'issue_tracker_all_issue',
+                    'issue_tracker_own_issue',
+                    'issue_tracker_site_issue',
+                    'issue_tracker_close_site_issue',
+                    'issue_tracker_close_all_issue',
                 ]
             );
             if ($canReport) {


### PR DESCRIPTION
Related to #8897

This PR modifies the existing permissions for the `issue_tracker` module. The permission has been extended to 5 permissions instead of 2. The permissions are as follows;

1. `issue_tracker_own_issue`: See/Edit/Comment and Close on Own Issues
2. `issue_tracker_all_issue`: See/Edit/Comment on all Issues
3. `issue_tracker_site_issue`: See/Edit/Comment on Own Site Issues
4. `issue_tracker_close_site_issue`: Close Own Site Issues
5. `issue_tracker_close_all_issue`: Close all Issues

Testing:
1. Give different users all the above permissions and see if they won't perform outside the specified actions.