### PR TITLE
[NDB_BVL_Instrument] addHourMin Warning

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1813,7 +1813,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "dnk"          => "DNK",
                 "refusal"      => "Refusal",
                 'not_answered' => 'Not Answered',
-            ]
+            ],
+            ['class' => 'form-control input-sm not-answered']
         );
         $this->addGroup($group, $field . "_group", $label, '');
         $this->XINRegisterRule(

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -458,7 +458,7 @@ class NDB_BVL_Instrument_Test extends TestCase
                     ],
                     ['label' => '',
                         'name'    => 'hourMinField_status',
-                        'class'   => 'form-control input-sm',
+                        'class'   => 'form-control input-sm not-answered',
                         'type'    => 'select',
                         'options' => [
                             ''             => '',
@@ -472,7 +472,7 @@ class NDB_BVL_Instrument_Test extends TestCase
                 ],
                 'label'     => 'hourMinLabel',
                 'delimiter' => ' ',
-                'options'   => false,
+                'options'   => null,
                 'html'      => $this->_instrument->form->groupHTML($groupEl)
             ]
         );


### PR DESCRIPTION
## Brief summary of changes

- updated addHourMinElement to have the yellow warning when a status is selected
<img width="264" alt="image" src="https://github.com/user-attachments/assets/90683ae6-9f82-43a8-83cc-0740986f24a1" />

#### Testing instructions (if applicable)

1. Open an instrument with `addHourMinElement`
2. Select an option from the status dropdown
3. Confirm that the yellow warning appears
4. Confirm that you can save with no errors

#### Link(s) to related issue(s)

* Resolves #9541
