### PR TITLE
Remove redundant NDB_Client lines

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -105,7 +105,7 @@ class NDB_BVL_InstrumentStatus
         // set the _commentID property
         $this->_commentID = $commentID;
 
-        $db = \NDB_Factory::singleton()->database();
+        $db = $this->loris->getDatabaseConnection();
 
         // get candidate data from database
         $query = "SELECT SessionID, Data_entry, Administration, Validity, Exclusion
@@ -195,7 +195,8 @@ class NDB_BVL_InstrumentStatus
             throw new Exception('Invalid data entry status');
         }
 
-        $GLOBALS['DB']->update(
+        $DB = $this->loris->getDatabaseConnection();
+        $DB->update(
             'flag',
             ['Data_entry' => $status],
             ['CommentID' => $this->_commentID]
@@ -211,7 +212,7 @@ class NDB_BVL_InstrumentStatus
             );
             $DDECommentId       = 'DDE_' . $principalCommentId;
 
-            $query = $GLOBALS['DB']->pselect(
+            $query = $DB->pselect(
                 "SELECT Data_entry FROM flag
                 WHERE CommentID=:PCID OR CommentID=:DDECID",
                 [
@@ -242,7 +243,7 @@ class NDB_BVL_InstrumentStatus
                 }
             }
 
-            $GLOBALS['DB']->update(
+            $DB->update(
                 'participant_accounts',
                 ['Status' => $status],
                 ['CommentID' => $this->_commentID]
@@ -254,10 +255,9 @@ class NDB_BVL_InstrumentStatus
         if ($this->getDataEntryStatus() != null && $status == 'In Progress') {
             $deleteWhere1 = ['CommentId1' => $this->_commentID];
             $deleteWhere2 = ['CommentId2' => $this->_commentID];
-            $GLOBALS['DB']->delete('conflicts_unresolved', $deleteWhere1);
-            $GLOBALS['DB']->delete('conflicts_unresolved', $deleteWhere2);
+            $DB->delete('conflicts_unresolved', $deleteWhere1);
+            $DB->delete('conflicts_unresolved', $deleteWhere2);
         }
-
     }
 
     /**
@@ -278,7 +278,8 @@ class NDB_BVL_InstrumentStatus
             throw new Exception('Invalid administration status');
         }
 
-        $GLOBALS['DB']->update(
+        $DB = $this->loris->getDatabaseConnection();
+        $DB->update(
             'flag',
             ['Administration' => $status],
             ['CommentID' => $this->_commentID]
@@ -304,7 +305,8 @@ class NDB_BVL_InstrumentStatus
             throw new Exception('Invalid administration status');
         }
 
-        $GLOBALS['DB']->update(
+        $DB = $this->loris->getDatabaseConnection();
+        $DB->update(
             'flag',
             ['Validity' => $status],
             ['CommentID' => $this->_commentID]
@@ -329,7 +331,8 @@ class NDB_BVL_InstrumentStatus
             throw new Exception('Invalid exclusion status');
         }
 
-        $GLOBALS['DB']->update(
+        $DB = $this->loris->getDatabaseConnection();
+        $DB->update(
             'flag',
             ['Exclusion' => $status],
             ['CommentID' => $this->_commentID]

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -78,12 +78,6 @@ class NDB_Client
             $s3client->registerStreamWrapper();
         }
 
-        // This must be done after the extra includes, as those may
-        // include Smarty
-        include_once "Smarty_hook.class.inc";
-
-        $GLOBALS['DB'] =& $DB;
-
         // stop here if this is a command line client
         if (!$this->_isWebClient) {
             // Set user as unix username.


### PR DESCRIPTION
This removes 2 unnecessary lines from NDB_Client.

The global $DB variable is defined in generic_includes for scripts. Outside of scripts, the database connection always comes from the LorisInstance object.

The include for Smarty_hook is unnecessary because the file is autoloaded by composer.