### PR TITLE
Move AWS to middleware

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -38,6 +38,7 @@ $client->initialize();
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.
 $middlewarechain = (new \LORIS\Middleware\ContentLength())
+    ->withMiddleware(new \LORIS\Middleware\AWS())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 
 $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -65,13 +65,23 @@ $serverrequest = $serverrequest->withUri($uri->withQuery($query));
 $factory = \NDB_Factory::singleton();
 $user    = $factory->user();
 
-$entrypoint = new \LORIS\Router\BaseRouter(
-    $user,
-    __DIR__ . "/../project/",
-    __DIR__ . "/../modules/"
+$lorisInstance = new \LORIS\LorisInstance(
+    $factory->database(),
+    $factory->config(),
+    [
+        __DIR__ . "/../project/",
+        __DIR__ . "/../modules/"
+    ]
 );
+$entrypoint    = new \LORIS\Router\BaseRouter(
+    $lorisInstance,
+    $user,
+);
+$serverrequest = $serverrequest->withAttribute("user", $user)
+    ->withAttribute("loris", $lorisInstance);
 
 // Now handle the request.
+//
 $response = $middlewarechain->process($serverrequest, $entrypoint);
 
 // Add the HTTP header line.

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -56,28 +56,6 @@ class NDB_Client
 
         $DB = $factory->database();
 
-        // Register S3 stream wrapper if configured
-        if (getenv('AWS_ACCESS_KEY_ID') !== false) {
-            // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-            // should both be set as environment variables
-            $s3config = [
-                'version' => '2006-03-01',
-            ];
-            $endpoint = $config->getSetting('AWS_S3_Endpoint');
-            if (!empty($endpoint)) {
-                $s3config['region']   = '';
-                $s3config['endpoint'] = $endpoint;
-            } else {
-                $s3config['region'] = $config->getSetting('AWS_S3_Region');
-            }
-
-            $s3client = new Aws\S3\S3Client($s3config);
-
-            // Register the stream wrapper so that s3:// urls can be
-            // treated as regular files.
-            $s3client->registerStreamWrapper();
-        }
-
         // stop here if this is a command line client
         if (!$this->_isWebClient) {
             // Set user as unix username.

--- a/src/AWS/Client.php
+++ b/src/AWS/Client.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\AWS;
+
+/**
+ * An AWS\Client handles access to an AWS S3 service connecting
+ * with credentials coming from a LORIS database
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Client
+{
+    protected $s3client;
+
+    /**
+     * Constructor for \LORIS\AWS\Client
+     *
+     * @param \LORIS\LorisInstance $loris The LorisInstance with AWS
+     *                                    credentials
+     */
+    public function __construct(protected \LORIS\LorisInstance $loris)
+    {
+        // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+        // should both be set as environment variables
+        // for the AWS SDK
+        if (getenv('AWS_ACCESS_KEY_ID') === false) {
+            throw new \Exception("No AWS_ACCESS_KEY_ID defined");
+        }
+        if (getenv('AWS_SECRET_ACCESS_KEY') === false) {
+            throw new \Exception("No AWS_SECRET_ACCESS_KEY defined");
+        }
+        $config   = $loris->getConfiguration();
+        $s3config = ['version' => '2006-03-01'];
+        $endpoint = $config->getSetting('AWS_S3_Endpoint');
+        if (!empty($endpoint)) {
+            $s3config['region']   = '';
+            $s3config['endpoint'] = $endpoint;
+        } else {
+            $s3config['region'] = $config->getSetting('AWS_S3_Region');
+        }
+
+        $this->s3client = new \Aws\S3\S3Client($s3config);
+
+        // Register the stream wrapper so that s3:// urls can be
+        // treated as regular files.
+    }
+
+    /**
+     * Register an AWS stream wrapper so that s3:// urls can be treated
+     * as regular files by PHP.
+     *
+     * @return void
+     */
+    public function registerStreamWrapper()
+    {
+        $this->s3client->registerStreamWrapper();
+    }
+}

--- a/src/Middleware/AWS.php
+++ b/src/Middleware/AWS.php
@@ -4,7 +4,6 @@ namespace LORIS\Middleware;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
-use \Psr\Http\Server\MiddlewareInterface;
 use \Psr\Http\Server\RequestHandlerInterface;
 
 /**
@@ -16,7 +15,7 @@ use \Psr\Http\Server\RequestHandlerInterface;
  *
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-class AWS implements MiddlewareInterface
+class AWS implements MiddlewareChainer
 {
     use MiddlewareChainerMixin;
 

--- a/src/Middleware/AWS.php
+++ b/src/Middleware/AWS.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\Middleware;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\MiddlewareInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * The AWS middleware registers a stream wrapper for accessing AWS S3 buckets
+ * through standard PHP file IO calls if AWS credentials are configured.
+ *
+ * It also adds a header to the response to make it easier to debug if it
+ * is in use.
+ *
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class AWS implements MiddlewareInterface
+{
+    use MiddlewareChainerMixin;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface  $request The incoming PSR7 request.
+     * @param RequestHandlerInterface $handler The PSR15 handler to delegate
+     *                                         content generation to.
+     *
+     * @return ResponseInterface the PSR15 response
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+        $response = $handler->handle($request);
+        if (getenv("AWS_ACCESS_KEY_ID") !== false) {
+            $loris = $request->getAttribute("loris");
+            (new \LORIS\AWS\Client($loris))->registerStreamWrapper();
+            $response = $response
+            ->withHeader("LORIS-S3-Enabled", "true");
+        }
+        return $response;
+    }
+}

--- a/src/Middleware/AWS.php
+++ b/src/Middleware/AWS.php
@@ -32,7 +32,7 @@ class AWS implements MiddlewareChainer
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ) : ResponseInterface {
-        $response = $handler->handle($request);
+        $response = $this->next->process($request, $handler);
         if (getenv("AWS_ACCESS_KEY_ID") !== false) {
             $loris = $request->getAttribute("loris");
             (new \LORIS\AWS\Client($loris))->registerStreamWrapper();

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -34,14 +34,14 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
     /**
      * Construct a BaseRouter
      *
-     * @param \User  $user       The user accessing LORIS. (May be an AnonymousUser
-     *                           instance).
-     * @param string $projectdir The base of the LORIS project directory.
-     * @param string $moduledir  The base of the LORIS modules directory.
+     * @param \LORIS\LorisInstance $loris The LORIS instance being routed
+     * @param \User                $user  The user accessing LORIS. (May be an
+     *                                    AnonymousUser instance).
      */
-    public function __construct(protected $loris,
-	    protected \User $user)
-    {
+    public function __construct(
+        protected \LORIS\LorisInstance $loris,
+        protected \User $user
+    ) {
     }
 
     /**

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -31,9 +31,6 @@ use \Psr\Http\Server\RequestHandlerInterface;
  */
 class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 {
-    protected $loris;
-    protected $user;
-
     /**
      * Construct a BaseRouter
      *
@@ -42,17 +39,9 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
      * @param string $projectdir The base of the LORIS project directory.
      * @param string $moduledir  The base of the LORIS modules directory.
      */
-    public function __construct(\User $user, string $projectdir, string $moduledir)
+    public function __construct(protected $loris,
+	    protected \User $user)
     {
-        $this->user  = $user;
-        $this->loris = new \LORIS\LorisInstance(
-            \NDB_Factory::singleton()->database(),
-            \NDB_Factory::singleton()->config(),
-            [
-             $projectdir . "/modules",
-             $moduledir,
-            ]
-        );
     }
 
     /**

--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -33,3 +33,7 @@ $lorisInstance = new \LORIS\LorisInstance(
         __DIR__ . "/../modules/",
     ],
 );
+// Register S3 stream wrapper if configured
+if (getenv('AWS_ACCESS_KEY_ID') !== false) {
+    (new \LORIS\AWS\Client($lorisInstance))->registerStreamWrapper();
+}


### PR DESCRIPTION
This refactors the way AWS S3 buckets are handled so that the stream wrapper registration is added by a middleware. For scripts, the logic of registering a stream wrapper is moved to generic_includes.

This is a first pass at addressing the comment in htdocs/index.php that most of the work of NDB_Client should be done by middleware.
