### PR TITLE
[Login Statistics] Fix query

### DIFF
--- a/SQL/Login_Summary_Statistics/04_Visit.sql
+++ b/SQL/Login_Summary_Statistics/04_Visit.sql
@@ -1,7 +1,8 @@
 SELECT 
     IFNULL(Project.Name, 'All Projects') as ProjectName, 
-    COUNT(CandID) AS count
-    FROM session s
+    COUNT(c.CandID) AS count
+    FROM candidate c
+    JOIN session s ON (c.ID=s.CandidateID)
     JOIN Project ON s.ProjectID = Project.ProjectID
 WHERE Project.showSummaryOnLogin = 1
 GROUP BY Project.Name WITH ROLLUP

--- a/SQL/Login_Summary_Statistics/04_Visit.sql
+++ b/SQL/Login_Summary_Statistics/04_Visit.sql
@@ -1,8 +1,7 @@
 SELECT 
     IFNULL(Project.Name, 'All Projects') as ProjectName, 
-    COUNT(c.CandID) AS count
-    FROM candidate c
-    JOIN session s ON (c.ID=s.CandidateID)
-    JOIN Project ON s.ProjectID = Project.ProjectID
+    COUNT(s.ID) AS count
+    FROM session s
+    JOIN Project ON (s.ProjectID = Project.ProjectID)
 WHERE Project.showSummaryOnLogin = 1
 GROUP BY Project.Name WITH ROLLUP


### PR DESCRIPTION
There was a semantic conflict between PR#9556 and one of the queries in PR#9518, as the CandID now needs to come from the candidate table.

This adds a JOIN from the session for the one query missing it, so that the update login statistics script doesn't fail with an SQL error.