### PR TITLE
[user_accounts] Made Site & Project multiselect expandable

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -928,3 +928,8 @@ legend {
 .highlighted {
     animation: highlight ease 3s;
 }
+
+select[multiple].input-sm.resizable {
+    height: 100px;
+    resize: both;
+}

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -807,6 +807,7 @@ class Edit_User extends \NDB_Form
             'Sites',
             $siteOptions,
             [
+                'class'    => 'form-control input-sm resizable',
                 'multiple' => 'multiple',
                 'required' => true,
             ]
@@ -826,6 +827,7 @@ class Edit_User extends \NDB_Form
             'Projects',
             $projectOptions,
             [
+                'class'    => 'form-control input-sm resizable',
                 'multiple' => 'multiple',
                 'required' => true,
             ]


### PR DESCRIPTION
## Brief summary of changes

CBIG has a lot of sites and projects and the tiny 10px  sized multiselects are just not cutting it anymore, they are extremely difficult to work with. This PR is 100% self isolated to the user_accounts module and only affects the site and project selects.

attached are 2 images to contrast the expandable selects vs the non expandable. NOTE that I made the changes to both sites and projects, the screeshots are simply to compare and contrast before vs after

![Screenshot from 2025-02-13 00-01-07](https://github.com/user-attachments/assets/b3298bf9-c111-4b05-8b60-342333341084)
![Screenshot from 2025-02-13 00-01-24](https://github.com/user-attachments/assets/f5e8eee5-b5a4-4876-a358-0a5a1c7ffbcb)

 


#### Testing instructions (if applicable)

1. make still work

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
