### PR TITLE
[SQL] Fix NULLability of CandidateID FK

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -193,7 +193,7 @@ CREATE TABLE `candidate` (
 
 CREATE TABLE `session` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `CenterID` integer unsigned NOT NULL,
   `ProjectID` int(10) unsigned NOT NULL,
   `VisitNo` smallint(5) unsigned DEFAULT NULL,
@@ -521,7 +521,7 @@ CREATE TABLE `mri_scanner` (
   `Model` varchar(255) default NULL,
   `Serial_number` varchar(255) default NULL,
   `Software` varchar(255) default NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY  (`ID`),
   KEY `FK_mri_scanner_1` (`CandidateID`),
   CONSTRAINT `FK_mri_scanner_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
@@ -976,7 +976,7 @@ CREATE TABLE `mri_violations_log` (
   `TarchiveID` int(11) DEFAULT NULL,
   `MincFile` varchar(255) DEFAULT NULL,
   `PatientName` varchar(255) DEFAULT NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned DEFAULT NULL,
   `Visit_label` varchar(255) DEFAULT NULL,
   `CheckID` int(11) DEFAULT NULL,
   `MriScanTypeID` int(11) unsigned DEFAULT NULL,
@@ -1290,7 +1290,7 @@ SET @tmp_val = NULL;
 
 CREATE TABLE `participant_status` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `UserID` varchar(255) DEFAULT NULL,
   `entry_staff` varchar(255) DEFAULT NULL,
   `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1329,7 +1329,7 @@ CREATE TABLE `participant_emails` (
 
 CREATE TABLE `participant_status_history` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `entry_staff` varchar(255) DEFAULT NULL,
   `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `participant_status` int(11) DEFAULT NULL,
@@ -1344,7 +1344,7 @@ CREATE TABLE `participant_status_history` (
 CREATE TABLE `family` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `FamilyID` int(6) NOT NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `Relationship_type` enum('half_sibling','full_sibling','1st_cousin') DEFAULT NULL,
   PRIMARY KEY (`ID`),
   CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
@@ -1537,7 +1537,7 @@ CREATE TABLE `issues` (
   `lastUpdatedBy` varchar(255) DEFAULT NULL,
   `sessionID` int(10) unsigned DEFAULT NULL,
   `centerID` integer unsigned DEFAULT NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned DEFAULT NULL,
   `category` varchar(255) DEFAULT NULL,
   `description` longtext DEFAULT NULL,
   `instrument` int(10) unsigned DEFAULT NULL,
@@ -1793,7 +1793,7 @@ INSERT INTO parameter_type_category_rel (ParameterTypeID,ParameterTypeCategoryID
 
 CREATE TABLE `parameter_candidate` (
   `ParameterCandidateID` int(10) unsigned NOT NULL auto_increment,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `ParameterTypeID` int(10) unsigned NOT NULL,
   `Value` varchar(255) default NULL,
   `InsertTime` int(10) unsigned NOT NULL default 0,
@@ -1904,7 +1904,7 @@ CREATE TABLE `SNP` (
 CREATE TABLE `SNP_candidate_rel` (
   `ID` bigint(20) NOT NULL AUTO_INCREMENT,
   `SNPID` bigint(20) NOT NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `AlleleA` enum('A','C','T','G') DEFAULT NULL,
   `AlleleB` enum('A','C','T','G') DEFAULT NULL,
   `ArrayReport` enum('Normal','Uncertain','Pending') DEFAULT NULL,
@@ -1922,7 +1922,7 @@ CREATE TABLE `SNP_candidate_rel` (
 
 CREATE TABLE `CNV` (
   `CNVID` bigint(20) NOT NULL AUTO_INCREMENT,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned DEFAULT NULL,
   `Description` text,
   `Type` enum('gain','loss','unknown') DEFAULT NULL,
   `EventName` varchar(255) DEFAULT NULL,
@@ -2005,7 +2005,7 @@ CREATE TABLE `genomic_files` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `genomic_candidate_files_rel` (
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `GenomicFileID` int(10) unsigned NOT NULL,
   PRIMARY KEY (`CandidateID`,`GenomicFileID`),
   KEY `GenomicFileID` (`GenomicFileID`),
@@ -2015,7 +2015,7 @@ CREATE TABLE `genomic_candidate_files_rel` (
 
 CREATE TABLE `genomic_sample_candidate_rel` (
   `sample_label` varchar(100) NOT NULL,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   PRIMARY KEY (`sample_label`,`CandidateID`),
   UNIQUE KEY `sample_label` (`sample_label`),
   KEY `CandidateID` (`CandidateID`),
@@ -2163,7 +2163,7 @@ INSERT INTO `feedback_bvl_type` (Name, Description) VALUES
 
 CREATE TABLE `feedback_bvl_thread` (
   `FeedbackID` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned DEFAULT NULL,
   `SessionID` int(11) unsigned DEFAULT NULL,
   `CommentID` varchar(255) DEFAULT NULL,
   `Feedback_level` enum('profile','visit','instrument') NOT NULL DEFAULT 'profile',
@@ -2312,7 +2312,7 @@ CREATE TABLE `consent` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `candidate_consent_rel` (
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned  NOT NULL,
   `ConsentID` integer unsigned NOT NULL,
   `Status` enum('yes','no', 'not_applicable') DEFAULT NULL,
   `DateGiven` date DEFAULT NULL,
@@ -2371,7 +2371,7 @@ CREATE TABLE `diagnosis_evolution` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `candidate_diagnosis_evolution_rel` (
-  `CandidateID` int(10) unsigned,
+  `CandidateID` int(10) unsigned NOT NULL,
   `DxEvolutionID` int(10) unsigned NOT NULL,
   `Diagnosis` text DEFAULT NULL,
   `Confirmed` enum('Y', 'N') DEFAULT NULL,
@@ -2554,7 +2554,7 @@ CREATE TABLE dataquery_starred_queries_rel (
 
 CREATE TABLE dataquery_run_results (
     RunID int(10) unsigned NOT NULL AUTO_INCREMENT,
-    CandidateID int(10) unsigned,
+    CandidateID int(10) unsigned NOT NULL,
     -- JSON or same format that's streamed in?
     RowData LONGTEXT DEFAULT NULL,
 

--- a/SQL/New_patches/2025_02_05_change_candid_fk_to_id.sql
+++ b/SQL/New_patches/2025_02_05_change_candid_fk_to_id.sql
@@ -1,74 +1,74 @@
 -- Change FKs from CandID to CandidateID which is now candidate.ID
 ALTER TABLE CNV DROP constraint CNV_ibfk_3;
 UPDATE CNV SET CandID=(SELECT ID from candidate c WHERE c.CandID=CNV.CandID);
-ALTER TABLE CNV CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE CNV CHANGE CandID CandidateID int(10) unsigned DEFAULT NULL;
 ALTER TABLE CNV ADD CONSTRAINT CNV_ibfk_3 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE candidate_consent_rel DROP CONSTRAINT `FK_candidate_consent_rel_CandidateID`;
 UPDATE candidate_consent_rel SET CandidateID=(SELECT ID from candidate c WHERE c.CandID=candidate_consent_rel.CandidateID);
-ALTER TABLE candidate_consent_rel CHANGE CandidateID CandidateID int(10) unsigned;
+ALTER TABLE candidate_consent_rel CHANGE CandidateID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE candidate_consent_rel ADD CONSTRAINT FK_candidate_consent_rel_CandidateID FOREIGN KEY (CandidateID) REFERENCES candidate(ID) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE participant_status DROP CONSTRAINT `fk_participant_status_3`;
 UPDATE participant_status SET CandID=(SELECT ID from candidate c WHERE c.CandID=participant_status.CandID);
-ALTER TABLE participant_status CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE participant_status CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE participant_status ADD CONSTRAINT FK_participant_status_3 FOREIGN KEY (CandidateID) REFERENCES candidate(ID) ON DELETE CASCADE ON UPDATE CASCADE;
 
 ALTER TABLE dataquery_run_results DROP CONSTRAINT `dataquery_run_results_ibfk_1`;
 UPDATE dataquery_run_results SET CandID=(SELECT ID from candidate c WHERE c.CandID=dataquery_run_results.CandID);
-ALTER TABLE dataquery_run_results CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE dataquery_run_results CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE dataquery_run_results ADD CONSTRAINT dataquery_run_results_ibfk_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE issues DROP CONSTRAINT `fk_issues_3`;
 UPDATE issues SET CandID=(SELECT ID from candidate c WHERE c.CandID=issues.CandID);
-ALTER TABLE issues CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE issues CHANGE CandID CandidateID int(10) unsigned DEFAULT NULL;
 ALTER TABLE issues ADD CONSTRAINT fk_issues_3 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE session DROP CONSTRAINT `fk_session_1`;
 UPDATE session SET CandID=(SELECT ID from candidate c WHERE c.CandID=session.CandID);
-ALTER TABLE session CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE session CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE session ADD CONSTRAINT fk_session_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE genomic_candidate_files_rel DROP CONSTRAINT `genomic_candidate_files_rel_ibfk_1`;
 UPDATE genomic_candidate_files_rel SET CandID=(SELECT ID from candidate c WHERE c.CandID=genomic_candidate_files_rel.CandID);
-ALTER TABLE genomic_candidate_files_rel CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE genomic_candidate_files_rel CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE genomic_candidate_files_rel ADD CONSTRAINT genomic_candidate_files_rel_ibfk_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE mri_scanner DROP CONSTRAINT `FK_mri_scanner_1`;
 UPDATE mri_scanner SET CandID=(SELECT ID from candidate c WHERE c.CandID=mri_scanner.CandID);
-ALTER TABLE mri_scanner CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE mri_scanner CHANGE CandID CandidateID int(10) unsigned DEFAULT NULL;
 ALTER TABLE mri_scanner ADD CONSTRAINT FK_mri_scanner_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE genomic_sample_candidate_rel DROP CONSTRAINT `genomic_sample_candidate_rel_ibfk_1`;
 UPDATE genomic_sample_candidate_rel SET CandID=(SELECT ID from candidate c WHERE c.CandID=genomic_sample_candidate_rel.CandID);
-ALTER TABLE genomic_sample_candidate_rel CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE genomic_sample_candidate_rel CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE genomic_sample_candidate_rel ADD CONSTRAINT `genomic_sample_candidate_rel_ibfk_1` FOREIGN KEY (CandidateID) REFERENCES `candidate`(`ID`);
 
 ALTER TABLE SNP_candidate_rel DROP CONSTRAINT `fk_SNP_candidate_rel_2`;
 UPDATE SNP_candidate_rel SET CandID=(SELECT ID from candidate c WHERE c.CandID=SNP_candidate_rel.CandID);
-ALTER TABLE SNP_candidate_rel CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE SNP_candidate_rel CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE SNP_candidate_rel ADD CONSTRAINT `fk_SNP_candidate_rel_2` FOREIGN KEY (CandidateID) REFERENCES candidate(ID) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE parameter_candidate DROP CONSTRAINT `FK_parameter_candidate_2`;
 UPDATE parameter_candidate SET CandID=(SELECT ID from candidate c WHERE c.CandID=parameter_candidate.CandID);
-ALTER TABLE parameter_candidate CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE parameter_candidate CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE parameter_candidate ADD CONSTRAINT FK_parameter_candidate_2 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 ALTER TABLE candidate_diagnosis_evolution_rel DROP CONSTRAINT `PK_candidate_diagnosis_evolution_rel`;
 ALTER TABLE candidate_diagnosis_evolution_rel DROP CONSTRAINT `FK_candidate_diagnosis_evolution_rel_CandID`;
 UPDATE candidate_diagnosis_evolution_rel SET CandID=(SELECT ID from candidate c WHERE c.CandID=candidate_diagnosis_evolution_rel.CandID);
-ALTER TABLE candidate_diagnosis_evolution_rel CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE candidate_diagnosis_evolution_rel CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE candidate_diagnosis_evolution_rel ADD CONSTRAINT PK_candidate_diagnosis_evolution_rel PRIMARY KEY (CandidateID, DxEvolutionID);
 ALTER TABLE candidate_diagnosis_evolution_rel ADD CONSTRAINT FK_candidate_diagnosis_evolution_rel_CandID FOREIGN KEY (CandidateID) REFERENCES candidate(ID) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 
 -- Changes references to candidate.CandID that were NOT FK. Add FK
 UPDATE feedback_bvl_thread SET CandID=(SELECT ID from candidate c WHERE c.CandID=feedback_bvl_thread.CandID);
-ALTER TABLE feedback_bvl_thread CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE feedback_bvl_thread CHANGE CandID CandidateID int(10) unsigned DEFAULT NULL;
 ALTER TABLE feedback_bvl_thread ADD CONSTRAINT FK_feedback_bvl_thread_candidate_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 UPDATE mri_violations_log SET CandID=(SELECT ID from candidate c WHERE c.CandID=mri_violations_log.CandID);
-ALTER TABLE mri_violations_log CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE mri_violations_log CHANGE CandID CandidateID int(10) unsigned DEFAULT NULL;
 ALTER TABLE mri_violations_log ADD CONSTRAINT FK_mri_violations_log_candidate_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 UPDATE mri_protocol_violated_scans SET CandID=(SELECT ID from candidate c WHERE c.CandID=mri_protocol_violated_scans.CandID);
@@ -76,11 +76,11 @@ ALTER TABLE mri_protocol_violated_scans CHANGE CandID CandidateID int(10) unsign
 ALTER TABLE mri_protocol_violated_scans ADD CONSTRAINT FK_mri_protocol_violated_scans_candidate_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 UPDATE participant_status_history SET CandID=(SELECT ID from candidate c WHERE c.CandID=participant_status_history.CandID);
-ALTER TABLE participant_status_history CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE participant_status_history CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE participant_status_history ADD CONSTRAINT FK_participant_status_history_candidate_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 UPDATE family SET CandID=(SELECT ID from candidate c WHERE c.CandID=family.CandID);
-ALTER TABLE family CHANGE CandID CandidateID int(10) unsigned;
+ALTER TABLE family CHANGE CandID CandidateID int(10) unsigned NOT NULL;
 ALTER TABLE family ADD CONSTRAINT FK_family_candidate_1 FOREIGN KEY (CandidateID) REFERENCES candidate(ID);
 
 


### PR DESCRIPTION
Closes #9564 .

This PR addresses the forgotten `NULL`ability annotations, found by Loris-MRI integration tests.

`NULL`ability should now be identical to how it was prior to the last patch in  #9556