### PR TITLE
Fix incorrect query in modules/dataquery/php/endpoints/queries/query/run.class.inc

### DIFF
--- a/modules/dataquery/php/endpoints/queries/query/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run.class.inc
@@ -86,7 +86,7 @@ class Run extends \LORIS\Http\Endpoint
                 );
                 if ((count($values) >= 2000 || $end) && count($values) > 0) {
                     $insertstmt = "INSERT INTO dataquery_run_results
-    					    (RunID, CandID, RowData) VALUES "
+    					    (RunID, CandidateID, RowData) VALUES "
                     . " (" . join('),(', $values) . ')';
                     $q          = $db->prepare($insertstmt);
                     $q->execute([]);


### PR DESCRIPTION
This PR changes a query in class `modules/dataquery/php/endpoints/queries/query/run.class.inc` so that it now references column `CandidateID` in table `dataquery_run_results` (the old code was incorrectly referencing column `CandID`). 