### PR TITLE
Fix user singleton when an argument is passed.

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -165,10 +165,19 @@ class User extends UserPermissions implements
      */
     public static function &singleton(?string $username = null): \User
     {
-        static $instance;
-        if (is_null($instance)) {
-            $instance = User::factory($username);
+        static $currentuser = null;
+        static $allusers    = [];
+        if ($username === null && $currentuser !== null) {
+            return $currentuser;
         }
+        if ($username !== null && isset($allusers[$username])) {
+            return $allusers[$username];
+        }
+        $instance = User::factory($username);
+        if ($currentuser === null) {
+            $currentuser = $instance;
+        }
+        $allusers[$username] = $instance;
         return $instance;
     }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -171,7 +171,7 @@ class User extends UserPermissions implements
             return $currentuser;
         }
         if ($username !== null && isset($allusers[$username])) {
-            return $allusers[$username ?? ''];
+            return $allusers[$username];
         }
         $instance = User::factory($username);
         if ($currentuser === null) {

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -171,13 +171,13 @@ class User extends UserPermissions implements
             return $currentuser;
         }
         if ($username !== null && isset($allusers[$username])) {
-            return $allusers[$username];
+            return $allusers[$username ?? ''];
         }
         $instance = User::factory($username);
         if ($currentuser === null) {
             $currentuser = $instance;
         }
-        $allusers[$username] = $instance;
+        $allusers[$username ?? ''] = $instance;
         return $instance;
     }
 


### PR DESCRIPTION
User::singleton currently always returns the logged in user. If the $username argument is passed, it still returns the logged in user instead of the user requested.

This updates the singleton so that it's possible to use it to get references to other users.