### PR TITLE
[candidate_list] Fix GROUP BY in row provisioner

### DIFF
--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -83,7 +83,9 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                     LEFT JOIN cohort sp ON (s.CohortID=sp.CohortID)
                 WHERE c.Active = 'Y'
                 AND c.RegistrationProjectID IS NOT NULL
-                GROUP BY c.CandID, psc.Name, c.PSCID, c.Sex
+                GROUP BY c.CandID, psc.Name, c.PSCID, c.Sex, c.Entity_type,
+                    pso.Description, c.DOB, c.Date_registered, p.Name,
+                    c.RegistrationCenterID, c.RegistrationProjectID
                 ORDER BY c.PSCID ASC
             ",
             []


### PR DESCRIPTION
## Brief summary of changes
The candidate list module was not loading on my VM with the following error:
`[Fri Feb 21 11:54:24.183216 2025] [php:error] [pid 41249] [client ::1:38026] PHP Fatal error: Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #6 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'cbeaudoin_dev.c.Entity_type' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by in /var/www/loris/src/Database/Query.php:46\nStack trace:\n#0 /var/www/loris/src/Database/Query.php(46): PDOStatement->execute()\n#1 /var/www/loris/src/Data/Provisioners/DBRowProvisioner.php(90): LORIS\\Database\\Query->getIterator()\n#2 [internal function]: LORIS\\Data\\Provisioners\\DBRowProvisioner->getAllInstances()\n#3 [internal function]: FilterIterator->rewind()\n#4 /var/www/loris/src/Http/DataIteratorBinaryStream.php(239): FilterIterator->rewind()\n#5 [internal function]: LORIS\\Http\\DataIteratorBinaryStream->rowGenerator()\n#6 /var/www/loris/src/Http/DataIteratorBinaryStream.php(189): Generator->valid()\n#7 /var/www/loris/src/Http/GzipStream.php(160): LORIS\\Http\\DataIteratorBinaryStream->read()\n#8 /var/www/loris/htdocs/index.php(102): LORIS\\Http\\GzipStream->read()\n#9 {main}\n thrown in /var/www/loris/src/Database/Query.php on line 46, referer: http://localhost:8080/candidate_list/`

There were fields missing from the GROUP BY statement. This PR adds all missing fields

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Click "Access profile" in the Candidate menu to get to the candidate_list module
2. Make sure the module loads

#### Link(s) to related issue(s)

* Resolves #NO ISSUE
