### PR TITLE
[tool - fix_timepoint_date_problems.php] Fix PHP Fatal error

### DIFF
--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -506,7 +506,7 @@ function fixDate($candID, $dateType, $newDate, $sessionID, $db)
     // check the date format (redundant)
     $dateArray = explode('-', $newDate);
     if (!is_array($dateArray)
-        || !checkdate($dateArray[1], $dateArray[2], $dateArray[0])
+        || !checkdate(intval($dateArray[1]), intval($dateArray[2]), intval($dateArray[0]))
     ) {
         throw new LorisException(
             "Invalid Date! Please use the following format: YYYY-MM-DD \n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -524,7 +524,11 @@ function fixDate($candID, $dateType, $newDate, $sessionID, $db)
     // check the date format (redundant)
     $dateArray = explode('-', $newDate);
     if (!is_array($dateArray)
-        || !checkdate(intval($dateArray[1]), intval($dateArray[2]), intval($dateArray[0]))
+        || !checkdate(
+            intval($dateArray[1]),
+            intval($dateArray[2]),
+            intval($dateArray[0])
+        )
     ) {
         throw new LorisException(
             "Invalid Date! Please use the following format: YYYY-MM-DD \n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -165,22 +165,7 @@ if (!in_array($action, ['diagnose', 'fix_date', 'add_instrument'])) {
     );
     return false;
 }
-<<<<<<< HEAD
-=======
-// check $candID
-if (!preg_match("/^([0-9]{1,10})$/", strval($candID))) {
-    fwrite(
-        STDERR,
-        "Error: invalid 2st argument CandID ($candID).\n " .
-        "It has to be a 6-digit number\n"
-    );
-    fwrite(
-        STDERR,
-        "For the script syntax type: fix_timepoint_date_problems.php help \n"
-    );
-    return false;
-}
->>>>>>> 278e8102c (Fix PHP Fatal error when running fix_timepoint_date_problems.php)
+
 // Candidate object - to check if valid $candID
 $candidate =& Candidate::singleton($candID);
 //get the list of timepoints (sessionIDs) for the profile
@@ -524,11 +509,7 @@ function fixDate($candID, $dateType, $newDate, $sessionID, $db)
     // check the date format (redundant)
     $dateArray = explode('-', $newDate);
     if (!is_array($dateArray)
-        || !checkdate(
-            intval($dateArray[1]),
-            intval($dateArray[2]),
-            intval($dateArray[0])
-        )
+        || !checkdate($dateArray[1], $dateArray[2], $dateArray[0])
     ) {
         throw new LorisException(
             "Invalid Date! Please use the following format: YYYY-MM-DD \n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -81,7 +81,7 @@ if (empty($argv[1]) || empty($argv[2]) || $argv[1] == 'help') {
 $action = strtolower($argv[1]);
 
 // loosely check that CandID has proper syntax
-if (!preg_match("/^([0-9]{1,10})$/", strval($candID))) {
+if (!preg_match("/^([0-9]{1,10})$/", strval($argv[2]))) {
     fwrite(
         STDERR,
         "Error: invalid 2st argument CandID ({$argv[2]}).\n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -524,7 +524,7 @@ function fixDate($candID, $dateType, $newDate, $sessionID, $db)
     // check the date format (redundant)
     $dateArray = explode('-', $newDate);
     if (!is_array($dateArray)
-        || !checkdate($dateArray[1], $dateArray[2], $dateArray[0])
+        || !checkdate(intval($dateArray[1]), intval($dateArray[2]), intval($dateArray[0]))
     ) {
         throw new LorisException(
             "Invalid Date! Please use the following format: YYYY-MM-DD \n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -506,7 +506,11 @@ function fixDate($candID, $dateType, $newDate, $sessionID, $db)
     // check the date format (redundant)
     $dateArray = explode('-', $newDate);
     if (!is_array($dateArray)
-        || !checkdate(intval($dateArray[1]), intval($dateArray[2]), intval($dateArray[0]))
+        || !checkdate(
+            intval($dateArray[1]),
+            intval($dateArray[2]),
+            intval($dateArray[0])
+        )
     ) {
         throw new LorisException(
             "Invalid Date! Please use the following format: YYYY-MM-DD \n"

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -165,6 +165,22 @@ if (!in_array($action, ['diagnose', 'fix_date', 'add_instrument'])) {
     );
     return false;
 }
+<<<<<<< HEAD
+=======
+// check $candID
+if (!preg_match("/^([0-9]{1,10})$/", strval($candID))) {
+    fwrite(
+        STDERR,
+        "Error: invalid 2st argument CandID ($candID).\n " .
+        "It has to be a 6-digit number\n"
+    );
+    fwrite(
+        STDERR,
+        "For the script syntax type: fix_timepoint_date_problems.php help \n"
+    );
+    return false;
+}
+>>>>>>> 278e8102c (Fix PHP Fatal error when running fix_timepoint_date_problems.php)
 // Candidate object - to check if valid $candID
 $candidate =& Candidate::singleton($candID);
 //get the list of timepoints (sessionIDs) for the profile

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -80,20 +80,17 @@ if (empty($argv[1]) || empty($argv[2]) || $argv[1] == 'help') {
 // get $action argument
 $action = strtolower($argv[1]);
 
-// CandID
-try {
-    $candID = new CandID($argv[2]);
-} catch (DomainException $e) {
+// loosely check that CandID has proper syntax
+if (!preg_match("/^([0-9]{1,10})$/", strval($candID))) {
     fwrite(
         STDERR,
         "Error: invalid 2st argument CandID ({$argv[2]}).\n"
     );
-    fwrite(
-        STDERR,
-        "For the script syntax type: fix_timepoint_date_problems.php help \n"
-    );
-    exit;
+    printUsage();
 }
+
+// CandID
+$candID = new CandID($argv[2]);
 
 // get the rest of the arguments
 switch ($action) {


### PR DESCRIPTION
## Brief summary of changes

This fixes the following errors when running the tool `fix_timepoint_date_problems.php`
```
PHP Fatal error:  Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, LORIS\StudyEntities\Candidate\CandID given in /var/www/Loris/tools/fix_timepoint_date_problems.php:157
Stack trace:
#0 /var/www/Loris/tools/fix_timepoint_date_problems.php(157): preg_match()
#1 {main}
  thrown in /var/www/Loris/tools/fix_timepoint_date_problems.php on line 157
```

```
PHP Fatal error:  Uncaught TypeError: checkdate(): Argument #1 ($month) must be of type int, string given in /var/www/Loris/tools/fix_timepoint_date_problems.php:519
Stack trace:
#0 /var/www/Loris/tools/fix_timepoint_date_problems.php(519): checkdate()
#1 /var/www/Loris/tools/fix_timepoint_date_problems.php(244): fixDate()
#2 {main}
  thrown in /var/www/Loris/tools/fix_timepoint_date_problems.php on line 519
```

```
PHP Warning:  Undefined variable $db in /var/www/Loris/php/libraries/NDB_BVL_Feedback.class.inc on line 717
PHP Fatal error:  Uncaught Error: Call to a member function pselectOne() on null in /var/www/Loris/php/libraries/NDB_BVL_Feedback.class.inc:717
Stack trace:
#0 /var/www/Loris/tools/fix_timepoint_date_problems.php(553): NDB_BVL_Feedback->createThread()
#1 /var/www/Loris/tools/fix_timepoint_date_problems.php(244): fixDate()
#2 {main}
  thrown in /var/www/Loris/php/libraries/NDB_BVL_Feedback.class.inc on line 717
```