### PR TITLE
[tools] Fix integrity script for CandidateID change

### DIFF
--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -73,9 +73,11 @@ class CouchDBIntegrityChecker
         );
         print "Sessions:\n";
         $activeExists = $this->SQLDB->prepare(
-            "SELECT count(*) AS count FROM 
-        candidate c LEFT JOIN session s USING (CandID) WHERE s.Active='Y' 
-        AND c.Active='Y' AND c.PSCID=:PID and s.Visit_label=:VL"
+            "SELECT count(*) AS count
+            FROM candidate c
+            LEFT JOIN session s ON (s.CandidateID = c.ID)
+            WHERE s.Active='Y' 
+            AND c.Active='Y' AND c.PSCID=:PID and s.Visit_label=:VL"
         );
         foreach ($sessions as $row) {
             $pscid = $row['key'][0];
@@ -83,7 +85,7 @@ class CouchDBIntegrityChecker
             $sqlDB = $this->SQLDB->pselectRow(
                 "SELECT c.*, s.Visit_label, s.Active, c.Active as cActive
                 FROM candidate c
-                LEFT JOIN session s USING (CandID)
+                LEFT JOIN session s ON (s.CandidateID = c.ID)
                 WHERE c.PSCID=:PID AND s.Visit_label=:VL",
                 [
                     "PID" => $pscid,


### PR DESCRIPTION
## Brief summary of changes
- script failed because of CandidateID change
![image](https://github.com/user-attachments/assets/4387e011-14f8-4f0d-80f1-e3ac977102c5)


#### Testing instructions (if applicable)

1. Try running the script
