### PR TITLE
[Examiner] Fix loading of edit examiner page

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -294,7 +294,9 @@ class EditExaminer extends \NDB_Form
             ['EID' => $this->identifier]
         );
 
-        $this->tpl_data['certification_history'] = $certification_history;
+        $this->tpl_data['certification_history'] = \iterator_to_array(
+            $certification_history
+        );
 
         $config = \NDB_Config::singleton();
 


### PR DESCRIPTION
A smarty was trying to use a variable that was directly set to a pselect output, causing an error. Explicitly convert it to an array.

Fixes #9605