### PR TITLE
[issue_tracker] Fix bug that prevents new issue creation

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1564,7 +1564,7 @@ CREATE TABLE `issues_history` (
   `issueHistoryID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `newValue` longtext NOT NULL,
   `dateAdded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description','watching','instrument') NOT NULL DEFAULT 'comment',
+  `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candidateID', 'description','watching','instrument') NOT NULL DEFAULT 'comment',
   `issueID` int(11) unsigned NOT NULL,
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),

--- a/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
+++ b/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
@@ -1,0 +1,6 @@
+ALTER TABLE issues_history CHANGE `fieldChanged` `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','CandidateID','candID','description','watching','instrument') NOT NULL DEFAULT 'comment';
+
+UPDATE issues_history SET `fieldChanged` = 'CandidateID' WHERE `fieldChanged` = 'candID';
+
+ALTER TABLE issues_history CHANGE `fieldChanged` `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','CandidateID', 'description','watching','instrument') NOT NULL DEFAULT 'comment';
+

--- a/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
+++ b/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
@@ -6,4 +6,4 @@ ALTER TABLE issues_history CHANGE `fieldChanged` `fieldChanged` enum('assignee',
 
 UPDATE issues_history
 JOIN candidate ON issues_history.newValue = candidate.CandID
-SET issues_history.newValue = candidate.ID WHERE issues_history.fieldChanged = 'candID';
+SET issues_history.newValue = candidate.ID WHERE issues_history.fieldChanged = 'CandidateID';

--- a/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
+++ b/SQL/New_patches/2025-02-26_alter_issues_history_fieldChanged.sql
@@ -4,3 +4,6 @@ UPDATE issues_history SET `fieldChanged` = 'CandidateID' WHERE `fieldChanged` = 
 
 ALTER TABLE issues_history CHANGE `fieldChanged` `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','CandidateID', 'description','watching','instrument') NOT NULL DEFAULT 'comment';
 
+UPDATE issues_history
+JOIN candidate ON issues_history.newValue = candidate.CandID
+SET issues_history.newValue = candidate.ID WHERE issues_history.fieldChanged = 'candID';

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -400,7 +400,7 @@ class Edit extends \NDB_Page implements ETagCalculator
 
         // Fetch issues
         $baseQuery = "
-            SELECT i.*, c.CandID as candID, c.PSCID, s.Visit_label AS visitLabel
+            SELECT i.*, c.PSCID, s.Visit_label AS visitLabel
             FROM issues AS i
             LEFT JOIN candidate c ON i.CandidateID = c.ID
             LEFT JOIN session s ON i.sessionID = s.ID
@@ -479,6 +479,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 : null;
 
             $issue['topComments'] = $this->getTopComments($issueID);
+            unset($issue['CandidateID']);
         }
 
         return [
@@ -537,7 +538,6 @@ class Edit extends \NDB_Page implements ETagCalculator
             $issueData = $db->pselectRow(
                 "SELECT
                             i.*,
-                            c.CandID AS candID,
                             c.PSCID,
                             s.Visit_label AS visitLabel,
                             t.Test_name as instrument_name
@@ -563,6 +563,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 $issueData['lastUpdatedBy']
             );
             // return
+            unset($issueData['CandidateID']);
             return $issueData;
         }
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -627,7 +627,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                     intval($comment['newValue'])
                 );
                 $comment['fieldChanged'] = 'site';
-            } else if ($comment['fieldChanged'] === 'candID') {
+            } else if ($comment['fieldChanged'] === 'CandidateID') {
                 $PSCID = $db->pselectOne(
                     "SELECT PSCID FROM candidate WHERE ID=:candidateID",
                     ['candidateID' => $comment['newValue']]
@@ -1290,7 +1290,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             if (!empty($value) || $key === 'centerID') {
                 $changedValues = [
                     'newValue'     => $value ?? '',
-                    'fieldChanged' => ($key == 'CandidateID')? 'candID' : $key,
+                    'fieldChanged' => $key,
                     'issueID'      => $issueID,
                     'addedBy'      => $user->getUsername(),
                 ];

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -629,8 +629,8 @@ class Edit extends \NDB_Page implements ETagCalculator
                 $comment['fieldChanged'] = 'site';
             } else if ($comment['fieldChanged'] === 'candID') {
                 $PSCID = $db->pselectOne(
-                    "SELECT PSCID FROM candidate WHERE CandID=:candID",
-                    ['candID' => $comment['newValue']]
+                    "SELECT PSCID FROM candidate WHERE ID=:candidateID",
+                    ['candidateID' => $comment['newValue']]
                 );
                 $comment['newValue']     = $PSCID;
                 $comment['fieldChanged'] = 'PSCID';
@@ -802,9 +802,12 @@ class Edit extends \NDB_Page implements ETagCalculator
         if (array_key_exists('sessionID', $validatedInput)) {
             $issueValues['sessionID'] = $validatedInput['sessionID'];
         }
-
         if (array_key_exists('candID', $validatedInput)) {
-            $issueValues['candID'] = $validatedInput['candID'];
+            $candidateID = $db->pselectOne(
+                "SELECT ID FROM candidate WHERE CandID=:candID",
+                ['candID' => $validatedInput['candID']]
+            );
+            $issueValues['CandidateID'] = $candidateID;
         }
 
         // Get changed values to save in history
@@ -1157,7 +1160,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         // If both are set, return SessionID and CandID
         if (isset($result['PSCID']) && isset($result['visit'])) {
             $session = iterator_to_array(
-                $db->pSelect(
+                $db->pselect(
                     "SELECT s.ID as sessionID, c.CandID as candID FROM candidate c
                 INNER JOIN session s on (c.ID = s.CandidateID)
                 WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
@@ -1193,7 +1196,7 @@ class Edit extends \NDB_Page implements ETagCalculator
                 $query .= " AND FIND_IN_SET(RegistrationCenterID,:CenterID)";
             }
 
-            $candidate = $db->pSelectOne($query, $params);
+            $candidate = $db->pselectOne($query, $params);
             if ($candidate) {
                 $result['candID'] = $candidate;
             } else {
@@ -1287,7 +1290,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             if (!empty($value) || $key === 'centerID') {
                 $changedValues = [
                     'newValue'     => $value ?? '',
-                    'fieldChanged' => $key,
+                    'fieldChanged' => ($key == 'CandidateID')? 'candID' : $key,
                     'issueID'      => $issueID,
                     'addedBy'      => $user->getUsername(),
                 ];

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -48,7 +48,6 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                i.dateCreated,
                i.lastUpdate,
                s.ID AS sessionId,
-               c.CandID AS candidateId,
                w.userID AS userId
         FROM issues AS i
         LEFT JOIN modules m ON m.ID = i.module

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -28,15 +28,15 @@ namespace LORIS\issue_tracker\Models;
  */
 class AttachmentDTO implements \LORIS\Data\DataInstance
 {
-    public string $ID;
-    public string $issueID;
+    public int $ID;
+    public int $issueID;
     public string $file_hash;
     public string $date_added;
     public string $file_name;
-    public string $deleted;
+    public int $deleted;
     public string $user;
     public string $description;
-    public string $file_size;
+    public int $file_size;
     public string $mime_type;
 
     /**


### PR DESCRIPTION
Related to #9606

- This PR fixes the issue description. The cause of the issue is the change of CandID => CandidateID.
- It also resolves a bug that causes the Edit Issue page to fail to display when an attachment is included in an issue. 

To Test:
- See if you can create a new issue or update existing issue
- Upload a file to an issue and see if the page doesn't break and you can see the attachments/file when the page refreshes.