### PR TITLE
[NDB_BVL_Instrument_LINST] Add Metadata Fields after adding to dictionary

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -854,10 +854,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $this->instanceData = $newData;
     }
-
     /**
      * Adds metadata fields (such as Examiner and Date_taken) to the
-     * current form
+     * current form. Note that NDB_BVL_Instrument_LINST.class.inc mimics the logic
+     * of this function to build the data dictionary, so any changes here should
+     * be reflected there as well.
      *
      * @return void
      * @access private

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -447,6 +447,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $pieces[1]
                         );
                     }
+                    // The sequence of if statements below building the data dictionary is designed to
+                    // mimic the same logic in the _addMetadataFields() function of
+                    // NDB_BVL_Instrument to keep the dictionary in sync with the fields added 
+                    // to the form, make sure to modify it accordingly
                     if ($this->DataEntryType!=="DirectEntry") {
                         $this->dictionary = array_merge(
                             $this->dictionary,

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -440,16 +440,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     break;
                 case 'title':
                     $this->fullName = trim($pieces[1]);
-                    if ($addElements) {
-                        $this->form->addElement(
-                            'header',
-                            'instrument_title',
-                            $pieces[1]
-                        );
-                        if ($this->DataEntryType!=="DirectEntry") {
-                            $this->_addMetadataFields();
-                        }
-                    }
                     $this->dictionary = array_merge(
                         $this->dictionary,
                         [
@@ -523,6 +513,16 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             ),
                         ]
                     );
+                    if ($addElements) {
+                        $this->form->addElement(
+                            'header',
+                            'instrument_title',
+                            $pieces[1]
+                        );
+                        if ($this->DataEntryType!=="DirectEntry") {
+                            $this->_addMetadataFields();
+                        }
+                    }
                     break;
                 case 'begingroup':
                     if ($addElements) {

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -447,7 +447,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $pieces[1]
                         );
                     }
-                    // The sequence of if statements below building the data dictionary
+                    // The sequence of if statements below building the data dict
                     // mimics the same logic in the _addMetadataFields() function of
                     // NDB_BVL_Instrument to keep the dictionary in sync with the
                     // fields added to the form, make sure to modify it accordingly

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -447,10 +447,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $pieces[1]
                         );
                     }
-                    // The sequence of if statements below building the data dictionary is designed to
-                    // mimic the same logic in the _addMetadataFields() function of
-                    // NDB_BVL_Instrument to keep the dictionary in sync with the fields added 
-                    // to the form, make sure to modify it accordingly
+                    // The sequence of if statements below building the data dictionary
+                    // mimics the same logic in the _addMetadataFields() function of
+                    // NDB_BVL_Instrument to keep the dictionary in sync with the
+                    // fields added to the form, make sure to modify it accordingly
                     if ($this->DataEntryType!=="DirectEntry") {
                         $this->dictionary = array_merge(
                             $this->dictionary,

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -440,45 +440,67 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     break;
                 case 'title':
                     $this->fullName = trim($pieces[1]);
-                    $this->dictionary = array_merge(
-                        $this->dictionary,
-                        [
-                            new DictionaryItem(
-                                $this->testName.'_Date_taken',
-                                'Date of Administration',
-                                $scope,
-                                new \LORIS\Data\Types\DateType(),
-                                new Cardinality(Cardinality::SINGLE),
-                                'Date_taken',
-                            ),
-                        ]
-                    );
-                    if (strrpos($this->testName ?? '', '_proband') === false) {
-                        if (!$this->postMortem) {
+                    if ($addElements) {
+                        $this->form->addElement(
+                            'header',
+                            'instrument_title',
+                            $pieces[1]
+                        );
+                    }
+                    if ($this->DataEntryType!=="DirectEntry") {
+                        $this->dictionary = array_merge(
+                            $this->dictionary,
+                            [
+                                new DictionaryItem(
+                                    $this->testName.'_Date_taken',
+                                    'Date of Administration',
+                                    $scope,
+                                    new \LORIS\Data\Types\DateType(),
+                                    new Cardinality(Cardinality::SINGLE),
+                                    'Date_taken',
+                                ),
+                            ]
+                        );
+                        if (strrpos($this->testName ?? '', '_proband') === false) {
+                            if (!$this->postMortem) {
+                                $this->dictionary = array_merge(
+                                    $this->dictionary,
+                                    [
+                                        new DictionaryItem(
+                                            $this->testName.'_Candidate_Age',
+                                            'Candidate Age (Months)',
+                                            $scope,
+                                            new \LORIS\Data\Types\Duration(),
+                                            new Cardinality(Cardinality::SINGLE),
+                                            'Candidate_Age',
+                                        ),
+                                    ]
+                                );
+                            } else {
+                                $this->dictionary = array_merge(
+                                    $this->dictionary,
+                                    [
+                                        new DictionaryItem(
+                                            $this->testName.'_Candidate_Age',
+                                            'Candidate Age at Death (Months)',
+                                            $scope,
+                                            new \LORIS\Data\Types\Duration(),
+                                            new Cardinality(Cardinality::SINGLE),
+                                            'Candidate_Age',
+                                        ),
+                                    ]
+                                );
+                            }
                             $this->dictionary = array_merge(
                                 $this->dictionary,
                                 [
                                     new DictionaryItem(
-                                        $this->testName.'_Candidate_Age',
-                                        'Candidate Age (Months)',
+                                        $this->testName.'_Window_Difference',
+                                        'Window difference from test battery (days)',
                                         $scope,
                                         new \LORIS\Data\Types\Duration(),
                                         new Cardinality(Cardinality::SINGLE),
-                                        'Candidate_Age',
-                                    ),
-                                ]
-                            );
-                        } else {
-                            $this->dictionary = array_merge(
-                                $this->dictionary,
-                                [
-                                    new DictionaryItem(
-                                        $this->testName.'_Candidate_Age',
-                                        'Candidate Age at Death (Months)',
-                                        $scope,
-                                        new \LORIS\Data\Types\Duration(),
-                                        new Cardinality(Cardinality::SINGLE),
-                                        'Candidate_Age',
+                                        'Window_Difference',
                                     ),
                                 ]
                             );
@@ -487,39 +509,19 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $this->dictionary,
                             [
                                 new DictionaryItem(
-                                    $this->testName.'_Window_Difference',
-                                    'Window difference from test battery (days)',
+                                    $this->testName.'_Examiner',
+                                    'Examiner',
                                     $scope,
-                                    new \LORIS\Data\Types\Duration(),
+                                    // This should be an enum of examiners, but
+                                    // getExaminerNames currently returns an empty
+                                    // array if CommentID is not set.
+                                    new StringType(255),
                                     new Cardinality(Cardinality::SINGLE),
-                                    'Window_Difference',
+                                    'Examiner',
                                 ),
                             ]
                         );
-                    }
-                    $this->dictionary = array_merge(
-                        $this->dictionary,
-                        [
-                            new DictionaryItem(
-                                $this->testName.'_Examiner',
-                                'Examiner',
-                                $scope,
-                                // This should be an enum of examiners, but
-                                // getExaminerNames currently returns an empty
-                                // array if CommentID is not set.
-                                new StringType(255),
-                                new Cardinality(Cardinality::SINGLE),
-                                'Examiner',
-                            ),
-                        ]
-                    );
-                    if ($addElements) {
-                        $this->form->addElement(
-                            'header',
-                            'instrument_title',
-                            $pieces[1]
-                        );
-                        if ($this->DataEntryType!=="DirectEntry") {
+                        if ($addElements) {
                             $this->_addMetadataFields();
                         }
                     }


### PR DESCRIPTION
## Brief summary of changes
- raisinbread BMI instrument was not opening due to a change I made in #9416 where getExaminerFields in NDB_BVL_Instrument now relied on data being present in the instrument's dictionary.
- Unfortunately, when loading a LINST instrument with Direct Entry enabled, it would first run _addMetadataFields, and then add metadata fields to the dictionary
- _addMetadataFields would then call getExaminerFields causing it to fail, since getExaminerFields relies on the dictionary having metadata, but the metadata is added after _addMetadataFields
- The change has been made so _addMetadataFields is run _after_ metadata is entered in the instance's dictionary. Further, metadata fields are only added to the instances dictionary if direct entry is not enabled. Otherwise they were added to the dictionary when they did not exist.

### **WHEN REVIEWING THIS PR, PRESS THE GEAR ICON, THEN HIDE WHITESPACE**

#### Testing instructions (if applicable)

1. Try to open the raisinbread LINST instrument
2. See that it opens
3. Try setting direct entry to true, see that it still opens

#### Link(s) to related issue(s)

* Resolves #9582, #9644
