### PR TITLE
[candidate_parameters] Make Participant Status Reason properly required

### DIFF
--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -97,9 +97,6 @@ class ParticipantStatus extends Component {
   setFormData(formElement, value) {
     let formData = this.state.formData;
     let required = this.state.Data.required;
-    if (formElement === 'participantStatus' && required.indexOf(value) < 0) {
-      formData.participantSuboptions = '';
-    }
     formData[formElement] = value;
     this.setState(
       {
@@ -148,21 +145,15 @@ class ParticipantStatus extends Component {
         this.state.formData.participantStatus :
         this.state.Data.participantStatus
     );
-
-    if (participantStatus && required.indexOf(participantStatus) > -1) {
+    if (participantStatus && required.includes(Number(participantStatus))) {
       subOptions = this.state.Data.parentIDs[participantStatus];
       suboptionsRequired = true;
     }
 
-    let commentsRequired = false;
     let statusOpts = this.state.Data.statusOptions;
-    if (
-      statusOpts &&
+    let commentsRequired = statusOpts &&
           statusOpts[participantStatus] !== 'Active' &&
-          statusOpts[participantStatus] !== 'Complete'
-    ) {
-      commentsRequired = true;
-    }
+          statusOpts[participantStatus] !== 'Complete';
 
     let formattedHistory = [];
     for (let statusKey in this.state.Data.history) {

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -96,7 +96,6 @@ class ParticipantStatus extends Component {
    */
   setFormData(formElement, value) {
     let formData = this.state.formData;
-    let required = this.state.Data.required;
     formData[formElement] = value;
     this.setState(
       {


### PR DESCRIPTION
## Brief summary of changes
This PR makes the participant status reason field show up as enabled and required when a participant status is configured to have a reason required. This is done by casting the participant status index as a number before checking if it is in the required array. I also removed some unnecessary code in setFormData() that was making the field highlight red before anything was saved.

<img width="804" alt="image" src="https://github.com/user-attachments/assets/f86a5d36-05d3-4563-a13c-e4fd6ad43686" />

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to participant status
2. Try selecting different participant status values and make sure that the reason field is only enabled / required when the participant status chosen has "Required" set to true in participant_status_options.
3. Try saving when the participant status reason is not required, make sure it saves properly without a value entered
4. Try saving when the participant status reason is required and nothing is entered. Make sure you get an error message
5. Try saving when the participant status reason is required and an option is selected. Make sure that it saves successfully
6. Check that the comment is only required for a participant status of "Active" or "Complete"

#### Link(s) to related issue(s)

* Resolves #9601
