### PR TITLE
[dictionary] Fix out of order cols

### DIFF
--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -161,6 +161,7 @@ class DataDictIndex extends Component {
         return resp.json();
       })
       .then((data) => {
+        console.log(data)
         this.setState({data});
       })
       .catch((error) => {
@@ -197,12 +198,6 @@ class DataDictIndex extends Component {
       return <td>{cell}
         <span style={{color: '#838383'}}>{edited} {editIcon} </span>
       </td>;
-    case 'Data Type':
-      if (cell == 'enumeration') {
-        const fieldOptions = rowData['Field Options'];
-        cell = Array.isArray(fieldOptions) ? fieldOptions.join(';') : '';
-      }
-      return <td>{cell}</td>;
     default:
       return <td>{cell}</td>;
     }
@@ -307,6 +302,15 @@ class DataDictIndex extends Component {
             'optional': 'Optional',
             'many': 'Many',
           },
+        },
+      },
+      {
+        label: 'Visits',
+        show: true,
+        filter: {
+          name: 'Visits',
+          type: 'multiselect',
+          options: options.visits,
         },
       },
       {

--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -73,11 +73,11 @@ class DataDictRow implements \LORIS\Data\DataInstance,
 
         $itype = $this->item->getDataType();
         if ($itype instanceof \LORIS\Data\Types\Enumeration) {
-            $val['options'] = $itype->getOptions();
+            $val['type'] = "enum(".implode(",",$itype->getOptions()).")";
         }
         if ($scope->__toString() == "session") {
-            $val['visits']  = $this->visits;
-            $val['cohorts'] = $this->cohorts;
+            $val['visits']  = implode(",",$this->visits);
+            $val['cohorts'] = implode(",",$this->cohorts);
         }
 
         return $val;

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -70,7 +70,7 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
                 }
 
                 $cohorts = $DB->pselectCol(
-                    "SELECT GROUP_CONCAT(DISTINCT c.title) FROM test_names tn
+                    "SELECT DISTINCT c.title FROM test_names tn
                         JOIN test_battery tb ON tn.Test_name=tb.Test_name
                         JOIN cohort c ON tb.CohortID=c.CohortID
                         WHERE tn.Test_name=:tn

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -62,10 +62,15 @@ class Dictionary extends \DataFrameworkMenu
         foreach (array_values($cohorts) as $name) {
             $cohort_options[$name] = $name;
         }
+        $visit_options = [];
+        foreach (\Utility::getVisitList() as $visit) {
+            $visit_options[$visit] = $visit;
+        }
         return [
             'modules'    => $amodules,
             'categories' => $this->categories,
-            'cohorts'    => $cohort_options
+            'visits'     => $visit_options,
+            'cohorts'    => $cohort_options,
         ];
     }
 


### PR DESCRIPTION
## Brief summary of changes
- Dictionary module had issues with columns being out of order
- Made the data displayed correctly by:
   - Separating visits into its own column for session level fields
   - Put enumeration data into the data type instead of a separate datapoint called options which was confusing
![image](https://github.com/user-attachments/assets/34d26ea6-e883-46ea-aa96-69890076bb2d)

#### Testing instructions (if applicable)

1. Poke around the dictionary module, confirm that the filters for visits and cohorts work
2. Confirm the enumeration options for enum fields are correct

#### Link(s) to related issue(s)

* Resolves #9656
