### PR TITLE
[timepoint] Incorporate 'all sites' permission into TimePoint::isAccessibleBy

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1249,7 +1249,9 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers);
-        return $projMatch && ($centerMatch || $user->hasPermission('access_all_profiles'));
+        return $projMatch && ($centerMatch ||
+            $user->hasPermission('access_all_profiles')
+        );
     }
 }
 

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1249,7 +1249,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers);
-        return $projMatch && $centerMatch;
+        return $projMatch && ($centerMatch || $user->hasPermission('access_all_profiles'));
     }
 }
 

--- a/raisinbread/test/api/LorisApiVisitsTest.php
+++ b/raisinbread/test/api/LorisApiVisitsTest.php
@@ -163,7 +163,7 @@ class LorisApiVisitsTest extends LorisApiAuthenticatedTest
             ]
         );
         // Verify the status code
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(400, $response->getStatusCode());
         // Verify the endpoint has a body
         $body = $response->getBody();
         $this->assertNotEmpty($body);

--- a/raisinbread/test/api/LorisApiVisitsTest.php
+++ b/raisinbread/test/api/LorisApiVisitsTest.php
@@ -139,7 +139,7 @@ class LorisApiVisitsTest extends LorisApiAuthenticatedTest
         // Erase sites that were setup in LorisApiAuthenticatedTest
         // setup for data access in other tests.
         $this->DB->run(
-            'DELETE FROM user_psc_rel WHERE UserID=999990 AND CenterID <> 1'
+            'DELETE FROM user_psc_rel WHERE UserID=999990'
         );
         /**
         * Test changing from a site with no affiliation to a site with affiliation
@@ -185,7 +185,7 @@ class LorisApiVisitsTest extends LorisApiAuthenticatedTest
             ]
         );
         // verify the status code
-        $this->assertequals(409, $response->getstatuscode());
+        $this->assertequals(403, $response->getstatuscode());
         // verify the endpoint has a body
         $body = $response->getbody();
         $this->assertnotempty($body);

--- a/raisinbread/test/api/LorisApiVisits_v0_0_3_Test.php
+++ b/raisinbread/test/api/LorisApiVisits_v0_0_3_Test.php
@@ -139,7 +139,7 @@ class LorisApiVisits_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
         // Erase sites that were setup in LorisApiAuthenticatedTest
         // setup for data access in other tests.
         $this->DB->run(
-            'DELETE FROM user_psc_rel WHERE UserID=999990 AND CenterID <> 1'
+            'DELETE FROM user_psc_rel WHERE UserID=999990 AND CenterID=1'
         );
         /**
         * Test changing from a site with no affiliation to a site with affiliation
@@ -185,7 +185,7 @@ class LorisApiVisits_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
             ]
         );
         // verify the status code
-        $this->assertequals(409, $response->getstatuscode());
+        $this->assertequals(403, $response->getstatuscode());
         // verify the endpoint has a body
         $body = $response->getbody();
         $this->assertnotempty($body);

--- a/raisinbread/test/api/LorisApiVisits_v0_0_3_Test.php
+++ b/raisinbread/test/api/LorisApiVisits_v0_0_3_Test.php
@@ -139,7 +139,7 @@ class LorisApiVisits_v0_0_3_Test extends LorisApiAuthenticated_v0_0_3_Test
         // Erase sites that were setup in LorisApiAuthenticatedTest
         // setup for data access in other tests.
         $this->DB->run(
-            'DELETE FROM user_psc_rel WHERE UserID=999990 AND CenterID=1'
+            'DELETE FROM user_psc_rel WHERE UserID=999990'
         );
         /**
         * Test changing from a site with no affiliation to a site with affiliation


### PR DESCRIPTION
## Brief summary of changes
The `isAccessibleBy` function in TimePoint.class.inc only considers the project & site permissions that a user has. This PR makes it so that if a user has the "Access Profile: View Candidates and Timepoints - All Sites" permission, then they can see tiempoints from any site. They still must have permission to the relevant project to view a timepoint. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Create a user who only has access to some sites / projects, and who only has the "Access Profile: View Candidates and Timepoints - Own Sites" permission
2. Set up a candidate who has some visits at the user's sites, and some visits at sites that the user does not have access to
3. Log in with the new user and access that same candidate. Make sure that you can only see the visits at sites that the user has access to
4. Grant the user the "Access Profile: View Candidates and Timepoints - All Sites" permission
5. Log in with the new user and access the same candidate. Now you should be able to see all visits
6. A user should still not be able to see any visits at projects that the user does not have access to

#### Link(s) to related issue(s)

* Resolves #9592
