### PR TITLE
[data_dict (legacy)] fix description not updating upon refresh

### DIFF
--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -29,6 +29,7 @@ $config =& NDB_Config::singleton();
 $client = new NDB_Client();
 $client->initialize();
 
+$DB = \NDB_Factory::singleton()->database();
 
 list($name,$extra) = explode("___", $_REQUEST['fieldname']);
 

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -59,7 +59,7 @@ class Datadict extends \DataFrameworkMenu
      */
     public function getFieldOptions() : array
     {
-        $instruments     = \Utility::getAllInstruments();
+        $instruments     = \NDB_BVL_Instrument::getInstrumentNamesList($this->loris);
         $dictInstruments = [];
         $user            = \User::singleton();
 

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -35,7 +35,7 @@ class Fields extends \NDB_Page
         }
         return new \LORIS\Http\Response\JSON\OK(
             [
-                'sourceFrom' => 
+                'sourceFrom' =>
                 \NDB_BVL_Instrument::getInstrumentNamesList($this->loris),
                 'cohort'     => $cohort_options
             ]

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -35,7 +35,8 @@ class Fields extends \NDB_Page
         }
         return new \LORIS\Http\Response\JSON\OK(
             [
-                'sourceFrom' => \Utility::getAllInstruments(),
+                'sourceFrom' => 
+                \NDB_BVL_Instrument::getInstrumentNamesList($this->loris),
                 'cohort'     => $cohort_options
             ]
         );


### PR DESCRIPTION
fixes #9618

To Test:
1. Log in as a user with permission data_dict_edit.
2. Edit the description of any field in the search result table.
3. Reload the page in the browser.
4. See the new description has been saved