### PR TITLE
[instrument_builder] Improve error message specificity for file upload

### DIFF
--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -63,7 +63,7 @@ class LoadPane extends Component {
       } else if (/\s/.test(nameWithoutExtension)) {
         errorMessage = 'Spaces are not allowed in the file name.';
       } else if ((nameWithoutExtension.match(/\./g) || []).length > 0) {
-        errorMessage = 'Multiple periods in the file name are not allowed.\n Works';
+        errorMessage = 'Multiple periods in the file name are not allowed.';
       } else if (!validNamePattern.test(nameWithoutExtension)) {
         errorMessage = 'Special characters are not allowed (only letters, numbers, and _).';
       } else if (invalidTrailingChars.test(nameWithoutExtension)) {

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -41,13 +41,48 @@ class LoadPane extends Component {
    */
   chooseFile(e) {
     let value = e.target.files[0];
-    this.setState({
-      file: value,
-      disabled: true,
-      alert: '',
-    });
+  
     if (value) {
-      this.setState({disabled: false});
+      const fileName = value.name;
+      const allowedExtension = '.linst';
+  
+      // Extract file name (without extension) and extension
+      const lastDotIndex = fileName.lastIndexOf('.');
+      const nameWithoutExtension = fileName.substring(0, lastDotIndex);
+      const fileExtension = fileName.substring(lastDotIndex);
+  
+      // Only allow letters, numbers, and underscores (_)
+      const validNamePattern = /^[a-zA-Z0-9_]+$/;
+      // File Name cannot be end with Special characters
+      const invalidTrailingChars = /[^a-zA-Z0-9]$/;
+
+      let errorMessage = '';
+  
+      if (fileExtension !== allowedExtension) {
+        errorMessage = 'Invalid extension. Only .linst files are allowed.';
+      } else if (/\s/.test(nameWithoutExtension)) {
+        errorMessage = 'Spaces are not allowed in the file name.';
+      } else if ((nameWithoutExtension.match(/\./g) || []).length > 0) {
+        errorMessage = 'Multiple periods in the file name are not allowed.\n Works';
+      } else if (!validNamePattern.test(nameWithoutExtension)) {
+        errorMessage = 'Special characters are not allowed (only letters, numbers, and _).';
+      } else if (invalidTrailingChars.test(nameWithoutExtension)) {
+        errorMessage = 'File name cannot end with a special character.';
+      }
+  
+      if (errorMessage) {
+        this.setState({
+          alert: 'typeError',
+          alertMessage: errorMessage, // Set the specific error message
+          disabled: true, // Disable button if invalid
+        });
+      } else {
+        this.setState({
+          file: value, // Store file
+          disabled: false, // Enable button if valid
+          alert: '', // Clear previous errors
+        });
+      }
     }
   }
   /**
@@ -109,7 +144,7 @@ class LoadPane extends Component {
     case 'typeError':
       alert = {
         message: 'Error!',
-        details: 'Wrong file format',
+        details: this.state.alertMessage,
         display: 'block',
         class: 'alert alert-danger alert-dismissible',
       };

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -41,23 +41,23 @@ class LoadPane extends Component {
    */
   chooseFile(e) {
     let value = e.target.files[0];
-  
+
     if (value) {
       const fileName = value.name;
       const allowedExtension = '.linst';
-  
+
       // Extract file name (without extension) and extension
       const lastDotIndex = fileName.lastIndexOf('.');
       const nameWithoutExtension = fileName.substring(0, lastDotIndex);
       const fileExtension = fileName.substring(lastDotIndex);
-  
+
       // Only allow letters, numbers, and underscores (_)
       const validNamePattern = /^[a-zA-Z0-9_]+$/;
       // File Name cannot be end with Special characters
       const invalidTrailingChars = /[^a-zA-Z0-9]$/;
 
       let errorMessage = '';
-  
+
       if (fileExtension !== allowedExtension) {
         errorMessage = 'Invalid extension. Only .linst files are allowed.';
       } else if (/\s/.test(nameWithoutExtension)) {
@@ -65,11 +65,12 @@ class LoadPane extends Component {
       } else if ((nameWithoutExtension.match(/\./g) || []).length > 0) {
         errorMessage = 'Multiple periods in the file name are not allowed.';
       } else if (!validNamePattern.test(nameWithoutExtension)) {
-        errorMessage = 'Special characters are not allowed (only letters, numbers, and _).';
+        errorMessage =
+        'Special characters are not allowed (only letters, numbers, and _).';
       } else if (invalidTrailingChars.test(nameWithoutExtension)) {
         errorMessage = 'File name cannot end with a special character.';
       }
-  
+
       if (errorMessage) {
         this.setState({
           alert: 'typeError',


### PR DESCRIPTION
## Brief Summary of Changes
- Improved error message handling for file uploads in Instrument Builder.
- Now provides **specific error messages** for:
  - Invalid extension. Only .linst files are allowed.
  - Spaces are not allowed in the file name.
  - Special characters are not allowed (only letters, numbers, and _).
  - Multiple periods in the file name are not allowed.
  - File name cannot end with a special character.

#### Testing Instructions
1. Try uploading different files with:
   - Valid names (`validFile.linst`) → Should succeed.
   - Names with **spaces** (`my file.linst`) → Should show `"Spaces are not allowed."`
   - Names with **special characters** (`file@name.linst`) → Should show `"Special characters are not allowed."`
   - Names with **multiple periods** (`file.name.linst`) → Should show `"Multiple periods in the file name are not allowed."`
   - Names **ending with special characters** (`file_.linst`) → Should show `"File name cannot end with a special character."`

2. Click "Load Instrument" after selecting a valid file → Should display a success message.

#### Additional Notes
- No changes were made to backend logic.
- This ensures **better user experience and validation**.

- Run:
```
npm run compile
```

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/8576
