### PR TITLE
[Instrument Builder] Fix error message for Question Name and Dropdown Option 'Build' tab

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -359,9 +359,9 @@ class DropdownOptions extends Component {
 
     return (
       <div>
-        <BasicOptions 
-        updateState={this.props.updateState} 
-        element={this.props.element} 
+        <BasicOptions
+        updateState={this.props.updateState}
+        element={this.props.element}
         />
         <div className={dropdownClass}>
           <label className="col-sm-2 control-label">Dropdown Option: </label>
@@ -394,9 +394,9 @@ class DropdownOptions extends Component {
         <div className="form-group">
           <label className="col-sm-2 control-label">Preview: </label>
           <div className="col-sm-2">
-            <select 
-              multiple={multi} 
-              id="selectOptions" 
+            <select
+              multiple={multi}
+              id="selectOptions"
               className="form-control">
               {Object.keys(options).map(function(option, key) {
                 return <option key={key}>{options[option]}</option>;
@@ -928,7 +928,7 @@ class AddElement extends Component {
    * @param {object} newState
    */
   updateState(newState) {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       let updatedState = {...prevState, ...newState};
 
       // If the Name field is changing, remove the duplicate error dynamically
@@ -938,7 +938,11 @@ class AddElement extends Component {
         updatedState.error = newErrorState;
       }
       // If dropdown options are updated, remove dropdown error dynamically
-      if (newState.Options && Object.keys(newState.Options.Values || {}).length >= 2) {
+      if 
+      (
+        newState.Options 
+        && Object.keys(newState.Options.Values || {}).length >= 2
+      ) {
         let newErrorState = {...prevState.error};
         delete newErrorState.dropdownOptions;
         updatedState.error = newErrorState;
@@ -963,21 +967,21 @@ class AddElement extends Component {
     }
 
     // Validate Dropdown Options only when the type is 'dropdown' or 'multiselect'
-    if ((selected === "dropdown" 
-        || selected === "multiselect") 
+    if ((selected === 'dropdown'
+        || selected === 'multiselect')
         && this.state.Options.Values) {
       let optionsCount = Object.keys(this.state.Options.Values).length;
 
       if (optionsCount === 0) {
         this.setState((state) => ({
-          error: {...state.error, 
+          error: {...state.error,
                  dropdownOptions: "Dropdown options cannot be empty!"
           },
         }));
         hasError = true;
       } else if (optionsCount < 2) {
         this.setState((state) => ({
-          error: {...state.error, 
+          error: {...state.error,
                   dropdownOptions: "A minimum of two options is required."
           },
         }));

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -285,9 +285,9 @@ class DropdownOptions extends Component {
 
     // Remove Add Row dropdown error when adding an option
     if (this.props.element.error && this.props.element.error.dropdownOptions) {
-      let tempError = { ...this.props.element.error };
+      let tempError = {...this.props.element.error};
       delete tempError.dropdownOptions;
-      this.props.updateState({ error: tempError });
+      this.props.updateState({error: tempError});
     }
 
     // Check for empty options
@@ -316,7 +316,7 @@ class DropdownOptions extends Component {
     this.props.updateState({Options: temp});
 
     // clear input field
-    this.setState({ option: '' });
+    this.setState({option: ''});
   }
 
   /**
@@ -351,7 +351,7 @@ class DropdownOptions extends Component {
     // If an error exists for "Dropdown options cannot be empty!" show it
     if (this.props.element.error && this.props.element.error.dropdownOptions) {
       dropdownErrorMessage = (
-        <div className="form-error" style={{ marginTop: "5px" }}>
+        <div className="form-error" style={{marginTop: '5px'}}>
           {this.props.element.error.dropdownOptions}
         </div>
       );
@@ -359,7 +359,10 @@ class DropdownOptions extends Component {
 
     return (
       <div>
-        <BasicOptions updateState={this.props.updateState} element={this.props.element} />
+        <BasicOptions 
+        updateState={this.props.updateState} 
+        element={this.props.element} 
+        />
         <div className={dropdownClass}>
           <label className="col-sm-2 control-label">Dropdown Option: </label>
           <div className="col-sm-3">
@@ -391,8 +394,11 @@ class DropdownOptions extends Component {
         <div className="form-group">
           <label className="col-sm-2 control-label">Preview: </label>
           <div className="col-sm-2">
-            <select multiple={multi} id="selectOptions" className="form-control">
-              {Object.keys(options).map(function (option, key) {
+            <select 
+              multiple={multi} 
+              id="selectOptions" 
+              className="form-control">
+              {Object.keys(options).map(function(option, key) {
                 return <option key={key}>{options[option]}</option>;
               })}
             </select>
@@ -923,17 +929,17 @@ class AddElement extends Component {
    */
   updateState(newState) {
     this.setState(prevState => {
-      let updatedState = { ...prevState, ...newState };
+      let updatedState = {...prevState, ...newState};
 
       // If the Name field is changing, remove the duplicate error dynamically
       if (newState.Name && prevState.error && prevState.error.questionName) {
-        let newErrorState = { ...prevState.error };
+        let newErrorState = {...prevState.error};
         delete newErrorState.questionName;
         updatedState.error = newErrorState;
       }
       // If dropdown options are updated, remove dropdown error dynamically
       if (newState.Options && Object.keys(newState.Options.Values || {}).length >= 2) {
-        let newErrorState = { ...prevState.error };
+        let newErrorState = {...prevState.error};
         delete newErrorState.dropdownOptions;
         updatedState.error = newErrorState;
       }
@@ -957,17 +963,23 @@ class AddElement extends Component {
     }
 
     // Validate Dropdown Options only when the type is 'dropdown' or 'multiselect'
-    if ((selected === "dropdown" || selected === "multiselect") && this.state.Options.Values) {
+    if ((selected === "dropdown" 
+        || selected === "multiselect") 
+        && this.state.Options.Values) {
       let optionsCount = Object.keys(this.state.Options.Values).length;
 
       if (optionsCount === 0) {
         this.setState((state) => ({
-          error: { ...state.error, dropdownOptions: "Dropdown options cannot be empty!" },
+          error: {...state.error, 
+                 dropdownOptions: "Dropdown options cannot be empty!"
+          },
         }));
         hasError = true;
       } else if (optionsCount < 2) {
         this.setState((state) => ({
-          error: { ...state.error, dropdownOptions: "A minimum of two options is required." },
+          error: {...state.error, 
+                  dropdownOptions: "A minimum of two options is required."
+          },
         }));
         hasError = true;
       }

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -979,13 +979,6 @@ class AddElement extends Component {
           },
         }));
         hasError = true;
-      } else if (optionsCount < 2) {
-        this.setState((state) => ({
-          error: {...state.error,
-            dropdownOptions: 'A minimum of two options is required.',
-          },
-        }));
-        hasError = true;
       }
     }
     // Stop execution only if dropdown validation fails

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -360,8 +360,8 @@ class DropdownOptions extends Component {
     return (
       <div>
         <BasicOptions
-        updateState={this.props.updateState}
-        element={this.props.element}
+          updateState={this.props.updateState}
+          element={this.props.element}
         />
         <div className={dropdownClass}>
           <label className="col-sm-2 control-label">Dropdown Option: </label>
@@ -938,9 +938,9 @@ class AddElement extends Component {
         updatedState.error = newErrorState;
       }
       // If dropdown options are updated, remove dropdown error dynamically
-      if 
+      if
       (
-        newState.Options 
+        newState.Options
         && Object.keys(newState.Options.Values || {}).length >= 2
       ) {
         let newErrorState = {...prevState.error};
@@ -975,14 +975,14 @@ class AddElement extends Component {
       if (optionsCount === 0) {
         this.setState((state) => ({
           error: {...state.error,
-                 dropdownOptions: "Dropdown options cannot be empty!"
+            dropdownOptions: 'Dropdown options cannot be empty!',
           },
         }));
         hasError = true;
       } else if (optionsCount < 2) {
         this.setState((state) => ({
           error: {...state.error,
-                  dropdownOptions: "A minimum of two options is required."
+            dropdownOptions: 'A minimum of two options is required.',
           },
         }));
         hasError = true;


### PR DESCRIPTION
## Brief summary of changes:

- [X] Remove the `Duplicate question name` error when it appears after the user changes its value dynamically.
- [X] Fixed dropdown validation to ensure the "Add Row" button is disabled until at least two options are added.
- [X] Improved error message handling to prevent duplicate messages.
- [X] Updated UI to display dropdown validation errors on separate lines for better readability.


#### **Testing instructions (if applicable)**
1. Navigate to the Build tab:
  - Add Question Name with the Dropdown Option click Add row, it should add the row successfully.
  - Add the same question again. The error message `Duplicate question name` will appear. Change the value of the field → The error message should disappear.

2. Navigate to the "Add Question" section.
  - Select **Dropdown** as the question type.
  - Click **Add Row** without adding options → **Error should appear**.
  - Add one option and click **Add Row** again → **Error about needing two options should appear**.
  - Add a second option. → **Errors should disappear, and Add Row should work**.
  
- Run:
```
npm run compile
```

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/8572
