### PR TITLE
Server process manager now displays updated process information

### DIFF
--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -50,6 +50,11 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
+        // This will update all process informations in the database
+        // Must execute this before loading the form
+        $serverProcessesMonitor = new ServerProcessesMonitor();
+        $serverProcessesMonitor->getProcessesState();
+
         // Columns displayed in the result table
         $this->columns = [
             'pid',


### PR DESCRIPTION
This PR modifies the server process manager so that it properly updates the status of processes before displaying the search result list. This fixes a bug that would cause some processes to be listed with an unknown exit code and/or exit text message.


Fixes #8593 