### PR TITLE
[Timepoint List] Fix Timepoint List Access Issue when User have access_all_profiles Permission

### DIFF
--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -127,7 +127,8 @@ class Timepoint_List extends \NDB_Menu
         $listOfTimePoints = array_filter(
             $listOfTimePoints,
             function ($timePoint) use ($user) {
-                return $timePoint->isAccessibleBy($user);
+                return $timePoint->isAccessibleBy($user)
+                    || $user->hasPermission('access_all_profiles');
             }
         );
 


### PR DESCRIPTION
## Brief summary of changes
 Currently the user cannot access other sites timepoints even if the user has access_all_profile permission. This PR fixes tat issue
#### Testing instructions (if applicable)

See if user with access_all_profiles permission can access all timepoints

#### Link(s) to related issue(s)

* Resolves #9628
