### PR TITLE
Dicom archive 'Download as CSV' button now works properly

### DIFF
--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -88,12 +88,10 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
             $cid = \CenterID::singleton(intval($row['CenterID']));
             $pid = \ProjectID::singleton(intval($row['ProjectID']));
             $sid = new \SessionID(strval($row['SessionID']));
-            unset($row['CenterID']);
             unset($row['ProjectID']);
             unset($row['CreatingUser']);
             return new DICOMArchiveRowWithSession($row, $cid, $pid, $sid, $creator);
         }
-        unset($row['CenterID']);
         unset($row['ProjectID']);
         unset($row['CreatingUser']);
         return new DICOMArchiveRowWithoutSession($row, $creator);


### PR DESCRIPTION
When accessing the dicom archive module and clicking on the 'Download as CSV' button, the downloaded file would be missing column 'Center ID'. This PR fixes the behaviour of the download button so that all columns appear in the result set.



Fixes #9663 