### PR TITLE
[timepoint_list] test plan

### DIFF
--- a/modules/dataquery/test/TestPlan.md
+++ b/modules/dataquery/test/TestPlan.md
@@ -1,12 +1,43 @@
 # Data Query - Test Plan
 
-## Welcome page
+### Table of Contents<br>
 
-1. Ensure the module loads only for a user that has the `dataquery_view` permission. They must also have access to the dictionary module.
-2. Assert that: `Instructions` panel, `Recent Queries` panel, and `Next Steps` panel (bottom-right corner) collapse as expected.
-3. Assert that: `Continue to Define Fields` button in the main panel, and `Choose Fields` button in the `Next Steps` panel are redirecting to the same page.
-4. `Recent Queries` panel
-   1. If not queries are available, make some so they will be added to this section.
+1. [Setup](#setup)
+2. [Test Data Query Permission](#test-data-query-view-permission)
+3. [Panel Tests](#panel-tests)
+      -[Test that Panels Collapse](#test-that-panels-collapse)
+      -[Test Panel Redirect](#test-panel-redirect)
+4. [Recent Queries Tests]
+
+## Setup
+
+Sign into your loris instance with an **admin** account.<br>
+
+- select Admin Accounts and click the Add User button.<br> 
+- enter all required information.<br>
+- select *ONE* site for example, "Rome".<br>
+- select *ONE* project, for example Pumpernickel.<br>
+- tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.<br>
+>This permission ensures that ONLY candidates who share the same site as your user are listed (in this case "Rome").<br>
+
+<br>
+
+## Test Data Query View Permission
+Ensure the module loads only for a user that has the `dataquery_view` permission. They must also have access to the dictionary module.<br>
+>if the test yield this, the test is successful<br>
+
+<br>
+
+## Panel Tests<br>
+
+### Test Panel Collapse
+-`Instructions` panel: click to open and click again to collapse ETCETC, `Recent Queries` panel, and `Next Steps` panel (bottom-right corner) collapse as expected.<br>
+
+### Test Panel Redirect
+Asser`Continue to Define Fields` button in the main panel, and `Choose Fields` button in the `Next Steps` panel are redirecting to the same page.
+
+### Test `Recent Queries` panel
+   - If not queries are available, make some so they will be added to this section.
    2. Assert that: queries you made have their parameters correctly displayed (i.e. fields and filters).
    3. Assert that: `text filter` immediately filter the queries.
    4. Assert that: clicking `Collapse queries` effectively collapse all queries.

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,105 +1,95 @@
-# Timepoint List - Test Plan :
+# Timepoint List - Test Plan
 
-### Table of Contents
+## Table of Contents
+
 1. [Setup](#setup)
 2. [Test Site Constraint](#test-site-constraint)
 3. [Test Project Constraint](#test-project-constraint)
 4. [Test All Sites Permission](#test-all-sites-permission)
 5. [Test Buttons](#test-buttons)
 
-<br>
-
 ## Setup
 
 Sign into your loris instance with an **admin** account.
 
-- Select Admin > User Accounts and click the Add User button. 
+- Select Admin > User Accounts and click the Add User button.
 - Enter all required information.
 - Select *ONE* site for example, "Rome".
 - Select *ONE* project, for example Pumpernickel.
 - Tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.
 - Open a separate **incognito** or **private** browser window.
-- Sign into your loris instance. Enter the credentials of the user that you just created. 
+- Sign into your loris instance. Enter the credentials of the user that you just created.
 
-<br>
+## Test Site Constraint
 
-## Test Site constraint
-
-#### List only candidates of same site<br>
+### List only candidates of same site
 
 - Click Candidate/Access Profile.
 
-**Assert that you see only candidates of that site "Rome" (in our example)**
+Assert that you see only candidates of that site "Rome" (in our example)**
 
-#### Load time points by entering CandID in url
+### Load time points by entering CandID in url
+
 - Copy the CandID of this user, paste as follows:
-https://\<yourInstance>\.loris.ca\/\<paste the candidateID here><br>
+https://\<yourInstance>\.loris.ca\/\<paste the candidateID here
 
-**Assert that this loads a list of timepoints **or** returns :**
->There are no timepoints associated with this candidate 
+Assert that this loads a list of timepoints **or** returns :
+>There are no timepoints associated with this candidate
 
-#### Deny access to candidate of a different site<br>
-- Enter a candidate ID into url that is from a different site.<br>
-**Assert that the following message is shown:** 
->Permission Denied<br>
+### Deny access to candidate of a different site
 
+- Enter a candidate ID into url that is from a different site.
 
-#### Open Profile Button
+Assert that the following message is shown:**
+
+>Permission Denied
+
+## Open Profile Button
+
 - Click the 'Open Profile' button.
 - Enter the CandID number and PSCID of the same candidate.
-This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.<br>
-**Assert that it does**
+This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.
 
-<br>
+Assert that it does
 
-## Test Project Constraint<br>
+## Test Project Constraint
+
 - Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?
 - Refresh your incognito (or private) browser.
-You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel").<br> 
+You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel")
+
 Assert that other projects are **not** shown
 
-<br>
-
 ## Test All Sites Permission
+
 - Tick : Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
 
 - Select a candidate from a different site and open up a timepoint.
 
-**Assert that, for this candidate, you can see timepoints from different sites.**
+Assert that, for this candidate, you can see timepoints from different sites.
 
-<br>
+## Test Buttons
 
-## Test Buttons<br>
 - For a Candidate of **same site** (Rome, in our example), there should be 3 Buttons, as follows:<br>
 
-#### Create Time Point<br>
+### Create Time Point
 
-- Click this. 
+- Click this.
 **Assert that it takes you to 'Create Time Point'.**
- 
-#### Candidate Info<br> 
-- Click this. 
+
+### Candidate Info
+
+- Click this.
 **Assert that you are taken to candidate parameters.**
-- If you get code 403, the<br> 
+- If you get code 403, the
 'Candidate Parameters: View Candidate Information' permission is needed.
 
+### View Imaging Datasets
 
-#### View Imaging Datasets<br>
-**Assert that, if you click this, you are taken to imaging browser**
+Assert that, if you click this, you are taken to imaging browser
 
 - If you don't see this button, got to User accounts from the admin page, and tick:
 'Imaging Browser: View Imaging Scans - Own Sites'
 - Refresh and try again.
 
-<br>
-
 ## End
-
-
-
-
-
-
-
-
-

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,98 +1,95 @@
-This test determines if permissions are working in the time_point module.<br>
-<br>
+# Timepoint List - Test Plan :
 
-## Table of Contents<br>
+### Table of Contents
 1. [Setup](#setup)
 2. [Test Site Constraint](#test-site-constraint)
-    - [list only candidates of same site](#list-only-candidates-of-same-site)
-    - [load time points by entering DDCID in url](#load-time-points-by-entering-DDCID-in-url)
-    - [deny access to candidate of different site](#deny-access-to-candidate-of-different-site)
-    - [open profile button](#open-profile-button)
-3. [Test Project constraint](#test-project-constraint)
-4. [Test All sites permission](#test-all-sites-permission)
+3. [Test Project Constraint](#test-project-constraint)
+4. [Test All Sites Permission](#test-all-sites-permission)
 5. [Test Buttons](#test-buttons)
-    - [create time point](#create-time-point)
-    - [candidate info](#candidate-info)
-    - [view imaging datasets](#view-imaging-data)
 
 <br>
 
 ## Setup
 
-Sign into your loris instance with an **admin** account.<br>
+Sign into your loris instance with an **admin** account.
 
-- select Admin Accounts and click the Add User button.<br> 
-- enter all required information.<br>
-- select *ONE* site for example, "Rome".<br>
-- select *ONE* project, for example Pumpernickel.<br>
-- tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.<br>
->This permission ensures that ONLY candidates who share the same site as your user are listed (in this case "Rome").<br>
+- Select Admin > User Accounts and click the Add User button. 
+- Enter all required information.
+- Select *ONE* site for example, "Rome".
+- Select *ONE* project, for example Pumpernickel.
+- Tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.
+- Open a separate **incognito** or **private** browser window.
+- Sign into your loris instance. Enter the credentials of the user that you just created. 
 
 <br>
 
-## Test Site constraint<br> 
+## Test Site constraint
 
-#### a) List only candidates of same site<br>
-open a separate **incognito** or **private** browser window.
-Sign into your loris instance. Enter the credentials of the user that you just created. Click Candidate/Access Profile.<br>
->You should see only candidates of that site "Rome" (in our example)
+#### List only candidates of same site<br>
 
-#### b) Load time points by entering DDCID in url<br>
-copy the DDCID of this user, paste as follows:
-https://\<yourInstance>\.loris.ca\<paste the candidateID here><br>
->if this loads a list of timepoints 
-OR returns:"there are no timepoints associated with this candidate" then this test is successful
+- Click Candidate/Access Profile.
 
-#### c) Deny access to candidate of a different site<br>
-enter a candidate ID into url that is from a different site.<br>
->If "Permission Denied" message is shown, then this test has passed
+**Assert that you see only candidates of that site "Rome" (in our example)**
 
-#### d) Open Profile Button<br>
-Does Open Profile button work with this permission enabled?<br>
-Click the 'Open Profile' button.<br>
-Enter the DDCID number and PSCID of the same candidate.
+#### Load time points by entering CandID in url
+- Copy the CandID of this user, paste as follows:
+https://\<yourInstance>\.loris.ca\/\<paste the candidateID here><br>
+
+**Assert that this loads a list of timepoints **or** returns :**
+>There are no timepoints associated with this candidate 
+
+#### Deny access to candidate of a different site<br>
+- Enter a candidate ID into url that is from a different site.<br>
+**Assert that the following message is shown:** 
+>Permission Denied<br>
+
+
+#### Open Profile Button
+- Click the 'Open Profile' button.
+- Enter the CandID number and PSCID of the same candidate.
 This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.<br>
->If it does, then the permission fully works. 
+**Assert that it does**
 
 <br>
 
-## Test Project constraint<br>
-Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?<br>Refresh your incognito (or private) browser.
+## Test Project Constraint<br>
+- Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?
+- Refresh your incognito (or private) browser.
 You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel").<br> 
->If other projects are shown, then this test has failed.<br>
+Assert that other projects are **not** shown
 
 <br>
 
-## Test All sites permission<br>
-tick : Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
+## Test All Sites Permission
+- Tick : Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
 
-Select a candidate from a different site and open up a timepoint.
+- Select a candidate from a different site and open up a timepoint.
 
->If you are allowed to view a list of timepoints for this candidates from different sites, then the permission has worked.
-
->if it reads 
-"You do not have access to any timepoints registered for this candidate," then this test has failed.
+**Assert that, for this candidate, you can see timepoints from different sites.**
 
 <br>
 
 ## Test Buttons<br>
-For a Candidate of **same site**, there should be 3 Buttons, as follows:<br>
+- For a Candidate of **same site** (Rome, in our example), there should be 3 Buttons, as follows:<br>
 
-#### a) Create time point<br>
+#### Create Time Point<br>
 
->Click this. If it takes you to 'Create Time Point', this test has passed
+- Click this. 
+**Assert that it takes you to 'Create Time Point'.**
  
-#### b) Candidate info<br> 
->Click this. If you get code 403, the 
+#### Candidate Info<br> 
+- Click this. 
+**Assert that you are taken to candidate parameters.**
+- If you get code 403, the<br> 
 'Candidate Parameters: View Candidate Information' permission is needed.
-Else, if you are taken to candidate parameters, this test has passed.
 
-#### c) View Imaging datasets<br>
->Click this. If you are taken to imaging browser, this test has passed.<br>
 
-If you don't see this button, tick the permission:
+#### View Imaging Datasets<br>
+**Assert that, if you click this, you are taken to imaging browser**
+
+- If you don't see this button, got to User accounts from the admin page, and tick:
 'Imaging Browser: View Imaging Scans - Own Sites'
-refresh and try again.
+- Refresh and try again.
 
 <br>
 

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,94 +1,70 @@
 # Timepoint List - Test Plan
 
-## Table of Contents
+This test plan aim to test the GUI functionality of access to a candidate's timepoints within incremental permissions changes.
 
-1. [Setup](#setup)
-2. [Test Site Constraint](#test-site-constraint)
-3. [Test Project Constraint](#test-project-constraint)
-4. [Test All Sites Permission](#test-all-sites-permission)
-5. [Test Buttons](#test-buttons)
+Table of Contents
 
-## Setup
+1. [Timepoint list](#timepoint-list)
+2. [Permission Leak](#permission-leak)
+3. [All Sites Permission](#all-sites-permission)
+4. [View Imaging Datasets Permission](#view-imaging-datasets-permission)
 
-Sign into your loris instance with an **admin** account.
+Begin with 2 users:
 
-- Select Admin > User Accounts and click the Add User button.
-- Enter all required information.
-- Select *ONE* site for example, "Rome".
-- Select *ONE* project, for example Pumpernickel.
-- [x] View/Create Candidates and Timepoints - Own Sites.
-- Open a separate **incognito** or **private** browser window.
-- Sign into your loris instance. Enter the credentials of the user that you just created.
+1. The first with a single site/
+2. The second with a different site.
 
-## Test Site Constraint
+Give both the following permission:
 
-### List only candidates of same site
+- [x] Access Profile: Candidates and Timepoints - Own
 
-- Click Candidate/Access Profile.
+## Timepoint List
 
-Assert that you see only candidates of that site "Rome" (in our example)**
+- Go into Access Profile and select the first PSCID in the list
 
-### Load time points by entering CandID in url
+1. Assert that there are timepoints in the Visit Label Column
+2. Click on a time point and assert that you are redirected to instrument_list where you see the candidate's instrument battery.
+3. Assert that the visit label is listed in the top table in the `Visit Label` field.
 
-- Copy the CandID of this user, paste as follows:
-https://\<yourInstance>\.loris.ca\/\<paste the candidateID here
+## Permission Leak
 
-Assert that this loads a list of timepoints **or** returns :
->There are no timepoints associated with this candidate
+- Copy the URL of this candidate's instrument list and paste it into the URL of user 2, who does **not** have permission to the same site
 
-### Deny access to candidate of a different site
+- assert that the user 2 is instead redirected to the their own list of candidates.
 
-- Enter a candidate ID into url that is from a different site.
+## All Sites Permission
 
-Assert that the following message is shown:**
+- Return to user 1 and give them the follwoing permission:
+- [x] Access Profile: Candidates and Timepoints - All Sites
+- Assert that the user can see all candidates from all sites.
+- Select a candidate from each site and assert the following:
 
->Permission Denied
+    1. you see a list of their timepoints
+    2. you can see the battery of instruments of each
+    3. For a candidate with a different site assert that you can not see the Candidate Information buttons `Create Time Point` and `Candidate info`
 
-## Open Profile Button
+- Select a candidate with the same site as your user setting. 
 
-- [x] View/Create Candidates and Timepoints - Own Sites.
+Assert that the following buttons appear under `Actions`:
 
-- Click the 'Open Profile' button.
-- Enter the CandID number and PSCID of the same candidate.
-This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.
+1. `Create time point`
+        - Assert that this links to `>Create Timepoint` and that the site configuration (the possibilities of sites that you see) is constrained to the user setting.
 
-Assert that it does
+2. `Candidate Info`
+        - Assert that by clicking this button you get a 403
 
-## Test Project Constraint
+- Add the following permission:
 
-- Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?
-- Refresh your incognito (or private) browser.
-You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel")
+- [x] Candidate Parameters : Candidate Information
+- Click on the `Candidate Info` button again and assert that you are redirected to the candidate's parameters.
+- Click on the `Candidate Information` button and assert that you are re-directed to  `>Candidate Parameters`  
 
-Assert that other projects are **not** shown
+## View Imaging Datasets Permission
 
-## Test All Sites Permission
+Add the following permission to user 1:
 
-- [x] View/Create Candidates and Timepoints - All Sites
+- [x] Imaging Browser: Imaging Scans - Own Sites
 
-- Select a candidate from a different site and open up a timepoint. Assert that, for this candidate, you can see timepoints from different sites.
+- Click on the `View Imaging Datasets` button and assert that you are taken to the imaging browser
 
-## Test Buttons
-
-- For a Candidate of **same site** (Rome, in our example), there should be 3 Buttons, as follows:
-
-### Create Time Point
-
-- Click this and assert that it takes you to 'Create Time Point'.**
-
-### Candidate Info
-
-- With the following permissions unchecked :
-- [ ] Candidate Parameters: View Candidate Information
-- [ ] Candidate Parameters: Edit Candidate Information
-Assert that you do not see the `Candidate Info` button. Assert that the button appears when one or both are checked.
-
-### View Imaging Datasets
-
-Assert that, if you click this button, you are taken to imaging browser
-
-- If you don't see this button, set the following permission :
-- [x] Imaging Browser: View Imaging Scans - Own Sites
-- Refresh and try again.
-
-## End
+- Assert that if `Scan Done` indicates yes, that the link takes you to the imaging browser and that images of that candidate are shown.

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,21 +1,92 @@
-# Timepoint List - Test Plan:
 
-1.  **Module access permissions**
-    - For a candidate of the same site as your user, accessing the timepoint_list module via the url (https://\<yourInstance>\.loris.ca/\<candidateID\>) should not require any permission (With data entry permisson, click on the "Open Profile" button can also lead to the page).
-    - For a candidate of a different site than your user, ensure that either 
-        - `access_all_profiles` permission is required 
-        - or that the candidate's registration site is the same as the user's site
-    - Ensure that you can always only see visits from projects that you are affiliated with.
-2. **Action buttons** 
-    - For a candidate of a different site than your user, attempt to access the timepoint list via the url. The page should load with a message of 'Permission Denied'.
-    - For a candidate of the same site as your user, there should be up to 3 additional buttons:
-        1. "Create time point" (links to create_timepoint module for that candidate) if your user has permission `data_entry`
-        2. "Candidate Info" (links to candidate_parameters module for that candidate) if your user has permission `data_entry`
-        3. "View Imaging Datasets" (links to the imaging_browser module menu page filtered for that candidate) if your user has permission `imaging_browser_view_site`, `imaging_browser_view_allsites`, `imaging_browser_phantom_allsites`, or `imaging_browser_phantom_ownsite`
-3.  **Button links**
-    - Ensure the "View Imaging datasets" button points to correct place. (imaging_browser module for that candidate)
-    - Ensure the "Create time point" button points to correct place. (create_timepoint module for that candidate)
-    - Ensure the "Candidate Info" button points to correct place. (candidate_parameters module for that candidate)
-5.  **Datatable content**
-    - Visit Label: Ensure correct visits are shown and links point to correct place. (instrument_list for that specific timepoint)
-    - Imaging Scan Done: If 'yes', ensure links point to correct place (imaging_browser session page for that visit)
+This test determines if permissions are working in the time_point module.<br>
+
+Setup:<br>
+-
+Sign into your loris instance with an **admin** account.<br>
+
+- select Admin Accounts and click the Add User button.<br> 
+- enter all required information.<br>
+- select *ONE* site for example, "Rome".<br>
+- select *ONE* project, for example Pumpernickel.<br>
+- tick box:Roles/
+- Access Profile: View/Create Candidates and Timepoints - Own Sites.<br>
+
+>This permission ensures that ONLY candidates who share the same site as your user are listed (in this case "Rome").<br>
+
+Test 1 : Acces Profile
+-
+ 
+(a)
+-
+open a separate **incognito** or **private** browser window.
+Sign into your loris instance. Enter the credentials of the user that you just created.<br>
+click Candidate/Access Profile.<br>
+>You should see only candidates of that site "Rome" (in our example)
+
+(b)
+-
+copy the DDCID of this user, paste as follows:
+https://\<yourInstance>\.loris.ca\<paste the candidateID here><br>
+>if this loads a list of timepoints 
+OR returns:"there are no timepoints associated with this candidate" then this test is successful
+
+(c)
+-
+Does Open Profile button work with this permission enabled?<br>
+Click the 'Open Profile' button.<br>
+Enter the DDCID number and PSCID of the same candidate.
+This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.<br>
+>If it does, then the permission fully works. 
+
+Test 2 : Projects
+-
+Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?<br>Refresh your incognito (or private) browser.
+You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel").<br> 
+>If other projects are shown, then this test has failed.<br>
+
+
+Test 3 : All sites
+- 
+
+tick 
+Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
+
+Select a candidate from a different site and open up a timepoint.
+
+>If you are allowed to view a list of timepoints for this candidates from different sites, then the permission has worked.
+
+>if it reads 
+"You do not have access to any timepoints registered for this candidate," then this test has failed.
+
+Test 4 : Access candidate of a different site
+-
+enter a candidate ID into url that is from a different site.
+
+>If "Permission Denied" message is shown, then this test has passed
+
+Test 5 : For a Candidate of **same site**, there should be 3 Buttons, as follows:<br>
+-
+(a) Create time point<br>
+- 
+
+Click this. If it takes you to 'Create Time Point', this test has passed
+ 
+(b) Candidate info<br> 
+-
+>Click this. If you get code 403, the 
+'Candidate Parameters: View Candidate Information' permission is needed.
+Else, if you are taken to candidate parameters, this test has passed.
+
+(c) View Imaging datasets<br>
+- 
+>Click this. If you are taken to imaging browser, this test has passed.<br>
+
+If you don't see this button, tick the permission:
+'Imaging Browser: View Imaging Scans - Own Sites'
+refresh and try again.
+
+
+End
+-
+

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -16,7 +16,7 @@ Sign into your loris instance with an **admin** account.
 - Enter all required information.
 - Select *ONE* site for example, "Rome".
 - Select *ONE* project, for example Pumpernickel.
-- Tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.
+- [x] View/Create Candidates and Timepoints - Own Sites.
 - Open a separate **incognito** or **private** browser window.
 - Sign into your loris instance. Enter the credentials of the user that you just created.
 
@@ -46,6 +46,8 @@ Assert that the following message is shown:**
 
 ## Open Profile Button
 
+- [x] View/Create Candidates and Timepoints - Own Sites.
+
 - Click the 'Open Profile' button.
 - Enter the CandID number and PSCID of the same candidate.
 This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.
@@ -62,34 +64,31 @@ Assert that other projects are **not** shown
 
 ## Test All Sites Permission
 
-- Tick : Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
+- [x] View/Create Candidates and Timepoints - All Sites
 
-- Select a candidate from a different site and open up a timepoint.
-
-Assert that, for this candidate, you can see timepoints from different sites.
+- Select a candidate from a different site and open up a timepoint. Assert that, for this candidate, you can see timepoints from different sites.
 
 ## Test Buttons
 
-- For a Candidate of **same site** (Rome, in our example), there should be 3 Buttons, as follows:<br>
+- For a Candidate of **same site** (Rome, in our example), there should be 3 Buttons, as follows:
 
 ### Create Time Point
 
-- Click this.
-**Assert that it takes you to 'Create Time Point'.**
+- Click this and assert that it takes you to 'Create Time Point'.**
 
 ### Candidate Info
 
-- Click this.
-**Assert that you are taken to candidate parameters.**
-- If you get code 403, the
-'Candidate Parameters: View Candidate Information' permission is needed.
+- With the following permissions unchecked :
+- [ ] Candidate Parameters: View Candidate Information
+- [ ] Candidate Parameters: Edit Candidate Information
+Assert that you do not see the `Candidate Info` button. Assert that the button appears when one or both are checked.
 
 ### View Imaging Datasets
 
-Assert that, if you click this, you are taken to imaging browser
+Assert that, if you click this button, you are taken to imaging browser
 
-- If you don't see this button, got to User accounts from the admin page, and tick:
-'Imaging Browser: View Imaging Scans - Own Sites'
+- If you don't see this button, set the following permission :
+- [x] Imaging Browser: View Imaging Scans - Own Sites
 - Refresh and try again.
 
 ## End

--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,56 +1,70 @@
-
 This test determines if permissions are working in the time_point module.<br>
+<br>
 
-Setup:<br>
--
+## Table of Contents<br>
+1. [Setup](#setup)
+2. [Test Site Constraint](#test-site-constraint)
+    - [list only candidates of same site](#list-only-candidates-of-same-site)
+    - [load time points by entering DDCID in url](#load-time-points-by-entering-DDCID-in-url)
+    - [deny access to candidate of different site](#deny-access-to-candidate-of-different-site)
+    - [open profile button](#open-profile-button)
+3. [Test Project constraint](#test-project-constraint)
+4. [Test All sites permission](#test-all-sites-permission)
+5. [Test Buttons](#test-buttons)
+    - [create time point](#create-time-point)
+    - [candidate info](#candidate-info)
+    - [view imaging datasets](#view-imaging-data)
+
+<br>
+
+## Setup
+
 Sign into your loris instance with an **admin** account.<br>
 
 - select Admin Accounts and click the Add User button.<br> 
 - enter all required information.<br>
 - select *ONE* site for example, "Rome".<br>
 - select *ONE* project, for example Pumpernickel.<br>
-- tick box:Roles/
-- Access Profile: View/Create Candidates and Timepoints - Own Sites.<br>
-
+- tick box:Roles/Access Profile: View/Create Candidates and Timepoints - Own Sites.<br>
 >This permission ensures that ONLY candidates who share the same site as your user are listed (in this case "Rome").<br>
 
-Test 1 : Acces Profile
--
- 
-(a)
--
+<br>
+
+## Test Site constraint<br> 
+
+#### a) List only candidates of same site<br>
 open a separate **incognito** or **private** browser window.
-Sign into your loris instance. Enter the credentials of the user that you just created.<br>
-click Candidate/Access Profile.<br>
+Sign into your loris instance. Enter the credentials of the user that you just created. Click Candidate/Access Profile.<br>
 >You should see only candidates of that site "Rome" (in our example)
 
-(b)
--
+#### b) Load time points by entering DDCID in url<br>
 copy the DDCID of this user, paste as follows:
 https://\<yourInstance>\.loris.ca\<paste the candidateID here><br>
 >if this loads a list of timepoints 
 OR returns:"there are no timepoints associated with this candidate" then this test is successful
 
-(c)
--
+#### c) Deny access to candidate of a different site<br>
+enter a candidate ID into url that is from a different site.<br>
+>If "Permission Denied" message is shown, then this test has passed
+
+#### d) Open Profile Button<br>
 Does Open Profile button work with this permission enabled?<br>
 Click the 'Open Profile' button.<br>
 Enter the DDCID number and PSCID of the same candidate.
 This will replicate the same behaviour as clicking on the candidate's PSCID, showing their list of timepoints.<br>
 >If it does, then the permission fully works. 
 
-Test 2 : Projects
--
+<br>
+
+## Test Project constraint<br>
 Are the projects shown the same as those you selected in your user settings (in our example: "Pumpernickel")?<br>Refresh your incognito (or private) browser.
 You will see a list of time points from all sites that share your selected project (in this case "Pumpernickel").<br> 
 >If other projects are shown, then this test has failed.<br>
 
+<br>
 
-Test 3 : All sites
-- 
-
-tick 
-Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
+## Test All sites permission<br>
+tick : Permissions/Access Profile: View/Create Candidates and Timepoints - All Sites
 
 Select a candidate from a different site and open up a timepoint.
 
@@ -59,34 +73,36 @@ Select a candidate from a different site and open up a timepoint.
 >if it reads 
 "You do not have access to any timepoints registered for this candidate," then this test has failed.
 
-Test 4 : Access candidate of a different site
--
-enter a candidate ID into url that is from a different site.
+<br>
 
->If "Permission Denied" message is shown, then this test has passed
+## Test Buttons<br>
+For a Candidate of **same site**, there should be 3 Buttons, as follows:<br>
 
-Test 5 : For a Candidate of **same site**, there should be 3 Buttons, as follows:<br>
--
-(a) Create time point<br>
-- 
+#### a) Create time point<br>
 
-Click this. If it takes you to 'Create Time Point', this test has passed
+>Click this. If it takes you to 'Create Time Point', this test has passed
  
-(b) Candidate info<br> 
--
+#### b) Candidate info<br> 
 >Click this. If you get code 403, the 
 'Candidate Parameters: View Candidate Information' permission is needed.
 Else, if you are taken to candidate parameters, this test has passed.
 
-(c) View Imaging datasets<br>
-- 
+#### c) View Imaging datasets<br>
 >Click this. If you are taken to imaging browser, this test has passed.<br>
 
 If you don't see this button, tick the permission:
 'Imaging Browser: View Imaging Scans - Own Sites'
 refresh and try again.
 
+<br>
 
-End
--
+## End
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
## Brief summary of changes
This test plan follows permission incrementally to check the changes in front end behaviour. Two users are enabled for this test.

The following permissions are enabled, one-by-one

- [x] Access Profile : Candidates and Timepoints - Own
- [x] Access Profile : Candidates and Timepoints - All Sites
- [x] Candidate Parameters : Candidate Information
- [x] Imaging Browser: Imaging Scans - Own Sites

The test is focused on the  additional functionality opened up by these permissions. 


