### PR TITLE
[candidate_parameters] Fixes Notice errors returned by getData.

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -281,7 +281,9 @@ function getFamilyInfoFields()
     // Remove own ID and sibling IDs from list of possible family members
     foreach ($candidatesList as $key => $candidate) {
         foreach ($candidate as $ID) {
-            if ($ID == $candID || in_array($ID, $siblings)) {
+            if (new CandID(strval($ID)) == $candID
+                || in_array($ID, $siblings, true)
+            ) {
                 unset($candidatesList[$key]);
             } else {
                 $candidates[$ID] = $ID;


### PR DESCRIPTION
## Brief summary of changes
Casting and instantiation before comparison.

#### Testing instructions (if applicable)

1. Please be sure the level of logs is at lease set to "NOTICE" in the apache config. 
2. Please open and monitor the apache error log file while performing the following actions.
3. Please in the LORIS from go to `MainMenu->CandidateProfile->AccessProfile` and choose a random candidate.
4. Click on the random candidate then in the `Candidate Info` button.
5. Please confirm in the apache log file (step 2) that the Notices error reported in #9602 are not longer present. The rest of the page should continue working as usual. 

#### Link(s) to related issue(s)

* Resolves #9602 
