### PR TITLE
[timepoint_list] Candidate Info button appears with proper permissions

### DIFF
--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -65,8 +65,10 @@ Class TimePoint_List_ControlPanel extends \Candidate
         $this->tpl_data['candID'] = $this->getCandID();
 
         $this->tpl_data['isDataEntryPerson'] = $user->hasCenterPermission(
-            "data_entry", $cand_CenterID);
-    
+            "data_entry",
+            $cand_CenterID
+        );
+
         $this->tpl_data['isImagingPerson'] = $user->hasAnyPermission(
             [
                 'imaging_browser_view_site',
@@ -76,11 +78,11 @@ Class TimePoint_List_ControlPanel extends \Candidate
             ]
         );
 
-        $this->tpl_data['isCandidatePerson'] = $user->hasAnyPermission(
-                [
-                    'candidate_parameter_view',
-                    'candidate_parameter_edit'
-                ]
+        $this->tpl_data['hasCandidateParameterAccess'] = $user->hasAnyPermission(
+            [
+                'candidate_parameter_view',
+                'candidate_parameter_edit'
+            ]
         );
 
         //set the baseurl of the tpl_data

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -64,9 +64,8 @@ Class TimePoint_List_ControlPanel extends \Candidate
 
         $this->tpl_data['candID'] = $this->getCandID();
 
-        $this->tpl_data['isDataEntryPerson']
-            = $user->hasCenterPermission("data_entry", $cand_CenterID);
-
+        $this->tpl_data['isDataEntryPerson'] = $user->hasCenterPermission("data_entry", $cand_CenterID);
+    
         $this->tpl_data['isImagingPerson'] = $user->hasAnyPermission(
             [
                 'imaging_browser_view_site',
@@ -74,6 +73,13 @@ Class TimePoint_List_ControlPanel extends \Candidate
                 'imaging_browser_phantom_allsites',
                 'imaging_browser_phantom_ownsite'
             ]
+        );
+
+        $this->tpl_data['isCandidatePerson'] = $user->hasAnyPermission(
+                [
+                    'candidate_parameter_view',
+                    'candidate_parameter_edit'
+                ]
         );
 
         //set the baseurl of the tpl_data

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -64,7 +64,8 @@ Class TimePoint_List_ControlPanel extends \Candidate
 
         $this->tpl_data['candID'] = $this->getCandID();
 
-        $this->tpl_data['isDataEntryPerson'] = $user->hasCenterPermission("data_entry", $cand_CenterID);
+        $this->tpl_data['isDataEntryPerson'] = $user->hasCenterPermission(
+            "data_entry", $cand_CenterID);
     
         $this->tpl_data['isImagingPerson'] = $user->hasAnyPermission(
             [

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -9,7 +9,7 @@
     {if $isImagingPerson}
         <a class="btn btn-default" role="button" href="{$baseurl}/imaging_browser/?DCCID={$candID}">View Imaging datasets</a>
     {/if}
-    {if $isCandidatePerson}
+    {if $hasCandidateParameterAccess}
     <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>
     {/if}
     <!-- </div> -->

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -1,14 +1,16 @@
-{if $isDataEntryPerson || $isImagingPerson}
+{if $isDataEntryPerson || $isImagingPerson ||$isCandidateParameterPerson}
     <!-- <div class="col-xs-1"> -->
         <h3>Actions:&nbsp&nbsp</h3>
     <!-- </div> -->
     <!-- <div class="col-xs-4"> -->
     {if $isDataEntryPerson}
         <a class="btn btn-default" role="button" href="{$baseurl}/create_timepoint/?candID={$candID}&identifier={$candID}">Create time point</a>
-        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>
     {/if}
     {if $isImagingPerson}
         <a class="btn btn-default" role="button" href="{$baseurl}/imaging_browser/?DCCID={$candID}">View Imaging datasets</a>
+    {/if}
+    {if $isCandidatePerson}
+    <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>
     {/if}
     <!-- </div> -->
 {/if}

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -1,4 +1,4 @@
-{if $isDataEntryPerson || $isImagingPerson ||$isCandidateParameterPerson}
+{if $isDataEntryPerson || $isImagingPerson ||$isCandidatePerson}
     <!-- <div class="col-xs-1"> -->
         <h3>Actions:&nbsp&nbsp</h3>
     <!-- </div> -->


### PR DESCRIPTION
## Brief summary of changes

- a new smarty variable "isCandidatePerson" was added in order to isolate the display of the `Candidate Info` Button. The .tpl file was adjusted accordingly 

- [ ] Have you updated related documentation? Not yet

## Testing instructions 

### User permissions settings:
- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
- [ ] Candidate Parameters: View Candidate Information
- [ ] Candidate Parameters: Edit Candidate Information
- go to : https://<your_instance.loris.ca/CandID  and click a timepoint.
- Asssert that there is no `Candidate Info` Button

### 
- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
- [x] Candidate Parameters: View Candidate Information
- [  ] Candidate Parameters: Edit Candidate Information 
- Save and Refresh the window with your user's account, and assert that the `Candidate Info` button appears.

### Link(s) to related issue(s)[](
https://github.com/aces/Loris/issues/9585#issuecomment-2718407731)
* Resolves 9585  (Reference the issue this fixes, if any.)
