### PR TITLE
[NDB_BVL_Battery] isDoubleDataEntryEnabledForInstrument should consider CohortID

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -241,7 +241,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
                 $ins = \NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
                     $this->timePoint->getVisitLabel(),
-                    $this->timePoint->getCohortID(),
+                    strval($this->timePoint->getCohortID()),
                     $instrument['Test_name']
                 );
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -194,12 +194,10 @@ class Instrument_List extends \NDB_Menu_Filter
         $battery = new \NDB_BVL_Battery;
         $battery->selectBattery($this->timePoint->getSessionID());
         $listOfInstruments = $battery->getBatteryVerbose();
-
         // display list of instruments
         if (!empty($listOfInstruments)) {
             $user     =& \User::singleton();
             $username = $user->getUsername();
-
             $feedback_select_inactive = false;
             if ($user->hasPermission('bvl_feedback')) {
                 $feedback_select_inactive = true;
@@ -243,6 +241,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
                 $ins = \NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
                     $this->timePoint->getVisitLabel(),
+                    $this->timePoint->getCohortID(),
                     $instrument['Test_name']
                 );
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -241,7 +241,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
                 $ins = \NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
                     $this->timePoint->getVisitLabel(),
-                    $this->timePoint->getCohortID(),
+                    intval($this->timePoint->getCohortID()),
                     $instrument['Test_name']
                 );
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -241,7 +241,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
                 $ins = \NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
                     $this->timePoint->getVisitLabel(),
-                    intval($this->timePoint->getCohortID()),
+                    $this->timePoint->getCohortID(),
                     $instrument['Test_name']
                 );
 

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -225,7 +225,7 @@ class NDB_BVL_Battery
 
         $DDEEnabled = $this->isDoubleDataEntryEnabledForInstrument(
             $sessionData['Visit_label'],
-            $sessionData['CohortID'],
+            strval($sessionData['CohortID']),
             $testName
         );
         if ($obj->usesJSONdata() !== true) {
@@ -390,7 +390,7 @@ class NDB_BVL_Battery
      */
     static function isDoubleDataEntryEnabledForInstrument(
         String $Visit_label,
-        int $CohortID,
+        String $CohortID,
         String $Test_name
     ) : bool {
         $DB  = \NDB_Factory::singleton()->database();

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -225,6 +225,7 @@ class NDB_BVL_Battery
 
         $DDEEnabled = $this->isDoubleDataEntryEnabledForInstrument(
             $sessionData['Visit_label'],
+            $sessionData['CohortID'],
             $testName
         );
         if ($obj->usesJSONdata() !== true) {
@@ -370,7 +371,6 @@ class NDB_BVL_Battery
 
         // get the list of instruments
         $rows = $DB->pselect($query, $qparams);
-
         // return all the data selected
         return iterator_to_array($rows);
     }
@@ -381,6 +381,8 @@ class NDB_BVL_Battery
      *
      * @param string $Visit_label The Visit_label that we want to
      *                            check if DDE is enabled for.
+     * @param string $CohortID    The CohortID that we want to
+     *                            check if DDE is enabled for.
      * @param string $Test_name   The test_name that we want to
      *                            check if DDE is enabled for.
      *
@@ -388,6 +390,7 @@ class NDB_BVL_Battery
      */
     static function isDoubleDataEntryEnabledForInstrument(
         String $Visit_label,
+        int $CohortID,
         String $Test_name
     ) : bool {
         $DB  = \NDB_Factory::singleton()->database();
@@ -395,8 +398,13 @@ class NDB_BVL_Battery
             'SELECT DISTINCT DoubleDataEntryEnabled
             FROM test_battery
             WHERE Visit_label=:Visit_label
+            AND CohortID=:CohortID
             AND Test_name=:Test_name',
-            ['Visit_label' => $Visit_label, 'Test_name' => $Test_name]
+            [
+                'Visit_label' => $Visit_label,
+                'CohortID'    => $CohortID,
+                'Test_name'   => $Test_name
+            ]
         ) == 'Y' ? true : false;
 
         return $ans;


### PR DESCRIPTION
## Brief summary of changes
- Make `isDoubleDataEntryEnabledForInstrument` consider CohortID as there can be instances in the test_battery with the same instrument and visit_label but different CohortID

#### Testing instructions (if applicable)

1. Try adding an instrument in two different cohorts with the same visit_label
2. Confirm you can open it and do not face an error with the function.

#### Link(s) to related issue(s)

- Found in testing round
