### PR TITLE
[configration] DiagnosisEvolution missing projectID - fix

### DIFF
--- a/modules/configuration/jsx/DiagnosisEvolution.js
+++ b/modules/configuration/jsx/DiagnosisEvolution.js
@@ -186,7 +186,7 @@ class DiagnosisEvolution extends Component {
                 label='Project'
                 options={this.state.formData.projects}
                 onUserInput={this.setFormData}
-                value={trajectoryData.ProjectID}
+                value={JSON.stringify(trajectoryData.ProjectID)}
                 required={true}
                 errorMessage={errorMessage.ProjectID}
               />


### PR DESCRIPTION
[configuration] Bugs found in this module #9599
test: step 1 go to configration page 
         step 2 create a new Diagnosis Evolution
          step 3 make sure the projects is in the option list.