### PR TITLE
[imaging_browser] Fix bugs in imaging browser's MRI feedback popup

### DIFF
--- a/modules/imaging_browser/php/feedback_mri_popup.class.inc
+++ b/modules/imaging_browser/php/feedback_mri_popup.class.inc
@@ -223,9 +223,7 @@ class Feedback_MRI_Popup extends \NDB_Page
                     );
             }
 
-            if (is_array($comment_array)) {
-                $CommentTpl['name'] = $comment_array['name'];
-            }
+            $CommentTpl['name'] = $comment_array['name'];
 
             // get the list of predefined feedbackObj for the current type
             $predefined_comments = $feedbackObj->getAllPredefinedComments(
@@ -304,9 +302,7 @@ class Feedback_MRI_Popup extends \NDB_Page
         }
 
         // save all comment status fields
-        if (isset($values['saveCommentStatusField'])
-            && is_array($values['saveCommentStatusField'])
-        ) {
+        if (isset($values['saveCommentStatusField'])) {
             foreach ($values['saveCommentStatusField'] as $status_field => $value) {
                 $feedbackObj->setMRIValue($status_field, $value);
             }

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -336,7 +336,7 @@ class FeedbackMRI
         // build the output array and keep overall section at the end of the array
         $commentNames = [];
         $overallName  = [];
-        $overallType  = [];
+        $overallType  = null;
         foreach ($result as $row) {
             $CommentName = $row['CommentName'];
             $CTID        = $row['CommentTypeID'];
@@ -368,7 +368,7 @@ class FeedbackMRI
         }
 
         // add overall row to the end of the output array
-        if ($overallType !== '' && !empty($overallName)) {
+        if (!is_null($overallType) && !empty($overallName)) {
             $commentNames[$overallType] = $overallName;
         }
 

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -153,16 +153,14 @@ class FeedbackMRI
 
         $comments = [];
         // build the output array
-        if (is_array($result)) {
-            foreach ($result as $row) {
-                $CTID         = $row['CommentTypeID'];
-                $PredefinedID = $row['PredefinedCommentID'];
+        foreach ($result as $row) {
+            $CTID         = $row['CommentTypeID'];
+            $PredefinedID = $row['PredefinedCommentID'];
 
-                if (empty($row['Comment'])) {
-                    $comments[$CTID]['predefined'][$PredefinedID] = true;
-                } else {
-                    $comments[$CTID]['text'] = stripslashes($row['Comment']);
-                }
+            if (empty($row['Comment'])) {
+                $comments[$CTID]['predefined'][$PredefinedID] = true;
+            } else {
+                $comments[$CTID]['text'] = stripslashes($row['Comment']);
             }
         }
 
@@ -193,13 +191,11 @@ class FeedbackMRI
 
         // build the output array
         $comments = [];
-        if (is_array($result)) {
-            foreach ($result as $row) {
-                $PredefinedID       = $row['PredefinedCommentID'];
-                $preDefinedComments = [];
-                $preDefinedComments['Comment'] = stripslashes($row['Comment']);
-                $comments[$PredefinedID]       = $preDefinedComments;
-            }
+        foreach ($result as $row) {
+            $PredefinedID       = $row['PredefinedCommentID'];
+            $preDefinedComments = [];
+            $preDefinedComments['Comment'] = stripslashes($row['Comment']);
+            $comments[$PredefinedID]       = $preDefinedComments;
         }
 
         // return the output array
@@ -341,40 +337,39 @@ class FeedbackMRI
         $commentNames = [];
         $overallName  = [];
         $overallType  = [];
-        if (is_array($result)) {
-            foreach ($result as $row) {
-                $CommentName = $row['CommentName'];
-                $CTID        = $row['CommentTypeID'];
-                $statusField = [];
-                // deal with CommentStatusField
-                if (!empty($row['CommentStatusField'])) {
-                    $statusField = unserialize($row['CommentStatusField']);
-                }
-
-                // if CommentName is overall, don't add them yet to
-                // commentNames array we want them only at the end
-                if ($CommentName == "Overall") {
-                    $overallType = $CTID;
-                    $overallName = [
-                        'name'   => stripslashes($CommentName),
-                        'field'  => $statusField['field'] ?? 'overall',
-                        'values' => $statusField['values'] ?? '',
-                    ];
-                } else {
-                    // add a row to the output array
-                    $commentNames[$CTID] = [
-                        'name'   => stripslashes($CommentName) ?? '',
-                        'field'  => $statusField['field'] ?? '',
-                        'values' => $statusField['values'] ?? '',
-                    ];
-                }
-
-                unset($statusField);
+        foreach ($result as $row) {
+            $CommentName = $row['CommentName'];
+            $CTID        = $row['CommentTypeID'];
+            $statusField = [];
+            // deal with CommentStatusField
+            if (!empty($row['CommentStatusField'])) {
+                $statusField = unserialize($row['CommentStatusField']);
             }
-            // add overall row to the end of the output array
-            if ($overallType !== '' && !empty($overallName)) {
-                $commentNames[$overallType] = $overallName;
+
+            // if CommentName is overall, don't add them yet to
+            // commentNames array we want them only at the end
+            if ($CommentName == "Overall") {
+                $overallType = $CTID;
+                $overallName = [
+                    'name'   => stripslashes($CommentName),
+                    'field'  => $statusField['field'] ?? 'overall',
+                    'values' => $statusField['values'] ?? '',
+                ];
+            } else {
+                // add a row to the output array
+                $commentNames[$CTID] = [
+                    'name'   => stripslashes($CommentName) ?? '',
+                    'field'  => $statusField['field'] ?? '',
+                    'values' => $statusField['values'] ?? '',
+                ];
             }
+
+            unset($statusField);
+        }
+
+        // add overall row to the end of the output array
+        if ($overallType !== '' && !empty($overallName)) {
+            $commentNames[$overallType] = $overallName;
         }
 
         // return the output array


### PR DESCRIPTION
This PR fixes the bugs in the imaging browser's MRI feedback popup during the testing phase for LORIS 27.0, namely:

- Incomplete MRI popup displayed when clicking "QC Comments" (all the comment sections are missing).
- Clicking on "Save" in the above popup yields an error.


Partial fix for #9587 