### PR TITLE
Publication Module Duplicate Email Issue

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -68,15 +68,14 @@ function uploadPublication() : void
     $leadInvest = $_POST['leadInvestigator'] ?? null;
     $leadInvestEmail = $_POST['leadInvestigatorEmail'] ?? null;
 
-    // check if lead investigator already exists in collaborator table
+    // check if lead investigator email already exists in collaborator table
     // use ID if exists, else insert
     $leadInvID = $db->pselectOne(
         'SELECT PublicationCollaboratorID '.
         'FROM publication_collaborator '.
-        'WHERE Name = :n AND Email = :e',
+        'WHERE Email = :e',
         [
-            'e' => $leadInvestEmail,
-            'n' => $leadInvest,
+            'e' => $leadInvestEmail
         ]
     );
     if (empty($leadInvID)) {
@@ -89,6 +88,8 @@ function uploadPublication() : void
         );
 
         $leadInvID = $db->getLastInsertId();
+    } else {
+        showPublicationError('Lead investigator with this email already exists', 400);
     }
     if (!isset($desc, $leadInvest, $leadInvestEmail)) {
         showPublicationError('A mandatory field is missing!', 400);


### PR DESCRIPTION
## Brief summary of changes
Lead Investigator email should be unique for each publication. Same name can be there; but email should be different to uniquely identify publication. So fixing the code to work in that way and fix the `duplicate entry '***' for key 'UK_publication_collaborator_Email` issue.


#### Link(s) to related issue(s)

* Resolves #9702 