### PR TITLE
[imaging_browser] Fix visit level feedback cannot be saved

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1115,7 +1115,7 @@ INSERT INTO `notification_types` (Type,private,Description) VALUES
 CREATE TABLE `notification_spool` (
   `NotificationID` int(11) NOT NULL auto_increment,
   `NotificationTypeID` int(11) NOT NULL,
-  `ProcessID` int(11) NOT NULL,
+  `ProcessID` int(11) DEFAULT NULL,
   `TimeSpooled` datetime DEFAULT NULL,
   `Message` text,
   `Error` enum('Y','N') default NULL,

--- a/SQL/New_patches/2024-07-16-CleanDefault.sql
+++ b/SQL/New_patches/2024-07-16-CleanDefault.sql
@@ -91,7 +91,7 @@ ALTER TABLE `notification_spool`
   ALTER `NotificationTypeID` DROP DEFAULT;
 
 ALTER TABLE `notification_spool`
-  ALTER `ProcessID` DROP DEFAULT;
+  CHANGE `ProcessID` `ProcessID` int(11) DEFAULT NULL;
 
 ALTER TABLE `participant_status`
   ALTER `CandID` DROP DEFAULT;


### PR DESCRIPTION
This PR fixes a bug that would prevent the following visit level properties from being saved: QC status, QC pending and visit level caveat. 


Partial fix for #9587 