### PR TITLE
[server_processes_manager] Monitor incomplete processes only

### DIFF
--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -55,7 +55,8 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
         $idsToMonitor = $DB->pselect(
             "SELECT id
             FROM server_processes
-            WHERE end_time IS NULL",
+            WHERE end_time IS NULL
+            OR exit_code IS NULL",
             []
         );
 

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -50,10 +50,28 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        // This will update all process informations in the database
-        // Must execute this before loading the form
-        $serverProcessesMonitor = new ServerProcessesMonitor();
-        $serverProcessesMonitor->getProcessesState();
+        // Get processes pending resolution
+        $DB           = $this->loris->getDatabaseConnection();
+        $idsToMonitor = $DB->pselect(
+            "SELECT id
+            FROM server_processes
+            WHERE end_time IS NULL",
+            []
+        );
+
+        if (count($idsToMonitor) > 0) {
+            // Update information of processes pending resolution
+            // Ensures data is up-to-date
+            $serverProcessesMonitor = new ServerProcessesMonitor();
+            $serverProcessesMonitor->getProcessesState(
+                array_map(
+                    function ($row) {
+                        return strval($row['id']);
+                    },
+                    iterator_to_array($idsToMonitor)
+                )
+            );
+        }
 
         // Columns displayed in the result table
         $this->columns = [
@@ -76,7 +94,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
             'userid',
         ];
 
-        $this->query = " FROM server_processes 
+        $this->query = " FROM server_processes
                          WHERE 1=1";
 
         $this->formToFilter = [


### PR DESCRIPTION
This PR adds a condition for which processes to monitor before loading the data table, significantly improving page load time.

It will only monitor `server_processes` that have either `end_time` or `exit_code` equal to `NULL` (default)

Feature introduced by #9685.