### PR TITLE
[examiner] Filter out sites user does not have access to

### DIFF
--- a/modules/examiner/php/examinerprovisioner.class.inc
+++ b/modules/examiner/php/examinerprovisioner.class.inc
@@ -40,6 +40,12 @@ class ExaminerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     function __construct(protected \LORIS\LorisInstance $loris)
     {
+        $user = \User::singleton();
+
+        $where  = $user->hasPermission('examiner_multisite') ? ''
+            : "AND upr.UserID=:uid";
+        $params = $user->hasPermission('examiner_multisite') ? []
+            : ['uid' => $user->getID()];
         parent::__construct(
             $loris,
             "SELECT 
@@ -57,10 +63,11 @@ class ExaminerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                         (c.examinerID=e.examinerID and c.pass = 'certified')
                     LEFT JOIN test_names tn ON (tn.ID = c.testID)
                     LEFT JOIN users u ON u.ID=e.userID
+                    LEFT JOIN user_psc_rel upr ON upr.CenterID=epr.CenterID
                 WHERE epr.active='Y'
-                GROUP BY e.examinerID
-",
-            [],
+                $where
+                GROUP BY e.examinerID",
+            $params,
         );
     }
 


### PR DESCRIPTION
## Brief summary of changes
This PR restricts the examiner sites shown in the examiner module to only the sites that the user has access to in the case that the user does not have the "All sites" permission for the examiner module. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Create a user with the "Examiner: Add and Certify Examiners - Own Sites" permission. Give this user access to some but not all sites
2. Access the examiner module with that user
3. Make sure that the module loads and that the "Site" column in the filterable datatable only includes the sites that the user has access to
4. Give the user the "Examiner: Add and Certify Examiners - All Sites" permission
5. Make sure that the "Site" column now shows all sites, not only the sites that the user has permission to. 

#### Link(s) to related issue(s)

* Resolves #9704
