### PR TITLE
[examiner] filter out NULL values in case 'site'

### DIFF
--- a/modules/examiner/jsx/examinerIndex.js
+++ b/modules/examiner/jsx/examinerIndex.js
@@ -170,6 +170,8 @@ class ExaminerIndex extends Component {
       // If user has multiple sites, join array of sites into string
       result = (
         <td>{cell
+          .filter((centerId) => this.state.data.fieldOptions.sites[centerId]
+          != null)
           .map((centerId) => this.state.data.fieldOptions.sites[centerId])
           .join(', ')}
         </td>


### PR DESCRIPTION
## Brief summary of changes

Added filter to filter out NULL values in case 'site'

- [ ] Have you updated related documentation? No

- checkout branch `examinerSitesJS`. 
- npm run compile
- create or go to existing user with 
-  [x] Examiner: Add and Certify Examiners - Own Sites
- select 1 2 or 3 sites for this user
- save 

- Go to Clinical/Examiner in front end  and assert that there are no commas in the string of Sites
#### Link(s) to related issue(s)
#9704

* Resolves #  (Reference the issue this fixes, if any.)
#9704
