### PR TITLE
[media] upload tab

### DIFF
--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -271,7 +271,8 @@ class MediaUploadForm extends Component {
     if (!this.isValidFileName(requiredFileName, fileName)) {
       swal.fire(
         'Invalid file name!',
-        'File name should begin with: ' + requiredFileName,
+        'Your file\'s base name should be: <code>'+ requiredFileName +'</code>'  
+        + '<br>followed by the file extension.',
         'error'
       );
       return;
@@ -282,8 +283,8 @@ class MediaUploadForm extends Component {
     if (isDuplicate >= 0) {
       swal.fire({
         title: 'Are you sure?',
-        text: 'A file with this name already exists!\n '
-              + 'Would you like to override existing file?',
+        text: 'A file with this name already exists!' + '\n'
+              + 'Would you like to overwrite the existing file?',
         type: 'warning',
         showCancelButton: true,
         confirmButtonText: 'Yes, I am sure!',
@@ -292,7 +293,7 @@ class MediaUploadForm extends Component {
         if (isConfirm) {
           this.uploadFile();
         } else {
-          swal.fire('Cancelled', 'Your imaginary file is safe :)', 'error');
+          swal.fire('Cancelled', 'Your file was not overwritten', 'error');
         }
       }.bind(this));
     } else {

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -272,7 +272,7 @@ class MediaUploadForm extends Component {
       swal.fire(
         'Invalid file name!',
         'Your file\'s base name should be: <code>'+ requiredFileName +'</code>'  
-        + '<br>followed by the file extension.',
+        + '<br>followed by the file extension.' ,
         'error'
       );
       return;


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation? NO. Testing not technically fully done because i am getting a "file too large" error as well. I opened a separate issue for that.

#### Testing instructions (if applicable)

- Checkout this remote branch  
- npm run compile

- Go to Clinical / Media
- Enter :  `OTT 311` , `V1`, `bmi.txt` in the fields.
- create a file named `ROM162_V2_bmi.mp4` . Browse for it and hit `Upload`

You should see the following message:

![Screenshot from 2025-03-21 13-01-06](https://github.com/user-attachments/assets/9f34ba34-fd36-4ee5-a989-ed5dea3221f3)

- Replicate this by selecting new fields and attempting to upload a non-corresponding file name. 
- Assert that the error message asks for the filename indicated in the fields.
- Try adding a file formatted the same way with **spaces** instead of underscores. Assert that the file is accepted.


#### Link(s) to related issue(s)

* Resolves # 9721 (Reference the issue this fixes, if any.)
