### PR TITLE
[dataquery] Restrict filter CSV to visit labels for session

### DIFF
--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -101,9 +101,9 @@ function ImportCSVModal(props: {
         if (!props.visitLabels.includes(visitLabelVal)) {
           swal.fire({
             type: 'error',
-            title: 'Invalid Value',
-            text: 'Invalid visit label ' + visitLabelVal
-                        + ' on line ' + (i + 1) + '.',
+            title: t('Invalid value', {ns: 'dataquery'}),
+            text: t('Invalid visit label {{visitLabelVal}} on line {{line}}.',
+              {ns: 'dataquery', visitLabelVal, line: i+1}),
           });
           return;
         }

--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -12,11 +12,13 @@ import {useTranslation} from 'react-i18next';
  * @param {object} props - React props
  * @param {function} props.setQuery - Function to set the current criteria
  * @param {function} props.closeModal - Callback to close the current modal
+ * @param {string[]} props.visitLabels - Array of allowed visit label values
  * @returns {React.ReactElement} - The import modal window
  */
 function ImportCSVModal(props: {
     setQuery: (root: QueryGroup) => void,
     closeModal: () => void,
+    visitLabels: string[],
 }) {
   const {t} = useTranslation('dataquery');
   const [csvFile, setCSVFile] = useState<string|null>(null);
@@ -92,6 +94,21 @@ function ImportCSVModal(props: {
         setCSVFile(null);
         return;
       }
+
+      // Second column must contain visit labels
+      if (csvType === 'session') {
+        const visitLabelVal = value.data[i][1]?.trim();
+        if (!props.visitLabels.includes(visitLabelVal)) {
+          swal.fire({
+            type: 'error',
+            title: 'Invalid Value',
+            text: 'Invalid visit label ' + visitLabelVal
+                        + ' on line ' + (i + 1) + '.',
+          });
+          return;
+        }
+      }
+
       if (idType === 'CandID') {
         if (candIDRegex.test(value.data[i][0]) !== true) {
           swal.fire({

--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -36,6 +36,7 @@ import {Trans, useTranslation} from 'react-i18next';
  *                                           to the existing QueryGroup
  * @param {function} props.removeQueryGroupItem - Function that will remove an item from a
  *                                                QueryGroup by index.
+ * @param {string[]} props.visitLabels - Array of allowed visit label values
  * @returns {React.ReactElement} - The Define Filters page
  */
 function DefineFilters(props: {
@@ -60,6 +61,7 @@ function DefineFilters(props: {
     ) => QueryGroup,
     addNewQueryGroup: (group: QueryGroup) => void,
     removeQueryGroupItem: (group: QueryGroup, i: number) => QueryGroup,
+    visitLabels: string[],
 }) : React.ReactElement {
   const {t} = useTranslation('dataquery');
   let displayquery: React.ReactNode = null;
@@ -370,6 +372,7 @@ function DefineFilters(props: {
     <ImportCSVModal
       setQuery={props.setQuery}
       closeModal={() => setCSVModal(false)}
+      visitLabels={props.visitLabels}
     />
   ) : '';
 

--- a/modules/dataquery/jsx/index.tsx
+++ b/modules/dataquery/jsx/index.tsx
@@ -227,6 +227,7 @@ function DataQueryApp(props: {
 
       mapModuleName={mapModuleName}
       mapCategoryName={mapCategoryName}
+      visitLabels={visits.all}
     />;
     break;
   case 'ViewData':

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -339,6 +339,9 @@ msgstr ""
 msgid "Expected {{expectedLength}} columns in CSV. Got {{gotLength}} on line {{line}}."
 msgstr ""
 
+msgid "Invalid visit label {{visitLabelVal}} on line {{line}}."
+msgstr ""
+
 msgid "Invalid DCCID"
 msgstr ""
 

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -480,6 +480,10 @@ msgstr ""
 "colonne trouvée à la ligne {{line}}."
 
 #, fuzzy
+msgid "Invalid visit label {{visitLabelVal}} on line {{line}}."
+msgstr "Label de visite invalide {{visitLabelVal}} à la ligne {{line}}."
+
+#, fuzzy
 msgid "Invalid DCCID"
 msgstr "DCCID invalide"
 

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -481,7 +481,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Invalid visit label {{visitLabelVal}} on line {{line}}."
-msgstr "Label de visite invalide {{visitLabelVal}} à la ligne {{line}}."
+msgstr "Le libellé de la visite {{visitLabelVal}} est invalide (ligne {{line}})"
 
 #, fuzzy
 msgid "Invalid DCCID"


### PR DESCRIPTION
## Brief summary of changes
This PR adds validation to the CSV upload for filters so that when "session" is selected the second column must only contain visit labels. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Add fields for a query
2. Go to add filters and click "Import from CSV"
3. Click "Sessions" and try uploading a CSV with 2 columns where the second column does not contain valid or relevant visit labels. Make sure an error SWAL shows up
4. Click "Sessions" and try uploading a CSV with 2 columns where the second column does contain valid and relevant visit labels. Make sure no error SWAL pops up and the filters are properly loaded

#### Link(s) to related issue(s)

* Resolves #9723
