### PR TITLE
[candidate_parameters] Fix DB select with iterator_to_array

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -631,23 +631,25 @@ function getDiagnosisEvolutionFields(): array
         ['candID' => $candID]
     );
 
-    $candidateDiagnosisEvolution = $db->pselect(
-        "SELECT
-            de.Name AS TrajectoryName,
-            p.Name AS Project,
-            visitLabel,
-            instrumentName,
-            sourceField,
-            Diagnosis,
-            Confirmed,
-            LastUpdate,
-            OrderNumber
-        FROM candidate_diagnosis_evolution_rel cder
-        JOIN diagnosis_evolution de USING (DxEvolutionID)
-        JOIN Project p USING (ProjectID)
-        JOIN candidate c ON c.ID=cder.CandidateID
-        WHERE c.CandID=:candID",
-        ['candID' => $candID]
+    $candidateDiagnosisEvolution = iterator_to_array(
+        $db->pselect(
+            "SELECT
+                de.Name AS TrajectoryName,
+                p.Name AS Project,
+                visitLabel,
+                instrumentName,
+                sourceField,
+                Diagnosis,
+                Confirmed,
+                LastUpdate,
+                OrderNumber
+            FROM candidate_diagnosis_evolution_rel cder
+            JOIN diagnosis_evolution de USING (DxEvolutionID)
+            JOIN Project p USING (ProjectID)
+            JOIN candidate c ON c.ID=cder.CandidateID
+            WHERE c.CandID=:candID",
+            ['candID' => $candID]
+        )
     );
 
     $projectList = \Utility::getProjectList();


### PR DESCRIPTION
## Brief summary of changes
This PR wraps the $db->pselect() call with iterator_to_array so that it can be processed with .map in [DiagnosisEvolution.js](https://github.com/aces/Loris/blob/main/modules/candidate_parameters/jsx/DiagnosisEvolution.js#L65). This is necessary following the change in #9334
- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Open the candidate parameters module for any participant and go to the Diagnosis Evolution tab
2. Make sure there are no errors

#### Link(s) to related issue(s)

* Resolves #9711

