### PR TITLE
[battery_manager] Add required DDE selection

### DIFF
--- a/modules/battery_manager/jsx/batteryManagerForm.js
+++ b/modules/battery_manager/jsx/batteryManagerForm.js
@@ -146,8 +146,9 @@ class BatteryManagerForm extends Component {
           label="Enable Double Data Entry"
           options={options.DoubleDataEntryEnabled}
           onUserInput={setTest}
-          required={false}
+          required={true}
           value={test.DoubleDataEntryEnabled}
+          emptyOption={false}
         />
         <ButtonElement
           label="Submit"


### PR DESCRIPTION
## Brief summary of changes
- Updated the New Test form in the Battery Manager to better showcase that selecting a DDE option is required.
- It defaults to No, and includes a red * that the field is required.
<img width="684" alt="image" src="https://github.com/user-attachments/assets/cbaace11-c0d8-44d1-9f01-bc3b211ac857" />


#### Testing instructions (if applicable)

1. Try to create a new Test without modifying the DDE selection and confirm it works
2. Try to create a new Test with DDE == 'Yes' and confirm it works

#### Link(s) to related issue(s)

* Resolves #9698 
