### PR TITLE
[DataTable] Fix multiselect containing commas

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -370,7 +370,12 @@ class DataTable extends Component {
         searchKey = filterData[i].toLowerCase();
         searchString = data ? data.toString().toLowerCase() : '';
 
-        let searchArray = searchString.split(',');
+        if (searchKey.includes(',')) {
+          match = (searchString == searchKey);
+        } else {
+          let searchArray = searchString.split(',');
+          match = (searchArray.includes(searchKey));
+        }
         match = (searchArray.includes(searchKey));
         if (match) {
           result = true;


### PR DESCRIPTION
## Brief summary of changes
When selected, multiselect filter options containing a comma would not display any data because they were being split by commas (see below). 

<img width="500" alt="Screenshot 2025-04-10 at 12 41 33 PM" src="https://github.com/user-attachments/assets/34405a44-a885-42b3-aa6e-17cbab6b9de4" />
<img width="700" alt="430114218-5992aec4-172f-4d70-8c5e-4c38155e4c96" src="https://github.com/user-attachments/assets/67eb3b9c-6417-406f-8105-322252a8f5aa" />

#### Testing instructions (if applicable)
1. In a multiselect filter that contains options with commas (eg. in CCNA, the Site filter in Access Profile) and see that the corresponding data appear in the table
2. Check that multiple options can be selected & displayed appropriately, including options that contain a comma

#### Link(s) to related issue(s)

* Resolves #7531 
* On CCNA: https://github.com/aces/CCNA/issues/7962 
