### PR TITLE
[Behavioural_QC] Incomplete Forms Data Entry Type

### DIFF
--- a/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
+++ b/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
@@ -173,6 +173,18 @@ class IncompleteForms extends Component {
         },
       },
       {
+        label: 'Data Entry Type',
+        show: true,
+        filter: {
+          name: 'Data Entry Type',
+          type: 'select',
+          options: {
+            'FDE': 'First Data Entry (FDE)',
+            'DDE': 'Double Data Entry (DDE)',
+          },
+        },
+      },
+      {
         label: 'DCCID',
         show: true,
         filter: {

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -28,6 +28,13 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
     private $_instrument = '';
 
     /**
+     * Data Entry Type (FDE or DDE)
+     *
+     * @var string
+     */
+    private $_data_entry_type = '';
+
+    /**
      * The candID
      *
      * @var string
@@ -134,18 +141,19 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument' => $this->_instrument,
-            'candID'     => $this->_candID,
-            'pscID'      => $this->_pscID,
-            'visit'      => $this->_visit,
-            'project'    => $this->_project,
-            'cohort'     => $this->_cohort,
-            'site'       => $this->_site,
-            'id'         => $this->_id,
-            'sessionID'  => $this->_sessionID,
-            'test_name'  => $this->_test_name,
-            'data_entry' => $this->_data_entry,
-            'commentID'  => $this->_commentID,
+            'instrument'      => $this->_instrument,
+            'data_entry_type' => $this->_data_entry_type,
+            'candID'          => $this->_candID,
+            'pscID'           => $this->_pscID,
+            'visit'           => $this->_visit,
+            'project'         => $this->_project,
+            'cohort'          => $this->_cohort,
+            'site'            => $this->_site,
+            'id'              => $this->_id,
+            'sessionID'       => $this->_sessionID,
+            'test_name'       => $this->_test_name,
+            'data_entry'      => $this->_data_entry,
+            'commentID'       => $this->_commentID,
         ];
     }
 }

--- a/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
@@ -26,6 +26,10 @@ class IncompleteProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             "
             SELECT DISTINCT
                 t.Full_name AS _instrument,
+                CASE
+                    WHEN f.commentid LIKE 'DDE_%' THEN 'DDE'
+                    ELSE 'FDE'
+                END AS _data_entry_type,
                 c.CandID AS _candID,
                 c.PSCID AS _pscID,
                 s.visit_label AS _visit,


### PR DESCRIPTION
## Brief summary of changes
- Adds a column to the Incomplete Forms page of Behavioural QC for Data Entry Type
- Would be great if this could go into 27 because it is very small

<img width="768" alt="image" src="https://github.com/user-attachments/assets/8a751a86-ee74-4244-a65f-1f8e6ec7b687" />

<img width="896" alt="image" src="https://github.com/user-attachments/assets/4e361f79-50ff-429c-b021-d7a51ab5c2cc" />

#### Testing instructions (if applicable)

1. Open the behavioural qc module incomplete forms page
2. Confirm that those with CommentID DDE show DDE, and those without show FDE
3. Try filtering

#### Link(s) to related issue(s)

* Resolves #9744
