### PR TITLE
[i18n] Dashboard -- My Tasks

### DIFF
--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -113,7 +113,9 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    dgettext("conflict_resolver", "Data entry conflict"),
+                    "conflict_resolver",
+                    "Data entry conflict",
+                    "Data entry conflicts",
                     $DB,
                     "SELECT COUNT(*) FROM conflicts_unresolved cu
                          LEFT JOIN flag ON (cu.CommentId1=flag.CommentID)

--- a/modules/dashboard/locale/dashboard.pot
+++ b/modules/dashboard/locale/dashboard.pot
@@ -24,3 +24,8 @@ msgstr ""
 msgid "My Tasks"
 msgstr ""
 
+msgid "Site: All"
+msgstr ""
+
+msgid "Site: All User Sites"
+msgstr ""

--- a/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
@@ -24,3 +24,8 @@ msgstr "ダッシュボード"
 msgid "My Tasks"
 msgstr "私のタスク"
 
+msgid "Site: All"
+msgstr "サイト: すべて"
+
+msgid "Site: All User Sites"
+msgstr "サイト: すべてのユーザーサイト"

--- a/modules/dashboard/php/taskquerywidget.class.inc
+++ b/modules/dashboard/php/taskquerywidget.class.inc
@@ -35,9 +35,11 @@ class TaskQueryWidget extends TaskWidget
      * Construct a TaskQueryWidget
      *
      * @param \User     $user         The user whose tasks are being displayed
-     * @param string    $label        The label for the task widget. It should be
-     *                                singular and phrased in a way that adding
-     *                                an "s" pluralizes.
+     * @param string    $labeldomain  The gettext textdomain to use for the label
+     * @param string    $label        The label for the task widget when the count
+     *                                is "1".
+     * @param string    $labelplural  The label for the task widget when the count
+     *                                is more than 1.
      * @param \Database $db           The database connection for the query.
      * @param string    $dbquery      The query to run to get a count.
      * @param string    $allperm      The permission to use to determine if the user
@@ -54,7 +56,9 @@ class TaskQueryWidget extends TaskWidget
      */
     public function __construct(
         \User $user,
+        string $labeldomain,
         string $label,
+        string $labelplural,
         \Database $db,
         string $dbquery,
         string $allperm,
@@ -64,13 +68,13 @@ class TaskQueryWidget extends TaskWidget
         string $cssclass
     ) {
         $queryparams = [];
-        $siteLabel   = 'Site: All';
+        $siteLabel   = dgettext("dashboard", 'Site: All');
         if ($allperm != '') {
             if (!$user->hasPermission($allperm)) {
                 $sites = $user->getCenterIDs();
                 $queryparams['SiteID'] = implode(',', $sites);
                 $dbquery  .= " AND FIND_IN_SET($sitefield, :SiteID)";
-                $siteLabel = 'Site: All User Sites';
+                $siteLabel = dgettext("dashboard", 'Site: All User Sites');
             }
         }
         if ($projectfield) {
@@ -79,9 +83,7 @@ class TaskQueryWidget extends TaskWidget
         }
 
         $number = (int )$db->pselectOne($dbquery, $queryparams);
-        if ($number != 1) {
-            $label .= "s";
-        }
+        $label  = dngettext($labeldomain, $label, $labelplural, $number);
 
         parent::__construct($label, $number, $link, $cssclass, $siteLabel);
     }

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -23,3 +23,9 @@ msgstr ""
 
 msgid "View Session"
 msgstr ""
+
+msgid "New and pending imaging session"
+msgstr ""
+
+msgid "New and pending imaging sessions"
+msgstr ""

--- a/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
@@ -23,3 +23,9 @@ msgstr "イメージングブラウザ"
 
 msgid "View Session"
 msgstr "セッションを見る"
+
+msgid "New and pending imaging session"
+msgstr "新規および保留中のMRI セッション"
+
+msgid "New and pending imaging sessions"
+msgstr "新規および保留中のMRI セッション"

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -70,7 +70,9 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
+                    "imaging_browser",
                     "New and pending imaging session",
+                    "New and pending imaging sessions",
                     $DB,
                     "SELECT COUNT(DISTINCT s.ID)
                      FROM files f

--- a/modules/instruments/locale/instruments.pot
+++ b/modules/instruments/locale/instruments.pot
@@ -21,3 +21,8 @@ msgstr ""
 msgid "Instruments"
 msgstr ""
 
+msgid "Incomplete form"
+msgstr ""
+
+msgid "Incomplete forms"
+msgstr ""

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -21,3 +21,9 @@ msgstr ""
 msgid "Instruments"
 msgstr "機器"
 
+
+msgid "Incomplete form"
+msgstr "不完全なフォーム"
+
+msgid "Incomplete forms"
+msgstr "不完全なフォーム"

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -127,7 +127,9 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
+                    "instruments",
                     "Incomplete form",
+                    "Incomplete forms",
                     $DB,
                     "SELECT COUNT(*) FROM flag
                         LEFT JOIN session s ON (s.ID=flag.SessionID)

--- a/modules/issue_tracker/locale/issue_tracker.pot
+++ b/modules/issue_tracker/locale/issue_tracker.pot
@@ -21,3 +21,8 @@ msgstr ""
 msgid "Issue Tracker"
 msgstr ""
 
+msgid "Your assigned issue"
+msgstr ""
+
+msgid "Your assigned issues"
+msgstr ""

--- a/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
@@ -21,3 +21,11 @@ msgstr ""
 msgid "Issue Tracker"
 msgstr "問題トラッカー"
 
+
+# Google Translate is giving me completely different translations for
+# singular and plural. Might be worth investigating.
+msgid "Your assigned issue"
+msgstr "担当する問題"
+
+msgid "Your assigned issues"
+msgstr "割り当てられた問題"

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -91,7 +91,9 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
+                    "issue_tracker",
                     "Your assigned issue",
+                    "Your assigned issues",
                     $DB,
                     "SELECT COUNT(*) FROM issues
                      WHERE status != 'closed' AND assignee="

--- a/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
@@ -21,3 +21,10 @@ msgstr ""
 msgid "MRI Violated Scans"
 msgstr "MRI違反スキャン"
 
+
+msgid "Violated scan"
+msgstr "違反スキャン"
+
+msgid "Violated scans"
+msgstr "違反スキャン"
+

--- a/modules/mri_violations/locale/mri_violations.pot
+++ b/modules/mri_violations/locale/mri_violations.pot
@@ -21,3 +21,9 @@ msgstr ""
 msgid "MRI Violated Scans"
 msgstr ""
 
+msgid "Violated scan"
+msgstr ""
+
+msgid "Violated scans"
+msgstr ""
+

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -87,9 +87,9 @@ class Module extends \Module
             $provisioner = new Provisioner($this->loris);
 
             if ($user->hasPermission('violated_scans_view_allsites')) {
-                $siteLabel = 'Site: All';
+                $siteLabel = dgettext("dashboard", 'Site: All');
             } else {
-                $siteLabel   = 'Site: All User Sites';
+                $siteLabel   = dgettext("dashboard", 'Site: All User Sites');
                 $provisioner = $provisioner->filter(new UserCenterMatchOrNull())
                     ->filter(new UserProjectMatchOrNull());
             }
@@ -104,7 +104,12 @@ class Module extends \Module
                 }
             }
 
-            $label = $number >  1 ? 'Violated scans' : 'Violated scan';
+            $label = dngettext(
+                "mri_violations",
+                "Violated scan",
+                "Violated scans",
+                $number
+            );
 
             $widget = new \LORIS\dashboard\TaskWidget(
                 $label,

--- a/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
+++ b/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
@@ -24,3 +24,8 @@ msgstr "ユーザーアカウント"
 msgid "Edit User"
 msgstr "ユーザーを編集"
 
+msgid "Pending account approval"
+msgstr "アカウント承認待ち"
+
+msgid "Pending account approvals"
+msgstr "保留中のアカウント承認"

--- a/modules/user_accounts/locale/user_accounts.pot
+++ b/modules/user_accounts/locale/user_accounts.pot
@@ -24,3 +24,8 @@ msgstr ""
 msgid "Edit User"
 msgstr ""
 
+msgid "Pending account approval"
+msgstr ""
+
+msgid "Pending account approvals"
+msgstr ""

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -83,7 +83,9 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
+                    "user_accounts",
                     "Pending account approval",
+                    "Pending account approvals",
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)


### PR DESCRIPTION
This builds on #9747 to add support for translating the "My Tasks" widgets on the LORIS dashboard. In the current code, an "s" is hardcoded to be added when count > 1, which doesn't work for other languages.

The signature had to be updated to include a singular and plural label, as well as the text domain that the labels come from, since they come from the module providing the widget and not the dashboard. (The dngettext call also could not be done in the module, because the module doesn't have the count to know if it's plural.)