### PR TITLE
[Core] Add the ability to sort menu categories

### DIFF
--- a/SQL/New_patches/2025-04-17_menu_category_order.sql
+++ b/SQL/New_patches/2025-04-17_menu_category_order.sql
@@ -1,0 +1,14 @@
+CREATE TABLE menu_categories (
+	name varchar(255) NOT NULL PRIMARY KEY,
+	orderby integer unsigned default 1
+);
+
+INSERT INTO menu_categories (name, orderby) VALUES
+('Candidate', 1),
+('Clinical', 2),
+('Electrophysiology', 3),
+('Genomics', 4),
+('Imaging', 5),
+('Reports', 6),
+('Tools', 7),
+('Admin', 8);

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -39,6 +39,8 @@ Profiler::checkpoint("Profiler started");
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.
 $middlewarechain = (new \LORIS\Middleware\ContentLength())
+    ->withMiddleware(new \LORIS\Middleware\LorisMenu())
+    ->withMiddleware(new \LORIS\Middleware\ContentLength())
     ->withMiddleware(new \LORIS\Middleware\AWS())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 

--- a/modules/acknowledgements/php/module.class.inc
+++ b/modules/acknowledgements/php/module.class.inc
@@ -47,11 +47,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/api_docs/php/module.class.inc
+++ b/modules/api_docs/php/module.class.inc
@@ -52,18 +52,12 @@ class Module extends \Module
     }
 
     /**
-     * Return a value which is used as the default menu category
-     * (dropdown) to add this module to in the LORIS frontend.
+     * {@inheritDoc}
      *
-     * Unless overridden, this defaults to the empty string (which
-     * results in the module not being added to the LORIS menu.)
-     *
-     * @return string The category (dropdown) of the LORIS menu to add
-     *                this module to.
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
-
 }

--- a/modules/battery_manager/php/module.class.inc
+++ b/modules/battery_manager/php/module.class.inc
@@ -48,11 +48,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/behavioural_qc/php/module.class.inc
+++ b/modules/behavioural_qc/php/module.class.inc
@@ -44,11 +44,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Clinical";
+        return \LORIS\GUI\MenuCategory::singleton("Clinical");
     }
 
     /**

--- a/modules/candidate_list/php/module.class.inc
+++ b/modules/candidate_list/php/module.class.inc
@@ -69,12 +69,13 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Candidate";
+        return \LORIS\GUI\MenuCategory::singleton("Candidate");
     }
+
 
     /**
      * {@inheritDoc}

--- a/modules/configuration/php/module.class.inc
+++ b/modules/configuration/php/module.class.inc
@@ -43,11 +43,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -76,11 +76,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Clinical";
+        return \LORIS\GUI\MenuCategory::singleton("Clinical");
     }
 
     /**

--- a/modules/data_release/php/module.class.inc
+++ b/modules/data_release/php/module.class.inc
@@ -49,11 +49,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/datadict/php/module.class.inc
+++ b/modules/datadict/php/module.class.inc
@@ -42,11 +42,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -26,11 +26,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Reports";
+        return \LORIS\GUI\MenuCategory::singleton("Reports");
     }
 
     /**

--- a/modules/dicom_archive/php/module.class.inc
+++ b/modules/dicom_archive/php/module.class.inc
@@ -113,11 +113,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Imaging";
+        return \LORIS\GUI\MenuCategory::singleton("Imaging");
     }
 
     /**

--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -42,11 +42,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -49,11 +49,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/dqt/php/module.class.inc
+++ b/modules/dqt/php/module.class.inc
@@ -42,11 +42,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Reports";
+        return \LORIS\GUI\MenuCategory::singleton("Reports");
     }
 
     /**

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -47,11 +47,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Electrophysiology";
+        return \LORIS\GUI\MenuCategory::singleton("Electrophysiology");
     }
 
     /**

--- a/modules/electrophysiology_uploader/php/module.class.inc
+++ b/modules/electrophysiology_uploader/php/module.class.inc
@@ -47,11 +47,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Electrophysiology";
+        return \LORIS\GUI\MenuCategory::singleton("Electrophysiology");
     }
 
     /**

--- a/modules/examiner/php/module.class.inc
+++ b/modules/examiner/php/module.class.inc
@@ -43,11 +43,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Clinical";
+        return \LORIS\GUI\MenuCategory::singleton("Clinical");
     }
 
     /**

--- a/modules/genomic_browser/php/module.class.inc
+++ b/modules/genomic_browser/php/module.class.inc
@@ -46,12 +46,13 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Genomics";
+        return \LORIS\GUI\MenuCategory::singleton("Genomics");
     }
+
 
     /**
      * {@inheritDoc}

--- a/modules/help_editor/php/module.class.inc
+++ b/modules/help_editor/php/module.class.inc
@@ -40,11 +40,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -33,11 +33,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Imaging";
+        return \LORIS\GUI\MenuCategory::singleton("Imaging");
     }
 
     /**

--- a/modules/imaging_qc/php/module.class.inc
+++ b/modules/imaging_qc/php/module.class.inc
@@ -43,11 +43,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Imaging";
+        return \LORIS\GUI\MenuCategory::singleton("Imaging");
     }
 
     /**

--- a/modules/imaging_uploader/php/module.class.inc
+++ b/modules/imaging_uploader/php/module.class.inc
@@ -47,11 +47,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Imaging";
+        return \LORIS\GUI\MenuCategory::singleton("Imaging");
     }
 
     /**

--- a/modules/instrument_builder/php/module.class.inc
+++ b/modules/instrument_builder/php/module.class.inc
@@ -41,11 +41,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/instrument_manager/php/module.class.inc
+++ b/modules/instrument_manager/php/module.class.inc
@@ -46,11 +46,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -47,11 +47,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -26,11 +26,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Clinical";
+        return \LORIS\GUI\MenuCategory::singleton("Clinical");
     }
 
     /**

--- a/modules/module_manager/php/module.class.inc
+++ b/modules/module_manager/php/module.class.inc
@@ -43,11 +43,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -46,11 +46,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Imaging";
+        return \LORIS\GUI\MenuCategory::singleton("Imaging");
     }
 
     /**

--- a/modules/new_profile/php/module.class.inc
+++ b/modules/new_profile/php/module.class.inc
@@ -43,11 +43,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Candidate";
+        return \LORIS\GUI\MenuCategory::singleton("Candidate");
     }
 
     /**

--- a/modules/publication/php/module.class.inc
+++ b/modules/publication/php/module.class.inc
@@ -48,11 +48,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Reports";
+        return \LORIS\GUI\MenuCategory::singleton("Reports");
     }
 
     /**

--- a/modules/schedule_module/php/module.class.inc
+++ b/modules/schedule_module/php/module.class.inc
@@ -42,11 +42,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Tools";
+        return \LORIS\GUI\MenuCategory::singleton("Tools");
     }
 
     /**

--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -97,11 +97,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -42,11 +42,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Reports";
+        return \LORIS\GUI\MenuCategory::singleton("Reports");
     }
 
     /**

--- a/modules/survey_accounts/php/module.class.inc
+++ b/modules/survey_accounts/php/module.class.inc
@@ -41,11 +41,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -46,11 +46,11 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @return string The menu category for this module
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "Admin";
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
     }
 
     /**

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -359,12 +359,11 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      * Unless overridden, this defaults to the empty string (which
      * results in the module not being added to the LORIS menu.)
      *
-     * @return string The category (dropdown) of the LORIS menu to add
-     *                this module to.
+     * @return ?\LORIS\GUI\MenuCategory
      */
-    public function getMenuCategory() : string
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
     {
-        return "";
+        return null;
     }
 
 
@@ -388,10 +387,11 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     {
         $category = $this->getMenuCategory();
         $name     = $this->getLongName();
-        if ($category !== "" && $name !== "") {
+        if ($category !== null && $name !== "") {
             $factory = \NDB_Factory::singleton();
             $baseURL = $factory->settings()->getBaseURL();
             $url     = $baseURL . '/' . $this->getName() . '/';
+
             return [
                 new \LORIS\GUI\MenuItem($category, $name, $url)
             ];

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -124,16 +124,16 @@
                    </div>
                    <div class="collapse navbar-collapse" id="example-navbar-collapse">
                         <ul class="nav navbar-nav">
-                            {foreach from=$menus item=menuitems key=category}
+		            {section name=category loop=$menus}
                                  <li class="dropdown">
-                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{$category}<b class="caret"></b>
+                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{$menus[category].Category->name}<b class="caret"></b>
                                         <ul class="dropdown-menu">
-                                            {section name=itemloop loop=$menuitems}
-                                            <li><a href="{$menuitems[itemloop]->getLink()}">{$menuitems[itemloop]->getLabel()}</a></li>
+                                            {section name=item loop=$menus[category].Items}
+                                            <li><a href="{$menuitems[itemloop]->link}">{$menus[category].Items[item]->label}</a></li>
                                             {/section}
                                         </ul>
                                     </a>
-                            {/foreach}
+                            {/section}
                         </ul>
                         <ul class="nav navbar-nav navbar-right" id="nav-right">
                             {if $bvl_feedback|default}

--- a/src/GUI/MenuCategory.php
+++ b/src/GUI/MenuCategory.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\GUI;
+
+/**
+ * A MenuCategory represents a dropdown group of MenuItems in the LORIS
+ * menu (top bar) to be displayed in the GUI.
+ */
+class MenuCategory
+{
+    /**
+     * Constructs a menu category. Should only be loaded via singleton.
+     *
+     * @param string $name  The label for the menu category
+     * @param int    $label The relative ordering of the category
+     */
+    private function __construct(
+        public readonly string $name,
+        public readonly int $order
+    ) {
+    }
+
+    private static array $cache = [];
+
+    /**
+     * Bulk load all menu categories so that they are available for singleton.
+     * This should only be called once.
+     */
+    public static function bulkLoad(\LORIS\LorisInstance $loris)
+    {
+        $DB   = $loris->getDatabaseConnection();
+        $cats = $DB->pselect("SELECT name, orderby FROM menu_categories", []);
+        foreach ($cats as $cat) {
+            assert(!isset(self::$cache[$cat['name']]));
+            self::$cache[$cat['name']] = new self($cat['name'], $cat['orderby']);
+        }
+    }
+    public static function singleton(string $name) : MenuCategory
+    {
+        if (isset(self::$cache[$name])) {
+            return self::$cache[$name];
+        }
+        throw new \LorisException("Menu category $name not found");
+    }
+}

--- a/src/GUI/MenuItem.php
+++ b/src/GUI/MenuItem.php
@@ -8,51 +8,18 @@ namespace LORIS\GUI;
  */
 class MenuItem
 {
-    protected string $category;
-    protected string $label;
-    protected string $link;
-
     /**
      * Constructs a menu item in a given category.
      *
-     * @param string $category The category (dropdown section) for the menu item.
-     * @param string $label    The label to use for the menu item.
-     * @param string $link     The URL that the menu should point to.
+     * @param MenuCategory $category The category (dropdown section) for the
+     *                               menu item.
+     * @param string $label          The label to use for the menu item.
+     * @param string $link           The URL that the menu should point to.
      */
-    public function __construct(string $category, string $label, string $link)
-    {
-        $this->category = $category;
-        $this->label    = $label;
-        $this->link     = $link;
-    }
-
-    /**
-     * Returns the category that the menu item should appear in
-     *
-     * @return string the category
-     */
-    public function getCategory() : string
-    {
-        return $this->category;
-    }
-
-    /**
-     * Returns the label that should be used for the menu item
-     *
-     * @return string the label
-     */
-    public function getLabel() : string
-    {
-        return $this->label;
-    }
-
-    /**
-     * Returns the URL to use for the menu item
-     *
-     * @return string the URL.
-     */
-    public function getLink() : string
-    {
-        return $this->link;
+    public function __construct(
+        public readonly MenuCategory $category,
+        public readonly string $label,
+        public readonly string $link
+    ) {
     }
 }

--- a/src/Middleware/LorisMenu.php
+++ b/src/Middleware/LorisMenu.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\Middleware;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\MiddlewareInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * The LorisMenu middleware pre-loads the LORIS menu categories so
+ * that modules respect the database defined ordering.
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class LorisMenu implements MiddlewareInterface, MiddlewareChainer
+{
+    use MiddlewareChainerMixin;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface  $request The incoming PSR7 request.
+     * @param RequestHandlerInterface $handler The PSR15 handler to delegate
+     *                                         content generation to.
+     *
+     * @return ResponseInterface the PSR15 response
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+        $loris = $request->getAttribute("loris");
+        \LORIS\GUI\MenuCategory::bulkLoad($loris);
+        return $this->next->process($request, $handler);
+    }
+}


### PR DESCRIPTION
This adds the ability to sort the top-level menus via a new "menu_categories" table. GetMenuCategory returns a new MenuCategory class rather than a string, which permits us to store the metadata that the UserPageDecoration needs for sorting.

A new (fairly trivial) middleware is added to populate the MenuCategory::singleton's cache and if a module uses a menu category that is not in the menu_categories table an exception is thrown. This is intended to prevent typos and ensure that all modules use a valid / existing menu category. It also takes the sorting out of the individual module's hands so that there are no inconsistencies between where any given module thinks the category should be sorted. 

Within each dropdown, the sorting is still alphabetical and there is no frontend for customizing it. The default should be the same as our current almost-alphabetical sorting.

Resolves #9748
