### PR TITLE
[instruments] test plan

### DIFF
--- a/modules/instruments/test/TestPlan.md
+++ b/modules/instruments/test/TestPlan.md
@@ -1,55 +1,110 @@
 # Instrument Test Plan
 
-1. Verify that in order to access the module the user meets one of the following criteria:
-   - User has permission `data_entry` (_"Access Profile: View/Create Candidates and Timepoints - Own Sites"_) and can access the instrument through the 
-     candidate_list module (Access Profile) 
-     - go to the candidate_list
-     - click on a PSCID to get to the timepoint_list module
-     - click on a timepoint to get to the instrument_list module
-     - click on an instrument to access the instrument itself.  
-     _**Note:** All steps before clicking on the instrument itself are handled 
-     by their own modules and necessary permissions to access these modules should be 
-     part of their respective testplans._
-   - User is provided a direct link to the instrument and has permission `data_entry` (_"Access Profile: View/Create Candidates and Timepoints - Own Sites"_).
-2. Ensure that the candidate info at the top (DoB, EDC, ...) are correct.
-3. Enter a date and click 'Save Data'. Check if age calculation
-is correct.
-4. Try to save the instruments without an examiner. You should have a box specifying that 
-'an examiner is required'.
-5. If the instrument has multiple pages (on the left pane), move from page to page and check that the
-saved data stays the same. The data that wasn't saved should be lost.
-6. Make sure that the 'Delete instrument data' button on the left pane is only visible when the user
-has the 'Send to DCC' (_"Send to DCC"_) permission, and the configuration `InstrumentResetting` (_"Instrument Resetting"_) is set to
-'Yes' in the Configuration module.
-7. Click on the 'Delete instrument data' button and check if the instrument's data is cleared.
-8. Check that an instrument with the `postMortem` variable set to true displays the label
-'Candidate Age at Death (Months)' instead of 'Candidate Age (Months)'. To set the `postMortem` variable
-for PHP instruments, assign the variable within the instrument's PHP class; for LINST instruments,
-include `postmortem{@}true` in the instrument's meta file.
-9.  Test both LINST & PHP instruments found in the `project/instruments` directory.
-    - Refer to the following guides for help.
-        1. The [Instrument Insertion](https://github.com/aces/Loris/wiki/Instrument-Insertion) for PHP instruments.
-        2. The [Creating and installing clinical instruments](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links) for LINST instruments.
-    - To test an instrument:
-        1. Register a candidate
-        2. Create a timepoint
-        3. Start its visit stage
-        4. Enter sample data, testing each field's type and logic constraints
-10.  Verify Validity flags are functioning for instruments.
-    - **Validity:** can be marked as “Valid”, “Questionable”, or “Invalid”. Whether or not this flag is shown for an instrument is by the boolean $ValidityEnabled. Whether the field is required before flagging an instrument as complete is determined by $ValidityRequired.
-    - You can test the forgoing flags by switching the corresponding boolean of the test instruments to either `true` or `false`.
+This test plan verifies that permissions and configurations do what they are supposed to do.
+The permissions are:
 
-### Visit the Dashboard module.
-   1. Dashboard Widget - "My Tasks" for Incomplete forms 
-      - Ensure the total of Incomplete forms correspond with the correct 
-            number of candidates inside the statistics/statistics_site module.
-      - Click on the total number of Incomplete forms and check if redirection
-            to the statistics/statistics_site module succeeds.
+1. `data_entry` permission, which allows users to enter information into instruments
+2. `view_instrument_data`, which only allows users to view the instrument data only
 
-### Visit the Candidate Dashboard module.
-   1. Candidate Widget - "Behavioural Data" for Candidate instruments entry.
-      - Ensure the appropriate visit labels are visible for the candidate. 
-      - The visit status, cohort status, site, date of visit, and age should be shown.
-      - Clicking on a visit should redirect to the instrument_list module for the candidate.
-      - Test making a new Time Point for a candidate and assign an instrument to the time point. 
-        The Behavioural Data widget should update accordingly.
+## with `data_entry` permission
+
+- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
+- enter `loris.ca/candidate_list` in url
+- click on a PSCID, click on a timepoint, click on an instrument
+- Assert that link to the instrument is shown, ex:`loris.ca/instruments/mri_parameter_form/?commentID=300166OTT166166241522092433&sessionID=166&candID=300166`
+- Enter a date and click 'Save Data'. Assert that `Age Calculation` is correct
+- Set Examiner to NULL and assert that `An Examiner is Required` appears.
+- If the instrument has multiple pages (on the left sidebar), enter some data, then move from page to page and assert that the
+saved data stays the same.
+- Change some data, but don't hit save, and change page. Assert that the data that wasn't saved is not still there (ie is not persistent)
+
+## View the instruments
+
+  1. go to `/new_profile` and enter data, click `Create` and `Access Profile`
+  2. click `Create Time Point` and enter data and click `Create Time Point` and click `OK`. Assert that you see your new time point with `Not Started` in the `Stage` field
+  3. Click the Visit Label you just created of your new candidate
+  4. In the side bar, click `Start Visit Stage` and enter `Date of Visit` and `Continue`. Assert that you are taken to a list of instruments assigned to this time point: `/instrument_list`
+
+  6.Enter sample data, testing each field's type and logic constraints
+
+## Test the Configurations
+
+### `instrumentResetting`
+
+- [x] Instrument List: Send to DCC
+
+in /configuration, set `InstrumentResetting`
+
+- in /configuration, set `InstrumentResetting` to `Yes`
+- Under `Subtests` in the sidebar, click `Top` and Assert that 'Delete instrument data' button is visible 
+- Click `Delete instrument data` button and assert that the instrument's data is cleared on every page
+
+### `postMortem`
+
+- Select a PHP instrument by looking in the /project/instruments folder for any instrument that begins with `NDB_BVL_Instrument`
+- Set the `$postMortem` object in the PHP programme to `true` and save the file. remember that in PHP a boolean value must be lower case ie `true` not `True`
+
+```    /**
+     * True if the instrument is administered after the candidate's death.
+     * This is used to determine which candidate age should be displayed as
+     * part of metadata fields. (Either Candidate Age or Candidate Age at Death).
+     * To be called from within individual instrument forms.
+     *
+     * @var    bool
+     * @access protected
+     */
+    
+    protected $postMortem = false; 
+```
+
+- Assert that `Candidate Age at Death (Months)` appears instead of `Candidate Age (Months)`  
+- Set it back to 'false' and reload the instrument and assert that `Candidate Age (Months)` appears
+- Select a LINST instrument by looking in /project/instruments and selecting a file that ends with .linst
+- set`postmortem{@}true` in the instrument's meta file, save, and assert that `Candidate Age at Death (Months)` appears. 
+- set it to `false` and assert that `Candidate Age (Months)` appears  
+
+### Verify Validity
+
+- Look in the (SECTION) of the PHP code of the instrument in question and set the $ValidityEnabled object to `true`
+
+```    /**
+     * Whether the "Validity" field is shown as a flag for an instrument
+     * or not.
+     *
+     * @access public
+     */
+    public $ValidityEnabled = true;
+```
+
+Assert that you see validity ticks in the side bar of the instruent, as follows:
+
+- [ ] Valid
+- [ ] Questionable
+- [ ] Invalid
+
+Now set `$validityEnabled` to `false`, reload the instrument, and assert that these do not appear
+
+### Dashboard module tests
+
+Go to the loris splash page `loris.ca/`
+
+- Under`My Tasks` click `Incomplete forms`
+- Assert that this re-directs to `statistics/statistics_site`
+
+-Assert that the total of Incomplete forms correspond with the correct number of candidates inside the
+
+### Visit the Candidate Dashboard module
+
+- click `Access Profile`, click a `PSCID`, click a `timepoint`
+
+Assert that this redirects to 
+
+`/instrument_list/?candID=<xxxx>$sessionID=<yyyy>`
+
+which, at the bottom, contains the Behavioural Battery of Instruments
+
+- Test making a new Time Point for a candidate and assign an instrument to the time point.
+
+using `php assign_missing_instruments`???!!!!
+
+The Behavioural Data widget should update accordingly.

--- a/modules/instruments/test/TestPlan.md
+++ b/modules/instruments/test/TestPlan.md
@@ -1,16 +1,28 @@
 # Instrument Test Plan
 
-This test plan verifies that permissions and configurations do what they are supposed to do.
-The permissions are:
+This test plan verifies that permissions and configurations do what they are supposed to do. The two permissions are called 'Data Entry' and 'View Instrument Data'
 
-1. `data_entry` permission, which allows users to enter information into instruments
-2. `view_instrument_data`, which only allows users to view the instrument data only
+Table of Contents
 
-## with `data_entry` permission
+- [Data Entry](#data-entry)
+  -  [View the Instruments](#view-the-instruments)
+  - [Test Configurations](#test-configurations)
+    - [Instrument Resetting](#instrument-resetting)
+    - [Post Mortem](#post-mortem)
+    - [Verify Validity](#verify-validity)
+  - [Dashboard Module tests](#dashboard-module-tests)
+
+- [View Instrument Data](#view-instrument-data)
+  - [Test the Data Query Tool](#test-the-data-query-tool)
+  - [Share a Link to a Frozen instrument](#share-a-link-to-a-frozen-instrument)
+  - [Test Configurations](#test-configurations)
+
+## Data Entry
 
 - [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
+
 - enter `loris.ca/candidate_list` in url
-- click on a PSCID, click on a timepoint, click on an instrument
+- click on a PSCID, click### Visit the Candidate Dashboard module on a timepoint, click on an instrument
 - Assert that link to the instrument is shown, ex:`loris.ca/instruments/mri_parameter_form/?commentID=300166OTT166166241522092433&sessionID=166&candID=300166`
 - Enter a date and click 'Save Data'. Assert that `Age Calculation` is correct
 - Set Examiner to NULL and assert that `An Examiner is Required` appears.
@@ -18,7 +30,7 @@ The permissions are:
 saved data stays the same.
 - Change some data, but don't hit save, and change page. Assert that the data that wasn't saved is not still there (ie is not persistent)
 
-## View the instruments
+### View the Instruments
 
   1. go to `/new_profile` and enter data, click `Create` and `Access Profile`
   2. click `Create Time Point` and enter data and click `Create Time Point` and click `OK`. Assert that you see your new time point with `Not Started` in the `Stage` field
@@ -27,34 +39,33 @@ saved data stays the same.
 
   6.Enter sample data, testing each field's type and logic constraints
 
-## Test the Configurations
+### Test Configurations
 
-### `instrumentResetting`
+#### Instrument Resetting
 
 - [x] Instrument List: Send to DCC
 
 in /configuration, set `InstrumentResetting`
 
 - in /configuration, set `InstrumentResetting` to `Yes`
-- Under `Subtests` in the sidebar, click `Top` and Assert that 'Delete instrument data' button is visible 
+- Under `Subtests` in the sidebar, click `Top` and Assert that 'Delete instrument data' button is visible
 - Click `Delete instrument data` button and assert that the instrument's data is cleared on every page
 
-### `postMortem`
+#### Post Mortem
 
 - Select a PHP instrument by looking in the /project/instruments folder for any instrument that begins with `NDB_BVL_Instrument`
-- Set the `$postMortem` object in the PHP programme to `true` and save the file. remember that in PHP a boolean value must be lower case ie `true` not `True`
+- enter the `$postMortem` variable as follows, set it to true and save the file
 
-```    /**
-     * True if the instrument is administered after the candidate's death.
-     * This is used to determine which candidate age should be displayed as
-     * part of metadata fields. (Either Candidate Age or Candidate Age at Death).
-     * To be called from within individual instrument forms.
-     *
-     * @var    bool
-     * @access protected
-     */
-    
-    protected $postMortem = false; 
+```
+ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
+{
+    use LegacyInstrumentTrait;
+    use \LorisFormDictionaryImpl;
+
+    var $ValidityEnabled  = false;
+    var $ValidityRequired = false;
+    var $postMortem = true;
+    /**
 ```
 
 - Assert that `Candidate Age at Death (Months)` appears instead of `Candidate Age (Months)`  
@@ -63,17 +74,12 @@ in /configuration, set `InstrumentResetting`
 - set`postmortem{@}true` in the instrument's meta file, save, and assert that `Candidate Age at Death (Months)` appears. 
 - set it to `false` and assert that `Candidate Age (Months)` appears  
 
-### Verify Validity
+#### Verify Validity
 
 - Look in the (SECTION) of the PHP code of the instrument in question and set the $ValidityEnabled object to `true`
 
-```    /**
-     * Whether the "Validity" field is shown as a flag for an instrument
-     * or not.
-     *
-     * @access public
-     */
-    public $ValidityEnabled = true;
+``` 
+public $ValidityEnabled = true;
 ```
 
 Assert that you see validity ticks in the side bar of the instruent, as follows:
@@ -86,14 +92,12 @@ Now set `$validityEnabled` to `false`, reload the instrument, and assert that th
 
 ### Dashboard module tests
 
-Go to the loris splash page `loris.ca/`
+Go to the loris instance splash page `loris.ca/`
 
 - Under`My Tasks` click `Incomplete forms`
 - Assert that this re-directs to `statistics/statistics_site`
 
--Assert that the total of Incomplete forms correspond with the correct number of candidates inside the
-
-### Visit the Candidate Dashboard module
+-Assert that the total of Incomplete forms correspond with the correct amount of candidates
 
 - click `Access Profile`, click a `PSCID`, click a `timepoint`
 
@@ -108,3 +112,33 @@ which, at the bottom, contains the Behavioural Battery of Instruments
 using `php assign_missing_instruments`???!!!!
 
 The Behavioural Data widget should update accordingly.
+
+## View Instrument Data
+
+In your admin account, set your user's permissions to
+
+- [ ] Access Profile: View/Create Candidates and Timepoints - Own Sites
+- [x] Data Query Tool - View Instrument Data
+
+### Test the Data Query Tool
+
+- Now, using that user's account, go into Data Query Tool /dataquery
+- in `Available Fields` select `Candidate identifiers` and select the `CandID LORIS Candidate identifier`
+- go back to `Available Fields` and select an instrument such as `Aosi` and click `Add all` and, at the bottom right, click `Run Query`
+- Assert that Fields and Records (columns and rows) show up for this query (they could contain actual data or `no data`)
+- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
+
+### Share a Link to a Frozen Instrument
+
+- In your admin account, navigate to Access/Candidate/Timepoint/Instrument and copy the part of the url that follows loris.ca
+for example `/instruments/mri_parameter_form/?commentID=300001MTL0011241522092423&sessionID=1&candID=300001`
+
+- go to your user's account and paste this in the url after loris.ca and assert that you can view the instrument but not edit it or enter data.
+
+### Test Configurations
+
+#### Instrument Resetting
+
+#### Post Mortem
+
+#### Verify Validity


### PR DESCRIPTION
## Brief summary of changes

The intention of this PR is to have a  complete test of the functionality of  `data_entry` and the new `view_instrument_data` permissions  proposed in PR 9762

This ended up on two branches because https://github.com/aces/Loris/pull/9762 is not merged.


- [ ] Have you updated related documentation? This is the documentation

#### Testing instructions (if applicable)
You can download the .md file here
[instrumentsTestPlan.md](https://github.com/user-attachments/files/20037570/instrumentsTestPlan.md)

- use the SQL insert from 9762
https://github.com/aces/Loris/pull/9762

- checkout addViewPermission2 remote branch

and test. 
I'd like to update the .md once the full functionality of both permissions is tested with all configurations and additional permissions.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
