### PR TITLE
[JSX] Revert CSV data transformation: replace flatMap with map

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -121,7 +121,7 @@ class DataTable extends Component {
     if (this.props.getMappedCell) {
       csvData = csvData
       .map((row, i) => this.props.fields
-        .flatMap((field, j) => this.props.getMappedCell(
+        .map((field, j) => this.props.getMappedCell(
             field.label,
             row[j],
             row,


### PR DESCRIPTION
This change modifies the transformation of csvData in the DataTable component by replacing .flatMap() with .map().
	•	Before: csvData was a flattened array of mapped cells across all fields and rows.
	•	After: csvData is now a nested array (Array<Array<Cell>>), preserving the structure of rows.
	•	This aligns better with expected downstream usage or fixes unintended flattening issues in CSV processing.