### PR TITLE
[instruments] Make legacy dictionary use OPTIONAL as a default

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -60,7 +60,7 @@ trait LorisFormDictionaryImpl
         $items = [];
         $scope = new Scope(Scope::SESSION);
         foreach ($elements AS $element) {
-            $card = new Cardinality(Cardinality::SINGLE);
+            $card = new Cardinality(Cardinality::OPTIONAL);
             if (!empty($element['label'])) {
                 $label = str_replace("&nbsp;", "", $element['label']);
                 $label = trim(preg_replace('/\s+/', ' ', $label));


### PR DESCRIPTION
## Brief summary of changes

When declared as single the new DQT does not allow to choose the option "is empty" in the filter. since this trait is used for all legacy instruments, it seems safer to use optional than SINGLE.


#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
