### PR TITLE
[jsx - document_repository] Add disabledLabel to ButtonElement

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2286,7 +2286,7 @@ export class ButtonElement extends Component {
           >
             {
               this.props.disabled
-                ? (this.props.disabledText ?? this.props.label)
+                ? (this.props.disabledLabel ?? this.props.label)
                 : this.props.label
             }
           </button>
@@ -2302,7 +2302,7 @@ ButtonElement.propTypes = {
   label: PropTypes.string,
   type: PropTypes.string,
   disabled: PropTypes.bool,
-  disabledText: PropTypes.string,
+  disabledLabel: PropTypes.string,
   style: PropTypes.object,
   onUserInput: PropTypes.func,
   columnSize: PropTypes.string,
@@ -2313,7 +2313,7 @@ ButtonElement.defaultProps = {
   label: 'Submit',
   type: 'submit',
   disabled: null,
-  disabledText: null,
+  disabledLabel: null,
   buttonClass: 'btn btn-primary',
   columnSize: 'col-sm-9 col-sm-offset-3',
   onUserInput: function() {

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2284,7 +2284,11 @@ export class ButtonElement extends Component {
             onClick={this.handleClick}
             disabled={this.props.disabled}
           >
-            {this.props.disabled ? 'Uploading...' : this.props.label}
+            {
+              this.props.disabled
+                ? (this.props.disabledText ?? this.props.label)
+                : this.props.label
+            }
           </button>
         </div>
       </div>
@@ -2298,6 +2302,7 @@ ButtonElement.propTypes = {
   label: PropTypes.string,
   type: PropTypes.string,
   disabled: PropTypes.bool,
+  disabledText: PropTypes.string,
   style: PropTypes.object,
   onUserInput: PropTypes.func,
   columnSize: PropTypes.string,
@@ -2308,6 +2313,7 @@ ButtonElement.defaultProps = {
   label: 'Submit',
   type: 'submit',
   disabled: null,
+  disabledText: null,
   buttonClass: 'btn btn-primary',
   columnSize: 'col-sm-9 col-sm-offset-3',
   onUserInput: function() {

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -177,6 +177,7 @@ class DocUploadForm extends Component {
             <ButtonElement
               label="Upload File(s)"
               disabled={this.state.uploadInProgress}
+              disabledText="Uploading..."
             />
           </FormElement>
         </div>

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -177,7 +177,7 @@ class DocUploadForm extends Component {
             <ButtonElement
               label="Upload File(s)"
               disabled={this.state.uploadInProgress}
-              disabledText="Uploading..."
+              disabledLabel="Uploading..."
             />
           </FormElement>
         </div>


### PR DESCRIPTION
Closes #9768 

This PR adds the `disabledLabel` attribute to `jsx/Form`'s `ButtonElement`.

It also sets this value to the intended value for the `document_repository`'s upload button.