### PR TITLE
[next_stage] adding missing CohotID php/libraries/NDB_BVL_Battery.class.inc

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -203,8 +203,8 @@ class NDB_BVL_Battery
             throw new \LorisException("Invalid instrument");
         }
 
-        // get SessionID, UserID, Visit_label
-        $query = "SELECT ID as SessionID, UserID, Visit_label
+        // get SessionID, UserID, Visit_label, CohortID
+        $query = "SELECT ID as SessionID, UserID, Visit_label, CohortID
                   FROM session WHERE ID=:SID";
         $rows  = $DB->pselect($query, ['SID' => $this->sessionID]);
         if (count($rows)==0) {


### PR DESCRIPTION
fix https://github.com/aces/Loris/issues/9783 since [NDB_BVL_Battery] isDoubleDataEntryEnabledForInstrument should consider CohortID (https://github.com/aces/Loris/pull/9705) is merged.

test: start a new visit in the instrument menu.