### PR TITLE
[Core] Fix redirect URL AGAIN

### DIFF
--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -46,7 +46,7 @@ class Error extends HtmlResponse
     ) {
         $uri          = $request->getURI();
         $serverParams = $request->getServerParams();
-        $redirectUrl  = $serverParams['REDIRECT_URL'] ?? null;
+        $redirectUrl  = $serverParams['REQUEST_URI'] ?? null;
         $baseurl      = $uri->getScheme() .'://'. $uri->getAuthority();
 
         $tpl_data = [


### PR DESCRIPTION
## Brief summary of changes

Fixes even further what was fixed in #9534. It seems like the fix in the previous PR did not account for arguments coming after the `?` in the URL, this new parameter should account for it.

Here is a list of Query params and what they look like in case nother might still be better
```
    [HTTP_HOST] => localhost:8083
    [REDIRECT_URL] => /candidate_parameters/
    [REDIRECT_QUERY_STRING] => lorispath=candidate_parameters/&candID=446836&identifier=446836
    [QUERY_STRING] => lorispath=candidate_parameters/&candID=446836&identifier=446836
    [REQUEST_URI] => /candidate_parameters/?candID=446836&identifier=446836
```

#### Testing instructions (if applicable)

1. Do the following for several different URLs
2. log in as a user and navigate to a page
3. copy the URL form that page and open an incognito window
4. paste the URL, you should get a 403 error with an option to "try logging in"
5. click on that option and enter your credentials
6. make sure you get to the same page as step 2
7. try same steps for other pages with a diversity of URL formats

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
