### PR TITLE
Fix eslint line rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,7 +91,8 @@
     "jsdoc/check-tag-names": "error",
     "jsdoc/check-types": "error",
     "jsdoc/valid-types": "error",
-    "jsdoc/no-undefined-types": "error"
+    "jsdoc/no-undefined-types": "error",
+    "jsdoc/tag-lines": ["error", "any", {"startLines": 1}]
   },
   "overrides": [
     {

--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -7,6 +7,7 @@ import {FileElement} from 'jsx/Form';
 
 /**
  * Render a modal window for adding a filter
+ *
  * @param {object} props - React props
  * @param {function} props.setQuery - Function to set the current criteria
  * @param {function} props.closeModal - Callback to close the current modal
@@ -22,6 +23,7 @@ function ImportCSVModal(props: {
   const [idType, setIdType] = useState<string>('PSCID');
   /**
    * Promise for handling modal closing. Always accepts.
+   *
    * @returns {Promise} - a stub promise
    */
   const submitPromise = () =>
@@ -34,6 +36,7 @@ function ImportCSVModal(props: {
 
   /**
    * Callback function for after papaparse has parsed the csv
+   *
    * @param {any} value - the value from papaparse callback
    */
   const csvParsed = (value: Papa.ParseResult<any>) => {

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -13,6 +13,7 @@ import IssueTrackerBatchMode from './IssueTrackerBatchMode';
 class IssueTrackerIndex extends Component {
   /**
    * @constructor
+   *
    * @param {object} props - React Component properties
    */
   constructor(props) {
@@ -40,6 +41,7 @@ class IssueTrackerIndex extends Component {
 
   /**
    * Called by React when the component updates.
+   *
    * @param {object} prevProps - Previous props
    * @param {object} prevState - Previous state
    */


### PR DESCRIPTION
"npm run lintfix;js" currently generates hundreds of changes because the rules enforced don't match the coding style of the codebase.

This fixes the rule for the number of lines between the tagblock and the params to match what's actually used by the codebase, and fixes the couple leftovers that were wrong.