### PR TITLE
[dataquery] fix "Selected Fields" panel width.

### DIFF
--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -423,6 +423,7 @@ function DefineFields(props: {
           {fieldList}
         </div>
         <div style={{
+          width: '20vw',
           padding: '1em',
           position: 'sticky',
           top: 0,


### PR DESCRIPTION
## Brief summary of changes
Changes the width of the right panel "Selected Fields" thus it's render properly when projects have multiples visits labels. 

#### Testing instructions (if applicable)

1. The issue observed in  #9771 when a project have multiple visits should be not longer present.

#### Link(s) to related issue(s)

* Resolves #9771
