### PR TITLE
Add key to the Comment field of feedback_mri_comments to improve querying time

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2349,6 +2349,7 @@ CREATE TABLE `feedback_mri_comments` (
   KEY `FK_feedback_mri_comments_2` (`PredefinedCommentID`),
   KEY `FK_feedback_mri_comments_3` (`FileID`),
   KEY `FK_feedback_mri_comments_4` (`SessionID`),
+  KEY `fmc_comment` (`Comment`),
   CONSTRAINT `FK_feedback_mri_comments_4` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`),
   CONSTRAINT `FK_feedback_mri_comments_1` FOREIGN KEY (`CommentTypeID`) REFERENCES `feedback_mri_comment_types` (`CommentTypeID`),
   CONSTRAINT `FK_feedback_mri_comments_2` FOREIGN KEY (`PredefinedCommentID`) REFERENCES `feedback_mri_predefined_comments` (`PredefinedCommentID`),

--- a/SQL/New_patches/2025-05-22_add_index_to_comment_field_of_feedback_mri_comments.sql
+++ b/SQL/New_patches/2025-05-22_add_index_to_comment_field_of_feedback_mri_comments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback_mri_comments ADD INDEX IF NOT EXISTS `fmc_comment` (`Comment`);


### PR DESCRIPTION
## Brief summary of changes

Adding this index improved querying from 2 minutes to 3 seconds on the feedback_mri_comments on HBCD (which contains 12063735). 

#### Testing instructions (if applicable)

1. run the SQL patch and make sure the index was added to feedback_mri_comments
2. source the default schema and make sure the index was created in feedback_mri_comments

