### PR TITLE
[wiki] fix README.md in 02_GETTING_STARTED

### DIFF
--- a/docs/wiki/02_GETTING_STARTED/README.md
+++ b/docs/wiki/02_GETTING_STARTED/README.md
@@ -1,4 +1,4 @@
-Information required to get a project started after having configured it's LORIS entities. These are data collection elements (what we currently find in project MOPs)
+Information required to get a project started after having configured its LORIS entities. These are data collection elements (what we currently find in project MOPs)
 
 - creating a candidate
 - creating users


### PR DESCRIPTION
## Brief summary of changes

Fixing typo in README.md inside 02_GETTING_STARTED in wiki

#### Testing instructions (if applicable)

1. Go to [](https://github.com/aces/Loris/tree/main/docs/wiki/02_GETTING_STARTED/README.md)
2. The typo in line 1 was changed from "it's" to "its" . 

#### Link(s) to related issue(s)

* Resolves #9782 

