### PR TITLE
[smarty] Allow instrument tables to expand off-screen

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -1,5 +1,8 @@
 <script type="text/javascript" src="{$baseurl}/js/instrument_form_control.js"></script>
 <style type="text/css">
+	.table-instrument {
+		white-space: nowrap;
+	}
 	.table-instrument>tbody>tr>th{
 		color: black;
 	}


### PR DESCRIPTION
## Brief summary of changes
- When an instrument has a very large table, it was getting cut off and the data was forced to be smaller, this fixes that and should not impact other instruments

Before on CCNA (notice the times are cut off):
![image](https://github.com/user-attachments/assets/6c753998-776c-4028-8b26-14af5e6b772c)
Now on CCNA:
![image](https://github.com/user-attachments/assets/47f595d2-efe1-4640-b1b5-f3a2bf4033f2)

#### Testing instructions (if applicable)

1. Confirm instruments are displayed correctly

#### Link(s) to related issue(s)

* [CCNA PR: 8113](https://github.com/aces/CCNA/pull/8113)
