### PR TITLE
Add the MRI variables in the imaging_browser's query engine

### DIFF
--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -66,12 +66,12 @@ class Genomicfile
         $this->_user         = $user;
         $this->_bytes        = $files['file']->getSize();
         $this->_values       = $values;
+        $uri                 = $files['file']->getStream()->getMetadata('uri');
         $this->_fileToUpload
             = (object) [
                 'file_type'         => $files['file']->getClientMediaType(),
                 'file_name'         => $files['file']->getClientFilename(),
-                'tmp_name'          => $files['file']
-                    ->getStream()->getMetadata('uri'),
+                'tmp_name'          => $uri,
                 'size'              => round($this->_bytes / 1048576, 0),
                 'inserted_by'       => $this->_user->getData('UserID'),
                 'genomic_file_type' => empty($this->_values['fileType']) ?

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -63,10 +63,10 @@ class Genomicfile
         ) {
             return false;
         }
-        $this->_user         = $user;
-        $this->_bytes        = $files['file']->getSize();
-        $this->_values       = $values;
-        $uri                 = $files['file']->getStream()->getMetadata('uri');
+        $this->_user   = $user;
+        $this->_bytes  = $files['file']->getSize();
+        $this->_values = $values;
+        $uri           = $files['file']->getStream()->getMetadata('uri');
         $this->_fileToUpload
             = (object) [
                 'file_type'         => $files['file']->getClientMediaType(),

--- a/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mricommentdictionaryitem.class.inc
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRICommentDictionaryItem extends ImagingDictionaryItem
+{
+    // Name of the comment associated to this record
+    private $commentName;
+
+    /**
+     * Construct an ImagingDictionaryItem
+     *
+     * @param string      $name        The field name of the dictionary item
+     * @param string      $desc        The dictionary item's description
+     * @param Scope       $scope       The scope to which this DictionaryItem applies
+     * @param Type        $t           The data type of this dictionary item
+     * @param Cardinality $c           The data cardinality
+     * @param string      $modality    The imaging modality that this item is for
+     * @param string      $commentName Name of the comment (i.e. value of column
+     *                                 CommentName in table
+     *                                 feedback_mri_comment_types).
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        string $commentName
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->commentName = $commentName;
+    }
+
+    /**
+     * Accessor for field $commentName.
+     *
+     * @return string Value of field $commentName.
+     */
+    public function getCommentName() : string
+    {
+        return $this->commentName;
+    }
+}

--- a/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mrifeedbackdictionaryitem.class.inc
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRIFeedbackDictionaryItem extends ImagingDictionaryItem
+{
+    private $parameterTypeName;
+
+    /**
+     * Construct an ImagingDictionaryItem
+     *
+     * @param string      $name              The field name of the dictionary item
+     * @param string      $desc              The dictionary item's description
+     * @param Scope       $scope             Scope to which this item applies
+     * @param Type        $t                 The data type of this dictionary item
+     * @param Cardinality $c                 The data cardinality
+     * @param string      $modality          The modality that this item is for
+     * @param string      $parameterTypeName Name of the parameter in table
+     *                                       parameter_type associated with this MRI
+     *                                       feedback object.
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        string $parameterTypeName
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->parameterTypeName = $parameterTypeName;
+    }
+
+    /**
+     * Accessor method for field $parameterTypeName.
+     *
+     * @return string Value of field $parameterTypeName.
+     */
+    public function getParameterTypeName() : string
+    {
+        return $this->parameterTypeName;
+    }
+}

--- a/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/mripredefinedcommentdictionaryitem.class.inc
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+use \LORIS\Data\Scope;
+use \LORIS\Data\Type;
+use \LORIS\Data\Cardinality;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class MRIPredefinedCommentDictionaryItem extends ImagingDictionaryItem
+{
+    // Value of column PredefinedCommentID in table feedback_mri_predefined_comments
+    // this record.
+    private $predefinedCommentID;
+
+    /**
+     * Construct an MRIPredefinedCommentDictionaryItem
+     *
+     * @param string      $name                The field name of the dictionary item
+     * @param string      $desc                The dictionary item's
+     *                                         description
+     * @param Scope       $scope               The scope to which this
+     *                                         DictionaryItem applies
+     * @param Type        $t                   The data type of this dictionary item
+     * @param Cardinality $c                   The data cardinality
+     * @param string      $modality            The imaging modality that this item
+     *                                         is for
+     * @param int         $predefinedCommentID Value of column PredefinedCommentID
+     *                                         in table
+     *                                         feedback_mri_predefined_comments
+     *                                         for this record
+     */
+    public function __construct(
+        string $name,
+        string $desc,
+        Scope $scope,
+        Type $t,
+        Cardinality $c,
+        string $modality,
+        int $predefinedCommentID
+    ) {
+        parent::__construct($name, $desc, $scope, $t, $c, $modality);
+        $this->predefinedCommentID = $predefinedCommentID;
+    }
+
+    /**
+     * Accessor for field $predefinedCommentID.
+     *
+     * @return int Value of field $predefinedCommentID.
+     */
+    public function getPredefinedCommentID() : int
+    {
+        return $this->predefinedCommentID;
+    }
+}

--- a/modules/imaging_browser/php/parameterdictionaryitem.class.inc
+++ b/modules/imaging_browser/php/parameterdictionaryitem.class.inc
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\imaging_browser;
+
+/**
+ * Describes a dictionary item for the imaging browser. Imaging browser items are
+ * like normal items, but have a modality attached to them in order to build
+ * modality-specific descriptions.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class ParameterDictionaryItem extends ImagingDictionaryItem
+{
+}

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -13,6 +13,162 @@ use \LORIS\Data\Cardinality;
  */
 class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 {
+    // Index of the data type in the arrays contained in $FILE_DICTIONARY_ITEMS
+    const FDI_DATA_TYPE_IDX = 0;
+    // Index of the info to select in the arrays contained in $FILE_DICTIONARY_ITEMS
+    const FDI_SELECT_IDX = 1;
+    // Index of the description in the arrays contained in $FILE_DICTIONARY_ITEMS
+    const FDI_DESCRIPTION_IDX = 2;
+
+    // Properties of all fields that are stored in the data dictionary as
+    // LocationDictionaryItem. The information in this array is used to create the
+    // item and to build the SQL query used to fetch the field value in the DB.
+    const FILE_DICTIONARY_ITEMS = [
+        'file'            => [
+            'StringType', 'File', 'acquisition file path'
+        ],
+        'OutputType'      => [
+            'StringType', 'OutputType', 'acquisition output type'
+        ],
+        'Pipeline'        => [
+            'StringType', 'SourcePipeline', 'acquisition source pipeline'
+        ],
+        'ScannerID'       => [
+            'IntegerType', 'ScannerID', 'acquisition scanner ID'
+        ],
+        'FileInsertDate'  => [
+            'DateType',
+            'FROM_UNIXTIME(InsertTime,"%Y-%m-%d")',
+            'acquisition file insert date'
+        ],
+        'Caveat'          => [
+            'IntegerType', 'Caveat', 'acquisition caveat'
+        ],
+        'url'             => [
+            'URI', 'File', 'acquisition file URL'
+        ],
+        'CoordinateSpace' => [
+            'StringType', 'CoordinateSpace', 'acquisition coordinate space'
+        ]
+    ];
+
+    // Index of the data type in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_DATA_TYPE_IDX = 0;
+    // Index of the parameter name in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_PARAMETER_NAME_IDX = 1;
+    // Index of the info to select in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_SELECT_IDX = 2;
+    // Index of the description in the arrays contained in
+    // $PARAMETER_DICTIONARY_ITEMS
+    const PDI_DESCRIPTION_IDX = 3;
+
+    // Properties of all fields that are stored in the data dictionary as
+    // ParameterDictionaryItem. The information in this array is used to create the
+    // item and to build the SQL query used to fetch the field value in the DB.
+    const PARAMETER_DICTIONARY_ITEMS = [
+        'AcquisitionDate'       => [
+            'StringType',
+            'acquisition_date',
+            'DATE_FORMAT(pf.value, "%Y-%m-%d")',
+            'acquisition date'
+        ],
+        // CouchDB_MRI_Importer gets this from table files but I think
+        // it's better to get it from table parameter_file
+        'AcquisitionProtocol'   => [
+            'StringType', 'acquisition:protocol', 'pf.value', 'acquisition protocol'
+        ],
+        'Algorithm'             => [
+            'StringType', 'Algorithm', 'pf.value', 'algorithm'
+        ],
+        'SeriesDescription'     => [
+            'StringType', 'series_description', 'pf.value', 'series description'
+        ],
+        'SeriesNumber'          => [
+            'IntegerType', 'series_number', 'pf.value', 'series number'
+        ],
+        'EchoTime'              => [
+            'DecimalType', 'echo_time', 'ROUND(1000 * pf.value, 2)', 'echo time'
+        ],
+        'RepetitionTime'        => [
+            'DecimalType',
+            'repetition_time',
+            'ROUND(1000 * pf.value, 2)',
+            'repetition time (TR)'
+        ],
+        'SliceThickness'        => [
+            'DecimalType',
+            'slice_thickness',
+            'ROUND(1000 * pf.value, 2)',
+            'slice thickness'
+        ],
+        'Time'                  => [
+            'DecimalType',
+            'time',
+            'ROUND(1000 * pf.value, 2)',
+            'time (No of volumes)'
+        ],
+        // I put 'acquisition:comment' as the parameter name but
+        // CouchDB_MRI_Importer has 'Comment' which does not seem to exist
+        // anywhere...
+        'Comment'               => [
+            'StringType', 'acquisition:comment', 'pf.value', 'acquisition comment'
+        ],
+        // List of directions obtained for SlicewiseRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'SlicewiseRejected'     => [
+            'StringType',
+            'processing:slicewise_rejected',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
+            'slicewise rejected'
+        ],
+        // List of directions obtained for InterlaceRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'InterlaceRejected'     => [
+            'StringType',
+            'processing:interlace_rejected',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
+            'interlace rejected'
+        ],
+        // List of directions obtained for IntergradientRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'IntergradientRejected' => [
+            'StringType',
+            'processing:intergradient_rejected',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
+            'intergradient rejected'
+        ],
+        // List of directions obtained for TotalRejected is not sorted as in
+        // CouchDB_MRI_Importer
+        'TotalRejected'         => [
+            'StringType',
+            'processing:total_rejected',
+            'IF(
+                 pf.Value LIKE "%(%",
+                 SUBSTR(pf.Value, 1, POSITION("(" in pf.Value) - 1),
+                 pf.Value
+            )',
+            'total rejected'
+        ],
+        'ProcessingPipeline'    => [
+            'StringType', 'processing:pipeline', 'pf.value', 'processing pipeline'
+        ]
+    ];
+
     protected $baseURL;
     /**
      * {@inheritDoc}
@@ -49,22 +205,39 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $scantypes = \Utility::getScanTypeList();
         foreach ($scantypes as $ScanType) {
-            $items[] = new LocationDictionaryItem(
-                $ScanType . "_file",
-                "$ScanType acquisition file path",
-                $scope,
-                new \LORIS\Data\Types\StringType(),
-                new Cardinality(Cardinality::MANY),
-                $ScanType,
-            );
-            $items[] = new LocationDictionaryItem(
-                $ScanType . "_url",
-                "$ScanType acquisition file URL",
-                $scope,
-                new \LORIS\Data\Types\URI(),
-                new Cardinality(Cardinality::MANY),
-                $ScanType,
-            );
+            foreach (self::FILE_DICTIONARY_ITEMS as $field => $properties) {
+                $fullyQualifiedType
+                    = '\LORIS\Data\Types\\' . $properties[self::FDI_DATA_TYPE_IDX];
+                $items[]            = new LocationDictionaryItem(
+                    sprintf("%s_%s", $ScanType, $field),
+                    sprintf(
+                        "%s %s",
+                        $ScanType,
+                        $properties[self::FDI_DESCRIPTION_IDX]
+                    ),
+                    $scope,
+                    new $fullyQualifiedType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                );
+            }
+
+            foreach (self::PARAMETER_DICTIONARY_ITEMS as $fieldName => $properties) {
+                $fullyQualifiedType
+                    = '\LORIS\Data\Types\\' . $properties[self::PDI_DATA_TYPE_IDX];
+                $items[]            = new ParameterDictionaryItem(
+                    sprintf('%s_%s', $ScanType, $fieldName),
+                    sprintf(
+                        '%s %s',
+                        $ScanType,
+                        $properties[self::PDI_DESCRIPTION_IDX]
+                    ),
+                    $scope,
+                    new $fullyQualifiedType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                );
+            }
             // TODO: Investigate adding a file scope instead of having this apply
             // on a session scope with a Many cardinality.
             $items[] = new QCDictionaryItem(
@@ -75,7 +248,74 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new Cardinality(Cardinality::MANY),
                 $ScanType,
             );
+            $items[] = new QCDictionaryItem(
+                $ScanType . "_Selected",
+                "Selected file for $ScanType for session",
+                $scope,
+                new \LORIS\Data\Types\Enumeration("true", "false"),
+                new Cardinality(Cardinality::MANY),
+                $ScanType,
+            );
+
+            // All MRI comment types
+            $allCommentTypes
+                = \FeedbackMRI::getAllCommentTypesForObjectType('volume');
+            foreach ($allCommentTypes as $commentTypeID => $commentProperties) {
+                if ($commentProperties['name'] != 'Overall') {
+                    //--------------------------------------------------//
+                    // Value of feedback for that specific comment type //
+                    //--------------------------------------------------//
+                    $items[] = new MRIFeedbackDictionaryItem(
+                        "{$ScanType}_feedback_{$commentProperties['field']}",
+                        "Value for {$commentProperties['name']} in the MRI"
+                        . " feedback form for $ScanType acquisitions",
+                        $scope,
+                        new \LORIS\Data\Types\Enumeration(
+                            ...$commentProperties['values']
+                        ),
+                        new Cardinality(Cardinality::MANY),
+                        $ScanType,
+                        $commentProperties['field']
+                    );
+
+                    //--------------------------------------------------------//
+                    // Values of all the predefined comments for this comment //
+                    // type.                                                  //
+                    //--------------------------------------------------------//
+                    $predefinedComments
+                        = \FeedbackMRI::getAllPredefinedComments($commentTypeID);
+                    foreach ($predefinedComments as $ID => $predefinedComment) {
+                        $items[] = new MRIPredefinedCommentDictionaryItem(
+                            "{$ScanType}_{$predefinedComment['Comment']}",
+                            "'{$predefinedComment['FullComment']}' in the MRI "
+                            . "feedback form is checked for $ScanType acquisitions",
+                            $scope,
+                            new \LORIS\Data\Types\Enumeration('Yes', 'No'),
+                            new Cardinality(Cardinality::MANY),
+                            $ScanType,
+                            $ID
+                        );
+                    }
+                }
+
+                //------------------------------------------------//
+                // Free form text comment for  this comment type  //
+                //------------------------------------------------//
+                $itemDescription = "Comment in section"
+                                 . "'{$commentProperties['name']}' of the MRI"
+                                 . " feedback form for $ScanType acquisitions";
+                $items[]         = new MRICommentDictionaryItem(
+                    "{$ScanType}_comment_{$commentProperties['field']}",
+                    $itemDescription,
+                    $scope,
+                    new \LORIS\Data\Types\StringType(),
+                    new Cardinality(Cardinality::MANY),
+                    $ScanType,
+                    $commentProperties['name']
+                );
+            }
         }
+
         $images = $images->withItems($items);
 
         return [$images];
@@ -137,22 +377,23 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                              WHEN s.Scan_Done='N' THEN false
                              ELSE NULL END";
         }
+
+        if (!($item instanceof ImagingDictionaryItem)) {
+            throw new \DomainException(
+                "Item is not an instance of ImagingDictionaryItem"
+            );
+        }
+
+        $modality = $item->getModality();
+
+        // $field = whatever's after the first underscore
+        $field = substr($item->getName(), strpos($item->getName(), '_') + 1);
+
+        $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
+        $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
+
         if ($item instanceof LocationDictionaryItem) {
-            $modality = $item->getModality();
-
-            $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
-            $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
-
-            // Because of complex interactions between joins that get
-            // out of hand when a scan type that doesn't exist is selected
-            // alongside one that does, we use a subselect here.
-            if (str_ends_with($item->getName(), "_file")) {
-                return "(SELECT File FROM files as files2
-                            JOIN mri_scan_type mst
-                                ON (files2.MriScanTypeID=mst.MriScanTypeID)
-                            WHERE files2.FileID=files.FileID
-                                AND mst.MriScanTypeName='{$modality}')";
-            } else if (str_ends_with($item->getName(), "_url")) {
+            if ($field == 'url') {
                 return "(SELECT CONCAT(
                             \"$this->baseURL\",
                             \"/api/v0.0.3/candidates/\",
@@ -166,20 +407,104 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                                 ON (files2.MriScanTypeID=mst.MriScanTypeID)
                             WHERE files2.FileID=files.FileID
                                 AND mst.MriScanTypeName='{$modality}')";
+            } else {
+                $fdi = self::FILE_DICTIONARY_ITEMS[$field];
+                // Because of complex interactions between joins that get
+                // out of hand when a scan type that doesn't exist is selected
+                // alongside one that does, we use a subselect here.
+                return sprintf(
+                    "(SELECT %s FROM files as files2
+                      JOIN mri_scan_type mst
+                          ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                      WHERE files2.FileID=files.FileID
+                          AND mst.MriScanTypeName='%s')
+                    ",
+                    $fdi[self::FDI_SELECT_IDX],
+                    $modality
+                );
             }
         }
-        if ($item instanceof QCDictionaryItem) {
-            $modality = $item->getModality();
 
-            $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
-            $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");
-            return "(SELECT QCStatus FROM files_qcstatus
-                        JOIN files as files2
-                        JOIN mri_scan_type mst
-                            ON (files2.MriScanTypeID=mst.MriScanTypeID)
-                        WHERE files_qcstatus.FileID=files.FileID
-                            AND files2.FileID=files.FileID
-                            AND mst.MriScanTypeName='{$modality}')";
+        if ($item instanceof QCDictionaryItem) {
+            return "(SELECT $field FROM files_qcstatus fqs
+                     JOIN files as files2
+                         ON (fqs.FileID=files2.FileID)
+                     JOIN mri_scan_type mst
+                         ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                     WHERE files2.FileID=files.FileID
+                         AND mst.MriScanTypeName='{$modality}')";
+        }
+
+        if ($item instanceof ParameterDictionaryItem) {
+            $pdi = self::PARAMETER_DICTIONARY_ITEMS[$field];
+            return sprintf(
+                "(SELECT %s FROM files as files2
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  JOIN parameter_file pf
+                      ON (pf.FileID=files2.FileID)
+                  JOIN parameter_type pt
+                      ON (pt.ParameterTypeID=pf.ParameterTypeID AND pt.name='%s')
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                )",
+                $pdi[self::PDI_SELECT_IDX],
+                $pdi[self::PDI_PARAMETER_NAME_IDX],
+                $modality,
+            );
+        }
+
+        if ($item instanceof MRIFeedbackDictionaryItem) {
+            return sprintf(
+                "(SELECT pf.Value FROM files AS files2
+                  JOIN parameter_file pf
+                      ON (pf.FileID=files2.FileID)
+                  JOIN parameter_type pt
+                      ON (pt.ParameterTypeID=pf.ParameterTypeID AND pt.Name='%s')
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                )",
+                $modality
+            );
+        }
+
+        if ($item instanceof MRICommentDictionaryItem) {
+            return sprintf(
+                "(SELECT fmc.Comment FROM files AS files2
+                  JOIN feedback_mri_comments fmc
+                      ON (fmc.FileID=files2.FileID)
+                  JOIN feedback_mri_comment_types fmct
+                      ON (fmc.CommentTypeID=fmct.CommentTypeID)
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND fmct.CommentName='%s'
+                      AND mst.MriScanTypeName='%s'
+                      AND fmc.Comment IS NOT NULL
+                )",
+                $item->getCommentName(),
+                $modality
+            );
+        }
+
+        if ($item instanceof MRIPredefinedCommentDictionaryItem) {
+            return sprintf(
+                "(SELECT 'Yes' FROM files AS files2
+                  JOIN feedback_mri_comments fmc
+                      ON (fmc.FileID=files2.FileID)
+                  JOIN feedback_mri_predefined_comments fmpc
+                      ON (fmc.PredefinedCommentID=fmpc.PredefinedCommentID)
+                  JOIN mri_scan_type mst
+                      ON (files2.MriScanTypeID=mst.MriScanTypeID)
+                  WHERE files2.FileID=files.FileID
+                      AND mst.MriScanTypeName='%s'
+                      AND fmpc.PredefinedCommentID=%d
+                )",
+                $modality,
+                $item->getPredefinedCommentID()
+            );
         }
 
         throw new \DomainException("Invalid field " . $item->getName());
@@ -210,6 +535,10 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
     ) {
         if ($item instanceof LocationDictionaryItem
             || $item instanceof QCDictionaryItem
+            || $item instanceof ParameterDictionaryItem
+            || $item instanceof MRIFeedbackDictionaryItem
+            || $item instanceof MRICommentDictionaryItem
+            || $item instanceof MRIPredefinedCommentDictionaryItem
         ) {
             $this->addTable('LEFT JOIN session s ON (s.CandidateID=c.ID)');
             $this->addTable("LEFT JOIN files ON (s.ID=files.SessionID)");

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -177,7 +177,7 @@ class FeedbackMRI
      * @return array A two-dimensional array with key (int) PredefinedCommentID
      *               and one-element array ('Comment'=> string CommentName)
      */
-    function getAllPredefinedComments(int $commentTypeID): array
+    public static function getAllPredefinedComments(int $commentTypeID): array
     {
         // create DB object
         $DB = \NDB_Factory::singleton()->database();
@@ -194,8 +194,9 @@ class FeedbackMRI
         foreach ($result as $row) {
             $PredefinedID       = $row['PredefinedCommentID'];
             $preDefinedComments = [];
-            $preDefinedComments['Comment'] = stripslashes($row['Comment']);
-            $comments[$PredefinedID]       = $preDefinedComments;
+            $preDefinedComments['Comment']     = stripslashes($row['Comment']);
+            $preDefinedComments['FullComment'] = $row['Comment'];
+            $comments[$PredefinedID]           = $preDefinedComments;
         }
 
         // return the output array
@@ -323,6 +324,26 @@ class FeedbackMRI
      */
     function getAllCommentTypes(): array
     {
+        return self::getAllCommentTypesForObjectType($this->objectType);
+    }
+
+    /**
+     * Gets the list of all comment types for a given object type.
+     *
+     * @param string $objectType Type of object (i.e value of column ComentType
+     *                           in table feedback_mri_comment_types).
+     *
+     * @return array A two-dimensional array of ints (CommentTypeID) and
+     *               three-element arrays ('name'=>string CommentName,
+     *               'field'=>string name of column in mri table for status,
+     *               'values'=>array of possible enum values for field)
+     */
+    public static function getAllCommentTypesForObjectType(string $objectType): array
+    {
+        if ($objectType != 'volume' && $objectType != 'visit') {
+            throw new \LorisException("Invalid object type $objectType");
+        }
+
         // create DB object
         $DB = \NDB_Factory::singleton()->database();
 
@@ -331,7 +352,7 @@ class FeedbackMRI
                     FROM feedback_mri_comment_types
                   WHERE CommentType=:CT";
 
-        $result = $DB->pselect($query, ['CT' => $this->objectType]);
+        $result = $DB->pselect($query, ['CT' => $objectType]);
 
         // build the output array and keep overall section at the end of the array
         $commentNames = [];


### PR DESCRIPTION
This PR that adds the MRI variables in the imaging_browser's query engine. The information used to set the variable values sometimes differs from those used in `CouchDB_MRI_Importer` but I put comments in the code for those cases.

(This is a re-issue of PR #9545 on branch `27.0-release`)

Fixes #9374 