### PR TITLE
[genomic_browser/27 branch] Fix build errors on 27 branch

### DIFF
--- a/modules/genomic_browser/jsx/tabs_content/gwas.js
+++ b/modules/genomic_browser/jsx/tabs_content/gwas.js
@@ -79,7 +79,7 @@ class GWAS extends Component {
     const hiddenHeaders = [
       'PSC',
       'DCCID',
-      'externalID'
+      'externalID',
     ];
     let reactElement;
     if (-1 === hiddenHeaders.indexOf(column)) {

--- a/modules/genomic_browser/php/filemanager.class.inc
+++ b/modules/genomic_browser/php/filemanager.class.inc
@@ -132,6 +132,9 @@ class FileManager extends \NDB_Page implements ETagCalculator
             $request->getUploadedFiles(), // file data
             $values // post request values.
         );
+        if (empty($response)) {
+            return new \LORIS\Http\Response\JSON\BadRequest();
+        }
 
         // Send file upload status.
         return new \LORIS\Http\Response\JsonResponse(

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -61,7 +61,7 @@ class Genomicfile
         if (!isset($files['file'])
             || empty($files['file']->getStream()->getMetadata('uri'))
         ) {
-            return false;
+            return [];
         }
         $this->_user   = $user;
         $this->_bytes  = $files['file']->getSize();


### PR DESCRIPTION
There were static tests that were failing on the 27.0-release branch related to the genomic browser. This fixes them so that the build passes.
