### PR TITLE
[dataquerytool] fix Numeric value out of range: 1264 Out of range value for column 'CandID' at row 

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -243,7 +243,7 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $DB->run("DROP TEMPORARY TABLE IF EXISTS querycandidates");
         $DB->run(
             "CREATE TEMPORARY TABLE querycandidates (
-                 CandID int(10),
+                 CandID int(10) UNSIGNED,
                  PRIMARY KEY (CandID)
             );"
         );


### PR DESCRIPTION
fix "query not run yet"
 Numeric value out of range: 1264 Out of range value for column 'CandID' at row 677#0 /var/www/Loris/modules/instruments/php/instrumentqueryengine.class.inc(257): PDOStatement->execute()\n#1 /var/www/Loris/modules/dataquery/php/querydataprovisioner.class.inc(82): LORIS\\instruments\\InstrumentQueryEngine->getCandidateData()\n#2 /var/www/Loris/src/Data/ProvisionerInstance.php(116): LORIS\\dataquery\\QueryDataProvisioner->getAllInstances()\n#3 /var/www/Loris/modules/dataquery/php/querydataprovisioner.class.inc(41): LORIS\\Data\\ProvisionerInstance->execute()\n#4 /var/www/Loris/modules/dataquery/php/endpoints/queries/query/run.class.inc(69): LORIS\\dataquery\\QueryDataProvisioner->execute()\n#5 /var/www/Loris/modules/dataquery/php/endpoints/queries/query/run.class.inc(47): LORIS\\dataquery\\endpoints\\queries\\query\\Run->runQuery()\n#6 /var/www/Loris/src/Middleware/Compression.php(36): LORIS\\dataquery\\endpoints\\queries\\query\\Run->handle()\n#7 /var/www/Loris/modules/dataquery/php/queries.class.inc(80): LORIS\\Middleware\\Compression->process()\n#8 /var/www/Loris/src/Middleware/UserPageDecorationMiddleware.php(249): LORIS\\dataquery\\Queries->handle()\n#9 /var/www/Loris/src/Middleware/PageDecorationMiddleware.php(59): LORIS\\Middleware\\UserPageDecorationMiddleware->process()\n#10 /var/www/Loris/php/libraries/NDB_Page.class.inc(731): LORIS\\Middleware\\PageDecorationMiddleware->process()\n#11 /var/www/Loris/php/libraries/Module.class.inc(322): NDB_Page->process()\n#12 /var/www/Loris/src/Middleware/ResponseGenerator.php(51): Module->handle()\n#13 /var/www/Loris/src/Middleware/AuthMiddleware.php(64): LORIS\\Middleware\\ResponseGenerator->process()\n#14 /var/www/Loris/src/Router/ModuleRouter.php(75): LORIS\\Middleware\\AuthMiddleware->process()\n#15 /var/www/Loris/src/Middleware/ExceptionHandlingMiddleware.php(55): LORIS\\Router\\ModuleRouter->handle()\n#16 /var/www/Loris/src/Router/BaseRouter.php(127): LORIS\\Middleware\\ExceptionHandlingMiddleware->process()\n#17 /var/www/Loris/src/Middleware/ResponseGenerator.php(51): LORIS\\Router\\BaseRouter->handle()\n#18 /var/www/Loris/src/Middleware/AWS.php(35): LORIS\\Middleware\\ResponseGenerator->process()\n#19 /var/www/Loris/src/Middleware/ContentLength.php(53): LORIS\\Middleware\\AWS->process()\n#20 /var/www/Loris/htdocs/index.php(115): LORIS\\Middleware\\ContentLength->process()\n#21 {main}, referer: https://test-dev-270.loris.ca/dataquery/
