### PR TITLE
[DataQueryTool] Query stuck when CandID is NULL — add safeguard  #9835 -fix

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -252,10 +252,10 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
          * @phan-suppress-next-line PhanParamSpecial1 */
             . join('),(', $candidates)
             . ')';
-
+        if (is_array($candidates) && !empty($candidates)) {
         $q = $DB->prepare($insertstmt);
-        $q->execute([]);
-
+        $q->execute([]);        
+        }
         $rows = $DB->pselect(
             "SELECT c.CandID, CommentID FROM flag f
 		JOIN test_names tn ON (f.TestID=tn.ID)


### PR DESCRIPTION
[DataQueryTool] Query stuck when CandID is NULL — add safeguard  #9835

test:
Add a condition to check if CandID is NULL in any query. If any CandID is 0, it will cause the query to hang or behave unexpectedly
What did you expect to happen?
It should show "no results found"

![Image](https://github.com/user-attachments/assets/3c458f3a-d3e4-4f23-9414-cdb3790cd09c)

<img width="648" alt="Image" src="https://github.com/user-attachments/assets/8072ef80-11f7-476f-b39a-5d16649b11a3" />
