### PR TITLE
REDCap module improvements

### DIFF
--- a/modules/redcap/php/client/models/mappings/iredcapinstrumentevent.class.inc
+++ b/modules/redcap/php/client/models/mappings/iredcapinstrumentevent.class.inc
@@ -24,11 +24,11 @@ namespace LORIS\redcap\client\models\mappings;
 interface IRedcapInstrumentEvent
 {
     /**
-     * Get the REDCap event name.
+     * Get the REDCap unique event name.
      *
      * @return string
      */
-    public function getEventName(): string;
+    public function getUniqueEventName(): string;
 
     /**
      * Get the REDCap form name.

--- a/modules/redcap/php/client/models/mappings/redcapinstrumenteventmap.class.inc
+++ b/modules/redcap/php/client/models/mappings/redcapinstrumenteventmap.class.inc
@@ -61,11 +61,11 @@ class RedcapInstrumentEventMap implements IRedcapInstrumentEvent
     }
 
     /**
-     * Get the REDCap event name.
+     * Get the REDCap unique event name.
      *
      * @return string
      */
-    public function getEventName(): string
+    public function getUniqueEventName(): string
     {
         return $this->unique_event_name;
     }

--- a/modules/redcap/php/client/models/mappings/redcaprepeatinginstrumentevent.class.inc
+++ b/modules/redcap/php/client/models/mappings/redcaprepeatinginstrumentevent.class.inc
@@ -26,12 +26,11 @@ use LORIS\redcap\client\RedcapProps;
 class RedcapRepeatingInstrumentEvent implements IRedcapInstrumentEvent
 {
     /**
-     * Redcap Event name.
-     * This is linked to a UNIQUE event name.
+     * A REDCap unique event name.
      *
      * @var string
      */
-    public readonly string $event_name;
+    public readonly string $unique_event_name;
 
     /**
      * Redcap Form name.
@@ -57,19 +56,19 @@ class RedcapRepeatingInstrumentEvent implements IRedcapInstrumentEvent
     {
         $props = new RedcapProps('repeating_instrument', $props);
 
-        $this->event_name   = $props->getString('event_name');
-        $this->form_name    = $props->getString('form_name');
-        $this->custom_label = $props->getStringNullable('custom_form_label');
+        $this->unique_event_name = $props->getString('event_name');
+        $this->form_name         = $props->getString('form_name');
+        $this->custom_label      = $props->getStringNullable('custom_form_label');
     }
 
     /**
-     * Get the REDCap event name.
+     * Get the REDCap unique event name.
      *
      * @return string
      */
-    public function getEventName(): string
+    public function getUniqueEventName(): string
     {
-        return $this->event_name;
+        return $this->unique_event_name;
     }
 
     /**
@@ -91,7 +90,7 @@ class RedcapRepeatingInstrumentEvent implements IRedcapInstrumentEvent
     {
         return [
             'form_name'         => $this->form_name,
-            'event_name'        => $this->event_name,
+            'event_name'        => $this->unique_event_name,
             'custom_form_label' => $this->custom_label
         ];
     }

--- a/modules/redcap/php/client/models/redcapnotification.class.inc
+++ b/modules/redcap/php/client/models/redcapnotification.class.inc
@@ -29,7 +29,7 @@ class RedcapNotification
     public readonly string $project_id;
     public readonly string $instrument_name;
     public readonly string $record_id;
-    public readonly string $event_name;
+    public readonly string $unique_event_name;
     public readonly string $username;
     public readonly string $complete;
 
@@ -75,7 +75,7 @@ class RedcapNotification
         $this->project_id        = $props['project_id'];
         $this->project_url       = $props['project_url'];
         $this->record_id         = $props['record'];
-        $this->event_name        = $props['redcap_event_name'];
+        $this->unique_event_name = $props['redcap_event_name'];
         $this->instance_url      = $props['redcap_url'];
         $this->complete          = $props[$complete_key] ?? '';
         $this->username          = $props['username'];
@@ -104,7 +104,7 @@ class RedcapNotification
             'project_url'       => $this->project_url,
             'received_dt'       => $this->received_datetime->format('Y-m-d H:i:s'),
             'record'            => $this->record_id,
-            'redcap_event_name' => $this->event_name,
+            'redcap_event_name' => $this->unique_event_name,
             'redcap_url'        => $this->instance_url,
             'complete'          => $this->complete,
             'username'          => $this->username,

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -648,7 +648,7 @@ class RedcapHttpClient
      *
      * @param string $instrument_name        A REDCap instrument name.
      * @param string $unique_event_name      A REDCap unique event name.
-     * @param string $record_id              A REDCAp record ID.
+     * @param string $record_id              A REDCap record ID.
      * @param bool   $completed_records_only Only return completed records.
      *
      * @throws \LorisException

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -301,6 +301,7 @@ class RedcapHttpClient
             $eventData = array_map(fn($e) => new RedcapEvent($e), $events);
             $this->_updateCache('event', $eventData);
         }
+
         return $this->_cache['event'];
     }
 
@@ -316,6 +317,7 @@ class RedcapHttpClient
         $data = [
             'content' => 'instrument',
         ];
+
         // update cache if first use
         if (empty($this->_cache['instrument'])) {
             $instruments = json_decode($this->_sendRequest($data), true);
@@ -399,46 +401,53 @@ class RedcapHttpClient
      *
      * Note: this method does not cache data.
      *
-     * @param string  $recordId       a record id
-     * @param string  $instrument     an instrument/form name
-     * @param ?string $event          an event
-     * @param ?string $repeatInstance a repeat instance index if any
+     * @param string  $instrument_name   A REDCap instrument name.
+     * @param ?string $unique_event_name A REDCap unique event name, if any.
+     * @param string  $record_id         A REDCap record ID.
+     * @param ?string $repeat_instance   A repeat instance index, if any.
      *
-     * @return ?string a link if found, else null
+     * @return ?string The corresponding REDCap survery link if found, else null.
      */
     public function getSurveyLink(
-        string $recordId,
-        string $instrument,
-        ?string $event,
-        ?string $repeatInstance
+        string $instrument_name,
+        ?string $unique_event_name,
+        string $record_id,
+        ?string $repeat_instance
     ): ?string {
-        if (empty($instrument)) {
+        if (empty($instrument_name)) {
             throw new \LorisException("[redcap] Error: 'instrument' null or empty.");
         }
-        if (empty($recordId)) {
-            throw new \LorisException("[redcap] Error: 'recordId' null or empty.");
+
+        if (empty($record_id)) {
+            throw new \LorisException("[redcap] Error: 'record_id' null or empty.");
         }
-        $event          = empty($event) ? null : $event;
-        $repeatInstance = empty($repeatInstance) ? null : $repeatInstance;
+
+        $unique_event_name = empty($unique_event_name) ? null : $unique_event_name;
+        $repeat_instance   = empty($repeat_instance) ? null : $repeat_instance;
 
         // check mapping exists
-        if (!$this->hasMappingInstrumentEvent($instrument, $event)) {
+        $mapping_instrument_event_exists = $this->hasMappingInstrumentEvent(
+            $instrument_name,
+            $unique_event_name
+        );
+
+        if (!$mapping_instrument_event_exists) {
             throw new \LorisException(
-                "[redcap] Error: mapping '$instrument'"
-                ."/'$event' does not exist"
+                "[redcap] Error: mapping '$instrument_name'"
+                ."/'$unique_event_name' does not exist"
             );
         }
 
         // data to send
         $data = [
             'content'    => 'surveyLink',
-            'instrument' => $instrument,
-            'event'      => $event,
-            'record'     => $recordId,
+            'instrument' => $instrument_name,
+            'event'      => $unique_event_name,
+            'record'     => $record_id,
         ];
 
-        if ($repeatInstance !== null) {
-            $data['repeat_instance'] = $repeatInstance;
+        if ($repeat_instance !== null) {
+            $data['repeat_instance'] = $repeat_instance;
         }
 
         // send request
@@ -448,19 +457,19 @@ class RedcapHttpClient
     /**
      * Get survey participants.
      *
-     * @param string $instrument_name The REDCap instrument name.
-     * @param string $event_name      The REDCap event name.
+     * @param string $instrument_name   The REDCap instrument name.
+     * @param string $unique_event_name The REDCap unique event name.
      *
      * @return RedcapSurveyParticipant[] all events.
      */
     public function getSurveyParticipants(
         string $instrument_name,
-        string $event_name,
+        string $unique_event_name,
     ): array {
         $data = [
             'content'    => 'participantList',
             'instrument' => $instrument_name,
-            'event'      => $event_name,
+            'event'      => $unique_event_name,
         ];
 
         $participants = json_decode($this->_sendRequest($data), true);
@@ -473,61 +482,61 @@ class RedcapHttpClient
     /**
      * Check if the instrument/event mapping exists.
      *
-     * @param string $instrument_name an instrument name
-     * @param string $event_name      an event name
+     * @param string $instrument_name   A REDCap instrument name.
+     * @param string $unique_event_name A REDCap unique event name.
      *
      * @return bool true if couple is found, else false
      */
     public function hasMappingInstrumentEvent(
         string $instrument_name,
-        string $event_name,
+        string $unique_event_name,
     ): bool {
         $map = $this->getInstrumentEventMapping();
         return $this->_hasMappingElement(
             $map,
             $instrument_name,
-            $event_name,
+            $unique_event_name,
         );
     }
 
     /**
      * Check if the repeating-instrument/event mapping exists.
      *
-     * @param string $instrument_name an repeating instrument name
-     * @param string $event_name      an event name
+     * @param string $instrument_name   A REDCap repeating instrument name.
+     * @param string $unique_event_name A REDCap unique event name.
      *
      * @return bool true if couple is found, else false
      */
     public function hasRepeatingInstrumentEvent(
         string $instrument_name,
-        string $event_name,
+        string $unique_event_name,
     ): bool {
         $map = $this->getRepeatingInstrumentsAndEvents();
         return $this->_hasMappingElement(
             $map,
             $instrument_name,
-            $event_name,
+            $unique_event_name,
         );
     }
 
     /**
      * Check if the instrument/event mapping exists in an arbitrary mapping array.
      *
-     * @param array  $instrument_event_mappings a mapping array
-     * @param string $instrument_name           an instrument name
-     * @param string $event_name                an event name
+     * @param array  $instrument_event_mappings A mapping array.
+     * @param string $instrument_name           A REDCap instrument name.
+     * @param string $unique_event_name         A REDCap unique event name.
      *
      * @return bool true if couple is found in the array, else false
      */
     private function _hasMappingElement(
         array &$instrument_event_mappings,
         string $instrument_name,
-        string $event_name
+        string $unique_event_name,
     ): bool {
         return array_any(
             $instrument_event_mappings,
             fn($mapping) => (
-                $mapping->getEventName() === $event_name
+                $mapping->getUniqueEventName() === $unique_event_name
                     && $mapping->getFormName() === $instrument_name
             )
         );
@@ -538,19 +547,19 @@ class RedcapHttpClient
      *
      * Note: this method does not cache data.
      *
-     * @param string $recordId a record ID
+     * @param string $record_id a record ID
      *
      * @return ?string a link if found, else null
      */
-    public function getSurveyQueueLink(string $recordId)
+    public function getSurveyQueueLink(string $record_id)
     {
-        if (empty($recordId)) {
-            throw new \LorisException("[redcap] Error: 'recordId' null or empty.");
+        if (empty($record_id)) {
+            throw new \LorisException("[redcap] Error: 'record_id' null or empty.");
         }
 
         $data = [
             'content' => 'surveyQueueLink',
-            'record'  => $recordId
+            'record'  => $record_id
         ];
 
         return $this->_sendRequest($data);
@@ -637,57 +646,66 @@ class RedcapHttpClient
     /**
      * Get all records for an single instrument.
      *
-     * @param string $instrument           an instrument name
-     * @param string $event                an event name
-     * @param string $recordId             a record ID
-     * @param bool   $completedRecordsOnly only consider complete records?
+     * @param string $instrument_name        A REDCap instrument name.
+     * @param string $unique_event_name      A REDCap unique event name.
+     * @param string $record_id              A REDCAp record ID.
+     * @param bool   $completed_records_only Only return completed records.
      *
      * @throws \LorisException
      *
      * @return IRedcapRecord[] an array of records
      */
     public function getInstrumentRecord(
-        string $instrument,
-        string $event,
-        string $recordId,
-        bool $completedRecordsOnly = true
+        string $instrument_name,
+        string $unique_event_name,
+        string $record_id,
+        bool $completed_records_only = true
     ): array {
-        if (empty($instrument)) {
-            throw new \LorisException("[redcap] Error: required 'instrument'.");
+        if (empty($instrument_name)) {
+            throw new \LorisException(
+                "[redcap] Error: required 'instrument_name'."
+            );
         }
-        if (empty($event)) {
-            throw new \LorisException("[redcap] Error: required 'event'.");
+
+        if (empty($unique_event_name)) {
+            throw new \LorisException(
+                "[redcap] Error: required 'unique_event_name'."
+            );
         }
-        if (empty($recordId)) {
-            throw new \LorisException("[redcap] Error: required 'recordId'.");
+
+        if (empty($record_id)) {
+            throw new \LorisException("[redcap] Error: required 'record_id'.");
         }
 
         // mapping check
-        if (!$this->hasMappingInstrumentEvent($instrument, $event)) {
+        $mapping_instrument_event_exists = $this->hasMappingInstrumentEvent(
+            $instrument_name,
+            $unique_event_name,
+        );
+
+        if (!$mapping_instrument_event_exists) {
             throw new \LorisException(
-                "[redcap] Error: mapping '$instrument'/"
-                . "'$event' does not exist in REDCap"
+                "[redcap] Error: mapping '$instrument_name'/"
+                . "'$unique_event_name' does not exist in REDCap"
             );
         }
 
         // request
-        $r = $this->_getRecords(
-            [$instrument],
-            [$event],
-            [$recordId]
+        $records = $this->_getRecords(
+            [$instrument_name],
+            [$unique_event_name],
+            [$record_id]
         );
 
-        if (empty($r)) {
+        if (empty($records)) {
             throw new \LorisException("[redcap] Error: no data found.");
         }
 
         // Only keep complete records
-        if ($completedRecordsOnly) {
+        if ($completed_records_only) {
             $completed = array_filter(
-                $r,
-                function ($record) use ($instrument) {
-                    return $record["{$instrument}_complete"] == 2;
-                }
+                $records,
+                fn ($record) => $record["{$instrument_name}_complete"] == 2
             );
 
             if (count($completed) === 0) {
@@ -697,14 +715,14 @@ class RedcapHttpClient
             }
         } else {
             // if not only completed records
-            $completed = $r;
+            $completed = $records;
         }
 
         // Order the records by ${instrument_name}_dtt field value
         usort(
             $completed,
-            function ($a, $b) use ($instrument) {
-                $dttField = "{$instrument}_dtt";
+            function ($a, $b) use ($instrument_name) {
+                $dttField = "{$instrument_name}_dtt";
                 $a_date   = new \DateTimeImmutable($a[$dttField]);
                 $b_date   = new \DateTimeImmutable($b[$dttField]);
                 return $a_date <=> $b_date;
@@ -714,19 +732,23 @@ class RedcapHttpClient
         // is a repeating instrument?
         $final = [];
         if ($this->getProjectInfo()->has_repeating_instruments
-            && $this->hasRepeatingInstrumentEvent($instrument, $event)
+            && $this->hasRepeatingInstrumentEvent(
+                $instrument_name,
+                $unique_event_name
+            )
         ) {
             foreach ($completed as $index => $record) {
                 $final[] = new RedcapRepeatingRecord(
-                    $instrument,
+                    $instrument_name,
                     $record,
                     $index + 1
                 );
             }
         } else {
             // return the only record
-            $final[] = new RedcapRecord($instrument, $completed[0]);
+            $final[] = new RedcapRecord($instrument_name, $completed[0]);
         }
+
         return $final;
     }
 
@@ -735,19 +757,22 @@ class RedcapHttpClient
      * Cannot return all values. At least one of the three parameters needs to
      * be filled with one value, else an exception will be generated.
      *
-     * @param array $instruments instrument names
-     * @param array $events      event names
-     * @param array $records     records IDs
+     * @param array $instrument_names   A list of REDCap instrument names.
+     * @param array $unique_event_names A list of REDCap unique event names.
+     * @param array $record_ids         A list of REDCap records IDs.
      *
      * @return array an array of records (array of [field name => field values])
      */
     private function _getRecords(
-        array $instruments = [],
-        array $events = [],
-        array $records = []
+        array $instrument_names = [],
+        array $unique_event_names = [],
+        array $record_ids = []
     ): array {
         // security, do not get all records
-        if (empty($instruments) && empty($events) && empty($records)) {
+        if (empty($instrument_names)
+            && empty($unique_event_names)
+            && empty($record_ids)
+        ) {
             throw new \LorisException(
                 "[redcap] Error: get all recrods forbidden without arguments."
             );
@@ -759,10 +784,10 @@ class RedcapHttpClient
             'action'                 => 'export',
             'type'                   => 'flat',
             'csvDelimiter'           => '',
-            'forms'                  => $instruments,
+            'forms'                  => $instrument_names,
             'fields'                 => [],
-            'events'                 => $events,
-            'records'                => $records,
+            'events'                 => $unique_event_names,
+            'records'                => $record_ids,
             'rawOrLabel'             => 'raw',
             'rawOrLabelHeaders'      => 'raw',
             'exportCheckboxLabel'    => true,

--- a/modules/redcap/php/config/redcapconfig.class.inc
+++ b/modules/redcap/php/config/redcapconfig.class.inc
@@ -22,13 +22,6 @@ namespace LORIS\redcap\config;
 class RedcapConfig
 {
     /**
-     * The LORIS user that is assigned the issues created by the REDCap module.
-     *
-     * @var \User
-     */
-    public readonly \User $issue_assignee;
-
-    /**
      * The REDCap project ID of the project.
      *
      * @var string
@@ -81,9 +74,6 @@ class RedcapConfig
     /**
      * Constructor.
      *
-     * @param \User                $issue_assignee             The LORIS issue
-     *                                                         assignee for the
-     *                                                         REDCap module.
      * @param string               $redcap_project_id          The REDCap project
      *                                                         ID.
      * @param string               $redcap_instance_url        The REDCap instance
@@ -103,7 +93,6 @@ class RedcapConfig
      *                                                         mappings.
      */
     public function __construct(
-        \User $issue_assignee,
         string $redcap_project_id,
         string $redcap_instance_url,
         string $redcap_api_token,
@@ -112,10 +101,9 @@ class RedcapConfig
         RedcapConfigLorisId $candidate_id,
         ?array $visits,
     ) {
-        $this->issue_assignee      = $issue_assignee;
-        $this->redcap_project_id   = $redcap_project_id;
-        $this->redcap_instance_url = $redcap_instance_url;
-        $this->redcap_api_token    = $redcap_api_token;
+        $this->redcap_project_id          = $redcap_project_id;
+        $this->redcap_instance_url        = $redcap_instance_url;
+        $this->redcap_api_token           = $redcap_api_token;
         $this->prefix_instrument_variable = $prefix_instrument_variable;
         $this->redcap_participant_id      = $redcap_participant_id;
         $this->candidate_id = $candidate_id;

--- a/modules/redcap/php/config/redcapconfigparser.class.inc
+++ b/modules/redcap/php/config/redcapconfigparser.class.inc
@@ -36,13 +36,6 @@ class RedcapConfigParser
     private \LORIS\LorisInstance $_loris;
 
     /**
-     * The LORIS database.
-     *
-     * @var \Database
-     */
-    private \Database $_db;
-
-    /**
      * The REDCap instance URL.
      *
      * @var string
@@ -69,7 +62,6 @@ class RedcapConfigParser
         string $redcap_project_id,
     ) {
         $this->_loris = $loris;
-        $this->_db    = $loris->getDatabaseConnection();
         $this->_redcap_instance_url = $redcap_instance_url;
         $this->_redcap_project_id   = $redcap_project_id;
     }
@@ -104,8 +96,6 @@ class RedcapConfigParser
      */
     private function _parseRedcapNode(array $redcap_node): ?RedcapConfig
     {
-        $issue_assignee = $this->_getIssueAssignee();
-
         $instance_node = $this->_getInstanceNode($redcap_node);
         if ($instance_node === null) {
             throw $this->_exception(
@@ -131,7 +121,6 @@ class RedcapConfigParser
         $visits       = $this->_parseVisits($project_node);
 
         return new RedcapConfig(
-            $issue_assignee,
             $this->_redcap_project_id,
             $this->_redcap_instance_url,
             $redcap_api_token,
@@ -140,55 +129,6 @@ class RedcapConfigParser
             $candidate_id,
             $visits,
         );
-    }
-
-    /**
-     * Get the REDCap issue assignee from configuration module.
-     *
-     * @return \User The REDCap issue assignee user.
-     */
-    private function _getIssueAssignee(): \User
-    {
-        $assignee_user_id = $this->_db->pselectOne(
-            "SELECT c.Value
-            FROM Config c
-                JOIN ConfigSettings cs ON (cs.ID = c.ConfigID)
-            WHERE cs.Name = 'redcap_issue_assignee'
-            ",
-            []
-        );
-
-        if (empty($assignee_user_id)) {
-            throw $this->_exception(
-                "no REDCap issue assignee in configuration, missing"
-                . " 'redcap_issue_assignee'."
-            );
-        }
-
-        $assignee = $this->_db->pselectOne(
-            "SELECT DISTINCT u.userID
-            FROM users u
-                JOIN user_perm_rel upr ON (upr.userid = u.id)
-                JOIN permissions p ON (p.permid = upr.permid)
-            WHERE u.userID = :usid
-                AND u.Active = 'Y'
-                AND u.Pending_approval = 'N'
-                AND (
-                    p.code = 'issue_tracker_developer'
-                    OR p.code = 'superuser'
-                )
-            ",
-            ['usid' => $assignee_user_id]
-        );
-
-        if ($assignee === null) {
-            throw $this->_exception(
-                "REDCap issue assignee '$assignee_user_id' does not exist or does"
-                . " not have enough privileges."
-            );
-        }
-
-        return \User::factory($assignee_user_id);
     }
 
     /**

--- a/modules/redcap/php/endpoints/notifications.class.inc
+++ b/modules/redcap/php/endpoints/notifications.class.inc
@@ -16,6 +16,7 @@ use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 use \LORIS\Http\Endpoint;
 use \LORIS\redcap\RedcapNotificationHandler;
+use \LORIS\redcap\RedcapQueries;
 use \LORIS\redcap\config\RedcapConfig;
 use \LORIS\redcap\config\RedcapConfigParser;
 use \LORIS\redcap\client\RedcapHttpClient;
@@ -97,7 +98,8 @@ class Notifications extends Endpoint
      */
     private function _handlePOST(ServerRequestInterface $request): ResponseInterface
     {
-        $db = $this->loris->getDatabaseConnection();
+        $db      = $this->loris->getDatabaseConnection();
+        $queries = new RedcapQueries($this->loris);
 
         // Try url-encoded first
         $data = $request->getParsedBody();
@@ -109,26 +111,27 @@ class Notifications extends Endpoint
         try {
             $received_datetime = new \DateTimeImmutable();
 
-            $notification = new RedcapNotification($data, $received_datetime);
+            $redcap_notif = new RedcapNotification($data, $received_datetime);
+
+            $this->_issue_assignee = $queries->getRedcapIssueAssignee();
 
             $config_parser = new RedcapConfigParser(
                 $this->loris,
-                $notification->instance_url,
-                $notification->project_id,
+                $redcap_notif->instance_url,
+                $redcap_notif->project_id,
             );
 
             $config = $config_parser->parse();
-            $this->_issue_assignee = $config->issue_assignee;
 
             // should the notification be ignored?
-            if ($this->_ignoreNotification($notification, $config)) {
+            if ($this->_ignoreNotification($redcap_notif, $config)) {
                 return new \LORIS\Http\Response();
             }
 
             // Add to the database
             $db->insert(
                 'redcap_notification',
-                $notification->toDatabaseArray()
+                $redcap_notif->toDatabaseArray()
             );
         } catch (\UnexpectedValueException $e) {
             $body = (string) $request->getBody();
@@ -165,9 +168,9 @@ class Notifications extends Endpoint
 
             $notification_handler = new RedcapNotificationHandler(
                 $this->loris,
-                $config,
                 $redcap_client,
-                $notification,
+                $redcap_notif,
+                $config,
             );
         } catch (\LorisException $le) {
             $this->_createIssue(
@@ -182,9 +185,9 @@ class Notifications extends Endpoint
             $notification_handler->handle();
         } catch (\DatabaseException $e) {
             $rec = "[redcap] Error: "
-                . "PSCID: " . $notification->record_id
-                . "Visit: " . $notification->event_name
-                . "instrument: " . $notification->instrument_name;
+                . "PSCID: " . $redcap_notif->record_id
+                . "Visit: " . $redcap_notif->unique_event_name
+                . "instrument: " . $redcap_notif->instrument_name;
             $this->_createIssue(
                 'Instrument data not updated - Database exception',
                 $e->getMessage(),
@@ -193,9 +196,9 @@ class Notifications extends Endpoint
             return new \LORIS\Http\Response\JSON\InternalServerError();
         } catch (\DomainException $e) {
             $rec = "[redcap] Error: "
-                . "PSCID: " . $notification->record_id
-                . "Visit: " . $notification->event_name
-                . "instrument: " . $notification->instrument_name;
+                . "PSCID: " . $redcap_notif->record_id
+                . "Visit: " . $redcap_notif->unique_event_name
+                . "instrument: " . $redcap_notif->instrument_name;
             $this->_createIssue(
                 'Instrument data not updated - Domain exception',
                 $e->getMessage(),
@@ -206,14 +209,14 @@ class Notifications extends Endpoint
             $this->_createIssue(
                 'Instrument data not updated - Configuration/Permission exception',
                 $ce->getMessage(),
-                json_encode($notification->toDatabaseArray())
+                json_encode($redcap_notif->toDatabaseArray())
             );
             return new \LORIS\Http\Response\JSON\InternalServerError();
         } catch (\Throwable $e) {
             $this->_createIssue(
                 'Instrument data not updated',
                 $e->getMessage(),
-                json_encode($notification->toDatabaseArray())
+                json_encode($redcap_notif->toDatabaseArray())
             );
             return new \LORIS\Http\Response\JSON\InternalServerError();
         }
@@ -226,18 +229,18 @@ class Notifications extends Endpoint
      * Ignored notifications will not trigger any issue creation.
      * Optionally prints an error in log on a case by case basis.
      *
-     * @param RedcapNotification $notif         The REDCap notification.
-     * @param ?RedcapConfig      $redcap_config The REDCap module configuration.
+     * @param RedcapNotification $redcap_notif The REDCap notification.
+     * @param ?RedcapConfig      $config       The REDCap module configuration.
      *
      * @return bool if the notification should be ignored, else false.
      */
     private function _ignoreNotification(
-        RedcapNotification $notif,
-        ?RedcapConfig $redcap_config,
+        RedcapNotification $redcap_notif,
+        ?RedcapConfig $config,
     ): bool {
-        $notif_data = json_encode($notif->toDatabaseArray());
+        $notif_data = json_encode($redcap_notif->toDatabaseArray());
 
-        if ($redcap_config === null) {
+        if ($config === null) {
             error_log(
                 "[redcap][notification:skip] unknown source/project: $notif_data"
             );
@@ -249,7 +252,7 @@ class Notifications extends Endpoint
         $authInstr = $config->getSetting('redcap_importable_instrument');
 
         // ignore instruments that are not in the authorized list
-        if (!in_array($notif->instrument_name, $authInstr, true)) {
+        if (!in_array($redcap_notif->instrument_name, $authInstr, true)) {
             error_log(
                 "[redcap][notification:skip] unauthorized instrument: $notif_data"
             );
@@ -257,7 +260,7 @@ class Notifications extends Endpoint
         }
 
         // ignore notifications that are not 'complete'
-        if (!$notif->isComplete()) {
+        if (!$redcap_notif->isComplete()) {
             error_log(
                 "[redcap][notification:skip] instrument not complete: $notif_data"
             );

--- a/modules/redcap/php/redcapmapper.class.inc
+++ b/modules/redcap/php/redcapmapper.class.inc
@@ -1,0 +1,280 @@
+<?php declare(strict_types=1);
+
+/**
+ * PHP Version 8
+ *
+ * @category REDCap
+ * @package  Main
+ * @author   Regis Ongaro-Carcy <regis.ongaro-carcy@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\redcap;
+
+use \LORIS\redcap\RedcapQueries;
+use \LORIS\redcap\config\RedcapConfig;
+use \LORIS\redcap\config\RedcapConfigLorisId;
+use \LORIS\redcap\config\RedcapConfigRedcapId;
+use \LORIS\redcap\client\RedcapHttpClient;
+use \LORIS\redcap\client\models\RedcapEvent;
+
+/**
+ * Mapping methods to match REDCap and LORIS identifiers in the REDCap module.
+ *
+ * PHP Version 8
+ *
+ * @category REDCap
+ * @package  Main
+ * @author   Regis Ongaro-Carcy <regis.ongaro-carcy@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class RedcapMapper
+{
+    /**
+     * The REDCap HTTP client.
+     *
+     * @var RedcapHttpClient
+     */
+    private RedcapHttpClient $_redcap_client;
+
+    /**
+     * The REDCap module configuration.
+     *
+     * @var RedcapConfig
+     */
+    private RedcapConfig $_config;
+
+    /**
+     * The REDCap module database queries.
+     *
+     * @var RedcapQueries
+     */
+    private RedcapQueries $_queries;
+
+    /**
+     * Constructor.
+     *
+     * @param RedcapHttpClient $redcap_client The REDCap HTTP client.
+     * @param RedcapConfig     $config        The REDCap module configuration.
+     * @param RedcapQueries    $queries       The REDCap module database queries.
+     */
+    public function __construct(
+        RedcapHttpClient $redcap_client,
+        RedcapConfig $config,
+        RedcapQueries $queries,
+    ) {
+        $this->_redcap_client = $redcap_client;
+        $this->_config        = $config;
+        $this->_queries       = $queries;
+    }
+
+    /**
+     * Get the LORIS visit label associated with a REDCap unique event name
+     * based on the REDCap module configuration.
+     *
+     * @param string $unique_event_name The REDCap unique event name.
+     *
+     * @return ?string The LORIS visit label associated with the REDCap
+     *                 notification, or `null` if no corresponding visit label is
+     *                 found.
+     */
+    public function getVisitLabel(string $unique_event_name): ?string
+    {
+        // Get the list of all the REDCap events for this REDCap project.
+        $redcap_events = $this->_redcap_client->getEvents();
+
+        // Find the REDCap event that matches the REDCap notification event.
+        $redcap_event = array_find(
+            $redcap_events,
+            fn($redcap_event) => $unique_event_name === $redcap_event->unique_name,
+        );
+
+        // There should always be a REDCap event that matches the REDCap
+        // notification event, but since this is an external API, check this
+        // assumption nonetheless.
+        if ($redcap_event === null) {
+            throw new \LorisException(
+                "[redcap] Error: No REDCap event found for unique event name"
+                . " '{$unique_event_name}'."
+            );
+        }
+
+        // If there are no visit mappings in the REDCap module configuration, simply
+        // use the REDCap event name as the LORIS vist name.
+        if ($this->_config->visits === null) {
+            return $redcap_event->name;
+        }
+
+        $event_name = $redcap_event->name;
+        $arm_name   = $this->_getRedcapEventArmName($redcap_event);
+
+        // Look for the REDCap module configuration visit mappings that match the
+        // REDCap notification event, using the event name and arm name.
+        $visit_mappings = array_filter(
+            $this->_config->visits,
+            function ($visit_config) use ($event_name, $arm_name) {
+                if ($visit_config->redcap_event_name !== null
+                    && $visit_config->redcap_event_name !== $event_name
+                ) {
+                    return false;
+                }
+
+                if ($visit_config->redcap_arm_name !== null
+                    && $visit_config->redcap_arm_name !== $arm_name
+                ) {
+                    return false;
+                }
+
+                return true;
+            },
+        );
+
+        // If there is no visit mapping that match the REDCap notification event,
+        // return `null` and ignore this notification.
+        if (count($visit_mappings) === 0) {
+            return null;
+        }
+
+        // If there are several visit mappings that match the REDCap notification
+        // event, raise an error.
+        if (count($visit_mappings) !== 1) {
+            throw new \LorisException(
+                "[redcap] Error: Multiple visits selectable for event name"
+                . " '$event_name' and arm name '$arm_name'."
+            );
+        }
+
+        // Return the LORIS visit label associated with the matching visit mapping.
+        return reset($visit_mappings)->visit_label;
+    }
+
+    /**
+     * Get the LORIS candidate identifier (CandID or PSCID) that matches a REDCap
+     * record ID, instrument name, and unique event named based on the REDCap module
+     * configuration.
+     *
+     * @param string $record_id         The REDCap record ID.
+     * @param string $instrument_name   The REDCap instrument name.
+     * @param string $unique_event_name The REDCap unique event name.
+     *
+     * @return string The LORIS candidate identifier.
+     */
+    public function getCandidateIdentifier(
+        string $record_id,
+        string $instrument_name,
+        string $unique_event_name,
+    ): string {
+        // If the REDCap module configuration is to use the REDCap record ID, simply
+        // return the REDCap notification record ID.
+        $condition = $this->_config->redcap_participant_id
+            === RedcapConfigRedcapId::RecordId;
+
+        if ($condition) {
+            return $record_id;
+        }
+
+        // Get the list of all REDCap survey participants for the notification
+        // instrument and event.
+        $participants = $this->_redcap_client->getSurveyParticipants(
+            $instrument_name,
+            $unique_event_name,
+        );
+
+        // Find the survey participant matching the notification record.
+        $participant = array_find(
+            $participants,
+            fn($participant) => $participant->record === $record_id
+        );
+
+        // If no survey participant is found for that record, raise an error. This
+        // can happen because even with surveys enabled in REDCap, there is no
+        // requirement for all records to be linked to survey participants.
+        if ($participant === null) {
+            throw new \LorisException(
+                "[redcap] Error: No survey participant found for record ID"
+                . " '$record_id'."
+            );
+        }
+
+        // If the REDCap survey participant does not have a custom identifier, raise
+        // an error. This can happen because the survey participant identifier must
+        // be set manually in REDCap and is optional.
+        if ($participant->identifier === null) {
+            throw new \LorisException(
+                "[redcap] Error: Survey participant has no identifier for"
+                . " record ID '$record_id'."
+            );
+        }
+
+        // Return the identifier of the survey participant.
+        return $participant->identifier;
+    }
+
+    /**
+     * Get the LORIS candidate that matches a candidate identifier (CandID or PSCID)
+     * based on the REDCap module configuration.
+     *
+     * @param string $candidate_identifier The candidate identifier obtained from
+     *                                     REDCap.
+     *
+     * @return \Candidate The LORIS candidate.
+     */
+    public function getCandidateWithIdentifier(
+        string $candidate_identifier,
+    ): \Candidate {
+        // Get the candidate using the REDCap participant identifier as a CandID or
+        // PSCID depending on the REDCap module configuration.
+        $candidate = match ($this->_config->candidate_id) {
+            RedcapConfigLorisId::CandId =>
+                $this->_queries->tryGetCandidateWithCandId($candidate_identifier),
+            RedcapConfigLorisId::PscId =>
+                $this->_queries->tryGetCandidateWithPscId($candidate_identifier),
+        };
+
+        // If no candidate matches the REDCap participant identifier, raise an
+        // error.
+        if ($candidate === null) {
+            throw new \LorisException(
+                "[redcap] Error: No LORIS candidate found for candidate identifier"
+                . " '$candidate_identifier'."
+            );
+        }
+
+        // Return the candidate.
+        return $candidate;
+    }
+
+    /**
+     * Get the REDCap arm name of a REDCap event.
+     *
+     * @param RedcapEvent $redcap_event The REDCap event.
+     *
+     * @return string The REDCap event arm name.
+     */
+    private function _getRedcapEventArmName(RedcapEvent $redcap_event): string
+    {
+        // Get the list of all the REDCap arms for this REDCap project.
+        $redcap_arms = $this->_redcap_client->getArms();
+
+        // Find the REDCap arm that matches the REDCap event.
+        $redcap_arm = array_find(
+            $redcap_arms,
+            fn($redcap_arm) => $redcap_arm->number === $redcap_event->arm_number,
+        );
+
+        // There should always be a REDCap arm that matches the REDCap event arm,
+        // but since this is an external API, check this
+        // assumption nonetheless.
+        if ($redcap_arm === null) {
+            throw new \LorisException(
+                "[redcap] Error: No REDCap arm found for event arm number"
+                . " '{$redcap_event->arm_number}'."
+            );
+        }
+
+        // Return the name of the REDCap arm.
+        return $redcap_arm->name;
+    }
+}

--- a/modules/redcap/php/redcapnotificationhandler.class.inc
+++ b/modules/redcap/php/redcapnotificationhandler.class.inc
@@ -13,13 +13,10 @@
 namespace LORIS\redcap;
 
 use \LORIS\LorisInstance;
-use \LORIS\redcap\Queries;
+use \LORIS\redcap\RedcapQueries;
 use \LORIS\redcap\client\RedcapHttpClient;
 use \LORIS\redcap\config\RedcapConfig;
-use \LORIS\redcap\config\RedcapConfigLorisId;
-use \LORIS\redcap\config\RedcapConfigRedcapId;
 use \LORIS\redcap\client\models\records\IRedcapRecord;
-use \LORIS\redcap\client\models\RedcapEvent;
 use \LORIS\redcap\client\models\RedcapNotification;
 
 /**
@@ -53,20 +50,6 @@ class RedcapNotificationHandler
     private LorisInstance $_loris;
 
     /**
-     * The database queries used by this pipeline.
-     *
-     * @var Queries
-     */
-    private Queries $_queries;
-
-    /**
-     * The REDCap module configuration.
-     *
-     * @var RedcapConfig
-     */
-    private RedcapConfig $_redcap_config;
-
-    /**
      * The REDCap HTTP client.
      *
      * @var RedcapHttpClient
@@ -81,24 +64,49 @@ class RedcapNotificationHandler
     private RedcapNotification $_redcap_notif;
 
     /**
-     * Contructor.
+     * The REDCap module configuration.
      *
-     * @param LorisInstance      $loris         A LORIS instance.
-     * @param RedcapConfig       $redcap_config A REDCap module configuration.
-     * @param RedcapHttpClient   $redcap_client A REDCap HTTP client.
-     * @param RedcapNotification $redcap_notif  A REDCap notification.
+     * @var RedcapConfig
+     */
+    private RedcapConfig $_config;
+
+    /**
+     * The REDCap mapper.
+     *
+     * @var RedcapMapper
+     */
+    private RedcapMapper $_mapper;
+
+    /**
+     * The REDCap module database queries.
+     *
+     * @var RedcapQueries
+     */
+    private RedcapQueries $_queries;
+
+    /**
+     * Constructor.
+     *
+     * @param LorisInstance      $loris         The LORIS instance.
+     * @param RedcapHttpClient   $redcap_client The REDCap HTTP client.
+     * @param RedcapNotification $redcap_notif  The REDCap notification.
+     * @param RedcapConfig       $config        The REDCap module configuration.
      */
     public function __construct(
         LorisInstance $loris,
-        RedcapConfig $redcap_config,
         RedcapHttpClient $redcap_client,
         RedcapNotification $redcap_notif,
+        RedcapConfig $config,
     ) {
+        $queries = new RedcapQueries($loris);
+        $mapper  = new RedcapMapper($redcap_client, $config, $queries);
+
         $this->_loris         = $loris;
-        $this->_queries       = new Queries($loris);
-        $this->_redcap_config = $redcap_config;
         $this->_redcap_client = $redcap_client;
         $this->_redcap_notif  = $redcap_notif;
+        $this->_config        = $config;
+        $this->_mapper        = $mapper;
+        $this->_queries       = $queries;
     }
 
     /**
@@ -121,7 +129,7 @@ class RedcapNotificationHandler
             // get data from redcap
             $records = $this->_redcap_client->getInstrumentRecord(
                 $this->_redcap_notif->instrument_name,
-                $this->_redcap_notif->event_name,
+                $this->_redcap_notif->unique_event_name,
                 $this->_redcap_notif->record_id,
                 true,
             );
@@ -129,7 +137,7 @@ class RedcapNotificationHandler
             $this->_queries->markRedcapNotifAsHandled(
                 $this->_redcap_notif->project_id,
                 $this->_redcap_notif->record_id,
-                $this->_redcap_notif->event_name,
+                $this->_redcap_notif->unique_event_name,
                 $this->_redcap_notif->instrument_name,
                 $this->_redcap_notif->received_datetime,
                 new \DateTimeImmutable(),
@@ -138,12 +146,21 @@ class RedcapNotificationHandler
             $this->_queries->releaseNotificationLock();
         }
 
-        $participant_id = $this->_getRedcapParticipantId();
+        $candidate_identifier = $this->_mapper->getCandidateIdentifier(
+            $this->_redcap_notif->record_id,
+            $this->_redcap_notif->instrument_name,
+            $this->_redcap_notif->unique_event_name,
+        );
 
-        $candidate = $this->_getCandidateWithRedcapParticipantId($participant_id);
-        $psc_id    = $candidate->getPSCID();
+        $candidate = $this->_mapper->getCandidateWithIdentifier(
+            $candidate_identifier
+        );
 
-        $visit_label = $this->_getVisitLabel();
+        $psc_id = $candidate->getPSCID();
+
+        $visit_label = $this->_mapper->getVisitLabel(
+            $this->_redcap_notif->unique_event_name,
+        );
 
         // Track which instruments are updated and not updated.
         $instruments_not_updated = [];
@@ -214,208 +231,7 @@ class RedcapNotificationHandler
     }
 
     /**
-     * Find the visit label associated with the REDCap notification based on the
-     * REDCap module configuration.
-     *
-     * @return ?string The LORIS visit label associated with the REDCap
-     *                 notification, or `NULL` if no corresponding visit label is
-     *                 found.
-     */
-    private function _getVisitLabel(): ?string
-    {
-        // Get the list of all the REDCap events for this REDCap project.
-        $redcap_events = $this->_redcap_client->getEvents();
-
-        // Find the REDCap event that matches the REDCap notification event.
-        $redcap_event = array_find(
-            $redcap_events,
-            fn($redcap_event) => (
-                $redcap_event->unique_name === $this->_redcap_notif->event_name
-            ),
-        );
-
-        // There should always be a REDCap event that matches the REDCap
-        // notification event, but since this is an external API, check this
-        // assumption nonetheless.
-        if ($redcap_event === null) {
-            throw new \LorisException(
-                "[redcap] Error: No REDCap event found for notification event name"
-                . " '{$this->_redcap_notif->event_name}'."
-            );
-        }
-
-        // If there is no visit mappings in the REDCap module configuration, simply
-        // use the REDCap event name as the LORIS vist name.
-        if ($this->_redcap_config->visits === null) {
-            return $redcap_event->name;
-        }
-
-        $event_name = $redcap_event->name;
-        $arm_name   = $this->_getRedcapEventArmName($redcap_event);
-
-        // Look for the REDCap module configuration visit mappings that match the
-        // REDCap notification event, using the event name and arm name.
-        $visit_mappings = array_filter(
-            $this->_redcap_config->visits,
-            function ($visit_config) use ($event_name, $arm_name) {
-                if ($visit_config->redcap_event_name !== null
-                    && $visit_config->redcap_event_name !== $event_name
-                ) {
-                    return false;
-                }
-
-                if ($visit_config->redcap_arm_name !== null
-                    && $visit_config->redcap_arm_name !== $arm_name
-                ) {
-                    return false;
-                }
-
-                return true;
-            },
-        );
-
-        // If there is no visit mapping that match the REDCap notification event,
-        // return `null` and ignore this notification.
-        if (count($visit_mappings) === 0) {
-            return null;
-        }
-
-        // If there are several visit mappings that match the REDCap notification
-        // event, raise an error.
-        if (count($visit_mappings) !== 1) {
-            throw new \LorisException(
-                "[redcap] Error: Multiple visits selectable for event name"
-                . " '$event_name' and arm name '$arm_name'."
-            );
-        }
-
-        // Return the LORIS visit label associated with the matching visit mapping.
-        return reset($visit_mappings)->visit_label;
-    }
-
-    /**
-     * Get the appropriate participant identifier of the REDCap notification based
-     * on the REDCap module configuration.
-     *
-     * @return string The REDCap participant identifier.
-     */
-    private function _getRedcapParticipantId(): string
-    {
-        $record_id = $this->_redcap_notif->record_id;
-
-        // If the REDCap module configuration is to use the REDCap record ID, simply
-        // return the REDCap notification record ID.
-        $condition = $this->_redcap_config->redcap_participant_id
-            === RedcapConfigRedcapId::RecordId;
-
-        if ($condition) {
-            return $record_id;
-        }
-
-        // Get the list of all REDCap survey participants for the notification
-        // instrument and event.
-        $participants = $this->_redcap_client->getSurveyParticipants(
-            $this->_redcap_notif->instrument_name,
-            $this->_redcap_notif->event_name,
-        );
-
-        // Find the survey participant matching the notification record.
-        $participant = array_find(
-            $participants,
-            fn($participant) => $participant->record === $record_id
-        );
-
-        // If no survey participant is found for that record, raise an error. This
-        // can happen because even with surveys enabled in REDCap, there is no
-        // requirement for all records to be linked to survey participants.
-        if ($participant === null) {
-            throw new \LorisException(
-                "[redcap] Error: No survey participant found for record ID"
-                . " '$record_id'."
-            );
-        }
-
-        // If the REDCap survey participant does not have a custom identifier, raise
-        // an error. This can happen because the survey participant identifier must
-        // be set manually in REDCap and is optional.
-        if ($participant->identifier === null) {
-            throw new \LorisException(
-                "[redcap] Error: Survey participant has no identifier for"
-                . " record ID '$record_id'."
-            );
-        }
-
-        // Return the identifier of the survey participant.
-        return $participant->identifier;
-    }
-
-    /**
-     * Get the LORIS candidate that matches a REDCap participant identifier based
-     * on the REDCap module configuration.
-     *
-     * @param string $redcap_participant_id The REDCap participant identifier.
-     *
-     * @return \Candidate The LORIS candidate.
-     */
-    private function _getCandidateWithRedcapParticipantId(
-        string $redcap_participant_id,
-    ): \Candidate {
-        // Get the candidate using the REDCap participant identifier as a CandID or
-        // PSCID depending on the REDCap module configuration.
-        $candidate = match ($this->_redcap_config->candidate_id) {
-            RedcapConfigLorisId::CandId =>
-                $this->_queries->tryGetCandidateWithCandId($redcap_participant_id),
-            RedcapConfigLorisId::PscId =>
-                $this->_queries->tryGetCandidateWithPscId($redcap_participant_id),
-        };
-
-        // If no candidate matches the REDCap participant identifier, raise an
-        // error.
-        if ($candidate === null) {
-            throw new \LorisException(
-                "[redcap] Error: No LORIS candidate found for REDCap participant"
-                . " identifier '$redcap_participant_id'."
-            );
-        }
-
-        // Return the candidate.
-        return $candidate;
-    }
-
-    /**
-     * Get the REDCap arm name of a REDCap event.
-     *
-     * @param RedcapEvent $redcap_event A REDCap event.
-     *
-     * @return string The REDCap event arm name.
-     */
-    private function _getRedcapEventArmName(RedcapEvent $redcap_event): string
-    {
-        // Get the list of all the REDCap arms for this REDCap project.
-        $redcap_arms = $this->_redcap_client->getArms();
-
-        // Find the REDCap arm that matches the REDCap event.
-        $redcap_arm = array_find(
-            $redcap_arms,
-            fn($redcap_arm) => $redcap_arm->number === $redcap_event->arm_number,
-        );
-
-        // There should always be a REDCap arm that matches the REDCap event arm,
-        // but since this is an external API, check this
-        // assumption nonetheless.
-        if ($redcap_arm === null) {
-            throw new \LorisException(
-                "[redcap] Error: No REDCap arm found for event arm number"
-                . " '{$redcap_event->arm_number}'."
-            );
-        }
-
-        // Return the name of the REDCap arm.
-        return $redcap_arm->name;
-    }
-
-    /**
-     * Check that REDCap and LORIS dictionaries matchfor this instrument.
+     * Check that the REDCap and LORIS dictionaries of an instrument match.
      *
      * @param \NDB_BVL_Instrument $instrument a LORIS instrument object
      * @param IRedcapRecord       $record     a REDCap instrument record
@@ -475,7 +291,7 @@ class RedcapNotificationHandler
 
         // Remove instrument name from REDCap variable names if the variables are
         // prefixed by the instrument name.
-        if ($this->_redcap_config->prefix_instrument_variable) {
+        if ($this->_config->prefix_instrument_variable) {
             $record_names = array_values(
                 array_map(
                     function ($name) use ($redcap_form_name) {
@@ -750,7 +566,7 @@ class RedcapNotificationHandler
             $this->_redcap_notif->received_datetime,
             $this->_redcap_notif->project_id,
             $this->_redcap_notif->record_id,
-            $this->_redcap_notif->event_name,
+            $this->_redcap_notif->unique_event_name,
             $this->_redcap_notif->instrument_name,
         );
 

--- a/modules/redcap/php/redcapqueries.class.inc
+++ b/modules/redcap/php/redcapqueries.class.inc
@@ -1,9 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- * This serves as a hint to LORIS that this module is a real module.
- * It does nothing but implement the module class in the module's namespace.
- *
  * PHP Version 8
  *
  * @category REDCap
@@ -29,7 +26,7 @@ use \LORIS\StudyEntities\Candidate\CandID;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Queries
+class RedcapQueries
 {
     /**
      * The LORIS database.
@@ -49,11 +46,60 @@ class Queries
     }
 
     /**
+     * Get the REDCap issue assignee from the configuration tables.
+     *
+     * @return \User The REDCap issue assignee user.
+     */
+    public function getRedcapIssueAssignee(): \User
+    {
+        $assignee_user_id = $this->_db->pselectOne(
+            "SELECT c.Value
+            FROM Config c
+                JOIN ConfigSettings cs ON (cs.ID = c.ConfigID)
+            WHERE cs.Name = 'redcap_issue_assignee'
+            ",
+            []
+        );
+
+        if ($assignee_user_id === null) {
+            throw new \LorisException(
+                "no REDCap issue assignee in configuration, missing"
+                . " 'redcap_issue_assignee'."
+            );
+        }
+
+        $assignee = $this->_db->pselectOne(
+            "SELECT DISTINCT u.userID
+            FROM users u
+                JOIN user_perm_rel upr ON (upr.userid = u.id)
+                JOIN permissions p ON (p.permid = upr.permid)
+            WHERE u.userID = :usid
+                AND u.Active = 'Y'
+                AND u.Pending_approval = 'N'
+                AND (
+                    p.code = 'issue_tracker_developer'
+                    OR p.code = 'superuser'
+                )
+            ",
+            ['usid' => $assignee_user_id]
+        );
+
+        if ($assignee === null) {
+            throw new \LorisException(
+                "REDCap issue assignee '$assignee_user_id' does not exist or does"
+                . " not have enough privileges."
+            );
+        }
+
+        return \User::factory($assignee_user_id);
+    }
+
+    /**
      * Get a candidate from the database using a given PSCID.
      *
      * @param string $psc_id A potential PSCID.
      *
-     * @return ?\Candidate A LORIS candidate, or `NULL` if no candidate matches the
+     * @return ?\Candidate A LORIS candidate, or `null` if no candidate matches the
      *                     given PSCID.
      */
     public function tryGetCandidateWithPscId(string $psc_id): ?\Candidate
@@ -75,7 +121,7 @@ class Queries
      *
      * @param string $cand_id A potential CandID.
      *
-     * @return ?\Candidate A LORIS candidate, or `NULL` if no candidate matches the
+     * @return ?\Candidate A LORIS candidate, or `null` if no candidate matches the
      *                     given CandID.
      */
     public function tryGetCandidateWithCandId(string $cand_id): ?\Candidate
@@ -98,7 +144,7 @@ class Queries
      *
      * @param string $full_name A potential examiner full name, case-insensitive.
      *
-     * @return ?string The examiner ID, or `NULL` if no examiner matches the given
+     * @return ?string The examiner ID, or `null` if no examiner matches the given
      *                 full name.
      */
     public function getExaminerIdWithFullName(string $full_name): ?string
@@ -120,7 +166,7 @@ class Queries
      *                                              received.
      * @param string             $project_id        The REDCap project ID.
      * @param string             $record_id         The REDCap record ID.
-     * @param string             $event_name        The REDCap event name.
+     * @param string             $unique_event_name The REDCap unique event name.
      * @param string             $instrument_name   The REDCap instrument name.
      *
      * @return array The list of unhandled notification IDs.
@@ -129,7 +175,7 @@ class Queries
         \DatetimeImmutable $received_datetime,
         string $project_id,
         string $record_id,
-        string $event_name,
+        string $unique_event_name,
         string $instrument_name,
     ): array {
         $query = "SELECT id
@@ -148,7 +194,7 @@ class Queries
             'v_received_dt'       => $received_datetime,
             'v_project_id'        => $project_id,
             'v_record'            => $record_id,
-            'v_redcap_event_name' => $event_name,
+            'v_redcap_event_name' => $unique_event_name,
             'v_instrument'        => $instrument_name,
         ];
 
@@ -164,8 +210,8 @@ class Queries
      *                                              ID.
      * @param string             $record_id         The REDCap notification record
      *                                              ID.
-     * @param string             $event_name        The REDCap notification event
-     *                                              name.
+     * @param string             $unique_event_name The REDCap notification unique
+     *                                              event name.
      * @param string             $instrument_name   The instrument name of the
      *                                              REDCap notification.
      * @param \DateTimeImmutable $received_datetime The time at which the REDCap
@@ -178,7 +224,7 @@ class Queries
     public function markRedcapNotifAsHandled(
         string $project_id,
         string $record_id,
-        string $event_name,
+        string $unique_event_name,
         string $instrument_name,
         \DateTimeImmutable $received_datetime,
         \DateTimeImmutable $handled_datetime,
@@ -201,7 +247,7 @@ class Queries
             'v_received_dt'       => $received_datetime,
             'v_project_id'        => $project_id,
             'v_record'            => $record_id,
-            'v_redcap_event_name' => $event_name,
+            'v_redcap_event_name' => $unique_event_name,
             'v_instrument'        => $instrument_name,
             'handled_dt'          => $handled_datetime,
         ];


### PR DESCRIPTION
This PR contains a few small code improvements to the REDCap module. It does not change the behavior of the module, but it will be followed up by another PR that adds automatic session creation when new data is received from REDCap.

List of changes:
- Extract REDCap / LORIS mapping methods from `RedcapNotificationHandler` to a new `RedcapMapper` class, allowing to use those methods without a REDCap notification, which is useful to write a clean REDCap bulk import script.
- Move the `getIssueAssignee()` method from the `RedcapConfigParser` class to the `RedcapQueries` (previously `Queries`) class, as the REDCap issue assignee has previously been moved from the XML configuration to the database.
- Correctly rename all relevant variables and methods to match REDCap "event names" and "unique event names". In REDCap, an "event name" is the user-facing name of an event, whereas a "unique event name" is the internal identifier of an event used in most REDCap API routes. The REDCap API naming is a little confusing on that matter. The differences are now correctly reflected in our code.
- Rename some variables for better code expliciteness and consistency (example: `$instrument` -> `$instrument_name`, snake_case as it is the most used convention in the module).

I can go back on some of these changes if someone disagrees.

The PR has been tested on C-BIG dev simultaneously with #9840.