### PR TITLE
Remove debug code in the REDCap module

### DIFF
--- a/modules/redcap/php/endpoints/notifications.class.inc
+++ b/modules/redcap/php/endpoints/notifications.class.inc
@@ -12,10 +12,6 @@
 
 namespace LORIS\redcap\Endpoints;
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 use \LORIS\Http\Endpoint;


### PR DESCRIPTION
Found this while doing some tests. This seems like a security issue.