### PR TITLE
[issue_tracker] Fix permissions

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -173,7 +173,8 @@ class Edit extends \NDB_Page implements ETagCalculator
 
         // Now get issue values
         $issueData  = $this->getIssueData(null, $user);
-        $isOwnIssue = $issueData['reporter'] == $user->getUsername();
+        $isOwnIssue = $issueData['reporter'] ==
+            $this->formatUserInformation($user->getUsername());
         if (!empty($values['issueID'])
             && $values['issueID'] != "new"
         ) { // if an existing issue
@@ -181,7 +182,8 @@ class Edit extends \NDB_Page implements ETagCalculator
             $issueData = $this->getIssueData($issueID, $user);
 
             // Re-set isOwnIssue variable if not a new issue
-            $isOwnIssue = $issueData['reporter'] == $user->getUsername();
+            $isOwnIssue = $issueData['reporter'] ==
+                $this->formatUserInformation($user->getUsername());
 
             $provisioner = (new AttachmentProvisioner($issueID));
             $attachments = (new \LORIS\Data\Table())
@@ -258,14 +260,28 @@ class Edit extends \NDB_Page implements ETagCalculator
         // Give "close" option if user has site close permissions and the issue
         // is at a user site, or if the user has close permissions for all sites,
         // or it is the user's own permission
+        $userHasSite = $user->hasPermission('issue_tracker_close_site_issue') &&
+            $issueData['centerID'] ?
+                $user->hasCenter(new \CenterID((string)$issueData['centerID'])) :
+                false;
         if ($user->hasPermission('issue_tracker_close_all_issue')
-            || ($user->hasPermission('issue_tracker_close_site_issue')
-            && in_array($issueData['centerID'], $user->getCenterIDs()))
+            || $userHasSite
             || ($user->hasPermission('issue_tracker_own_issue')
             && $isOwnIssue)
         ) {
             $statuses['closed'] = 'Closed';
         }
+
+        // Give edit permission if they are able to see all issues, site issues,
+        // or their own issue
+        $hasEditPermission = $user->hasAnyPermission(
+            [
+                'issue_tracker_all_issue',
+                'issue_tracker_site_issue',
+            ]
+        )
+            || ($user->hasPermission('issue_tracker_own_issue')
+            && $isOwnIssue);
 
         $result = [
             'assignees'         => $assignees,
@@ -278,12 +294,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             'instruments'       => $instruments,
             'otherWatchers'     => $otherWatchers,
             'issueData'         => $issueData,
-            'hasEditPermission' => $user->hasAnyPermission(
-                [
-                    'issue_tracker_all_issue',
-                    'issue_tracker_site_issue',
-                ]
-            ),
+            'hasEditPermission' => $hasEditPermission,
             'isOwnIssue'        => $isOwnIssue,
         ];
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -94,7 +94,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             $assignee_expanded = $db->pselect(
                 "SELECT DISTINCT u.Real_name, u.UserID FROM users u
                  LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
-                 WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
+                 WHERE (FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC))
                  AND Active='Y' AND Pending_approval='N'",
                 [
                     'CenterID' => $CenterID,
@@ -142,36 +142,6 @@ class Edit extends \NDB_Page implements ETagCalculator
             }
         }
 
-        // can't set to closed if no any of the persmissions.
-        $reporter         = $db->pselectOne(
-            "SELECT reporter FROM issues WHERE IssueID=:issueID",
-            ['issueID' => $values['issueID']]
-        );
-        $hasPartialAccess = $user->hasAnyPermission(
-            [
-                'issue_tracker_close_site_issue',
-                'issue_tracker_close_all_issue',
-            ]
-        ) || $reporter == $user->getUsername();
-        if ($hasPartialAccess) {
-            $statuses = [
-                'new'          => 'New',
-                'acknowledged' => 'Acknowledged',
-                'assigned'     => 'Assigned',
-                'feedback'     => 'Feedback',
-                'resolved'     => 'Resolved',
-                'closed'       => 'Closed',
-            ];
-        } else {
-            $statuses = [
-                'new'          => 'New',
-                'acknowledged' => 'Acknowledged',
-                'assigned'     => 'Assigned',
-                'feedback'     => 'Feedback',
-                'resolved'     => 'Resolved',
-            ];
-        }
-
         $priorities = [
             'low'       => 'Low',
             'normal'    => 'Normal',
@@ -202,12 +172,16 @@ class Edit extends \NDB_Page implements ETagCalculator
         $instruments = \NDB_BVL_Instrument::getInstrumentNamesList($this->loris);
 
         // Now get issue values
-        $issueData = $this->getIssueData(null, $user);
+        $issueData  = $this->getIssueData(null, $user);
+        $isOwnIssue = $issueData['reporter'] == $user->getUsername();
         if (!empty($values['issueID'])
             && $values['issueID'] != "new"
         ) { // if an existing issue
             $issueID   = intval($values['issueID']);
             $issueData = $this->getIssueData($issueID, $user);
+
+            // Re-set isOwnIssue variable if not a new issue
+            $isOwnIssue = $issueData['reporter'] == $user->getUsername();
 
             $provisioner = (new AttachmentProvisioner($issueID));
             $attachments = (new \LORIS\Data\Table())
@@ -273,8 +247,25 @@ class Edit extends \NDB_Page implements ETagCalculator
         }
         $issueData['comment'] = null;
 
-        $isOwnIssue = $issueData['reporter']
-            == $this->formatUserInformation($user->getUsername());
+        $statuses = [
+            'new'          => 'New',
+            'acknowledged' => 'Acknowledged',
+            'assigned'     => 'Assigned',
+            'feedback'     => 'Feedback',
+            'resolved'     => 'Resolved',
+        ];
+
+        // Give "close" option if user has site close permissions and the issue
+        // is at a user site, or if the user has close permissions for all sites,
+        // or it is the user's own permission
+        if ($user->hasPermission('issue_tracker_close_all_issue')
+            || ($user->hasPermission('issue_tracker_close_site_issue')
+            && in_array($issueData['centerID'], $user->getCenterIDs()))
+            || ($user->hasPermission('issue_tracker_own_issue')
+            && $isOwnIssue)
+        ) {
+            $statuses['closed'] = 'Closed';
+        }
 
         $result = [
             'assignees'         => $assignees,

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -105,16 +105,23 @@ class Issue extends \NDB_Form
             return true;
         }
         $issueData  = \NDB_Factory::singleton()->database()->pselectRow(
-            "SELECT centerID FROM issues WHERE issueID=:issueID",
+            "SELECT centerID, reporter FROM issues WHERE issueID=:issueID",
             ['issueID' => $issueID]
         );
         $centerIDs  = $user->getCenterIDs();
         $centerList = implode(",", $centerIDs);
         $centerList = explode(',', $centerList);
+        $isOwnIssue = $issueData['reporter'] == $user->getUsername();
+
         return (is_null($issueData)
-            || in_array($issueData['centerID'], $centerList)
+            || ($user->hasPermission('issue_tracker_site_issue') &&
+                (
+                    in_array($issueData['centerID'], $centerList) ||
+                    empty($issueData['centerID'])
+                )
+            )
+            || ($user->hasPermission('issue_tracker_own_issue') && $isOwnIssue)
             || ($user->hasPermission('issue_tracker_all_issue'))
-            || (empty($issueData['centerID']))
         );
     }
 

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -111,7 +111,7 @@ class Issue extends \NDB_Form
         $centerIDs  = $user->getCenterIDs();
         $centerList = implode(",", $centerIDs);
         $centerList = explode(',', $centerList);
-        $isOwnIssue = $issueData['reporter'] == $user->getUsername();
+        $isOwnIssue = ($issueData['reporter'] ?? null) == $user->getUsername();
 
         return (is_null($issueData)
             || ($user->hasPermission('issue_tracker_site_issue') &&


### PR DESCRIPTION
## Brief summary of changes
This PR edits the issue tracker code to fix a users abilities for various permissions. Following this PR, users should only be able to do exactly what the permission describes that they should be able to do. 
- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Make sure you do not have access to the issue tracker module without any issue tracker permissions
2. Grant your user the `Issue Tracker: View/Edit/Comment/Close Issues - Own` permission. 
3. Make sure you are able to view, create, and close (in the status option) your own issues and no others. 
4. Other issues should not be viewable in the filterable datatable or through a direct link
5. Grant your use the `Issue Tracker: View/Edit/Comment Issues - Own Sites` permission. 
6. You should now be able to view, edit, and comment on issues at your user's sites, or at "All sites", but not issues at a site that your user does not have permission to (through filterable datatable or a direct link)
7. You should still only be able to close your own issues. Issues other than your own should not have "Closed" in the status drop down
8. Next, give your user the `Issue Tracker: Close Issues - Own Sites` permission.
9. The "Closed" option should now show up in your own issues and issues at sites that you have permission to, but not at issues that have "All sites" selected
10. Next, give your user the `Issue Tracker: View/Edit/Comment Issues - All Sites` permission. 
11. You should now be able to see, edit, and comment on all issues, but only close your own issues or issues at your sites
12. Lastly, give yourself the `Issue Tracker: Close Issues - All Sites` permission. You should now be able to see, edit, comment, and close all issues.

#### Link(s) to related issue(s)

* Resolves # None