### PR TITLE
[candidate_parameters] Add hasAccess to module class #9834 

### DIFF
--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -14,6 +14,19 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
+     * @param \User $user The user whose access is being checked.
+     *
+     * @return bool whether access is granted
+     */
+    public function hasAccess(\User $user) : bool
+    {
+        return parent::hasAccess($user) &&
+		$user->hasAnyPermission(['candidate_parameter_view',
+		       	'candidate_parameter_edit']);
+    }	
+    /**
+     * {@inheritDoc}
+     *
      * @return string The human readable name for this module
      */
     public function getLongName() : string

--- a/modules/dictionary/php/categories.class.inc
+++ b/modules/dictionary/php/categories.class.inc
@@ -39,9 +39,18 @@ class Categories extends \NDB_Page
 
         $modulesassoc = [];
 
-        foreach ($modulesandcats['Modules'] as $module) {
+	foreach ($modulesandcats['Modules'] as $module) {
             $modulesassoc[$module->getName()] = $module->getLongName();
-        }
+	}
+           if (!$user->hasAnyPermission(
+                [
+                    'acknowledgements_view',
+                    'acknowledgements_edit'
+                ]
+	   ) || !$user->hasPermission('superuser')) {
+	           unset($modulesassoc['candidate_parameters']);
+        unset($modulesandcats['Categories']['candidate_parameters']); 
+	   }
 
         return new \LORIS\Http\Response\JSON\OK(
             [


### PR DESCRIPTION
## Brief summary of changes

[candidate_parameters] Add hasAccess to module class #9834

Add hasAccess to module class and dataquery 

Test:
The user can't view the candidate_parameters module in dataquery without the candidate_parameter_view  or candidate_parameter_edit permissions. 