### PR TITLE
fix cs error in github actions

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -253,8 +253,8 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
             . join('),(', $candidates)
             . ')';
         if (is_array($candidates) && !empty($candidates)) {
-        $q = $DB->prepare($insertstmt);
-        $q->execute([]);        
+            $q = $DB->prepare($insertstmt);
+            $q->execute([]);
         }
         $rows = $DB->pselect(
             "SELECT c.CandID, CommentID FROM flag f


### PR DESCRIPTION
" FILE: ...r/work/Loris/Loris/modules/instruments/php/instrumentqueryengine.class.inc

 256 | ERROR | [x] Line indented incorrectly; expected at least 12 spaces,
     |       |     found 8
 257 | ERROR | [x] Line indented incorrectly; expected at least 12 spaces,
     |       |     found 8
 257 | ERROR | [x] Whitespace found at end of line

Time: [37](https://github.com/aces/Loris/actions/runs/15588881822/job/43902390350?pr=9843#step:12:38).25 secs; Memory: 28MB
make: *** [Makefile:[38](https://github.com/aces/Loris/actions/runs/15588881822/job/43902390350?pr=9843#step:12:39): checkstatic] Error 2"