### PR TITLE
[dataquery] Add 'PSCID' as a default field

### DIFF
--- a/modules/dataquery/jsx/hooks/usequery.tsx
+++ b/modules/dataquery/jsx/hooks/usequery.tsx
@@ -50,7 +50,7 @@ function useQuery(): useQueryReturnType {
   const [fields, setFields] = useState<APIQueryField[]>([{
     'module': 'candidate_parameters',
     'category': 'Identifiers',
-    'field': 'PSCID'
+    'field': 'PSCID',
   }]);
   const [criteria, setCriteria] = useState<QueryGroup>(new QueryGroup('and'));
 


### PR DESCRIPTION
Closes #9838

This encourages the user to use the Candidate Identifier "PSCID" to prevent empty rows when visits are empty.