### PR TITLE
[DQT beta] fix or to and for candidate parameters

### DIFF
--- a/modules/dictionary/php/categories.class.inc
+++ b/modules/dictionary/php/categories.class.inc
@@ -42,16 +42,6 @@ class Categories extends \NDB_Page
         foreach ($modulesandcats['Modules'] as $module) {
             $modulesassoc[$module->getName()] = $module->getLongName();
         }
-        if (!$user->hasAnyPermission(
-            [
-                'candidate_parameter_view',
-                'candidate_parameter_edit'
-            ]
-        ) && !$user->hasPermission('superuser')
-        ) {
-               unset($modulesassoc['candidate_parameters']);
-            unset($modulesandcats['Categories']['candidate_parameters']);
-        }
 
         return new \LORIS\Http\Response\JSON\OK(
             [


### PR DESCRIPTION
[DQT beta] fix or to and for candidate parameters
if an user does not have any candidate_parameters_edit or view perm **AND** does not have the superuser perm will disable the candidate parameters option in new DQT. 