### PR TITLE
[dataquery] Return 0 results when a query is partially built

### DIFF
--- a/modules/dataquery/php/query.class.inc
+++ b/modules/dataquery/php/query.class.inc
@@ -766,10 +766,17 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
             \Profiler::checkpoint("Done group");
         }
         $combinedresult = [];
-        if (count($results) == 1) {
+        switch (count($results)) {
+        case 0:
+            // One side has the empty set as part of the criteria. This can
+            // happen while building a query, and is better than crashing.
+            $combinedresult = [];
+            break;
+        case 1:
             // Doesn't matter if it's 'and' or 'or', there's only 1 criteria
             $combinedresult = $results[0];
-        } else {
+            break;
+        default:
             if ($criteria['operator'] == 'and') {
                 $combinedresult = array_intersect(...$results);
             } else if ($criteria['operator'] == 'or') {


### PR DESCRIPTION
When a query is being built there are situations where an empty set is part of the query. This is logically equivalent to code that says "if (x and) { ..}" and clearly wrong in the general case but can happen while constructing the query as it's not yet complete and gets submitted to get a count.

Update the query class to return 0 results in that case instead of crashing.

Fixes #9851
