### PR TITLE
[dictionary] Fixes description field been populated with the latest select option, not the actual field name.

### DIFF
--- a/php/libraries/LorisFormDictionaryImpl.class.inc
+++ b/php/libraries/LorisFormDictionaryImpl.class.inc
@@ -97,14 +97,14 @@ trait LorisFormDictionaryImpl
                 // the array and coerce things to a string.
                 $keys   = [];
                 $labels = [];
-                foreach ($element['options'] as $key => $label) {
+                foreach ($element['options'] as $key => $olabel) {
                     if ($key === '' || $key === null) {
                         continue;
                     }
 
                     // Coerce it to a string
                     $keys[]   = "$key";
-                    $labels[] = "$label";
+                    $labels[] = "$olabel";
                 }
                 if (array_key_exists('multiple', $element)) {
                     $card = new Cardinality(Cardinality::MANY);


### PR DESCRIPTION
## Brief summary of changes
Modifies LorisFormDictionaryImpl.class.inc library file to properly populate the values in the data-dictionary. Thus it fixed the original issue identified in the dataquery module.

#### Testing instructions (if applicable)

1. Go the new dictionary.
2. The fields should be properly populated and the issue reported and commented in #9801 not longer present. 

#### Link(s) to related issue(s)

* Resolves #9801 
