### PR TITLE
Update version number in LORIS 27 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 
 * Try the LORIS demo instance at https://demo.loris.ca.
 
-This Readme covers installation of LORIS version <b>26.0</b> on <b>Ubuntu</b>.
+This Readme covers installation of LORIS version <b>27.0</b> on <b>Ubuntu</b>.
 
 ([CentOS Readme also available](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -10,9 +10,9 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 # System Requirements - Install dependencies
 
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
-* MariaDB 10.3 is supported for LORIS 26.
+* MariaDB 10.3 is supported for LORIS 27.
 
-* PHP 8.2 (or higher) is supported for LORIS 26.
+* PHP 8.3 (or higher) is supported for LORIS 27.
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher  

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -18,7 +18,7 @@ LORIS requires a LAMP stack in order to run, specifically:
 
 * MySQL 5.7 (or MariaDB 10.3) (or higher)
 
-* PHP 8.1 (or higher)
+* PHP 8.3 (or higher)
 
 Additionally, the following package manager are required to build LORIS:  
 
@@ -46,19 +46,19 @@ The following Ubuntu packages are required and should be installed using
 
 * software-properties-common
 
-* php8.2-mysql
+* php8.3-mysql
 
-* php8.2-xml
+* php8.3-xml
 
-* php8.2-mbstring
+* php8.3-mbstring
 
-* php8.2-gd
+* php8.3-gd
 
-* php8.2-zip
+* php8.3-zip
 
-* php8.2-curl (for development instances only)
+* php8.3-curl (for development instances only)
 
-* libapache2-mod-php8.2
+* libapache2-mod-php8.3
 
 ## Creating the lorisadmin user
 Create the _lorisadmin_ user and group and give _lorisadmin_ `sudo` permission. 


### PR DESCRIPTION
Change the same locations as PR#9297 did for LORIS 26.

Also update the PHP minimum version to match what's tested by GitHub Actions.

Fixes #9823