### PR TITLE
[dataquery - jsx/Modal] Add 'name' attribute to FormElement

### DIFF
--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -212,7 +212,10 @@ const Modal = ({
         </div>
         <div>
           {onSubmit ? (
-            <FormElement onSubmit={handleSubmit}>
+            <FormElement
+              name='modal'
+              onSubmit={handleSubmit}
+            >
               {content}
             </FormElement>
           ) : content}


### PR DESCRIPTION
Closes #9854.

This was not a critical error but is fixed by adding `name` to `FormElement` in `jsx/Modal.tsx`