### PR TITLE
[imaging_browser] Fix invalid query in imaging browser's query engine

### DIFF
--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -466,6 +466,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                   WHERE files2.FileID=files.FileID
                       AND mst.MriScanTypeName='%s'
                 )",
+                $item->getParameterTypeName(),
                 $modality
             );
         }


### PR DESCRIPTION
This PR fixes an invalid query in the imaging browser's query engine (a `printf` statement with two placeholders and only one argument).