### PR TITLE
[dataquery] Changes to table dataquery_queries are not saved in the history table anymore

### DIFF
--- a/modules/dataquery/php/endpoints/queries.class.inc
+++ b/modules/dataquery/php/endpoints/queries.class.inc
@@ -125,7 +125,7 @@ class Queries extends \LORIS\Http\Endpoint
         );
         if ($queryID === null) {
             // Dealing with JSON need to use the unsafe wrapper
-            $oldTrackChanges = $DB->_trackChanges;
+            $oldTrackChanges   = $DB->_trackChanges;
             $DB->_trackChanges = false;
             $DB->unsafeInsert(
                 'dataquery_queries',
@@ -134,7 +134,7 @@ class Queries extends \LORIS\Http\Endpoint
                 ],
             );
             $DB->_trackChanges = $oldTrackChanges;
-            $queryID = $DB->getLastInsertId();
+            $queryID           = $DB->getLastInsertId();
         }
         return intval($queryID);
     }

--- a/modules/dataquery/php/endpoints/queries.class.inc
+++ b/modules/dataquery/php/endpoints/queries.class.inc
@@ -125,12 +125,15 @@ class Queries extends \LORIS\Http\Endpoint
         );
         if ($queryID === null) {
             // Dealing with JSON need to use the unsafe wrapper
+            $oldTrackChanges = $DB->_trackChanges;
+            $DB->_trackChanges = false;
             $DB->unsafeInsert(
                 'dataquery_queries',
                 [
                     'Query'  => $requestjson,
                 ],
             );
+            $DB->_trackChanges = $oldTrackChanges;
             $queryID = $DB->getLastInsertId();
         }
         return intval($queryID);


### PR DESCRIPTION
This PR modifies the data query endpoint so that changes to table `dataquery_queries` are not saved in the `history` table anymore.

Fixes #9847 