### PR TITLE
[dataquery]Remove Strikethrough From New Flters Subgroup

### DIFF
--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -343,6 +343,7 @@ function DefineFilters(props: {
             backgroundColour='rgb(240, 240, 240)'
             newGroup={props.addNewQueryGroup}
             fulldictionary={props.fulldictionary}
+            setDeleteItemIndex={setDeleteItemIndex}
           />
         </fieldset>
       </form>

--- a/modules/dataquery/jsx/querytree.tsx
+++ b/modules/dataquery/jsx/querytree.tsx
@@ -3,6 +3,7 @@ import {QueryGroup, QueryTerm} from './querydef';
 import {CriteriaTerm} from './criteriaterm';
 import {ButtonElement} from 'jsx/Form';
 import {FullDictionary} from './types';
+import {useEffect} from 'react'; // already present
 
 /**
  * Alternate background colour for a QueryTree
@@ -54,12 +55,18 @@ function QueryTree(props: {
     newItem?: (items: QueryGroup) => void,
     removeQueryGroupItem?: (items: QueryGroup, i: number) => QueryGroup,
     setModalGroup?: (newgroup: QueryGroup) => void,
+    setDeleteItemIndex?: (index: number | null) => void,
     fulldictionary: FullDictionary,
     mapModuleName: (module: string) => string,
     mapCategoryName: (module: string, category: string) => string,
 }) {
   const [deleteItemIndex, setDeleteItemIndex] = useState<number|null>(null);
 
+  useEffect(() => {
+    // Reset strikethrough when group is empty or changed
+    setDeleteItemIndex(null);
+  }, [props.items]);
+  
   /**
    * Render a single term of the QueryTree group.
    *
@@ -98,6 +105,9 @@ function QueryTree(props: {
               );
               if (props.setModalGroup) {
                 props.setModalGroup(newquery);
+              }
+              if (props.setDeleteItemIndex) {
+                props.setDeleteItemIndex(null);
               }
             }
           };
@@ -156,7 +166,7 @@ function QueryTree(props: {
                   }
                   subtree={true}
                   fulldictionary={props.fulldictionary}
-
+                  setDeleteItemIndex={props.setDeleteItemIndex}
                 />
               </div>
               <div style={operatorStyle}>{operator}</div>

--- a/modules/dataquery/jsx/querytree.tsx
+++ b/modules/dataquery/jsx/querytree.tsx
@@ -65,7 +65,7 @@ function QueryTree(props: {
   useEffect(() => {
     // Reset strikethrough when group is empty or changed
     setDeleteItemIndex(null);
-  }, [props.items]);
+  }, [props.items.group.length]);
 
   /**
    * Render a single term of the QueryTree group.

--- a/modules/dataquery/jsx/querytree.tsx
+++ b/modules/dataquery/jsx/querytree.tsx
@@ -66,7 +66,7 @@ function QueryTree(props: {
     // Reset strikethrough when group is empty or changed
     setDeleteItemIndex(null);
   }, [props.items]);
-  
+
   /**
    * Render a single term of the QueryTree group.
    *


### PR DESCRIPTION
## Brief summary of changes

- Removing the strikethrough from the subgroup after delete and re-add.

#### Testing instructions (if applicable)

1. go to Beta(dataquery).
2. Add filters.
3. Add a condition (Add two conditions).
4. Add a subgroup and remove it.
5. Re-add the subgroup. You will notice the strikethrough is removed.

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/9849
