### PR TITLE
[dataquery] Fixed Import csv for Empty csv and submitting without uploading

### DIFF
--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -24,7 +24,7 @@ function ImportCSVModal(props: {
    * Promise for handling modal closing. Always accepts.
    * @returns {Promise} - a stub promise
    */
- const submitPromise = () =>
+  const submitPromise = () =>
     new Promise((resolve, reject) => {
       if (!csvFile) {
         swal.fire({
@@ -53,7 +53,7 @@ function ImportCSVModal(props: {
         title: 'Invalid CSV',
         text: 'Could not parse CSV file',
       });
-      setCSVFile(null); 
+      setCSVFile(null);
       return;
     }
 
@@ -65,7 +65,7 @@ function ImportCSVModal(props: {
         title: 'Empty CSV',
         text: 'The uploaded CSV file is empty.',
       });
-      setCSVFile(null); 
+      setCSVFile(null);
       return;
     }
 


### PR DESCRIPTION
## Brief summary of changes

1. An error is thrown for empty CSVs for both choices in the 'CSV containing list of' dropdown (Candidates and Sessions)
2. If an incorrectly formatted csv is uploaded, it is cleared from selection and not allowed to submit.
3. If user clicks on 'Submit' without uploading a csv, an error is thrown.

#### Testing instructions 

1. Go to DQT (Beta)
2. Click on "Continue to Define Field"
3. Select any number of fields
4. Under Define Filters, click on "Import from CSV"
5. In the ‘CSV containing a list of’ dropdown:
       - First select Candidates
       - Upload an empty CSV file.
       -> An error message would be thrown and no CSV would be loaded
6. Repeat the same steps but this time:
     -Select Sessions
     -Upload an empty CSV file.
     -> An error message would be thrown and no CSV would be loaded
7. After step 4, Click on Submit without uploading any CSV. An error would be thrown notifying the user that no CSV is uploaded.


#### Link(s) to related issue(s)

* Resolves #9880 
