### PR TITLE
The SQL engine now supports dictionary names containing question marks

### DIFF
--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -167,14 +167,17 @@ abstract class SQLQueryEngine implements QueryEngine
         $sessionVariables = false;
         $keyFields        = [];
         foreach ($items as $dict) {
+            // Quote the question marks otherwise PDO will interpret
+            // these as positional placeholders
+            $dictName = str_replace('?', '??', $dict->getName());
             $fields[] = $this->getFieldNameFromDict($dict)
                 . ' as '
-                . "`{$dict->getName()}`";
+                . "`$dictName`";
             if ($dict->getScope() == 'session') {
                 $sessionVariables = true;
             }
             if ($dict->getCardinality()->__toString() === "many") {
-                $keyFields[] = $this->getCorrespondingKeyField($dict) . " as `{$dict->getName()}:key`";
+                $keyFields[] = $this->getCorrespondingKeyField($dict) . " as `$dictName:key`";
             }
         }
 
@@ -213,6 +216,8 @@ abstract class SQLQueryEngine implements QueryEngine
         $query .= ' ORDER BY c.CandID';
         $rows   = $DB->prepare($query);
 
+        error_log("***** query is $query\n");
+        error_log("***** prepbindings = " . print_r($prepbindings, true));
         $result = $rows->execute($prepbindings);
 
         if ($result === false) {

--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -216,8 +216,6 @@ abstract class SQLQueryEngine implements QueryEngine
         $query .= ' ORDER BY c.CandID';
         $rows   = $DB->prepare($query);
 
-        error_log("***** query is $query\n");
-        error_log("***** prepbindings = " . print_r($prepbindings, true));
         $result = $rows->execute($prepbindings);
 
         if ($result === false) {


### PR DESCRIPTION
This PR fixes a bug that would cause the queries run by the SQL engine to fail if any of the variables it depended on contained a question mark. The PR escapes escapes the question marks so that PDO does not interpret them as positional placeholders.

Reference: [https://www.php.net/manual/en/pdo.prepare.php](url)

Fixes #9884 