### PR TITLE
[document_repository] - fix global filter always return null.

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -86,7 +86,7 @@ class DocIndex extends React.Component {
         });
         let filterData = this.state.data.Data;
         let fillData = filterData.filter((data) => {
-          return Object.values(nodesArray).includes(data[10]);
+          return Object.values(nodesArray).includes(data[10].toString());
         });
         this.setState({
           global: true,


### PR DESCRIPTION
[document_repository] global filter returning null and crashing when used inside a folder  #9892
[document_repository] Fix global filter returning null and crashing when used inside a folder
test: Clicking the global filter should display a table containing all files.

