### PR TITLE
Translate DataTable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ locales:
 	msgfmt -o modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.mo modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
 
 
+acknowledgements:
+	target=acknowledgements npm run compile
+
 data_release: 
 	target=data_release npm run compile
 
@@ -145,4 +148,7 @@ dashboard:
 
 publication:
 	target=publication npm run compile
+
+server_processes_manager:
+	target=server_processes_manager npm run compile
 

--- a/Makefile
+++ b/Makefile
@@ -152,3 +152,5 @@ publication:
 server_processes_manager:
 	target=server_processes_manager npm run compile
 
+conflict_resolver:
+	target=conflict_resolver npm run compile

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import PaginationLinks from 'jsx/PaginationLinks';
 import createFragment from 'react-addons-create-fragment';
 import {CTA} from 'jsx/Form';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Data Table component
@@ -555,7 +556,12 @@ class DataTable extends Component {
       </select>
     );
 
-    const loading = this.props.loading ? 'Loading...' : '';
+    // This doesn't feel like a very robust way to handle the dropdown.
+    // It's not clear if there's any good way to structure this for locales that
+    // use RTL languages or prefer a different kind of parenthesis.
+    let changeRowsDropdown = <span>
+       ({this.props.t('Maximum rows per page:')} {rowsPerPageDropdown})
+    </span>;
 
     let header = this.props.hide.rowsPerPage === true ? '' : (
       <div className="table-header">
@@ -571,9 +577,14 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-              {rows.length} rows displayed of {filteredCount}.
-              (Maximum rows per page: {rowsPerPageDropdown})
-              {loading}
+              {this.props.t(
+                '{{pageCount}} rows displayed of {{totalCount}}.',
+                {
+                  pageCount: rows.length,
+                  totalCount: filteredCount,
+                }
+              )}
+              {changeRowsDropdown}
             </div>
             <div style={{
               order: '2',
@@ -590,7 +601,7 @@ class DataTable extends Component {
                   className="btn btn-primary"
                   onClick={this.downloadCSV.bind(null, filteredRowIndexes)}
                 >
-                Download Table as CSV
+                  {this.props.t('Download Table as CSV')}
                 </button>)
               }
               <PaginationLinks
@@ -619,8 +630,14 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-              {rows.length} rows displayed of {filteredCount}.
-              (Maximum rows per page: {rowsPerPageDropdown})
+              {this.props.t(
+                '{{pageCount}} rows displayed of {{totalCount}}.',
+                {
+                  pageCount: rows.length,
+                  totalCount: filteredCount,
+                }
+              )}
+              {changeRowsDropdown}
             </div>
             <div style={{
               order: '2',
@@ -678,6 +695,9 @@ DataTable.propTypes = {
   freezeColumn: PropTypes.string,
   loading: PropTypes.element,
   folder: PropTypes.element,
+
+  // Provided by withTranslation HOC
+  t: PropTypes.func,
 };
 DataTable.defaultProps = {
   headers: [],
@@ -693,4 +713,4 @@ DataTable.defaultProps = {
   noDynamicTable: false,
 };
 
-export default DataTable;
+export default withTranslation(['loris'])(DataTable);

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import PaginationLinks from 'jsx/PaginationLinks';
 import createFragment from 'react-addons-create-fragment';
 import {CTA} from 'jsx/Form';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Data Table component
@@ -557,6 +558,11 @@ class DataTable extends Component {
 
     const loading = this.props.loading ? 'Loading...' : '';
 
+    // This doesn't feel like a very robust way to handle the dropdown.
+    // It's not clear if there's any good way to structure this for locales that
+    // use RTL languages or prefer a different kind of parenthesis.
+    let changeRowsDropdown = <span>({this.props.t('Maximum rows per page:')} {rowsPerPageDropdown})</span>;
+
     let header = this.props.hide.rowsPerPage === true ? '' : (
       <div className="table-header">
         <div className="row">
@@ -571,9 +577,12 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-              {rows.length} rows displayed of {filteredCount}.
-              (Maximum rows per page: {rowsPerPageDropdown})
-              {loading}
+	    {this.props.t('{{rowLength}} rows displayed of {{filteredCount}}.',
+	      {
+		      rowLength: rows.length,
+		      filteredCount,
+	      })}
+	    {changeRowsDropdown}
             </div>
             <div style={{
               order: '2',
@@ -590,7 +599,7 @@ class DataTable extends Component {
                   className="btn btn-primary"
                   onClick={this.downloadCSV.bind(null, filteredRowIndexes)}
                 >
-                Download Table as CSV
+		      {this.props.t('Download Table as CSV')}
                 </button>)
               }
               <PaginationLinks
@@ -619,8 +628,12 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-              {rows.length} rows displayed of {filteredCount}.
-              (Maximum rows per page: {rowsPerPageDropdown})
+	    {this.props.t('{{rowLength}} rows displayed of {{filteredCount}}.',
+	      {
+		      rowLength: rows.length,
+		      filteredCount,
+	      })}
+	    {changeRowsDropdown}
             </div>
             <div style={{
               order: '2',
@@ -693,4 +706,4 @@ DataTable.defaultProps = {
   noDynamicTable: false,
 };
 
-export default DataTable;
+export default withTranslation(['loris'])(DataTable);

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import PaginationLinks from 'jsx/PaginationLinks';
 import createFragment from 'react-addons-create-fragment';
 import {CTA} from 'jsx/Form';
-import {withTranslation} from 'react-i18next';
 
 /**
  * Data Table component
@@ -558,11 +557,6 @@ class DataTable extends Component {
 
     const loading = this.props.loading ? 'Loading...' : '';
 
-    // This doesn't feel like a very robust way to handle the dropdown.
-    // It's not clear if there's any good way to structure this for locales that
-    // use RTL languages or prefer a different kind of parenthesis.
-    let changeRowsDropdown = <span>({this.props.t('Maximum rows per page:')} {rowsPerPageDropdown})</span>;
-
     let header = this.props.hide.rowsPerPage === true ? '' : (
       <div className="table-header">
         <div className="row">
@@ -577,12 +571,9 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-	    {this.props.t('{{rowLength}} rows displayed of {{filteredCount}}.',
-	      {
-		      rowLength: rows.length,
-		      filteredCount,
-	      })}
-	    {changeRowsDropdown}
+              {rows.length} rows displayed of {filteredCount}.
+              (Maximum rows per page: {rowsPerPageDropdown})
+              {loading}
             </div>
             <div style={{
               order: '2',
@@ -599,7 +590,7 @@ class DataTable extends Component {
                   className="btn btn-primary"
                   onClick={this.downloadCSV.bind(null, filteredRowIndexes)}
                 >
-		      {this.props.t('Download Table as CSV')}
+                Download Table as CSV
                 </button>)
               }
               <PaginationLinks
@@ -628,12 +619,8 @@ class DataTable extends Component {
               order: '1',
               padding: '5px 0',
             }}>
-	    {this.props.t('{{rowLength}} rows displayed of {{filteredCount}}.',
-	      {
-		      rowLength: rows.length,
-		      filteredCount,
-	      })}
-	    {changeRowsDropdown}
+              {rows.length} rows displayed of {filteredCount}.
+              (Maximum rows per page: {rowsPerPageDropdown})
             </div>
             <div style={{
               order: '2',
@@ -706,4 +693,4 @@ DataTable.defaultProps = {
   noDynamicTable: false,
 };
 
-export default withTranslation(['loris'])(DataTable);
+export default DataTable;

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -11,6 +11,7 @@ import {
   TextboxElement,
 } from 'jsx/Form';
 import DateTimePartialElement from 'jsx/form/DateTimePartialElement';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Filter component
@@ -160,7 +161,7 @@ function Filter(props) {
       {filterPresets()}
       <li>
         <a role='button' name='reset' onClick={props.clearFilters}>
-          Clear Filter
+	  {props.t('Clear Filters')}
         </a>
       </li>
     </ul>
@@ -204,4 +205,4 @@ Filter.propTypes = {
   clearFilters: PropTypes.func,
 };
 
-export default Filter;
+export default withTranslation(['loris'])(Filter);

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -11,7 +11,6 @@ import {
   TextboxElement,
 } from 'jsx/Form';
 import DateTimePartialElement from 'jsx/form/DateTimePartialElement';
-import {withTranslation} from 'react-i18next';
 
 /**
  * Filter component
@@ -161,7 +160,7 @@ function Filter(props) {
       {filterPresets()}
       <li>
         <a role='button' name='reset' onClick={props.clearFilters}>
-	  {props.t('Clear Filters')}
+          Clear Filter
         </a>
       </li>
     </ul>
@@ -205,4 +204,4 @@ Filter.propTypes = {
   clearFilters: PropTypes.func,
 };
 
-export default withTranslation(['loris'])(Filter);
+export default Filter;

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -11,6 +11,7 @@ import {
   TextboxElement,
 } from 'jsx/Form';
 import DateTimePartialElement from 'jsx/form/DateTimePartialElement';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Filter component
@@ -160,7 +161,7 @@ function Filter(props) {
       {filterPresets()}
       <li>
         <a role='button' name='reset' onClick={props.clearFilters}>
-          Clear Filter
+          {props.t('Clear Filters')}
         </a>
       </li>
     </ul>
@@ -202,6 +203,8 @@ Filter.propTypes = {
   filterPresets: PropTypes.array,
   updateFilters: PropTypes.func,
   clearFilters: PropTypes.func,
+  // Provided by withTranslation HOC
+  t: PropTypes.func,
 };
 
-export default Filter;
+export default withTranslation(['loris'])(Filter);

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -6,6 +6,8 @@ import DataTable from 'jsx/DataTable';
 import Filter from 'jsx/Filter';
 import ProgressBar from 'jsx/ProgressBar';
 
+import {withTranslation} from 'react-i18next';
+
 /**
  * FilterableDataTable component.
  * A wrapper for all datatables that handles filtering.
@@ -141,6 +143,7 @@ class FilterableDataTable extends Component {
         id={this.props.name + '_filter'}
         columns={this.props.columns}
         filters={filters}
+        title={this.props.t('Selection Filter')}
         filterPresets={this.props.filterPresets}
         fields={this.props.fields}
         addFilter={this.addFilter}
@@ -202,4 +205,4 @@ FilterableDataTable.propTypes = {
   children: PropTypes.node,
 };
 
-export default FilterableDataTable;
+export default withTranslation(['loris'])(FilterableDataTable);

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -6,8 +6,6 @@ import DataTable from 'jsx/DataTable';
 import Filter from 'jsx/Filter';
 import ProgressBar from 'jsx/ProgressBar';
 
-import {withTranslation} from 'react-i18next';
-
 /**
  * FilterableDataTable component.
  * A wrapper for all datatables that handles filtering.
@@ -143,7 +141,6 @@ class FilterableDataTable extends Component {
         id={this.props.name + '_filter'}
         columns={this.props.columns}
         filters={filters}
-        title={this.props.t('Selection Filter')}
         filterPresets={this.props.filterPresets}
         fields={this.props.fields}
         addFilter={this.addFilter}
@@ -205,4 +202,4 @@ FilterableDataTable.propTypes = {
   children: PropTypes.node,
 };
 
-export default withTranslation(['loris'])(FilterableDataTable);
+export default FilterableDataTable;

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -6,6 +6,8 @@ import DataTable from 'jsx/DataTable';
 import Filter from 'jsx/Filter';
 import ProgressBar from 'jsx/ProgressBar';
 
+import {withTranslation} from 'react-i18next';
+
 /**
  * FilterableDataTable component.
  * A wrapper for all datatables that handles filtering.
@@ -141,6 +143,7 @@ class FilterableDataTable extends Component {
         id={this.props.name + '_filter'}
         columns={this.props.columns}
         filters={filters}
+        title={this.props.t('Selection Filter')}
         filterPresets={this.props.filterPresets}
         fields={this.props.fields}
         addFilter={this.addFilter}
@@ -200,6 +203,9 @@ FilterableDataTable.propTypes = {
   folder: PropTypes.element,
   nullTableShow: PropTypes.element,
   children: PropTypes.node,
+
+  // Provided by withTranslation HOC
+  t: PropTypes.func,
 };
 
-export default FilterableDataTable;
+export default withTranslation(['loris'])(FilterableDataTable);

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -165,3 +165,13 @@ msgstr "フィードバック"
 
 msgid "Scans"
 msgstr "スキャン"
+
+# Data table strings
+msgid "{{rowLength}} rows displayed of {{filteredCount}}."
+msgstr "{{filteredCount}}行中{{rowLength}}行を表示"
+
+msgid "Maximum rows per page:"
+msgstr "ページあたりの最大行数:"
+
+msgid "Download Table as CSV"
+msgstr "表をCSVとしてダウンロード"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -165,13 +165,3 @@ msgstr "フィードバック"
 
 msgid "Scans"
 msgstr "スキャン"
-
-# Data table strings
-msgid "{{rowLength}} rows displayed of {{filteredCount}}."
-msgstr "{{filteredCount}}行中{{rowLength}}行を表示"
-
-msgid "Maximum rows per page:"
-msgstr "ページあたりの最大行数:"
-
-msgid "Download Table as CSV"
-msgstr "表をCSVとしてダウンロード"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -165,3 +165,13 @@ msgstr "フィードバック"
 
 msgid "Scans"
 msgstr "スキャン"
+
+# Data table strings
+msgid "{{pageCount}} rows displayed of {{totalCount}}."
+msgstr "{{totalCount}}行中{{pageCount}}行を表示"
+
+msgid "Maximum rows per page:"
+msgstr "ページあたりの最大行数:"
+
+msgid "Download Table as CSV"
+msgstr "表をCSVとしてダウンロード"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -152,3 +152,13 @@ msgstr ""
 
 msgid "Scans"
 msgstr ""
+
+# Data table strings
+msgid "{{rowLength}} rows displayed of {{filteredCount}}."
+msgstr ""
+
+msgid "Maximum rows per page:"
+msgstr ""
+
+msgid "Download Table as CSV"
+msgstr ""

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -152,13 +152,3 @@ msgstr ""
 
 msgid "Scans"
 msgstr ""
-
-# Data table strings
-msgid "{{rowLength}} rows displayed of {{filteredCount}}."
-msgstr ""
-
-msgid "Maximum rows per page:"
-msgstr ""
-
-msgid "Download Table as CSV"
-msgstr ""

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -152,3 +152,13 @@ msgstr ""
 
 msgid "Scans"
 msgstr ""
+
+# Data table strings
+msgid "{{pageCount}} rows displayed of {{totalCount}}."
+msgstr ""
+
+msgid "Maximum rows per page:"
+msgstr ""
+
+msgid "Download Table as CSV"
+msgstr ""

--- a/modules/acknowledgements/jsx/acknowledgementsIndex.js
+++ b/modules/acknowledgements/jsx/acknowledgementsIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import swal from 'sweetalert2';
 import Modal from 'Modal';
 import Panel from 'Panel';
@@ -480,10 +483,14 @@ AcknowledgementsIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'acknowledgements', {});
+  const Index = withTranslation(
+    ['acknowledgements', 'loris']
+  )(AcknowledgementsIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <AcknowledgementsIndex
+    <Index
       dataURL={`${loris.BaseURL}/acknowledgements/?format=json`}
       submitURL={`${loris.BaseURL}/acknowledgements/AcknowledgementsProcess`}
       hasPermission={loris.userHasPermission}

--- a/modules/battery_manager/jsx/batteryManagerIndex.js
+++ b/modules/battery_manager/jsx/batteryManagerIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import Modal from 'Modal';
@@ -512,10 +515,14 @@ BatteryManagerIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'battery_manager', {});
+  const Index = withTranslation(
+    ['battery_manager', 'loris']
+  )(BatteryManagerIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <BatteryManagerIndex
+    <Index
       testEndpoint={`${loris.BaseURL}/battery_manager/testendpoint/`}
       optionEndpoint={`${loris.BaseURL}/battery_manager/testoptionsendpoint`}
       hasPermission={loris.userHasPermission}

--- a/modules/behavioural_qc/jsx/behaviouralQCIndex.js
+++ b/modules/behavioural_qc/jsx/behaviouralQCIndex.js
@@ -1,6 +1,10 @@
 import {createRoot} from 'react-dom/client';
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import {TabPane, Tabs} from 'jsx/Tabs';
 import IncompleteForms from './tabs_content/incompleteForms';
 import DataConflicts from './tabs_content/dataConflicts';
@@ -51,10 +55,14 @@ BehaviouralQC.propTypes = {
  * Render Behavioural Quality Control on page load.
  */
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'behavioural_qc', {});
+  const Index = withTranslation(
+    ['behavioural_qc', 'loris']
+  )(BehaviouralQC);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <BehaviouralQC
+    <Index
       baseURL={loris.BaseURL}
     />
   );

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -123,6 +123,7 @@ class CandidateListIndex extends Component {
 
   /**
    * Modify behaviour of specified column cells in the Data Table component
+   *
    * @param {string} column - column name
    * @param {string} cell - cell content
    * @param {object} row - row content indexed by column

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -123,7 +123,6 @@ class CandidateListIndex extends Component {
 
   /**
    * Modify behaviour of specified column cells in the Data Table component
-   *
    * @param {string} column - column name
    * @param {string} cell - cell content
    * @param {object} row - row content indexed by column

--- a/modules/conflict_resolver/jsx/conflict_resolver.js
+++ b/modules/conflict_resolver/jsx/conflict_resolver.js
@@ -1,9 +1,11 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import {Tabs, TabPane} from 'Tabs';
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import UnresolvedFilterableDataTable from './unresolved_filterabledatatable';
 import ResolvedFilterableDataTable from './resolved_filterabledatatable';
-import i18n from 'I18nSetup';
 
 /**
  * Conflict Resolver class.
@@ -74,8 +76,11 @@ class ConflictResolver extends Component {
 
 window.addEventListener('load', () => {
   i18n.addResourceBundle('ja', 'conflict_resolver', {});
+  const Index = withTranslation(
+    ['conflict_resolver', 'loris']
+  )(ConflictResolver);
   createRoot(
     document.getElementById('lorisworkspace')
-  ).render(<ConflictResolver />);
+  ).render(<Index />);
 });
 

--- a/modules/conflict_resolver/jsx/conflict_resolver.js
+++ b/modules/conflict_resolver/jsx/conflict_resolver.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import {Tabs, TabPane} from 'Tabs';
 import UnresolvedFilterableDataTable from './unresolved_filterabledatatable';
 import ResolvedFilterableDataTable from './resolved_filterabledatatable';
+import i18n from 'I18nSetup';
 
 /**
  * Conflict Resolver class.
@@ -72,6 +73,7 @@ class ConflictResolver extends Component {
 }
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'conflict_resolver', {});
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(<ConflictResolver />);

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {withTranslation} from 'react-i18next';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -206,4 +207,7 @@ class ResolvedFilterableDataTable extends Component {
   }
 }
 
-export default ResolvedFilterableDataTable;
+export default withTranslation(
+  ['conflict_resolver', 'loris'],
+  ResolvedFilterableDataTable
+);

--- a/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/resolved_filterabledatatable.js
@@ -208,6 +208,5 @@ class ResolvedFilterableDataTable extends Component {
 }
 
 export default withTranslation(
-  ['conflict_resolver', 'loris'],
-  ResolvedFilterableDataTable
-);
+  ['conflict_resolver', 'loris']
+)(ResolvedFilterableDataTable);

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import Loader from 'Loader';
+import {withTranslation} from 'react-i18next';
 import FilterableDataTable from 'FilterableDataTable';
 import FixConflictForm from './fix_conflict_form';
 
@@ -197,4 +198,7 @@ class UnresolvedFilterableDataTable extends Component {
   }
 }
 
-export default UnresolvedFilterableDataTable;
+export default withTranslation(
+  ['conflict_resolver', 'loris'],
+  UnresolvedFilterableDataTable
+);

--- a/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
+++ b/modules/conflict_resolver/jsx/unresolved_filterabledatatable.js
@@ -199,6 +199,5 @@ class UnresolvedFilterableDataTable extends Component {
 }
 
 export default withTranslation(
-  ['conflict_resolver', 'loris'],
-  UnresolvedFilterableDataTable
-);
+  ['conflict_resolver', 'loris']
+)(UnresolvedFilterableDataTable);

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -1,6 +1,10 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -227,10 +231,14 @@ DataDictIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'datadict', {});
+  const Index = withTranslation(
+    ['datadict', 'loris']
+  )(DataDictIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <DataDictIndex
+    <Index
       dataURL={`${loris.BaseURL}/datadict/?format=binary`}
       fieldsURL={`${loris.BaseURL}/datadict/fields`}
     />

--- a/modules/dicom_archive/jsx/dicom_archive.js
+++ b/modules/dicom_archive/jsx/dicom_archive.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -189,9 +192,13 @@ DicomArchive.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'dicom_archive', {});
+  const Index = withTranslation(
+    ['dicom_archive', 'loris']
+  )(DicomArchive);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <DicomArchive dataURL={loris.BaseURL + '/dicom_archive/?format=json'}/>
+    <Index dataURL={loris.BaseURL + '/dicom_archive/?format=json'}/>
   );
 });

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -1,6 +1,10 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import swal from 'sweetalert2';
@@ -339,10 +343,14 @@ DataDictIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'dictionary', {});
+  const Index = withTranslation(
+    ['dictionary', 'loris']
+  )(DataDictIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <DataDictIndex
+    <Index
       dataURL={`${loris.BaseURL}/dictionary/?format=json`}
       BaseURL={loris.BaseURL}
     />

--- a/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
@@ -1,6 +1,10 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -170,10 +174,14 @@ ElectrophysiologyBrowserIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'electrophysiology_browser', {});
+  const Index = withTranslation(
+    ['electrophysiology_browser', 'loris']
+  )(ElectrophysiologyBrowserIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ElectrophysiologyBrowserIndex
+    <Index
       dataURL={`${loris.BaseURL}/electrophysiology_browser/?format=json`}
     />
   );

--- a/modules/examiner/jsx/examinerIndex.js
+++ b/modules/examiner/jsx/examinerIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import swal from 'sweetalert2';
 import Modal from 'Modal';
 import Loader from 'Loader';
@@ -328,10 +331,14 @@ ExaminerIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'examiner', {});
+  const Index = withTranslation(
+    ['examiner', 'loris']
+  )(ExaminerIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ExaminerIndex
+    <Index
       dataURL={`${loris.BaseURL}/examiner/?format=json`}
       submitURL={`${loris.BaseURL}/examiner/addExaminer`}
       hasPermission={loris.userHasPermission}

--- a/modules/genomic_browser/jsx/genomicBrowserIndex.js
+++ b/modules/genomic_browser/jsx/genomicBrowserIndex.js
@@ -1,6 +1,10 @@
 import {createRoot} from 'react-dom/client';
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import {TabPane, Tabs} from 'jsx/Tabs';
 import Profiles from './tabs_content/profiles';
 import GWAS from './tabs_content/gwas';
@@ -66,10 +70,14 @@ GenomicBrowser.propTypes = {
  * Render Genomic Browser on page load.
  */
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'genomic_browser', {});
+  const GenomicB = withTranslation(
+    ['genomic_browser', 'loris']
+  )(GenomicBrowser);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <GenomicBrowser
+    <GenomicB
       baseURL={loris.BaseURL}
     />
   );

--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -1,5 +1,9 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
@@ -199,10 +203,14 @@ ImagingBrowserIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'imaging_browser', {});
+  const Index = withTranslation(
+    ['imaging_browser', 'loris']
+  )(ImagingBrowserIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ImagingBrowserIndex
+    <Index
       dataURL={`${loris.BaseURL}/imaging_browser/?format=json`}
     />
   );

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import {Tabs, TabPane} from 'Tabs';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
@@ -287,10 +290,14 @@ MediaIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'media', {});
+  const Index = withTranslation(
+    ['media', 'loris']
+  )(MediaIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <MediaIndex
+    <Index
       dataURL={`${loris.BaseURL}/media/?format=json`}
       hasPermission={loris.userHasPermission}
     />

--- a/modules/server_processes_manager/jsx/server_processes_managerIndex.js
+++ b/modules/server_processes_manager/jsx/server_processes_managerIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -123,10 +126,16 @@ ServerProcessesManagerIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  // FIXME: This is adding an empty object so that eslint doesn't complain about
+  // i18n being unused. Translate the module
+  i18n.addResourceBundle('ja', 'server_processes_manager', {});
+  const SPMIndex = withTranslation(
+    ['server_processes_manager', 'loris']
+  )(ServerProcessesManagerIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ServerProcessesManagerIndex
+    <SPMIndex
       dataURL={`${loris.BaseURL}/server_processes_manager/?format=json`}
     />
   );

--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -27,7 +27,7 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Module extends \Module
 {
-    const ERR_MSG_CONFIG_MISSING = 'Required configuration settings for Server '
+    const ERR_MSG_CONFIG_MISSING = 'Required configuration setting for Server '
         . 'Processes Manager are missing. Cannot continue.';
 
     /**

--- a/modules/statistics/jsx/WidgetIndex.js
+++ b/modules/statistics/jsx/WidgetIndex.js
@@ -197,15 +197,15 @@ const WidgetIndex = (props) => {
   };
 
   /**
-     * Similar to componentDidMount and componentDidUpdate.
-     */
+   * Similar to componentDidMount and componentDidUpdate.
+   */
   useEffect(
     () => {
       /**
-          * setup - fetch recruitment and study progression data.
-          *
-          * @return {Promise<void>}
-          */
+       * setup - fetch recruitment and study progression data.
+       *
+       * @return {Promise<void>}
+       */
       const setup = async () => {
         const data = await fetchData(
           `${props.baseURL}/Widgets`

--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -89,10 +89,12 @@ const QueryChartForm = (props) => {
   };
 
   /**
-     * Renders the React component.
-     *
-     * @return {JSX.Element} - React markup for component.
-     */
+   * Renders the React component.
+   *
+   * @param name
+   * @param value
+   * @return {JSX.Element} - React markup for component.
+   */
   return (
     <FormElement
       Module ={props.Module}

--- a/modules/survey_accounts/jsx/surveyAccountsIndex.js
+++ b/modules/survey_accounts/jsx/surveyAccountsIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -144,10 +147,14 @@ SurveyAccountsIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'survey_accounts', {});
+  const Index = withTranslation(
+    ['survey_accounts', 'loris']
+  )(SurveyAccountsIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <SurveyAccountsIndex
+    <Index
       dataURL={`${loris.BaseURL}/survey_accounts/?format=json`}
     />
   );

--- a/modules/user_accounts/jsx/userAccountsIndex.js
+++ b/modules/user_accounts/jsx/userAccountsIndex.js
@@ -2,6 +2,9 @@ import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 
@@ -210,10 +213,14 @@ UserAccountsIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'user_accounts', {});
+  const Index = withTranslation(
+    ['user_accounts', 'loris']
+  )(UserAccountsIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <UserAccountsIndex
+    <Index
       dataURL={`${loris.BaseURL}/user_accounts/?format=json`}
       hasPermission={loris.userHasPermission}
     />


### PR DESCRIPTION
This translates the DataTable jsx component used within LORIS menus, so that the candidate_list menu is fully translated.

Blocked by #9797 (because of javascript dependencies) and will be easier to review once that is merged.