### PR TITLE
[publication] Fix collaborator behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ core section.***
 - ***When possible please provide the number of the pull request(s) containing the 
 changes in the following format: PR #1234***
 
+## LORIS 27.x (Release Date: TBD)
+### Core
+#### Summary
+- Minor release after v27 release
+### Notes For Existing Projects
+
+Upgrading LORIS requires following the upgrade process each major and minor release (bug fix releases can be script) to ensure the schema is up to date.
+
+For upgrading to 27.x from 27:
+- Run the `tools/single_use/27_Publication_Collaborators_Into_New_Entries.php` to move publication collaborators into their own database entries rather than relying on eachother.
+
+## LORIS 27.0 (Release Date: 2025-06-20)
+### Core
+#### Summary
+The LORIS 27 release adds many new features and optimizations detailed below such as:
+- Optimizations for the new dataquery tool which also optimize various components throughout LORIS
+- Improvements to permission handling through different modules
+- A new "Batch Mode" for the issue tracker
+- The CandID in LORIS is now 10 digits instead of 6 to support larger projects
+- Foreign Key references to the `candidate` table are now standardized: `CandidateID` which refers to `candidate`.`ID`
+- Instrument's `flag`.`data` moved to `instrument_data` table
+- LORIS now has the ability to display summary statistics of the LORIS instance (either from an SQL query or a query built with the new data query tool) on the login page.
+- A new redcap module allows to importing of data from redcap into LORIS
+- Various other bug fixes and features detailed below
+
+### Notes For Existing Projects
+
+Upgrading LORIS requires following the upgrade process each major and minor release (bug fix releases can be script) to ensure the schema is up to date.
+
+For upgrading to 27 from 26:
+- Source the `SQL/Release_patches/26.0_To_27.0_upgrade.sql`
+- Run the `tools/update_issues_with_description.php` to back-populate the new issue tracker description column. (The description was previously based on the first comment.)
+
+
 ## LORIS 26.0 (Release Date: 2024-06-13)
 ### Core
 #### Features

--- a/SQL/New_patches/2025-07-10-Publication_Collaborators_To_Own_Entries.sql
+++ b/SQL/New_patches/2025-07-10-Publication_Collaborators_To_Own_Entries.sql
@@ -1,0 +1,21 @@
+-- Publication Lead Investigators do not need to be collaborators
+ALTER TABLE publication
+ADD COLUMN LeadInvestigatorEmail VARCHAR(255) NULL;
+
+UPDATE publication
+SET LeadInvestigator = (SELECT Name FROM publication_collaborator WHERE PublicationCollaboratorID = LeadInvestigatorID),
+    LeadInvestigatorEmail = (SELECT Email FROM publication_collaborator WHERE PublicationCollaboratorID = LeadInvestigatorID)
+WHERE LeadInvestigatorID IS NOT NULL;
+
+ALTER TABLE publication
+DROP FOREIGN KEY `FK_publication_LeadInvestigatorID`;
+
+ALTER TABLE publication_collaborator
+DROP INDEX `UK_publication_collaborator_Email`;
+
+-- Remove the LeadInvestigatorID column from publication
+ALTER TABLE publication
+DROP COLUMN LeadInvestigatorID;
+
+DELETE FROM publication_collaborator
+WHERE PublicationCollaboratorID NOT IN (SELECT PublicationCollaboratorID FROM publication_collaborator_rel);

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -68,29 +68,6 @@ function uploadPublication() : void
     $leadInvest = $_POST['leadInvestigator'] ?? null;
     $leadInvestEmail = $_POST['leadInvestigatorEmail'] ?? null;
 
-    // check if lead investigator email already exists in collaborator table
-    // use ID if exists, else insert
-    $leadInvID = $db->pselectOne(
-        'SELECT PublicationCollaboratorID '.
-        'FROM publication_collaborator '.
-        'WHERE Email = :e',
-        [
-            'e' => $leadInvestEmail
-        ]
-    );
-    if (empty($leadInvID)) {
-        $db->insert(
-            'publication_collaborator',
-            [
-                'Name'  => $leadInvest,
-                'Email' => $leadInvestEmail,
-            ]
-        );
-
-        $leadInvID = $db->getLastInsertId();
-    } else {
-        showPublicationError('Lead Investigator email already exists', 400);
-    }
     if (!isset($desc, $leadInvest, $leadInvestEmail)) {
         showPublicationError('A mandatory field is missing!', 400);
     }
@@ -99,17 +76,18 @@ function uploadPublication() : void
     $today = date('Y-m-d');
     // insert the title to avoid double escaping
     $fields = [
-        'UserID'             => $uid,
-        'Title'              => $title,
-        'Description'        => $desc,
-        'project'            => $project,
-        'publishingStatus'   => $publishingStatus,
-        'datePublication'    => $datePublication,
-        'journal'            => $journal,
-        'doi'                => $doi,
-        'link'               => $link,
-        'LeadInvestigatorID' => $leadInvID,
-        'DateProposed'       => $today,
+        'UserID'                => $uid,
+        'Title'                 => $title,
+        'Description'           => $desc,
+        'project'               => $project,
+        'publishingStatus'      => $publishingStatus,
+        'datePublication'       => $datePublication,
+        'journal'               => $journal,
+        'doi'                   => $doi,
+        'link'                  => $link,
+        'LeadInvestigator'      => $leadInvest,
+        'LeadInvestigatorEmail' => $leadInvestEmail,
+        'DateProposed'          => $today,
     ];
 
     $db->insert('publication', $fields);
@@ -215,37 +193,42 @@ function processFiles($pubID) : void
  */
 function insertCollaborators(int $pubID) : void
 {
+    $db = \NDB_Factory::singleton()->database();
+    // Delete all collaborators for this publication
+    $currentPublicationCollaborators = $db->pselectCol(
+        "SELECT pc.PublicationCollaboratorID
+         FROM publication_collaborator_rel pcr
+         JOIN publication_collaborator pc
+         ON pc.PublicationCollaboratorID =
+            pcr.PublicationCollaboratorID
+         WHERE PublicationID = :pid",
+        ['pid' => $pubID]
+    );
+    $db->delete(
+        'publication_collaborator_rel',
+        ['PublicationID' => $pubID]
+    );
+    foreach ($currentPublicationCollaborators as $currentPublicationCollaborator) {
+        $db->delete(
+            'publication_collaborator',
+            ['PublicationCollaboratorID' => $currentPublicationCollaborator]
+        );
+    }
     if (!isset($_POST['collaborators'])) {
         return;
     }
-    $db = \NDB_Factory::singleton()->database();
-
     $collaborators = json_decode($_POST['collaborators'], true);
+    // Add all collaborators again
     foreach ($collaborators as $c) {
-        $cid = $db->pselectOne(
-            'SELECT PublicationCollaboratorID '.
-            'FROM publication_collaborator '.
-            'WHERE Name=:c',
-            ['c' => $c['name']]
+        $collabInsert = [
+            'Name'  => $c['name'],
+            'Email' => $c['email'],
+        ];
+        $db->insert(
+            'publication_collaborator',
+            $collabInsert
         );
-        // if collaborator does not already exist in table, add them
-        if (!$cid) {
-            $collabInsert = [
-                'Name'  => $c['name'],
-                'Email' => $c['email'],
-            ];
-
-            $db->insert(
-                'publication_collaborator',
-                $collabInsert
-            );
-            $cid = $db->pselectOne(
-                'SELECT PublicationCollaboratorID ' .
-                'FROM publication_collaborator ' .
-                'WHERE Name=:c',
-                ['c' => $c['name']]
-            );
-        }
+        $cid = $db->getLastInsertId();
         $collabRelInsert = [
             'PublicationID'             => $pubID,
             'PublicationCollaboratorID' => $cid,
@@ -453,10 +436,8 @@ function notify($pubID, $type, $baseURL) : void
     $emailData = [];
 
     $data = $db->pselectRow(
-        "SELECT Title, DateProposed, pc.Email as LeadInvestigatorEmail " .
+        "SELECT Title, DateProposed, LeadInvestigatorEmail " .
         "FROM publication p " .
-        "LEFT JOIN publication_collaborator pc ".
-        "ON p.LeadInvestigatorID=pc.PublicationCollaboratorID " .
         "WHERE PublicationID=:pubID",
         ['pubID' => $pubID]
     );
@@ -552,17 +533,14 @@ function editProject() : void
     $publishingStatus = $_POST['publishingStatus'] ?? null;
     $datePublication  = $_POST['datePublication'] ?? null;
     $journal          = $_POST['journal'] ?? null;
-    $doi  = $_POST['doi'] ?? null;
-    $link = $_POST['link'] ?? null;
-    $leadInvestigator      = $_POST['leadInvestigator'] ?? null;
-    $leadInvestigatorEmail = $_POST['leadInvestigatorEmail'] ?? null;
+    $doi        = $_POST['doi'] ?? null;
+    $link       = $_POST['link'] ?? null;
+    $leadInvest = $_POST['leadInvestigator'] ?? null;
+    $leadInvestEmail = $_POST['leadInvestigatorEmail'] ?? null;
 
     $pubData = $db->pselectRow(
-        'SELECT p.*, pc.Name as LeadInvestigator, ' .
-        'pc.Email as LeadInvestigatorEmail ' .
+        'SELECT p.* ' .
         'FROM publication p ' .
-        'LEFT JOIN publication_collaborator pc '.
-        'ON p.LeadInvestigatorID=pc.PublicationCollaboratorID '.
         'WHERE PublicationID=:pid',
         ['pid' => $id]
     );
@@ -573,8 +551,7 @@ function editProject() : void
     }
 
     // build array of changed values
-    $toUpdate        = [];
-    $leadInvToUpdate = [];
+    $toUpdate = [];
     if ($pubData['Title'] !== $title) {
         $toUpdate['Title'] = $title;
     }
@@ -605,45 +582,15 @@ function editProject() : void
     if ($pubData['link'] !== $link) {
         $toUpdate['link'] = $link;
     }
-    $leadInvToUpdate['Name'] = $leadInvestigator;
-
-    if ($pubData['LeadInvestigatorEmail'] !== $leadInvestigatorEmail) {
-        // check if email exists in database
-        $cid = $db->pselectOne(
-            'SELECT PublicationCollaboratorID '.
-            'FROM publication_collaborator '.
-            'WHERE Email=:email',
-            ['email' => $leadInvestigatorEmail]
-        );
-        $leadInvToUpdate['Email'] = $leadInvestigatorEmail;
-
-        // if email exists in database, update new email association to name & cid
-        if ($cid) {
-            $db->update(
-                'publication_collaborator',
-                $leadInvToUpdate,
-                ['PublicationCollaboratorID' => $cid]
-            );
-             $toUpdate['LeadInvestigatorID'] = $cid;
-        } else {
-            // otherwise, create new collaborator with a new id
-            $db->insert(
-                'publication_collaborator',
-                $leadInvToUpdate
-            );
-            $toUpdate['LeadInvestigatorID'] = $db->getLastInsertId();
-        }
-        // if only name is updated, update name associated to the email
-    } else if ($pubData['LeadInvestigator'] !== $leadInvestigator) {
-        $db->update(
-            'publication_collaborator',
-            $leadInvToUpdate,
-            ['PublicationCollaboratorID' => $pubData['LeadInvestigatorID']]
-        );
+    if ($pubData['LeadInvestigator'] !== $leadInvest) {
+        $toUpdate['LeadInvestigator'] = $leadInvest;
+    }
+    if ($pubData['LeadInvestigatorEmail'] !== $leadInvestEmail) {
+        $toUpdate['LeadInvestigatorEmail'] = $leadInvestEmail;
     }
 
     editEditors($id);
-    editCollaborators($id);
+    insertCollaborators($id);
     editKeywords($id);
     editVOIs($id);
     editUploads($id);
@@ -702,93 +649,6 @@ function editEditors($id) : void
                     'UserID'        => $uid,
                     'PublicationID' => $id,
                 ]
-            );
-        }
-    }
-}
-
-/**
- * Edit collaborators
- *
- * @param int $id Publication ID
- *
- * @return void
- */
-function editCollaborators($id) : void
-{
-    $db = \NDB_Factory::singleton()->database();
-    $submittedCollaborators = isset($_POST['collaborators'])
-        ? json_decode($_POST['collaborators'], true) : null;
-
-    $currentCollabs       = $db->pselectCol(
-        'SELECT Name FROM publication_collaborator pc '.
-        'LEFT JOIN publication_collaborator_rel pcr '.
-        'ON pcr.PublicationCollaboratorID=pc.PublicationCollaboratorID '.
-        'WHERE pcr.PublicationID=:pid',
-        ['pid' => $id]
-    );
-    $currCollabNames      = array_values($currentCollabs);
-    $submittedCollabNames = array_column($submittedCollaborators, 'name');
-    if ($submittedCollabNames != $currCollabNames) {
-        $newCollabs = array_diff($submittedCollabNames, $currCollabNames);
-        $oldCollabs = array_diff($currentCollabs, $submittedCollabNames);
-    }
-
-    if (!empty($newCollabs)) {
-        insertCollaborators($id);
-    }
-    if (!empty($oldCollabs)) {
-        foreach ($oldCollabs as $name) {
-            $cid = $db->pselectOne(
-                'SELECT PublicationCollaboratorID '.
-                'FROM publication_collaborator '.
-                'WHERE Name=:n',
-                ['n' => $name]
-            );
-            $db->delete(
-                'publication_collaborator_rel',
-                [
-                    'PublicationCollaboratorID' => $cid,
-                    'PublicationID'             => $id,
-                ]
-            );
-        }
-    }
-    // update emails if any have changed
-    $currentCollabs = iterator_to_array(
-        $db->pselect(
-            'SELECT Name, Email FROM publication_collaborator pc '.
-            'LEFT JOIN publication_collaborator_rel pcr '.
-            'ON pcr.PublicationCollaboratorID=pc.PublicationCollaboratorID '.
-            'WHERE pcr.PublicationID=:pid',
-            ['pid' => $id]
-        )
-    );
-
-    $currCollabEmails      = array_column($currentCollabs, 'email');
-    $submittedCollabEmails = array_column($submittedCollaborators, 'email');
-    $staleEmails           = [];
-    if ($submittedCollabEmails != $currCollabEmails) {
-        // only care about updated emails here
-        $staleEmails = array_diff($currCollabEmails, $submittedCollabEmails);
-    }
-    if (!empty($staleEmails)) {
-        $currentCollabs = array_combine(
-            array_column($currentCollabs, 'email'),
-            array_column($currentCollabs, 'name')
-        );
-
-        $submittedCollaborators = array_combine(
-            array_column($submittedCollaborators, 'name'),
-            array_column($submittedCollaborators, 'email')
-        );
-        foreach ($staleEmails as $s) {
-            $name     = $currentCollabs[$s];
-            $newEmail = $submittedCollaborators[$name];
-            $db->update(
-                'publication_collaborator',
-                ['Email' => $newEmail],
-                ['Name' => $name]
             );
         }
     }

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -122,19 +122,12 @@ function getData($db) : array
     );
     $kws = array_combine($kws, $kws);
 
-    $collabs = $db->pselectCol(
-        'SELECT Name FROM publication_collaborator',
-        []
-    );
-    $collabs = array_combine($collabs, $collabs);
-
     $data['projectOptions'] = $projectOptions;
     $data['users']          = $users;
     $data['uploadTypes']    = getUploadTypes();
     $data['existingTitles'] = $titles;
     $data['allVOIs']        = $allVOIs;
     $data['allKWs']         = $kws;
-    $data['allCollabs']     = $collabs;
     return $data;
 }
 
@@ -152,11 +145,9 @@ function getProjectData($db, $user, $id) : array
     $query  = 'SELECT Title, Description, ' .
         'p.project as project, pr.Name as projectName, datePublication, '.
         'journal, link, publishingStatus, DateProposed, '.
-        'pc.Name as LeadInvestigator, pc.Email as LeadInvestigatorEmail, '.
+        'LeadInvestigator, LeadInvestigatorEmail, '.
         'PublicationStatusID, UserID, RejectedReason  '.
         'FROM publication p '.
-        'LEFT JOIN publication_collaborator pc '.
-        'ON p.LeadInvestigatorID = pc.PublicationCollaboratorID '.
         'LEFT JOIN Project pr '.
         'ON p.project = pr.ProjectID '.
         'WHERE p.PublicationID=:pid ';

--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -524,9 +524,6 @@ class ProjectFormFields extends React.Component {
           name="collaborators"
           id="collaborators"
           label="Collaborators"
-          options={this.props.allCollabs}
-          useSearch={true}
-          strictSearch={false}
           onUserInput={this.props.setFormData}
           onUserAdd={this.addCollaborator}
           onUserRemove={this.removeCollaborator}
@@ -600,7 +597,6 @@ ProjectFormFields.propTypes = {
   users: PropTypes.object,
   addListItem: PropTypes.func,
   removeListItem: PropTypes.func,
-  allCollabs: PropTypes.object,
   allKWs: PropTypes.object,
   editMode: PropTypes.string,
   projectOptions: PropTypes.object,

--- a/modules/publication/jsx/uploadForm.js
+++ b/modules/publication/jsx/uploadForm.js
@@ -291,7 +291,6 @@ class PublicationUploadForm extends React.Component {
               users={this.state.Data.users}
               allVOIs={this.state.Data.allVOIs}
               allKWs={this.state.Data.allKWs}
-              allCollabs={this.state.Data.allCollabs}
               editMode={false}
             />
           </FormElement>

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -85,7 +85,9 @@ class ViewProject extends React.Component {
         return;
       }
 
-      swal.fire('Edit Successful!', '', 'success');
+      swal.fire('Edit Successful!', '', 'success').then(() => {
+        window.location.replace(loris.BaseURL + '/publication/');
+      });
     }).catch((error) => {
       // Network error
       console.error(error);
@@ -156,7 +158,6 @@ class ViewProject extends React.Component {
             userCanEdit: data.userCanEdit,
             allVOIs: data.allVOIs,
             allKWs: data.allKWs,
-            allCollabs: data.allCollabs,
             uploadTypes: data.uploadTypes,
             files: data.files,
             isLoaded: true,
@@ -372,7 +373,6 @@ class ViewProject extends React.Component {
           users={this.state.users}
           allVOIs={this.state.allVOIs}
           allKWs={this.state.allKWs}
-          allCollabs={this.state.allCollabs}
           editMode={true}
           fetchData={this.fetchData}
         />

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -77,10 +77,6 @@ class Publication extends \NDB_Menu_Filter_Form
             "ON pcr.PublicationID=p.PublicationID ".
             "LEFT JOIN publication_collaborator pc ".
             "ON pcr.PublicationCollaboratorID=pc.PublicationCollaboratorID ".
-            // make separate join for getting LeadInvestigator from collaborator
-            // table (pcli)
-            "LEFT JOIN publication_collaborator pcli ".
-            "ON pcli.PublicationCollaboratorID=p.LeadInvestigatorID ".
             "LEFT JOIN publication_keyword_rel pkr ".
             "ON p.PublicationID=pkr.PublicationID ".
             "LEFT JOIN publication_keyword pk ".
@@ -91,7 +87,7 @@ class Publication extends \NDB_Menu_Filter_Form
             "ON u.ID=p.UserID ".
             "LEFT JOIN Project pr ".
             "ON p.project=pr.ProjectID ";
-        $query .= " WHERE 1=1 ";
+        $query  .= " WHERE 1=1 ";
         // allow user access to module if they have edit
         // access to any project proposal
         // but only those that they do have access to
@@ -106,7 +102,7 @@ class Publication extends \NDB_Menu_Filter_Form
 
         $this->columns = [
             'p.Title',
-            'pcli.Name as LeadInvestigator',
+            'p.LeadInvestigator',
             'p.DateProposed',
             'ps.Label', // Status (Approved, Pending, Rejected, etc.)
             'pr.Name as project',
@@ -148,20 +144,11 @@ class Publication extends \NDB_Menu_Filter_Form
 
         $this->validFilters = [
             'p.Title',
+            'p.LeadInvestigator',
             'p.ApprovalStatus',
             'pc.Name',
             'pk.Label',
-            'pcli.Name', // Lead Investigator's name
             'pt.Name',
-        ];
-
-        $this->formToFilter = [
-            'titleOrDescription'  => 'p.Title',
-            'approvalStatus'      => 'ps.Label',
-            'collaborators'       => 'pc.Name',
-            'keywords'            => 'pk.Label',
-            'variablesOfInterest' => 'pt.Name',
-            'leadInvestigator'    => 'pcli.Name',
         ];
     }
 

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -41,19 +41,8 @@ find docs modules htdocs php src tools \
 
 # except:
 declare -a ignored_files=(
-    tools/single_use/Cleanup_Consent_Data.php
-    tools/single_use/Engine_Change_MyISAM_to_INNODB.php
-    tools/single_use/normalize_mri_protocol_range_data.php
-    tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
-    tools/single_use/instrument_double_escape_report.php
-    tools/single_use/cleanup_mri_tables_for_19-0_release.php
-    tools/single_use/Normalize_protocol_split_rows.php
-    tools/single_use/migrate_sql_to_json.php
-    tools/single_use/data_dictionary_cleaner.php
-    tools/single_use/Normalize_Consent_Data.php
-    tools/single_use/remove_logged_passwords.php
-    tools/deprecated/create_candidates.php
-    tools/deprecated/excelDump.php
+    tools/single_use/*
+    tools/deprecated/*
 )
 
 declare -a params=(

--- a/tools/single_use/27_Publication_Collaborators_Into_New_Entries.php
+++ b/tools/single_use/27_Publication_Collaborators_Into_New_Entries.php
@@ -1,0 +1,85 @@
+<?php 
+/**
+ * 
+ * This single use script updates the existing publication_collaborator entries in the database
+ * to be unique for each publication.
+ * 
+ * PHP Version 8
+ *
+ * @category   Main
+ * @package    Loris
+ * @subpackage Tools
+ * @author     Saagar Arya <saagar.arya@mcin.ca>
+ * @license    Loris license
+ * @link       https://www.github.com/aces/Loris-Trunk/
+ * 
+ */
+
+require_once __DIR__ . "/../generic_includes.php";
+
+$helper = new OutputWrapper();
+$helper->enableLogging(basename($argv[0]));
+
+$helper->printSuccess("########## UPDATING PUBLICATION COLLABORATORS ##########");
+$existingPublicationCollaborators = $DB->pselect(
+    "SELECT DISTINCT pcr.PublicationID, pc.Name, pc.Email
+    FROM publication_collaborator_rel pcr
+    JOIN publication_collaborator pc ON pc.PublicationCollaboratorID = pcr.PublicationCollaboratorID
+    WHERE pcr.PublicationID IS NOT NULL
+    AND pc.PublicationCollaboratorID IS NOT NULL",
+    []
+);
+
+if (empty($existingPublicationCollaborators)) {
+    $helper->printWarning("No existing publication collaborators found.");
+    exit;
+}
+
+$helper->printWarning("There were " . count($existingPublicationCollaborators) . " existing publication collaborators found.");
+
+$helper->printSuccess("########## DELETING ALL EXISTING PUBLICATION COLLABORATORS ##########");
+$DB->run("DELETE FROM publication_collaborator_rel");
+$DB->run("DELETE FROM publication_collaborator");
+
+$helper->printSuccess("########## INSERTING PUBLICATION COLLABORATORS PROPERLY ##########");
+foreach ($existingPublicationCollaborators as $publicationCollaborator) {
+    $publicationID = $publicationCollaborator['PublicationID'];
+    $name = $publicationCollaborator['Name'];
+    $email = $publicationCollaborator['Email'];
+
+    $helper->printSuccess("PublicationID: $publicationID, Name: $name, Email: $email");
+    // Insert the new publication collaborator
+    $DB->insert(
+        "publication_collaborator",
+        [
+            'Name' => $name,
+            'Email' => $email
+        ]
+    );
+
+    $newPublicationCollaboratorID = $DB->getLastInsertId();
+
+    // Insert the new publication collaborator relationship
+    $DB->insert(
+        "publication_collaborator_rel",
+        [
+            'PublicationID' => $publicationID,
+            'PublicationCollaboratorID' => $newPublicationCollaboratorID
+        ]
+    );
+}
+
+$newPublicationCollaborators = $DB->pselect(
+    "SELECT DISTINCT pcr.PublicationID, pc.Name, pc.Email
+    FROM publication_collaborator_rel pcr
+    JOIN publication_collaborator pc ON pc.PublicationCollaboratorID = pcr.PublicationCollaboratorID
+    WHERE pcr.PublicationID IS NOT NULL
+    AND pc.PublicationCollaboratorID IS NOT NULL",
+    []
+);
+
+if (empty($newPublicationCollaborators)) {
+    $helper->printWarning("No new publication collaborators found.");
+    exit;
+}
+$helper->printWarning("There are now " . count($newPublicationCollaborators) . " publication collaborators.");

--- a/tools/single_use/README.md
+++ b/tools/single_use/README.md
@@ -5,3 +5,7 @@ executed successfully. The scripts in this directory do not get removed
 unless they have been converted to a data_integrity tool or are 
 completely deprecated in which case they get moved into the appropriate 
 directory before removal.
+
+Single use tools should start with the LORIS Core version that they are
+targeted to. For example, a tool that is meant to be used when upgrading
+to LORIS Core v27, should be prefixed with `27_`.


### PR DESCRIPTION
## Brief summary of changes
- Publication collaborator behaviour was a bit confusing and not future proof. Issues such as:
    - Two publications could not have a collaborator with the same name and different emails
    - Same issue with Lead Investigator and a collaborator in another publication
- Resolved by separating the publication_collaborator table to have one entry per collaborator per publication. There is no reason for two publications to point to the same collaborator since they are editable in each publication.

#### Testing instructions (if applicable)

1. Create a publication with lead investigator x, and collaborator y
2. Create another publication with lead investigator y and collaborator x
3. Create another publication with lead investigator x but a different email
4. create another publication with collaborator y but with a different email
5. create another publication with some other name, but collaborator y's email

#### Link(s) to related issue(s)

* Resolves # 9590
