### PR TITLE
[notifications] only send to active users

### DIFF
--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -242,6 +242,7 @@ abstract class NDB_Notifier_Abstract
                     JOIN user_psc_rel upsc ON (u.ID=upsc.UserID)
                   WHERE nm.module_name=:nm
                     AND nm.operation_type=:ot
+                    AND u.Pending_approval = 'N' AND u.Active = 'Y' AND u.active_to < NOW()
                     ";
         $params = [
             "nm" => $this->module,


### PR DESCRIPTION
## Brief summary of changes

- Found an issue on CCNA where a user that was set to Active = 'N' but was still receiving emails months later
- Solved this by enforcing the active_to, Active and pending_approval fields from the users table

#### Testing instructions (if applicable)

1. Add a notification for an active user such as for issue tracker
2. Cause a notification to be sent and confirm that it is
3. Make the user inactive
4. Cause another notification and confirm that it does not happen