### PR TITLE
[dataquery - dictionary - NDB_BVL_Instrument] Return Examiners as enum

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -899,7 +899,15 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             );
         }
         $examiners = $this->_getExaminerNames();
-        $this->addSelect('Examiner', 'Examiner', $examiners);
+
+        $this->addSelect(
+            'Examiner',
+            'Examiner',
+            array_merge(
+                [null => ''],
+                array_column($examiners, 'examinerID', 'full_name')
+            )
+        );
 
         $this->addRule(
             'Date_taken',
@@ -989,7 +997,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _getExaminerNames(): array
     {
         if (empty($this->getCommentID())) {
-            return [];
+            return Utility::getAllActiveExaminers();
         }
 
         $db = $this->loris->getDatabaseConnection();
@@ -2423,7 +2431,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 		    JOIN test_names tn ON (tn.ID=f.TestID)
                     JOIN session s ON (f.SessionID=s.ID)
                     JOIN candidate c ON (s.CandidateID=c.ID)
-                     
 		    $where";
             \Profiler::checkpoint("Running query (table instrument): " . $query);
             $data = $db->pselect($query, $params);

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -516,10 +516,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     $this->testName.'_Examiner',
                                     'Examiner',
                                     $scope,
-                                    // This should be an enum of examiners, but
-                                    // getExaminerNames currently returns an empty
-                                    // array if CommentID is not set.
-                                    new StringType(255),
+                                    new Enumeration(
+                                        ...array_map(
+                                            function ($e) {
+                                                return $e['full_name'];
+                                            },
+                                            array_values($this->_getExaminerNames())
+                                        )
+                                    ),
                                     new Cardinality(Cardinality::SINGLE),
                                     'Examiner',
                                 ),

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -343,6 +343,29 @@ class Utility
         return self::getCohortList($projectID);
     }
 
+
+    /**
+     * Return list of all active examiners
+     *
+     * @return array
+     */
+    static function getAllActiveExaminers(): array
+    {
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
+        return $DB->pselectWithIndexKey(
+            "SELECT DISTINCT e.examinerID, e.full_name, u.Email
+                 FROM examiners e
+                 JOIN examiners_psc_rel epr
+                 JOIN users u ON (u.ID = e.userID)
+                 WHERE epr.active = 'Y'
+                 ORDER BY full_name",
+            [],
+            'examinerID'
+        );
+    }
+
+
     /**
      * Returns a list of visits associated with the supplied cohort.
      * The visits are in an associative array format [VisitName=>VisitLabel]


### PR DESCRIPTION
Closes #9852

Return all active examiners as enum when commentID is null, like in data dictionary.

Screenshot: `bmi` is LINST, rest are PHP
<img width="1319" height="811" alt="Screenshot 2025-07-16 at 4 48 09 PM" src="https://github.com/user-attachments/assets/42955517-848a-4c8e-9ff7-27a6c05b254b" />


