### PR TITLE
Dqt welcome

### DIFF
--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -25,7 +25,7 @@ function NextSteps(props: {
 
   const canRun = (props.fields && props.fields.length > 0);
   const fieldLabel = (props.fields && props.fields.length > 0)
-    ? 'Modify Fields'
+    ? 'Define Fields'
     : 'Choose Fields';
   const filterLabel = (props.filters && props.filters.group.length > 0)
     ? 'Modify Filters'

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -60,7 +60,7 @@ function Welcome(props: {
         id: string,
     }[] = [];
   panels.push({
-    title: 'Instructions',
+    title: 'How to Start',
     content: <IntroductionMessage
       hasStudyQueries={props.topQueries.length > 0}
       onContinue={props.onContinue}
@@ -70,21 +70,21 @@ function Welcome(props: {
     id: 'p1',
   });
   panels.push({
-    title: 'Recent Queries',
+    title: 'Query History',
     content: (
       <div>
         <div>
-        Recent Queries stores the queries you have run.
+        <p>Query History stores the queries you have run.</p>
         </div>
         <div>
-          <ul>
+          <ul style ={{lineHeight: 2.0}}>
             <li>Click on the Star icon to mark your query as 'starred'</li>
             <li>Click on <ShareIcon /> to share your query with all users who
             have access to the fields in it.</li>
             <li>Click on <LoadIcon /> to load your query.</li>
             <li>Click on <NameIcon /> to name (or rename) your query.</li>
             <li>Click on the the pin icon to display your query on the Loris
-              welcome page.</li>
+              welcome page and in the 'Important Queries' pane.</li>
             <li>Use Filter to find your query or queries by name.</li>
             <li>Use the checkboxes to customize your queries.</li>
           </ul>
@@ -112,7 +112,7 @@ function Welcome(props: {
       </div>
     ),
     alwaysOpen: false,
-    defaultOpen: true,
+    defaultOpen: false,
     id: 'p2',
   });
   if (props.topQueries.length > 0) {
@@ -120,8 +120,10 @@ function Welcome(props: {
       title: 'Important Queries',
       content: (
         <div>
-          <div> Important Queries is a list of queries that your administrator
-            has selected for other users to view</div>
+          <div>
+            <p> Important Queries is a list of queries that your administrator
+              has marked as important.</p>
+          </div>
           <QueryList
             useAdminName={true}
 
@@ -140,7 +142,7 @@ function Welcome(props: {
         </div>
       ),
       alwaysOpen: false,
-      defaultOpen: true,
+      defaultOpen: false,
       id: 'p3',
     });
   }
@@ -165,7 +167,7 @@ function Welcome(props: {
           />
         </div>
       ),
-      alwaysOpen: false,
+      alwaysOpen: true,
       defaultOpen: true,
       id: 'p4',
     });
@@ -1085,18 +1087,18 @@ function IntroductionMessage(props: {
     onContinue: () => void,
     hasStudyQueries: boolean,
 }): React.ReactElement {
-  const studyQueriesParagraph = props.hasStudyQueries ? (
-    <p>Above, there is also a <code>Study Queries</code> panel. This
-        are a special type of shared queries that have been pinned
-        by a study administer to always display at the top of this
-        page.</p>
-  ) : '';
+  // const studyQueriesParagraph = props.hasStudyQueries ? (
+  //   <p>Above, there is also a <code>Study Queries</code> panel. This
+  //       are a special type of shared queries that have been pinned
+  //       by a study administer to always display at the top of this
+  //       page.</p>
+  // ) : '';
   return (
     <div>
       <p>The data query tool allows you to query data
-          within LORIS.
-      </p>
-      <ul>
+          within LORIS. Start with <code>Next Steps</code> at the
+          bottom right of your browser window.</p>
+      <ul style ={{lineHeight: 2.0}}>
         <li>Click <code>Define Fields</code> to select what you are looking
         for.</li>
         <li>Click <code>Add Filters</code> to filter what you have

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -86,16 +86,16 @@ function Welcome(props: {
       id: 'p1',
     });
   }
-  panels.push({
-    title: 'Instructions',
-    content: <IntroductionMessage
-      hasStudyQueries={props.topQueries.length > 0}
-      onContinue={props.onContinue}
-    />,
-    alwaysOpen: false,
-    defaultOpen: true,
-    id: 'p2',
-  });
+  // panels.push({
+  //   title: 'Instructions',
+  //   content: <IntroductionMessage
+  //     hasStudyQueries={props.topQueries.length > 0}
+  //     onContinue={props.onContinue}
+  //   />,
+  //   alwaysOpen: false,
+  //   defaultOpen: true,
+  //   id: 'p2',
+  // });
   panels.push({
     title: 'Recent Queries',
     content: (
@@ -1063,61 +1063,61 @@ function NameIcon(props: {
  * @param {boolean} props.hasStudyQueries - Whether or not study queries exist
  * @returns {React.ReactElement} - The React element
  */
-function IntroductionMessage(props: {
-    onContinue: () => void,
-    hasStudyQueries: boolean,
-}): React.ReactElement {
-  const studyQueriesParagraph = props.hasStudyQueries ? (
-    <p>Above, there is also a <code>Study Queries</code> panel. This
-        are a special type of shared queries that have been pinned
-        by a study administer to always display at the top of this
-        page.</p>
-  ) : '';
-  return (
-    <div>
-      <p>The data query tool allows you to query data
-          within LORIS. There are three steps to defining
-          a query:
-      </p>
-      <ol>
-        <li>First, you must select the fields that you're
-                interested in on the <code>Define Fields</code>
-                page.</li>
-        <li>Next, you can optionally define filters on the
-          <code>Define Filters</code> page to restrict
-                the population that is returned.</li>
-        <li>Finally, you view your query results on
-                the <code>View Data</code> page</li>
-      </ol>
-      <p>The <code>Next Steps</code> on the bottom right of your
-             screen always the context-sensitive next steps that you
-             can do to build your query.</p>
-      <p>Your recently run queries will be displayed in the
-        <code>Recent Queries</code> panel below. Instead of building
-             a new query, you can reload a query that you've recently run
-             by clicking on the <LoadIcon /> icon next to the query.</p>
-      <p>Queries can be shared with others by clicking the <ShareIcon />
-             icon. This will cause the query to be shared with all users who
-             have access to the fields used by the query. It will display
-             in a <code>Shared Queries</code> panel below the
-        <code>Recent Queries</code>.</p>
-      <p>You may also give a query a name at any time by clicking the
-        <NameIcon /> icon. This makes it easier to find queries you care
-             about by giving them an easier to remember name that can be used
-             for filtering. When you share a query, the name will be shared
-             along with it.</p>
-      {studyQueriesParagraph}
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}>
-        <ButtonElement
-          columnSize="col-sm-12"
-          onUserInput={props.onContinue}
-          label="Continue to Define Fields" />
-      </div>
-    </div>
-  );
-}
+// function IntroductionMessage(props: {
+//     onContinue: () => void,
+//     hasStudyQueries: boolean,
+// }): React.ReactElement {
+//   const studyQueriesParagraph = props.hasStudyQueries ? (
+//     <p>Above, there is also a <code>Study Queries</code> panel. This
+//         are a special type of shared queries that have been pinned
+//         by a study administer to always display at the top of this
+//         page.</p>
+//   ) : '';
+//   return (
+//     <div>
+//       <p>The data query tool allows you to query data
+//           within LORIS. There are three steps to defining
+//           a query:
+//       </p>
+//       <ol>
+//         <li>First, you must select the fields that you're
+//                 interested in on the <code>Define Fields</code>
+//                 page.</li>
+//         <li>Next, you can optionally define filters on the
+//           <code>Define Filters</code> page to restrict
+//                 the population that is returned.</li>
+//         <li>Finally, you view your query results on
+//                 the <code>View Data</code> page</li>
+//       </ol>
+//       <p>The <code>Next Steps</code> on the bottom right of your
+//              screen always the context-sensitive next steps that you
+//              can do to build your query.</p>
+//       <p>Your recently run queries will be displayed in the
+//         <code>Recent Queries</code> panel below. Instead of building
+//              a new query, you can reload a query that you've recently run
+//              by clicking on the <LoadIcon /> icon next to the query.</p>
+//       <p>Queries can be shared with others by clicking the <ShareIcon />
+//              icon. This will cause the query to be shared with all users who
+//              have access to the fields used by the query. It will display
+//              in a <code>Shared Queries</code> panel below the
+//         <code>Recent Queries</code>.</p>
+//       <p>You may also give a query a name at any time by clicking the
+//         <NameIcon /> icon. This makes it easier to find queries you care
+//              about by giving them an easier to remember name that can be used
+//              for filtering. When you share a query, the name will be shared
+//              along with it.</p>
+//       {studyQueriesParagraph}
+//       <div style={{
+//         display: 'flex',
+//         flexDirection: 'column',
+//         alignItems: 'center',
+//       }}>
+//         <ButtonElement
+//           columnSize="col-sm-12"
+//           onUserInput={props.onContinue}
+//           label="Continue to Define Fields" />
+//       </div>
+//     </div>
+//   );
+// }
 export default Welcome;

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -59,6 +59,62 @@ function Welcome(props: {
         defaultOpen: boolean,
         id: string,
     }[] = [];
+  panels.push({
+    title: 'Instructions',
+    content: <IntroductionMessage
+      hasStudyQueries={props.topQueries.length > 0}
+      onContinue={props.onContinue}
+    />,
+    alwaysOpen: false,
+    defaultOpen: true,
+    id: 'p1',
+  });
+  panels.push({
+    title: 'Recent Queries',
+    content: (
+      <div>
+        <div>
+        Recent Queries stores the queries you have run.
+        </div>
+        <div>
+          <ul>
+            <li>Click on the Star icon to mark your query as 'starred'</li>
+            <li>Click on <ShareIcon /> to share your query with all users who have 
+            access to the fields in it.</li>
+            <li>Click on <LoadIcon /> to load your query.</li>
+            <li>Click on <NameIcon /> to names (or rename) your query.</li>
+            <li>Click on the the pin icon to display your query on the Loris 
+              welcome page.</li>
+            <li>Use Filter to find your query or queries by name.</li>
+            <li>Use the checkboxes to customize your queries.</li>
+          </ul>
+        </div>  
+      <div>
+        <QueryRunList
+          queryruns={props.recentQueries}
+          loadQuery={props.loadQuery}
+          defaultCollapsed={false}
+          starQuery={props.starQuery}
+          unstarQuery={props.unstarQuery}
+
+          shareQuery={props.shareQuery}
+          unshareQuery={props.unshareQuery}
+
+          reloadQueries={props.reloadQueries}
+
+          getModuleFields={props.getModuleFields}
+          mapModuleName={props.mapModuleName}
+          mapCategoryName={props.mapCategoryName}
+          fulldictionary={props.fulldictionary}
+          queryAdmin={props.queryAdmin}
+        />
+      </div>
+    </div>
+    ),
+    alwaysOpen: false,
+    defaultOpen: true,
+    id: 'p2',
+  });
   if (props.topQueries.length > 0) {
     panels.push({
       title: 'Study Queries',
@@ -83,49 +139,9 @@ function Welcome(props: {
       ),
       alwaysOpen: false,
       defaultOpen: true,
-      id: 'p1',
+      id: 'p3',
     });
   }
-  // panels.push({
-  //   title: 'Instructions',
-  //   content: <IntroductionMessage
-  //     hasStudyQueries={props.topQueries.length > 0}
-  //     onContinue={props.onContinue}
-  //   />,
-  //   alwaysOpen: false,
-  //   defaultOpen: true,
-  //   id: 'p2',
-  // });
-  panels.push({
-    title: 'Recent Queries',
-    content: (
-      <div>
-        <QueryRunList
-          queryruns={props.recentQueries}
-          loadQuery={props.loadQuery}
-          defaultCollapsed={false}
-
-          starQuery={props.starQuery}
-          unstarQuery={props.unstarQuery}
-
-          shareQuery={props.shareQuery}
-          unshareQuery={props.unshareQuery}
-
-          reloadQueries={props.reloadQueries}
-
-          getModuleFields={props.getModuleFields}
-          mapModuleName={props.mapModuleName}
-          mapCategoryName={props.mapCategoryName}
-          fulldictionary={props.fulldictionary}
-          queryAdmin={props.queryAdmin}
-        />
-      </div>
-    ),
-    alwaysOpen: false,
-    defaultOpen: true,
-    id: 'p3',
-  });
-
   if (props.sharedQueries.length > 0) {
     panels.push({
       title: 'Shared Queries',
@@ -510,7 +526,7 @@ function QueryList(props: {
     // query list
   const duplicateFilter = props.shareQuery ?
     <CheckboxElement name='noduplicate'
-      label='No run times (eliminate duplicates)'
+      label='Remove date'
       value={noDuplicates}
       offset=''
       onUserInput={
@@ -1063,61 +1079,46 @@ function NameIcon(props: {
  * @param {boolean} props.hasStudyQueries - Whether or not study queries exist
  * @returns {React.ReactElement} - The React element
  */
-// function IntroductionMessage(props: {
-//     onContinue: () => void,
-//     hasStudyQueries: boolean,
-// }): React.ReactElement {
-//   const studyQueriesParagraph = props.hasStudyQueries ? (
-//     <p>Above, there is also a <code>Study Queries</code> panel. This
-//         are a special type of shared queries that have been pinned
-//         by a study administer to always display at the top of this
-//         page.</p>
-//   ) : '';
-//   return (
-//     <div>
-//       <p>The data query tool allows you to query data
-//           within LORIS. There are three steps to defining
-//           a query:
-//       </p>
-//       <ol>
-//         <li>First, you must select the fields that you're
-//                 interested in on the <code>Define Fields</code>
-//                 page.</li>
-//         <li>Next, you can optionally define filters on the
-//           <code>Define Filters</code> page to restrict
-//                 the population that is returned.</li>
-//         <li>Finally, you view your query results on
-//                 the <code>View Data</code> page</li>
-//       </ol>
-//       <p>The <code>Next Steps</code> on the bottom right of your
-//              screen always the context-sensitive next steps that you
-//              can do to build your query.</p>
-//       <p>Your recently run queries will be displayed in the
-//         <code>Recent Queries</code> panel below. Instead of building
-//              a new query, you can reload a query that you've recently run
-//              by clicking on the <LoadIcon /> icon next to the query.</p>
-//       <p>Queries can be shared with others by clicking the <ShareIcon />
-//              icon. This will cause the query to be shared with all users who
-//              have access to the fields used by the query. It will display
-//              in a <code>Shared Queries</code> panel below the
-//         <code>Recent Queries</code>.</p>
-//       <p>You may also give a query a name at any time by clicking the
-//         <NameIcon /> icon. This makes it easier to find queries you care
-//              about by giving them an easier to remember name that can be used
-//              for filtering. When you share a query, the name will be shared
-//              along with it.</p>
-//       {studyQueriesParagraph}
-//       <div style={{
-//         display: 'flex',
-//         flexDirection: 'column',
-//         alignItems: 'center',
-//       }}>
-//         <ButtonElement
-//           columnSize="col-sm-12"
-//           onUserInput={props.onContinue}
-//           label="Continue to Define Fields" />
-//       </div>
-//     </div>
-//   );
-// }
+function IntroductionMessage(props: {
+    onContinue: () => void,
+    hasStudyQueries: boolean,
+}): React.ReactElement {
+  const studyQueriesParagraph = props.hasStudyQueries ? (
+    <p>Above, there is also a <code>Study Queries</code> panel. This
+        are a special type of shared queries that have been pinned
+        by a study administer to always display at the top of this
+        page.</p>
+  ) : '';
+  return (
+    <div>
+      <p>The data query tool allows you to query data
+          within LORIS. 
+      </p>
+      <ul>
+        <li>Click <code>Define Fields</code> to select what you are looking 
+        for.</li>
+        <li>Click <code>Add Filters</code> to filter what you have 
+        selected.</li>
+        <li>Click <code>Run Query</code> to view the results.</li>
+      {/* <li><code>Recent Queries</code> stores the queries you have run.</li> */}
+      </ul>
+      {/* <p>Click <ShareIcon /> to share your queries with all users who have access
+      to the fields in your query.
+        <code>Recent Queries</code>.</p>
+      <p>Rename your query by clicking the
+        <NameIcon /> icon.</p> */}
+      {/* {studyQueriesParagraph}
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}>
+        <ButtonElement
+          columnSize="col-sm-12"
+          onUserInput={props.onContinue}
+          label="Continue to Define Fields" />
+      </div> */}
+    </div>
+  );
+}
 export default Welcome;

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -79,8 +79,8 @@ function Welcome(props: {
         <div>
           <ul>
             <li>Click on the Star icon to mark your query as 'starred'</li>
-            <li>Click on <ShareIcon /> to share your query with all users who have 
-            access to the fields in it.</li>
+            <li>Click on <ShareIcon /> to share your query with all users who
+            have access to the fields in it.</li>
             <li>Click on <LoadIcon /> to load your query.</li>
             <li>Click on <NameIcon /> to names (or rename) your query.</li>
             <li>Click on the the pin icon to display your query on the Loris 
@@ -88,28 +88,28 @@ function Welcome(props: {
             <li>Use Filter to find your query or queries by name.</li>
             <li>Use the checkboxes to customize your queries.</li>
           </ul>
-        </div>  
-      <div>
-        <QueryRunList
-          queryruns={props.recentQueries}
-          loadQuery={props.loadQuery}
-          defaultCollapsed={false}
-          starQuery={props.starQuery}
-          unstarQuery={props.unstarQuery}
+        </div>
+        <div>
+          <QueryRunList
+            queryruns={props.recentQueries}
+            loadQuery={props.loadQuery}
+            defaultCollapsed={false}
+            starQuery={props.starQuery}
+            unstarQuery={props.unstarQuery}
 
-          shareQuery={props.shareQuery}
-          unshareQuery={props.unshareQuery}
+            shareQuery={props.shareQuery}
+            unshareQuery={props.unshareQuery}
 
-          reloadQueries={props.reloadQueries}
+            reloadQueries={props.reloadQueries}
 
-          getModuleFields={props.getModuleFields}
-          mapModuleName={props.mapModuleName}
-          mapCategoryName={props.mapCategoryName}
-          fulldictionary={props.fulldictionary}
-          queryAdmin={props.queryAdmin}
-        />
+            getModuleFields={props.getModuleFields}
+            mapModuleName={props.mapModuleName}
+            mapCategoryName={props.mapCategoryName}
+            fulldictionary={props.fulldictionary}
+            queryAdmin={props.queryAdmin}
+          />
+        </div>
       </div>
-    </div>
     ),
     alwaysOpen: false,
     defaultOpen: true,
@@ -1092,15 +1092,15 @@ function IntroductionMessage(props: {
   return (
     <div>
       <p>The data query tool allows you to query data
-          within LORIS. 
+          within LORIS.
       </p>
       <ul>
-        <li>Click <code>Define Fields</code> to select what you are looking 
+        <li>Click <code>Define Fields</code> to select what you are looking
         for.</li>
         <li>Click <code>Add Filters</code> to filter what you have 
         selected.</li>
         <li>Click <code>Run Query</code> to view the results.</li>
-      {/* <li><code>Recent Queries</code> stores the queries you have run.</li> */}
+        {/* <li><code>Recent Queries</code> stores the queries you have run.</li> */}
       </ul>
       {/* <p>Click <ShareIcon /> to share your queries with all users who have access
       to the fields in your query.

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -744,7 +744,7 @@ function SingleQueryDisplay(props: {
 
   if (query.Starred) {
     starredIcon = <span
-      style={{cursor: 'pointer'}}
+      style={{cursor: 'default'}}
       onClick={
         () => props.unstarQuery(query.QueryID)
       }
@@ -761,7 +761,7 @@ function SingleQueryDisplay(props: {
     </span>;
   } else {
     starredIcon = <span
-      style={{cursor: 'pointer'}}
+      style={{cursor: 'default'}}
       title="Star"
       onClick={
         () => props.starQuery(query.QueryID)
@@ -1023,7 +1023,7 @@ function LoadIcon(props: {
 }) {
   return <span onClick={props.onClick}
     title="Reload query"
-    style={{cursor: 'pointer'}}
+    style={{cursor: 'default'}}
     className="fa-stack">
     <i className="fas fa-sync fa-stack-1x"></i>
   </span>;
@@ -1044,7 +1044,7 @@ function ShareIcon(props: {
     isShared?: boolean,
 }) {
   return <span className="fa-stack"
-    style={{cursor: 'pointer'}}
+    style={{cursor: 'default'}}
     title={props.title}
     onClick={props.onClick}>
     <i style={props.isShared ? {color: 'blue'} : {}}
@@ -1063,7 +1063,7 @@ function NameIcon(props: {
     onClick?: () => void
 }): React.ReactElement {
   return (<span title="Name query"
-    style={{cursor: 'pointer'}}
+    style={{cursor: 'default'}}
     className="fa-stack"
     onClick={props.onClick}
   >

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -82,7 +82,7 @@ function Welcome(props: {
             <li>Click on <ShareIcon /> to share your query with all users who
             have access to the fields in it.</li>
             <li>Click on <LoadIcon /> to load your query.</li>
-            <li>Click on <NameIcon /> to names (or rename) your query.</li>
+            <li>Click on <NameIcon /> to name (or rename) your query.</li>
             <li>Click on the the pin icon to display your query on the Loris
               welcome page.</li>
             <li>Use Filter to find your query or queries by name.</li>
@@ -117,9 +117,11 @@ function Welcome(props: {
   });
   if (props.topQueries.length > 0) {
     panels.push({
-      title: 'Study Queries',
+      title: 'Important Queries',
       content: (
         <div>
+          <div> Important Queries is a list of queries that your administrator
+            has selected for other users to view</div>
           <QueryList
             useAdminName={true}
 

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -8,7 +8,7 @@ import NameQueryModal from './welcome.namequerymodal';
 import AdminQueryModal from './welcome.adminquerymodal';
 import getDictionaryDescription from './getdictionarydescription';
 import PaginationLinks from 'jsx/PaginationLinks';
-import {ButtonElement, CheckboxElement, TextboxElement} from 'jsx/Form';
+import {CheckboxElement, TextboxElement} from 'jsx/Form';
 import {APIQueryField} from './types';
 import {FullDictionary} from './types';
 import {FlattenedField, FlattenedQuery, VisitOption} from './types';
@@ -60,7 +60,7 @@ function Welcome(props: {
         id: string,
     }[] = [];
   panels.push({
-    title: 'How to Start',
+    title: 'Getting Started',
     content: <IntroductionMessage
       hasStudyQueries={props.topQueries.length > 0}
       onContinue={props.onContinue}
@@ -74,19 +74,19 @@ function Welcome(props: {
     content: (
       <div>
         <div>
-        <p>Query History stores the queries you have run.</p>
+          <p>Query History stores the queries you have run.</p>
         </div>
         <div>
           <ul style ={{lineHeight: 2.0}}>
-            <li>Click on the Star icon to mark your query as 'starred'</li>
-            <li>Click on <ShareIcon /> to share your query with all users who
+            <li>Click on the <strong>Star</strong> icon to mark your query as 'starred'</li>
+            <li>Click on <ShareIcon /> to <strong>share</strong> your query with all users who
             have access to the fields in it.</li>
-            <li>Click on <LoadIcon /> to load your query.</li>
-            <li>Click on <NameIcon /> to name (or rename) your query.</li>
-            <li>Click on the the pin icon to display your query on the Loris
+            <li>Click on <LoadIcon /> to <strong>load</strong> your query.</li>
+            <li>Click on <NameIcon /> to <strong>name</strong> (or rename) your query.</li>
+            <li>Click on the the pin icon to <strong>display</strong> your query on the Loris
               welcome page and in the 'Important Queries' pane.</li>
-            <li>Use Filter to find your query or queries by name.</li>
-            <li>Use the checkboxes to customize your queries.</li>
+            <li>Use Filter to <strong>find</strong> your query or queries by name.</li>
+            <li>Use the checkboxes to customize your query</li>
           </ul>
         </div>
         <div>
@@ -1083,7 +1083,7 @@ function NameIcon(props: {
  * @param {boolean} props.hasStudyQueries - Whether or not study queries exist
  * @returns {React.ReactElement} - The React element
  */
-function IntroductionMessage(props: {
+function IntroductionMessage(_props: {
     onContinue: () => void,
     hasStudyQueries: boolean,
 }): React.ReactElement {
@@ -1095,9 +1095,6 @@ function IntroductionMessage(props: {
   // ) : '';
   return (
     <div>
-      <p>The data query tool allows you to query data
-          within LORIS. Start with <code>Next Steps</code> at the
-          bottom right of your browser window.</p>
       <ul style ={{lineHeight: 2.0}}>
         <li>Click <code>Define Fields</code> to select what you are looking
         for.</li>

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -83,7 +83,7 @@ function Welcome(props: {
             have access to the fields in it.</li>
             <li>Click on <LoadIcon /> to load your query.</li>
             <li>Click on <NameIcon /> to names (or rename) your query.</li>
-            <li>Click on the the pin icon to display your query on the Loris 
+            <li>Click on the the pin icon to display your query on the Loris
               welcome page.</li>
             <li>Use Filter to find your query or queries by name.</li>
             <li>Use the checkboxes to customize your queries.</li>
@@ -1097,7 +1097,7 @@ function IntroductionMessage(props: {
       <ul>
         <li>Click <code>Define Fields</code> to select what you are looking
         for.</li>
-        <li>Click <code>Add Filters</code> to filter what you have 
+        <li>Click <code>Add Filters</code> to filter what you have
         selected.</li>
         <li>Click <code>Run Query</code> to view the results.</li>
         {/* <li><code>Recent Queries</code> stores the queries you have run.</li> */}


### PR DESCRIPTION
-  instructions touch-up
- `Define Fields` button removed because it's in `Next Steps`
- `Recent Queries` renamed to `Query History` (are they necessarily "recent"?)
- Panes could start collapsed 