### PR TITLE
[NDB_Client] Remove unused method

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -179,23 +179,5 @@ class NDB_Client
         // finished initializing
         return true;
     }
-
-    /**
-     * Returns true if the user is logged in
-     *
-     * @return true only if user is logged in
-     */
-    function isLoggedIn()
-    {
-        if (!isset($_SESSION['State'])) {
-            $_SESSION['State'] =& State::singleton();
-            $login = new SinglePointLogin();
-            $_SESSION['State']->setProperty('login', $login);
-        } else {
-            $login = $_SESSION['State']->getProperty('login');
-        }
-
-        return $login->isLoggedIn();
-    }
 }
 


### PR DESCRIPTION
The isLoggedIn method in NDB_Client does not appear to be used. References to isLoggedIn() within the class all reference SinglePointLogin's isLoggedIn method, not NDB_Client's.
