### PR TITLE
[Scripts] Consistent use of generic_includes

### DIFF
--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -41,17 +41,8 @@ use LORIS\StudyEntities\Candidate\CandID;
 //foreach candidate we need to look at each timepoint
 //compare the looked up battery to the actual assigned battery
 //add missing instruments.
-set_include_path(
-    get_include_path().":".
-    __DIR__."/../project/libraries:".
-    __DIR__."/../php/libraries:"
-);
-
 require_once __DIR__ . "/../vendor/autoload.php";
-require_once "NDB_Client.class.inc";
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize();
+require_once __DIR__ . "/generic_includes.php";
 
 $confirm = false;
 if ((isset($argv[1]) && $argv[1] === "confirm")

--- a/tools/data_integrity/data_deletion/delete_ignored_conflicts.php
+++ b/tools/data_integrity/data_deletion/delete_ignored_conflicts.php
@@ -31,19 +31,8 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-set_include_path(
-    get_include_path().":".
-    __DIR__."../../../project/libraries:" .
-    __DIR__."../../../php/libraries:"
-);
-
 require_once __DIR__ . "/../../../vendor/autoload.php";
 require_once __DIR__ . "/../../generic_includes.php";
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize();
-
-$config =& NDB_Config::singleton();
 
 // Meta fields that should be removed
 $defaultFields = [

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -52,17 +52,7 @@
  */
 use LORIS\StudyEntities\Candidate\CandID;
 
-set_include_path(get_include_path().":../project/libraries:../php/libraries:");
-
-// path to config file
-$configFile = dirname(__FILE__) . "/../project/config.xml";
-
 require_once __DIR__ . "/generic_includes.php";
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize($configFile);
-
-$db = $lorisInstance->getDatabaseConnection();
 
 /**
  * HELP SCREEN

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -16,13 +16,8 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once __DIR__ . "/generic_includes.php";
-
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize("../project/config.xml");
 
 $instrumentsToSkip = [];
 $instruments       = getExcludedInstruments();

--- a/tools/mri_violations_resolver.php
+++ b/tools/mri_violations_resolver.php
@@ -17,24 +17,12 @@
  * @license  Loris License
  * @link     https://www.github.com/aces/Loris/
  */
-
-set_include_path(get_include_path().":../project/libraries:../php/libraries:");
-
-// path to config file
-$configFile = "../project/config.xml";
-
 require_once __DIR__ . "/generic_includes.php";
 
 $confirm = false;
 if (isset($argv[1]) && $argv[1] === "confirm") {
     $confirm = true;
 }
-
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize($configFile);
-
-$DB = $lorisInstance->getDatabaseConnection();
 
 // Query as it is in the mri violation module
 // It is complete as it apears in the module for two reasons:

--- a/tools/single_use/DB_date_zeros_removal.php
+++ b/tools/single_use/DB_date_zeros_removal.php
@@ -15,14 +15,8 @@
  */
 require_once __DIR__ . '/../generic_includes.php';
 
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize(__DIR__."/../../project/config.xml");
-$config   = NDB_Config::singleton();
-$db       = $DB;
 $database = $config->getSetting('database');
 
-$base = $config->getSetting('base');
 $db->_trackChanges = false;
 
 // Set up variables
@@ -44,7 +38,7 @@ echo "\n#################################################################\n\n".
 
 $database_name = $database['database'];
 
-$field_names = $db->pselect(
+$field_names = $DB->pselect(
     "
                       SELECT
                           TABLE_NAME,
@@ -85,7 +79,7 @@ foreach ($field_names as $key => $field) {
     $autoUpdateSQL = '';
     if (array_key_exists($field['TABLE_NAME'], $autoUpdateFields)) {
         foreach ($autoUpdateFields[$field['TABLE_NAME']] as $col) {
-            $autoUpdateSQL .= ", ".$db->escape($col)."=".$col;
+            $autoUpdateSQL .= ", ".$DB->escape($col)."=".$col;
         }
     }
 
@@ -95,9 +89,9 @@ foreach ($field_names as $key => $field) {
             . "` FIELD: `"
             . $field['COLUMN_NAME']
             . "` to default to NULL\n";
-        $alters .= "ALTER TABLE ".$db->escape($field['TABLE_NAME'])
+        $alters .= "ALTER TABLE ".$DB->escape($field['TABLE_NAME'])
             . " MODIFY "
-            . $db->escape($field['COLUMN_NAME'])
+            . $DB->escape($field['COLUMN_NAME'])
             . " "
             . $field['COLUMN_TYPE']." NULL DEFAULT NULL;\n";
     } elseif ($field['COLUMN_DEFAULT']=='0000-00-00 00:00:00') {
@@ -107,9 +101,9 @@ foreach ($field_names as $key => $field) {
             . $field['COLUMN_NAME']
             . "` to default to NULL\n";
         $alters .= "ALTER TABLE "
-            . $db->escape($field['TABLE_NAME'])
+            . $DB->escape($field['TABLE_NAME'])
             . " MODIFY "
-            . $db->escape($field['COLUMN_NAME'])
+            . $DB->escape($field['COLUMN_NAME'])
             . " "
             . $field['COLUMN_TYPE']
             . " NULL DEFAULT NULL;\n";
@@ -117,28 +111,28 @@ foreach ($field_names as $key => $field) {
 
     if ($field['DATA_TYPE'] == 'date' && $field['IS_NULLABLE'] == 'YES') {
         $updates .= "UPDATE "
-            . $db->escape($database['database'])
+            . $DB->escape($database['database'])
             . "."
-            . $db->escape($field['TABLE_NAME'])
+            . $DB->escape($field['TABLE_NAME'])
             . " SET "
-            . $db->escape($field['COLUMN_NAME'])
+            . $DB->escape($field['COLUMN_NAME'])
             . "=NULL"
             . $autoUpdateSQL
-            . " WHERE CAST(".$db->escape($field['COLUMN_NAME'])
+            . " WHERE CAST(".$DB->escape($field['COLUMN_NAME'])
             . " AS CHAR(20))='0000-00-00';\n";
     } elseif (($field['DATA_TYPE']=='datetime' || $field['DATA_TYPE']=='timestamp')
         && $field['IS_NULLABLE']=='YES'
     ) {
         $updates .= "UPDATE "
-            . $db->escape($database['database'])
+            . $DB->escape($database['database'])
             . "."
-            . $db->escape($field['TABLE_NAME'])
+            . $DB->escape($field['TABLE_NAME'])
             . " SET "
-            . $db->escape($field['COLUMN_NAME'])
+            . $DB->escape($field['COLUMN_NAME'])
             . "=NULL"
             . $autoUpdateSQL
             . " WHERE CAST("
-            . $db->escape($field['COLUMN_NAME'])
+            . $DB->escape($field['COLUMN_NAME'])
             . " AS CHAR(20))='0000-00-00 00:00:00';\n";
     } else {
         if ($field['DATA_TYPE'] == 'date') {
@@ -150,14 +144,14 @@ foreach ($field_names as $key => $field) {
                 . "A date '1000-01-01' will be entered "
                 . "instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE "
-                . $db->escape($database['database'])
+                . $DB->escape($database['database'])
                 . "."
-                . $db->escape($field['TABLE_NAME'])
+                . $DB->escape($field['TABLE_NAME'])
                 . " SET "
-                . $db->escape($field['COLUMN_NAME'])
+                . $DB->escape($field['COLUMN_NAME'])
                 . "='1000-01-01'"
                 . $autoUpdateSQL
-                . " WHERE CAST(".$db->escape($field['COLUMN_NAME'])
+                . " WHERE CAST(".$DB->escape($field['COLUMN_NAME'])
                 . " AS CHAR(20))='0000-00-00';\n";
         } elseif ($field['DATA_TYPE'] == 'datetime') {
             echo "COLUMN "
@@ -168,15 +162,15 @@ foreach ($field_names as $key => $field) {
                 . "A datetime '1000-01-01 00:00:00' will be entered "
                 . "instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE "
-                . $db->escape($database['database'])
+                . $DB->escape($database['database'])
                 . "."
-                . $db->escape($field['TABLE_NAME'])
+                . $DB->escape($field['TABLE_NAME'])
                 . " SET "
-                . $db->escape($field['COLUMN_NAME'])
+                . $DB->escape($field['COLUMN_NAME'])
                 . "='1000-01-01 00:00:00'"
                 . $autoUpdateSQL
                 . " WHERE CAST("
-                . $db->escape($field['COLUMN_NAME'])
+                . $DB->escape($field['COLUMN_NAME'])
                 . " AS CHAR(20))='0000-00-00 00:00:00';\n";
         } elseif ($field['DATA_TYPE'] == 'timestamp') {
             echo "COLUMN "
@@ -187,15 +181,15 @@ foreach ($field_names as $key => $field) {
                 . "A timestamp '1970-01-01 00:00:01' will be entered "
                 . "instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE "
-                . $db->escape($database['database'])
+                . $DB->escape($database['database'])
                 . "."
-                . $db->escape($field['TABLE_NAME'])
+                . $DB->escape($field['TABLE_NAME'])
                 . " SET "
-                . $db->escape($field['COLUMN_NAME'])
+                . $DB->escape($field['COLUMN_NAME'])
                 . "='1970-01-01 00:00:01'"
                 . $autoUpdateSQL
                 . " WHERE CAST("
-                . $db->escape($field['COLUMN_NAME'])
+                . $DB->escape($field['COLUMN_NAME'])
                 . " AS CHAR(20))='0000-00-00 00:00:00';\n";
         }
     }

--- a/tools/update_issues_with_description.php
+++ b/tools/update_issues_with_description.php
@@ -17,21 +17,8 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-require_once __DIR__ . "/generic_includes.php";
-
-set_include_path(
-    get_include_path().":".
-    __DIR__."/../project/libraries:".
-    __DIR__."/../php/libraries:"
-);
-
 require_once __DIR__ . "/../vendor/autoload.php";
-require_once "NDB_Client.class.inc";
-$client = new NDB_Client();
-$client->makeCommandLine();
-$client->initialize();
-
-$DB = \NDB_Factory::singleton()->database();
+require_once __DIR__ . "/generic_includes.php";
 
 $allIssueIDsWithComments = $DB->pselectCol(
     "SELECT issueID FROM issues_comments",


### PR DESCRIPTION
This makes the tools directory scripts which independently called NDB_Client use generic_includes.php, including it where necessary and removing duplicated code that is already done by generic_includes.php.