### PR TITLE
[IBIS 27] category.php fix can't have empty description

### DIFF
--- a/src/Data/Dictionary/Category.php
+++ b/src/Data/Dictionary/Category.php
@@ -43,9 +43,9 @@ class Category
     /**
      * Return the human readable description of the Category
      *
-     * @return string
+     * @return ?string
      */
-    public function getDescription() : string
+    public function getDescription() : ?string
     {
         return $this->description;
     }

--- a/src/Data/Dictionary/Category.php
+++ b/src/Data/Dictionary/Category.php
@@ -18,12 +18,12 @@ class Category
      * Construct a dictionary Category
      *
      * @param string $name             The machine name of the category
-     * @param string $desc             The human readable description of
+     * @param ?string $desc             The human readable description of
      *                                 the category
      * @param ?DictionaryItem[] $items An optional iterable of items which
      *                                 the category contains.
      */
-    public function __construct(string $name, string $desc, ?iterable $items = null)
+    public function __construct(string $name, ?string $desc, ?iterable $items = null)
     {
         $this->name        = $name;
         $this->description = $desc;


### PR DESCRIPTION
IBIS rc "dictionary" can't load the page, error reason: some description is empty in IBIS RC dataset