### PR TITLE
[redcap] Fix REDCap to LINST test name prefix

### DIFF
--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -230,7 +230,7 @@ function writeLINSTFile(
     fwrite(STDERR, " -> writing '$instrument_name'\n");
     //
     $fp = fopen("$output_dir/$instrument_name.linst", "w");
-    fwrite($fp, "{-@-}testname{@}$instrument_name\n");
+    fwrite($fp, "testname{@}$instrument_name\n");
     fwrite($fp, "table{@}$instrument_name\n");
     fwrite($fp, "title{@}$instrument_title\n");
 
@@ -258,6 +258,8 @@ function writeLINSTFile(
 
         }
     }
+
+    fwrite($fp, "{-@-}\n");
     fclose($fp);
 
     // META file


### PR DESCRIPTION
## Description

Remove the `{-@-}` prefix from the `redcap2linst.php` script as it is deprecated. As discussed on Slack, it was currently present because HBCD uses an old version of the data dictionary, but newer projects such as C-BIG do not want it and it should be handled by HBCD at the project level.

## Alternative

* Add an opt-in option `--use-legacy-linst` (name not fixed) to keep the old behavior ?