### PR TITLE
[datadict] Fix missing variables & ignore meta fields

### DIFF
--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -159,8 +159,10 @@ foreach ($instruments AS $instrument) {
 
         case "header":
             break;
-
-            //for HTML_QuickForm versions of standard HTML Form Elements...
+        case "jsondata":
+        case "norules":
+            break;
+        //for HTML_QuickForm versions of standard HTML Form Elements...
         default:
             //continue; // jump straight to validity for debugging
             if (isset($bits[1]) && preg_match("/^Examiner/", $bits[1])) {
@@ -308,6 +310,52 @@ foreach ($instruments AS $instrument) {
         "Type"        => $_type_enum,
         "Description" => "Administration for $testname",
         "SourceField" => "Administration",
+        "SourceFrom"  => $testname,
+        "Queryable"   => "1",
+    ];
+
+    if (array_key_exists($Name, $parameter_types)) {
+        $ParameterTypeID = $parameter_types[$Name];
+        $query_params["ParameterTypeID"] = $ParameterTypeID;
+    } else {
+        $ParameterTypeID = "";
+    }
+
+    $DB->insert(
+        "parameter_type",
+        $query_params
+    );
+
+    if ($ParameterTypeID === "") {
+        $paramId = $DB->lastInsertID;
+    } else {
+        $paramId = $ParameterTypeID;
+    }
+
+    $parameterNames[$paramId] = $query_params["Name"];
+    $DB->insert(
+        "parameter_type_category_rel",
+        [
+            "ParameterTypeID"         => $paramId,
+            "ParameterTypeCategoryID" => $catId,
+        ]
+    );
+
+    // INSTRUMENT DATA ENTRY
+    print "\tInserting data entry for $testname\n";
+    $Name = $testname . "_Data_entry";
+    if (in_array($Name, $parameterNames, true)) {
+        // this specific table_Data_entry combination
+        // was already inserted, skip.
+        continue;
+    }
+
+    $_type_enum   = "enum('Complete', 'In Progress')";
+    $query_params = [
+        "Name"        => $Name,
+        "Type"        => $_type_enum,
+        "Description" => "Data Entry for $testname",
+        "SourceField" => "Data_entry",
         "SourceFrom"  => $testname,
         "Queryable"   => "1",
     ];

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -105,7 +105,7 @@ foreach ($files as $file) {
 if (empty($output)) {
     echo "Nothing to output, 'ip_output.txt' not created\n";
 } else {
-    $fp =fopen("ip_output.txt", "w");
+    $fp =fopen( __DIR__ ."/ip_output.txt", "w");
     fwrite($fp, $output);
     fclose($fp);
 }


### PR DESCRIPTION
## Brief summary of changes

Just some fixes that were necessary on CBIG to be able to build the dictionary

1. ignore .meta fields for LINST files
2. re-add DATA ENTRY common filed to all instruments
3. make the script runnable from anywhere

TODO if I get time make the script check if the instrument is an instance of the Instrument class rather than pattern matching on 'extends NDB_BVL_Instrument'

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
