### PR TITLE
Fix MariaDB initialization hang in GitHub Actions - main

### DIFF
--- a/Dockerfile.test.db
+++ b/Dockerfile.test.db
@@ -1,4 +1,4 @@
-FROM mariadb:10.5
+FROM mariadb:11.8
 
 ARG BASE_DIR
 
@@ -18,17 +18,8 @@ RUN cat /sql/0000-00-00-schema.sql \
         /RB_files/*.sql \
     > /docker-entrypoint-initdb.d/0000-compiled.sql
 
-# 1. Use the database
-RUN echo "USE LorisTest;" >> /docker-entrypoint-initdb.d/0001-paths.sql
-
-# 2. Update Config table
-RUN echo "UPDATE Config SET Value='${BASE_DIR}/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');" >> /docker-entrypoint-initdb.d/0002-config.sql
-
-# 3. Create user (required for MariaDB 10.5)
-RUN echo "CREATE USER IF NOT EXISTS 'SQLTestUser'@'%' IDENTIFIED BY 'TestPassword';" >> /docker-entrypoint-initdb.d/0003-create-user.sql
-
-# 4. Grant privileges
-RUN echo "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'%';" >> /docker-entrypoint-initdb.d/0004-grant.sql
-
-# 5. Flush privileges
-RUN echo "FLUSH PRIVILEGES;" >> /docker-entrypoint-initdb.d/0005-flush.sql
+RUN echo "USE LorisTest;" > /docker-entrypoint-initdb.d/0001-paths.sql \
+    && echo "UPDATE Config SET Value='${BASE_DIR}/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');" >> /docker-entrypoint-initdb.d/0001-paths.sql \
+    && echo "CREATE USER IF NOT EXISTS 'SQLTestUser'@'%' IDENTIFIED BY 'TestPassword';" >> /docker-entrypoint-initdb.d/0001-paths.sql \
+    && echo "GRANT UPDATE, INSERT, SELECT, DELETE, DROP, CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'%';" >> /docker-entrypoint-initdb.d/0001-paths.sql \
+    && echo "FLUSH PRIVILEGES;" >> /docker-entrypoint-initdb.d/0001-paths.sql


### PR DESCRIPTION
update mariadb in gitaction from 10.5 (10.5 CREATE USER IF NOT EXISTS not support)  to 11.8. 
In MariaDB 10.5, if you’re using an init script like 0004-sql-user.sql, it may not execute as expected because of differences in how MariaDB/MySQL handle CREATE USER, GRANT, and init scripts in /docker-entrypoint-initdb.d.