### PR TITLE
[Database]: Differentiate between inserts and updates for history tracking

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -422,10 +422,20 @@ class Database implements LoggerAwareInterface
             );
         }
 
+        $operation = 'I'; // Default to an insert
+
+        // If it was an 'ON DUPLICATE KEY UPDATE' query, check the PDO rowCount()
+        if ($onDuplicateUpdate) {
+            $rowsAffected = $prep->rowCount();
+            if ($rowsAffected !== 2) {
+                $operation = 'U'; // It was an update
+            }
+        }
+
         $this->lastInsertID = $this->_PDO->lastInsertId();
 
         // Track changes must be called after last insertId is set
-        $this->trackChanges($table, $set, '2=1', 'I');
+        $this->trackChanges($table, $set, '2=1', $operation);
         return true;
     }
 


### PR DESCRIPTION
This pull request modifies the _realinsert function to accurately distinguish between a new row insertion and an existing row update when using insertOnDuplicateUpdate.

Previously, the trackChanges method was always called with an 'I' (insert) operation code for these queries, regardless of the outcome. This change leverages the PDO rowCount() method, which returns 1 for an insert and 2 for an update, to determine the correct operation.

The trackChanges method is now passed the appropriate operation type ('I' or 'U'), ensuring the history logs are accurate and reflect whether a record was newly created or simply modified.