### PR TITLE
[issue_tracker] Null CenterID for new issues

### DIFF
--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -572,7 +572,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         return [
             'reporter'      => $this->formatUserInformation($user->getUsername()),
             'dateCreated'   => date('Y-m-d H:i:s'),
-            'centerID'      => $user->getCenterIDs(),
+            'centerID'      => null,
             'status'        => 'new',
             'priority'      => 'normal',
             'issueID'       => 0, // TODO: this is dumb


### PR DESCRIPTION
## Brief summary of changes
When opening the "Edit issue" page there was a 500 error because the default CenterID for an issue was set to all of the user's sites. This caused an array to string conversion error on line 265, but also does not reflect what the default behaviour should be. By default, a blank issue should have no site assigned. 

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to the issue tracker module with a user who has access to some but not all sites
2. Make sure that you are only able to view and open issues at the user's sites if you have the view / own sites permission, and that you are able to view all issues with the view / all sites permission. 
3. Open a blank issue and make sure that it loads with no default site set. 
4. Create the issue with a site selected
5. Refresh the module and make sure that the relevant site loads in the issue data

#### Link(s) to related issue(s)

* Resolves #9973
