### PR TITLE
[Login/NDB_Client] Create logout endpoint

### DIFF
--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -617,7 +617,7 @@ class DashboardTest extends LorisIntegrationTest
      */
     private function _testPlan1()
     {
-        $this->safeGet($this->url . '/main.php?logout=true');
+        $this->safeGet($this->url . '/login/logout');
         $this->login("UnitTester", $this->validPassword);
         $welcomeText = $this->safeFindElement(
             WebDriverBy::cssSelector(".welcome")

--- a/modules/login/php/logout.class.inc
+++ b/modules/login/php/logout.class.inc
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace LORIS\login;
 
 use \Psr\Http\Message\ServerRequestInterface;
@@ -13,21 +14,38 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Logout extends \LORIS\Http\Endpoint
 {
-    public function _hasAccess(\User $user) : bool {
-	    // Logged out users can not further log out
-	    return !($user instanceof \AnonymousUser);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        // Logged out users can not further log out
+        return !($user instanceof \LORIS\AnonymousUser);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request.
+     *
+     * @return ResponseInterface
+     */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-	    $baseURL = \NDB_Factory::singleton()->settings()->getBaseURL();
-	    $uri = \GuzzleHttp\Psr7\Utils::uriFor($baseURL);
+        $baseURL = \NDB_Factory::singleton()->settings()->getBaseURL();
+        $uri     = \GuzzleHttp\Psr7\Utils::uriFor($baseURL);
 
-	    // NDB_Client called session_write_close, so we need to re-start
-	    // the session in order to destroy it.
-	    session_start();
-	    session_destroy();
+        // NDB_Client called session_write_close, so we need to re-start
+        // the session in order to destroy it.
+        session_start();
+        session_destroy();
 
-	    return new \LORIS\Http\Response\JSON\SeeOther($uri);
+        return new \LORIS\Http\Response\JSON\SeeOther($uri);
 
     }
 }

--- a/modules/login/php/logout.class.inc
+++ b/modules/login/php/logout.class.inc
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+namespace LORIS\login;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
+/**
+ * Implements the main LORIS user logout page to handle
+ * logging a user out of LORIS and destroying their
+ * session.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class Logout extends \LORIS\Http\Endpoint
+{
+    public function _hasAccess(\User $user) : bool {
+	    // Logged out users can not further log out
+	    return !($user instanceof \AnonymousUser);
+    }
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+	    $baseURL = \NDB_Factory::singleton()->settings()->getBaseURL();
+	    $uri = \GuzzleHttp\Psr7\Utils::uriFor($baseURL);
+
+	    // NDB_Client called session_write_close, so we need to re-start
+	    // the session in order to destroy it.
+	    session_start();
+	    session_destroy();
+
+	    return new \LORIS\Http\Response\JSON\SeeOther($uri);
+
+    }
+}

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -198,7 +198,7 @@
                                     </li>
                                     {/if}
                                     <li>
-                                        <a href="{$baseurl}/?logout=true">
+                                        <a href="{$baseurl}/login/logout">
                                             {dgettext("loris", "Log Out")}
                                         </a>
                                     </li>


### PR DESCRIPTION
There is no need to be able to log out on every request. This creates a specific logout endpoint to be explicitly called when the user wants to log out and removes the unnecessary code from NDB_Client.