### PR TITLE
[NDB_Client] Remove guard on session_cache_limiter

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -75,14 +75,7 @@ class NDB_Client
         // it gets lost after the redirect.
         $sessionOptions['cookie_samesite'] = "Lax";
 
-        // API Detect
-        if (strpos(
-            $_SERVER['REDIRECT_URL'] ?? $_SERVER['REQUEST_URI'] ?? '',
-            '/api/v0.0.3/'
-        ) !== false
-        ) {
-            session_cache_limiter('private');
-        }
+        session_cache_limiter('private');
 
         session_start($sessionOptions);
         // if exiting, destroy the php session


### PR DESCRIPTION
All logged in user session data is private. There is no reason to restrict the session_cache_limiter to the API. (In fact, it is a bad idea.)