### PR TITLE
[docs] Add intl dependency

### DIFF
--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -56,7 +56,9 @@ The following Ubuntu packages are required and should be installed using
 
 * php8.3-zip
 
-* php8.3-curl (for development instances only)
+* php8.3-curl
+
+* php8.3-intl
 
 * libapache2-mod-php8.3
 


### PR DESCRIPTION
The IntlDateFormatter used in PR #9981 to provide locale specific date formatting is a standard part of PHP, but requires the php8.3-intl to be installed. Update the docs to mention it.

I believe we also require the curl extension in general now, because of a dependency that uses it, so remove the note saying it's "for development only".