### PR TITLE
[dashboard/intl] Add intl support for welcome message on dashboard

### DIFF
--- a/modules/dashboard/locale/dashboard.pot
+++ b/modules/dashboard/locale/dashboard.pot
@@ -29,3 +29,12 @@ msgstr ""
 
 msgid "Site: All User Sites"
 msgstr ""
+
+msgid "...never. Welcome!"
+msgstr ""
+
+msgid "Welcome, %s!"
+msgstr ""
+
+msgid "Last login:"
+msgstr ""

--- a/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
@@ -29,3 +29,13 @@ msgstr "サイト: すべて"
 
 msgid "Site: All User Sites"
 msgstr "サイト: すべてのユーザーサイト"
+
+msgid "...never. Welcome!"
+msgstr "…絶対にない。初めまして！"
+
+msgid "Welcome, %s!"
+msgstr "ようこそ、%s ！"
+
+msgid "Last login:"
+msgstr "最終ログイン:"
+

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -102,12 +102,15 @@ class Module extends \Module
         }
 
         if ($last_login === null) {
-            $logindatestring = "...never. Welcome!";
+            $logindatestring = dgettext("dashboard", "...never. Welcome!");
         } else {
-            // Note: This is the format from MySQL for historical reasons.
-            // We might want to make it a more human-friendly since we have
-            // a \DateTime object.
-            $logindatestring = $last_login->format('Y-m-d H:i:s');
+            $formatter = new \IntlDateFormatter(
+                '',
+                \IntlDateFormatter::TRADITIONAL,
+                \IntlDateFormatter::SHORT
+            );
+
+            $logindatestring = $formatter->format($last_login);
         }
 
         return new Widget(

--- a/modules/dashboard/templates/welcomebody.tpl
+++ b/modules/dashboard/templates/welcomebody.tpl
@@ -1,4 +1,7 @@
-<h3 class="welcome">Welcome, {$username}.</h3>
-<p class="pull-right small login-time">Last login: {$last_login}</p>
+{* We use printf for the strings that include variables so
+   that they can be translated in the .po files before the
+   variable interpolation *}
+<h3 class="welcome">{sprintf(dgettext("dashboard", "Welcome, %s!"), $username)}</h3>
+<p class="pull-right small login-time">{dgettext("dashboard", "Last login:")} {$last_login}</p>
 <p id="project-description" class="project-description"></p>
 <script src="/dashboard/js/welcome.js"></script>


### PR DESCRIPTION
This adds localization to the "Welcome, (accountname)!" message on the dashboard and the "Last login: " string. The last login date is also now localized using the IntlDateFormatter to the user's locale using the "traditional" date formatting.

The paragraph of text in the widget remains untranslated for the moment because it comes from a database config setting.