### PR TITLE
[candidate_list] Fix Japanese translation namespaces

### DIFF
--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -166,6 +166,24 @@ msgstr "フィードバック"
 msgid "Scans"
 msgstr "スキャン"
 
+msgid "Date of Birth"
+msgstr "生年月日"
+
+msgid "An error occured while loading the page."
+msgstr "このページの読み込み中にエラーが発生しました"
+
+msgid "Entity Type"
+msgstr "エンティティタイプ"
+
+msgid "Scan Done"
+msgstr "スキャン完了"
+
+msgid "Show Advanced Filters"
+msgstr "詳細フィルターを表示"
+
+msgid "Hide Advanced Filters"
+msgstr "詳細フィルターを非表示"
+
 # Data table strings
 msgid "{{pageCount}} rows displayed of {{totalCount}}."
 msgstr "{{totalCount}}行中{{pageCount}}行を表示"

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
@@ -21,20 +21,9 @@ msgstr ""
 msgid "Access Profile"
 msgstr "アクセスプロファイル"
 
-msgid "Entity Type"
-msgstr "エンティティタイプ"
-
-msgid "Scan Done"
-msgstr "スキャン完了"
-
 msgid "Visit Count"
 msgstr "訪問回数"
 
 msgid "Open Profile"
 msgstr "プロフィールを開く"
 
-msgid "Show Advanced Filters"
-msgstr "詳細フィルターを表示"
-
-msgid "Hide Advanced Filters"
-msgstr "詳細フィルターを非表示"


### PR DESCRIPTION
Some incorrect namespaces were fixed in the Hindi translation in PR#9899, but they had already been incorrectly merged into the Japanese .po files in another PR.

This moves the strings in the Japanese localization so that they load again.
