### PR TITLE
[Localization] add LocalizableString class

### DIFF
--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -113,9 +113,11 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "conflict_resolver",
-                    "Data entry conflict",
-                    "Data entry conflicts",
+                    new \LORIS\GUI\LocalizableString(
+                        "conflict_resolver",
+                        "Data entry conflict",
+                        "Data entry conflicts",
+                    ),
                     $DB,
                     "SELECT COUNT(*) FROM conflicts_unresolved cu
                          LEFT JOIN flag ON (cu.CommentId1=flag.CommentID)

--- a/modules/dashboard/php/taskquerywidget.class.inc
+++ b/modules/dashboard/php/taskquerywidget.class.inc
@@ -13,6 +13,7 @@
  */
 
 namespace LORIS\dashboard;
+use \LORIS\GUI\LocalizableString;
 
 /**
  * A TaskQueryWidget is a special type of TaskWidget which gets its data from
@@ -34,31 +35,30 @@ class TaskQueryWidget extends TaskWidget
     /**
      * Construct a TaskQueryWidget
      *
-     * @param \User     $user         The user whose tasks are being displayed
-     * @param string    $labeldomain  The gettext textdomain to use for the label
-     * @param string    $label        The label for the task widget when the count
-     *                                is "1".
-     * @param string    $labelplural  The label for the task widget when the count
-     *                                is more than 1.
-     * @param \Database $db           The database connection for the query.
-     * @param string    $dbquery      The query to run to get a count.
-     * @param string    $allperm      The permission to use to determine if the user
-     *                                has access to all sites, or only user sites.
-     *                                If the empty string, center permissions will
-     *                                not be used.
-     * @param string    $sitefield    The field to use in the query to site-restrict
-     *                                the results.
-     * @param string    $projectfield The field to use in the query to restrict the
-     *                                project in results.
-     * @param string    $link         The link for the widget to go to when clicked.
-     * @param string    $cssclass     An optional css class to add to the task for
-     *                                testing.
+     * @param \User             $user         The user whose tasks are being
+     *                                        displayed
+     * @param LocalizableString $label        The gettext textdomain to use for
+     *                                        the label
+     * @param \Database         $db           The database connection for the
+     *                                        query.
+     * @param string            $dbquery      The query to run to get a count.
+     * @param string            $allperm      The permission to use to determine
+     *                                        if the user has access to all sites,
+     *                                        or only user sites. If the empty
+     *                                        string, center permissions will
+     *                                        not be used.
+     * @param string            $sitefield    The field to use in the query to
+     *                                        site-restrict the results.
+     * @param string            $projectfield The field to use in the query to
+     *                                        restrict the project in results.
+     * @param string            $link         The link for the widget to go to
+     *                                        when clicked.
+     * @param string            $cssclass     An optional css class to add to
+     *                                        the task for testing.
      */
     public function __construct(
         \User $user,
-        string $labeldomain,
-        string $label,
-        string $labelplural,
+        LocalizableString $label,
         \Database $db,
         string $dbquery,
         string $allperm,
@@ -83,8 +83,13 @@ class TaskQueryWidget extends TaskWidget
         }
 
         $number = (int )$db->pselectOne($dbquery, $queryparams);
-        $label  = dngettext($labeldomain, $label, $labelplural, $number);
 
-        parent::__construct($label, $number, $link, $cssclass, $siteLabel);
+        parent::__construct(
+            $label->getN($number),
+            $number,
+            $link,
+            $cssclass,
+            $siteLabel
+        );
     }
 }

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -70,9 +70,11 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "imaging_browser",
-                    "New and pending imaging session",
-                    "New and pending imaging sessions",
+                    new \LORIS\GUI\LocalizableString(
+                        "imaging_browser",
+                        "New and pending imaging session",
+                        "New and pending imaging sessions",
+                    ),
                     $DB,
                     "SELECT COUNT(DISTINCT s.ID)
                      FROM files f

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -129,9 +129,11 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "instruments",
-                    "Incomplete form",
-                    "Incomplete forms",
+                    new \LORIS\GUI\LocalizableString(
+                        "instruments",
+                        "Incomplete form",
+                        "Incomplete forms",
+                    ),
                     $DB,
                     "SELECT COUNT(*) FROM flag
                         LEFT JOIN session s ON (s.ID=flag.SessionID)

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -91,9 +91,11 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "issue_tracker",
-                    "Your assigned issue",
-                    "Your assigned issues",
+                    new \LORIS\GUI\LocalizableString(
+                        "issue_tracker",
+                        "Your assigned issue",
+                        "Your assigned issues",
+                    ),
                     $DB,
                     "SELECT COUNT(*) FROM issues
                      WHERE status != 'closed' AND assignee="

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -83,9 +83,11 @@ class Module extends \Module
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
-                    "user_accounts",
-                    "Pending account approval",
-                    "Pending account approvals",
+                    new \LORIS\GUI\LocalizableString(
+                        "user_accounts",
+                        "Pending account approval",
+                        "Pending account approvals",
+                    ),
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)

--- a/src/GUI/LocalizableString.php
+++ b/src/GUI/LocalizableString.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\GUI;
+
+/**
+ * A LocalizeableString is a type of string that should be translated
+ * on the LORIS frontend according to the user's locale. This allows
+ * modules (mostly widgets) to defer to define the textdomain, singular,
+ * and plural forms, but defer the rendering of the string until it
+ * knows the n for which the data is referring.
+ */
+class LocalizableString
+{
+    /**
+     * Construct a new LocalizableString
+     *
+     * @param readonly string $domain   The textdomain of the string
+     * @param readonly string $singular The gettext singular form
+     * @param readonly string $plural   The gettext singular form
+     */
+    public function __construct(
+        public readonly string $textdomain,
+        public readonly string $singular,
+        public readonly string $plural
+    ) {
+    }
+
+    /**
+     * Render the string for a cardinality of "n"
+     *
+     * @param int $n The cardinality to get the translation for
+     *
+     * @return string
+     */
+    public function getN(int $n) : string
+    {
+        return dngettext($this->textdomain, $this->singular, $this->plural, $n);
+    }
+}


### PR DESCRIPTION
There are numerous places in the code where we need to provide a label, but don't yet know the cardinality of the data that the label is going to be provided for. (Often in widgets.)

This provides a "LocalizableString" class for strings that will eventually need to be translated by dngettext, but where we don't yet know the number of things for the label at the point where we are creating it.

#### Testing instructions (if applicable)
1. There should be no visible changes to LORIS. In particular, the "My Tasks" widgets should all have the exact same behaviour as before.
