### PR TITLE
[Dashboard/Multilingual] Translate labels in Study Progression panel

### DIFF
--- a/modules/behavioural_qc/locale/behavioural_qc.pot
+++ b/modules/behavioural_qc/locale/behavioural_qc.pot
@@ -21,3 +21,6 @@ msgstr ""
 msgid "Behavioural Quality Control"
 msgstr ""
 
+msgid  "Behavioural Session"
+msgid_plural "Behavioural Sessions"
+msgstr[0] ""

--- a/modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
+++ b/modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
@@ -17,7 +17,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 
 msgid "Behavioural Quality Control"
 msgstr "行動品質管理"
 
+msgid  "Behavioural Session"
+msgid_plural "Behavioural Sessions"
+msgstr[0] "行動品質管理"

--- a/modules/behavioural_qc/php/module.class.inc
+++ b/modules/behavioural_qc/php/module.class.inc
@@ -98,7 +98,11 @@ class Module extends \Module
             );
             return [
                 new \LORIS\dashboard\DataWidget(
-                    "Behavioural Session",
+                    new \LORIS\GUI\LocalizableString(
+                        "behavioural_qc",
+                        "Behavioural Session",
+                        "Behavioural Sessions"
+                    ),
                     $data,
                     "",
                     'rgb(252, 241, 255)'

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
@@ -1,9 +1,5 @@
 {
     "Access Profile": "アクセスプロファイル",
-    "Entity Type": "エンティティタイプ",
-    "Scan Done": "スキャン完了",
     "Visit Count": "訪問回数",
-    "Open Profile": "プロフィールを開く",
-    "Show Advanced Filters": "詳細フィルターを表示",
-    "Hide Advanced Filters": "詳細フィルターを非表示"
+    "Open Profile": "プロフィールを開く"
 }

--- a/modules/candidate_list/php/module.class.inc
+++ b/modules/candidate_list/php/module.class.inc
@@ -140,7 +140,11 @@ class Module extends \Module
             );
             return [
                 new \LORIS\dashboard\DataWidget(
-                    "Candidate",
+                    new \LORIS\GUI\LocalizableString(
+                        "loris",
+                        "Candidate",
+                        "Candidates"
+                    ),
                     $data,
                     "",
                     'rgb(255, 252, 199)',

--- a/modules/dashboard/php/datawidget.class.inc
+++ b/modules/dashboard/php/datawidget.class.inc
@@ -12,6 +12,7 @@
  * @link     https://www.github.com/aces/Loris
  */
 namespace LORIS\dashboard;
+use \LORIS\GUI\LocalizableString;
 
 /**
  * A DataWidget is a type of dashboard widget which contains data from
@@ -33,13 +34,13 @@ class DataWidget implements \LORIS\GUI\Widget
     /**
      * Construct a DataWidget with the given properties.
      *
-     * @param string $label    The label to describe the data.
-     * @param array  $data     The array data.
-     * @param string $cssclass A CSS class to add to the element.
-     * @param string $colour   The colour to use for the element.
+     * @param LocalizableString $label    The label to describe the data.
+     * @param array             $data     The array data.
+     * @param string            $cssclass A CSS class to add to the element.
+     * @param string            $colour   The colour to use for the element.
      */
     public function __construct(
-        string $label,
+        \LORIS\GUI\LocalizableString $label,
         array $data,
         string $cssclass,
         string $colour,
@@ -53,9 +54,9 @@ class DataWidget implements \LORIS\GUI\Widget
     /**
      * Returns the label for this task.
      *
-     * @return string
+     * @return LocalizableString
      */
-    public function label() : string
+    public function label() : LocalizableString
     {
         return $this->label;
     }

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -29,3 +29,7 @@ msgstr ""
 
 msgid "New and pending imaging sessions"
 msgstr ""
+
+msgid "Imaging Session"
+msgid_plural "Imaging Sessions"
+msgstr[0] ""

--- a/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
@@ -17,6 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 
 msgid "Imaging Browser"
 msgstr "イメージングブラウザ"
@@ -29,3 +30,7 @@ msgstr "新規および保留中のMRI セッション"
 
 msgid "New and pending imaging sessions"
 msgstr "新規および保留中のMRI セッション"
+
+msgid "Imaging Session"
+msgid_plural "Imaging Sessions"
+msgstr[0] "イメージングセッション"

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -145,7 +145,11 @@ class Module extends \Module
             );
             return [
                 new \LORIS\dashboard\DataWidget(
-                    "Imaging Session",
+                    new \LORIS\GUI\LocalizableString(
+                        "imaging_browser",
+                        "Imaging Session",
+                        "Imaging Sessions"
+                    ),
                     $data,
                     "",
                     'rgb(235, 255, 254)',

--- a/modules/statistics/jsx/widgets/studyprogression.js
+++ b/modules/statistics/jsx/widgets/studyprogression.js
@@ -108,10 +108,7 @@ const StudyProgression = (props) => {
                             return (
                               <a {...commonProps} href={data['url']}>
                                 <h4>{data['count']}</h4>
-                                <div>
-                                  {data['title']}
-                                  {data['count'] !== 1 && 's'}
-                                </div>
+                                <div>{data['title']}</div>
                               </a>
                             );
                           })}

--- a/modules/statistics/php/widgets.class.inc
+++ b/modules/statistics/php/widgets.class.inc
@@ -451,7 +451,8 @@ class Widgets extends \NDB_Page implements ETagCalculator
 
                 $widgetData = [
                     ...$widget->data(),
-                    "colour" => $widget->colour()
+                    "colour" => $widget->colour(),
+                    "ref"    => $widget,
                 ];
 
                 // Remove URLs if user doesn't have access to the module
@@ -459,7 +460,7 @@ class Widgets extends \NDB_Page implements ETagCalculator
                     $widgetData = $this->_removeUrlsFromWidgetData($widgetData);
                 }
 
-                $studyWidgets[$widget->label()] = $widgetData;
+                $studyWidgets[$widget->label()->getN(1)] = $widgetData;
             }
         }
 
@@ -570,15 +571,17 @@ class Widgets extends \NDB_Page implements ETagCalculator
     {
         $projectData = [];
 
-        foreach ($widgets as $widgetName => $widgetConfig) {
+        foreach ($widgets as $widgetConfig) {
             // Search through numeric indices for matching ProjectID
             foreach ($widgetConfig as $value) {
                 if (is_array($value)
                     && isset($value['ProjectID'])
                     && strval($value['ProjectID']) === $projectID
                 ) {
+                    $title = $widgetConfig['ref']->label()->getN($value['count']);
+
                     $projectData[] = [
-                        'title'  => $widgetName,
+                        'title'  => $title,
                         'url'    => $value['url'] ?? null,
                         'colour' => $widgetConfig['colour'] ?? null,
                         'count'  => $value['count'] ?? 0


### PR DESCRIPTION
This moves the hardcoded "s" from javascript to the "title" on the PHP side for
pluralizing the chips in the Study Progression panel using the new LocalizableString
class introduced in https://github.com/aces/Loris/pull/9997

It is easier to do the translations/pluralization in PHP with gettext (via the
ajax call) than in Javascript with i18next here, because by the time widgets are
being rendered on the dashboard we have lost context of which module the string
should come from.

Blocked by #9997