### PR TITLE
[module_manager] Add Translations to Module_Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ locales:
 	msgfmt -o modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.mo modules/behavioural_qc/locale/ja/LC_MESSAGES/behavioural_qc.po
 	msgfmt -o modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.mo modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po
 	msgfmt -o modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.mo modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
+	msgfmt -o modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
+	npx i18next-conv -l hi -s modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po -t modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.json
 	msgfmt -o modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
 	npx i18next-conv -l ja -s modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po -t modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
 	msgfmt -o modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
@@ -109,6 +111,8 @@ locales:
 	msgfmt -o modules/login/locale/ja/LC_MESSAGES/login.mo modules/login/locale/ja/LC_MESSAGES/login.po
 	msgfmt -o modules/media/locale/ja/LC_MESSAGES/media.mo modules/media/locale/ja/LC_MESSAGES/media.po
 	msgfmt -o modules/module_manager/locale/ja/LC_MESSAGES/module_manager.mo modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
+	msgfmt -o modules/module_manager/locale/hi/LC_MESSAGES/module_manager.mo modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po
+	npx i18next-conv -l hi -s modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po -t modules/module_manager/locale/hi/LC_MESSAGES/module_manager.json
 	msgfmt -o modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.mo modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
 	msgfmt -o modules/next_stage/locale/ja/LC_MESSAGES/next_stage.mo modules/next_stage/locale/ja/LC_MESSAGES/next_stage.po
 	msgfmt -o modules/oidc/locale/ja/LC_MESSAGES/oidc.mo modules/oidc/locale/ja/LC_MESSAGES/oidc.po
@@ -141,6 +145,8 @@ login:
 	target=login npm run compile
 
 module_manager:
+	msgfmt -o modules/module_manager/locale/hi/LC_MESSAGES/module_manager.mo modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po
+	npx i18next-conv -l hi -s modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po -t modules/module_manager/locale/hi/LC_MESSAGES/module_manager.json
 	target=module_manager npm run compile
 
 mri_violations:

--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -5,6 +5,10 @@ import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import swal from 'sweetalert2';
 import {SelectElement} from 'jsx/Form';
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
+import hiStrings from '../locale/hi/LC_MESSAGES/module_manager.json';
 
 /**
  * Module Manager React Component
@@ -63,12 +67,13 @@ class ModuleManagerIndex extends Component {
    * @return {string} a mapped value for the table cell at a given column
    */
   mapColumn(column, cell) {
+    const {t} = this.props;
     switch (column) {
-    case 'Active':
+    case t('Active', {ns: 'module_manager'}):
       if (cell === 'Y') {
-        return 'Yes';
+        return t('Yes', {ns: 'loris'});
       } else if (cell === 'N') {
-        return 'No';
+        return t('No', {ns: 'loris'});
       }
       // This shouldn't happen, it's a non-nullable
       // enum in the backend.
@@ -85,6 +90,7 @@ class ModuleManagerIndex extends Component {
    * @param {number} id
    */
   toggleActive(name, value, id) {
+    const {t} = this.props;
     fetch(
       this.props.BaseURL + '/module_manager/modules/' + name,
       {
@@ -98,18 +104,25 @@ class ModuleManagerIndex extends Component {
       }
     ).then((response) => {
       if (response.status != 205) {
-        swal.fire('Error!', 'Could not update ' + name + '.', 'error');
+        swal.fire(
+          t('Error!', {ns: 'module_manager'}),
+          t('Could not update ', {ns: 'module_manager'}) + name + '.',
+          'error'
+        );
       } else {
         const success = this.setModuleDisplayStatus(name, value);
         if (success === true) {
           swal.fire({
-            title: 'Success!',
-            text: 'Updated ' + name + ' status! ' +
-                  'To apply changes the interface must be reloaded. Proceed?',
+            title: t('Success!', {ns: 'module_manager'}),
+            text: t('Updated', {ns: 'module_manager'}) +
+            name + t(' status! ', {ns: 'module_manager'}) +
+                  t('To apply changes the interface must be reloaded. Proceed?',
+                    {ns: 'module_manager'}),
             type: 'success',
             showCancelButton: true,
-            confirmButtonText: 'Reload the page',
-            cancelButtonText: 'Continue',
+            confirmButtonText: t('Reload the page',
+              {ns: 'module_manager'}),
+            cancelButtonText: t('Continue', {ns: 'module_manager'}),
           }).then((status) => {
             if (status.value) {
               window.location.href = this.props.BaseURL
@@ -120,8 +133,9 @@ class ModuleManagerIndex extends Component {
           // If we get here something went very wrong, because somehow
           // a module was toggled that isn't in the table.
           swal.fire(
-            'Error!',
-            'Could not find module ' + id + '.',
+            t('Error!', {ns: 'module_manager'}),
+            t('Could not find module ',
+              {ns: 'module_manager'}) + id + '.',
             'error'
           );
         }
@@ -160,13 +174,16 @@ class ModuleManagerIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
-    if (column == 'Active' && this.props.hasEditPermission) {
+    const {t} = this.props;
+    if (column == t('Active',
+      {ns: 'module_manager'}) && this.props.hasEditPermission) {
       return <td><SelectElement
         name={row.Name}
         id={row.Name}
         label=''
         emptyOption={false}
-        options={{'Y': 'Yes', 'N': 'No'}}
+        options={{'Y': t('Yes',
+          {ns: 'loris'}), 'N': t('No', {ns: 'loris'})}}
         value={cell}
         onUserInput={this.toggleActive}
         noMargins={true}
@@ -184,8 +201,10 @@ class ModuleManagerIndex extends Component {
   render() {
     // If error occurs, return a message.
     // XXX: Replace this with a UI component for 500 errors.
+    const {t} = this.props;
     if (this.state.error) {
-      return <h3>An error occured while loading the page.</h3>;
+      return <h3>{t('An error occured while loading the page.',
+        {ns: 'loris'})}</h3>;
     }
 
     // Waiting for async data to load
@@ -194,20 +213,20 @@ class ModuleManagerIndex extends Component {
     }
 
     const fields = [
-      {label: 'Name', show: true, filter: {
+      {label: t('Name', {ns: 'module_manager'}), show: true, filter: {
         name: 'Name',
         type: 'text',
       }},
-      {label: 'Full Name', show: true, filter: {
+      {label: t('Full Name', {ns: 'module_manager'}), show: true, filter: {
         name: 'Full Name',
         type: 'text',
       }},
-      {label: 'Active', show: true, filter: {
+      {label: t('Active', {ns: 'module_manager'}), show: true, filter: {
         name: 'Active',
         type: 'select',
         options: {
-          'Y': 'Yes',
-          'N': 'No',
+          'Y': t('Yes', {ns: 'loris'}),
+          'N': t('No', {ns: 'loris'}),
         },
       }},
     ];
@@ -226,13 +245,19 @@ ModuleManagerIndex.propTypes = {
   dataURL: PropTypes.string.isRequired,
   BaseURL: PropTypes.string,
   hasEditPermission: PropTypes.bool,
+  t: PropTypes.func.isRequired,
 };
 
+const TranslatedModuleManagerIndex =
+        withTranslation(['module_manager', 'loris'])(ModuleManagerIndex);
+
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('hi', 'module_manager', hiStrings);
+
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ModuleManagerIndex
+    <TranslatedModuleManagerIndex
       dataURL={`${loris.BaseURL}/module_manager/?format=json`}
       BaseURL={loris.BaseURL}
       hasEditPermission={loris.userHasPermission('module_manager_edit')}

--- a/modules/module_manager/locale/hi/LC_MESSAGES/module_manager.json
+++ b/modules/module_manager/locale/hi/LC_MESSAGES/module_manager.json
@@ -1,0 +1,13 @@
+{
+    "Module Manager": "मॉड्यूल प्रबंधक",
+    "Error!": "त्रुटि!",
+    "Could not update ": "अद्यतन नहीं कर सका ",
+    "Success!": "सफलता!",
+    "Updated": "अद्यतन किया गया",
+    "status!": "स्थिति!",
+    "To apply changes the interface must be reloaded. Proceed?": "परिवर्तनों को लागू करने के लिए इंटरफ़ेस को पुनः लोड करना आवश्यक है। क्या आप आगे बढ़ना चाहते हैं?",
+    "Reload the page": "पृष्ठ पुनः लोड करें",
+    "Continue": "जारी रखें",
+    "Could not find module ": "मॉड्यूल नहीं मिला ",
+    "Full Name": "पूरा नाम"
+}

--- a/modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po
+++ b/modules/module_manager/locale/hi/LC_MESSAGES/module_manager.po
@@ -13,40 +13,40 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Module Manager"
-msgstr ""
+msgstr "मॉड्यूल प्रबंधक"
 
 msgid "Error!"
-msgstr ""
+msgstr "त्रुटि!"
 
 msgid "Could not update "
-msgstr ""
+msgstr "अद्यतन नहीं कर सका "
 
 msgid "Success!"
-msgstr ""
+msgstr "सफलता!"
 
 msgid "Updated"
-msgstr ""
+msgstr "अद्यतन किया गया"
 
 msgid "status!"
-msgstr ""
+msgstr "स्थिति!"
 
 msgid "To apply changes the interface must be reloaded. Proceed?"
-msgstr ""
+msgstr "परिवर्तनों को लागू करने के लिए इंटरफ़ेस को पुनः लोड करना आवश्यक है। क्या आप आगे बढ़ना चाहते हैं?"
 
 msgid "Reload the page"
-msgstr ""
+msgstr "पृष्ठ पुनः लोड करें"
 
 msgid "Continue"
-msgstr ""
+msgstr "जारी रखें"
 
 msgid "Could not find module "
-msgstr ""
+msgstr "मॉड्यूल नहीं मिला "
 
 msgid "Full Name"
-msgstr ""
+msgstr "पूरा नाम"


### PR DESCRIPTION
This PR is responsible for translating the module module_manager to different languages. Currently only 'Hindi' language is supported but other languages can be added as required.

Testing instructions (if applicable)

1. Run 'make dev' to load changes
2. Change language_preference to Hindi in my_preferences Tab
3. Go to module_manager tab to see translated web page.