### PR TITLE
[notification_modules] Add Issue Tracker notifications to schema

### DIFF
--- a/SQL/New_patches/2025-09-09_Issue_tracker_notification_description.sql
+++ b/SQL/New_patches/2025-09-09_Issue_tracker_notification_description.sql
@@ -1,3 +1,0 @@
-UPDATE notification_modules 
-	SET Description='Issue Tracker: All issues created or edited' 
-	WHERE module_name='issue_tracker' AND operation_type='create/edit';


### PR DESCRIPTION
## Brief summary of changes
The issue tracker notification was added here https://github.com/aces/Loris/pull/9396 but it was only added as a new patch and not to the schema. This PR adds it to the schema as of 27.0-release since that is when the feature was added. 

<img width="1325" height="541" alt="image" src="https://github.com/user-attachments/assets/b08922bd-a568-4850-92c2-c9d02850ac9f" />

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Load raisinbread data dump from inside this PR
2. Check that the notification setting for issue tracker is available
3. Give yourself the notification setting
4. Check that your user does receive notifications for new issues / issue updates as described in #9396

#### Link(s) to related issue(s)

* Resolves #NO ISSUE