### PR TITLE
[dictionary] Fix override functionality in non-English languages

### DIFF
--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -119,6 +119,9 @@ msgstr "はい"
 msgid "No"
 msgstr "いいえ"
 
+msgid "Cancel"
+msgstr "取り消す"
+
 # Filters
 msgid "Selection Filter"
 msgstr "'選択フィルター"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -119,6 +119,9 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+msgid "Cancel"
+msgstr ""
+
 # Common candidate terms
 msgid "PSCID"
 msgstr ""

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
@@ -1,5 +1,0 @@
-{
-    "Access Profile": "アクセスプロファイル",
-    "Visit Count": "訪問回数",
-    "Open Profile": "プロフィールを開く"
-}

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -79,7 +79,7 @@ class DataDictIndex extends Component {
         inputValue: row.Description,
         confirmButtonText: t('Modify', {ns: 'dictionary'}),
         showCancelButton: true,
-        cancelButtonText: t('Cancel', {ns: 'dictionary'}),
+        cancelButtonText: t('Cancel', {ns: 'loris'}),
         inputValidator: (value) => {
           if (!value) {
             return t('Missing description', {ns: 'dictionary'});

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -76,7 +76,7 @@ class DataDictIndex extends Component {
       swal.fire({
         title: t('Edit Description', {ns: 'dictionary'}),
         input: 'text',
-        inputValue: row.Description,
+        inputValue: row[t('Description', {ns: 'dictionary'})],
         confirmButtonText: t('Modify', {ns: 'dictionary'}),
         showCancelButton: true,
         cancelButtonText: t('Cancel', {ns: 'loris'}),

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -79,6 +79,7 @@ class DataDictIndex extends Component {
         inputValue: row.Description,
         confirmButtonText: t('Modify', {ns: 'dictionary'}),
         showCancelButton: true,
+        cancelButtonText: t('Cancel', {ns: 'dictionary'}),
         inputValidator: (value) => {
           if (!value) {
             return t('Missing description', {ns: 'dictionary'});
@@ -89,9 +90,10 @@ class DataDictIndex extends Component {
           return;
         }
 
+        const fieldname = row[t('Field Name', {ns: 'dictionary'})];
         const url = this.props.BaseURL
               + '/dictionary/fields/'
-              + encodeURI(row['Field Name']);
+              + encodeURI(fieldname);
 
         // The fetch happens asynchronously, which means that the
         // swal closes before it returns. We find the index that
@@ -101,7 +103,7 @@ class DataDictIndex extends Component {
         let odesc;
         let ostat;
         for (i = 0; i < this.state.data.Data.length; i++) {
-          if (this.state.data.Data[i][2] == row['Field Name']) {
+          if (this.state.data.Data[i][2] == fieldname) {
             // Store the original values in case the fetch
             // fails and we need to restore them.
             odesc = this.state.data.Data[i][3];

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -142,7 +142,10 @@ class DataDictIndex extends Component {
           // good, but it's possible the status was changed
           // back to the original. So update the status
           // based on what the response said the value was.
-          this.state.data.Data[i][4] = response.headers.get('X-StatusDesc');
+          this.state.data.Data[i][4] = this.props.t(
+            response.headers.get('X-StatusDesc'),
+            {ns: 'dictionary'}
+          );
           this.setState({state: this.state});
         }).catch(() => {
           // Something went wrong, restore the original

--- a/modules/dictionary/locale/dictionary.pot
+++ b/modules/dictionary/locale/dictionary.pot
@@ -24,9 +24,6 @@ msgstr ""
 msgid "Edit Description"
 msgstr ""
 
-msgid "Cancel"
-msgstr ""
-
 msgid "Modify"
 msgstr ""
 

--- a/modules/dictionary/locale/dictionary.pot
+++ b/modules/dictionary/locale/dictionary.pot
@@ -24,6 +24,9 @@ msgstr ""
 msgid "Edit Description"
 msgstr ""
 
+msgid "Cancel"
+msgstr ""
+
 msgid "Modify"
 msgstr ""
 

--- a/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
+++ b/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
@@ -24,9 +24,6 @@ msgstr "データ辞書"
 msgid "Edit Description"
 msgstr "説明を編集"
 
-msgid "Cancel"
-msgstr "取り消す"
-
 msgid "Modify"
 msgstr "修正する"
 

--- a/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
+++ b/modules/dictionary/locale/ja/LC_MESSAGES/dictionary.po
@@ -24,6 +24,9 @@ msgstr "データ辞書"
 msgid "Edit Description"
 msgstr "説明を編集"
 
+msgid "Cancel"
+msgstr "取り消す"
+
 msgid "Modify"
 msgstr "修正する"
 
@@ -74,3 +77,4 @@ msgstr "多くの"
 
 msgid "Description"
 msgstr "説明"
+

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -57,16 +57,16 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
 
             foreach ($cat->getItems() as $item) {
                 $name   = $item->getName();
-                $status = 'Unchanged';
+                $status = dgettext('dictionary', 'Unchanged');
                 if (isset($overrides[$name])) {
                     $desc   = $overrides[$name]['Description'];
-                    $status = 'Modified';
+                    $status = dgettext('dictionary', 'Modified');
                 } else {
                     $desc = $item->getDescription();
                 }
 
                 if ($desc == '') {
-                    $status = 'Empty';
+                    $status = dgettext('dictionary', 'Empty');
                 }
 
                 $cohorts = $DB->pselectCol(

--- a/modules/dictionary/php/dictionary.class.inc
+++ b/modules/dictionary/php/dictionary.class.inc
@@ -114,7 +114,10 @@ class Dictionary extends \DataFrameworkMenu
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
         return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb('Data Dictionary', "/$this->name")
+            new \LORIS\Breadcrumb(
+                dgettext('dictionary', 'Data Dictionary'),
+                "/$this->name"
+            )
         );
     }
 


### PR DESCRIPTION
The row name keys in the json passed by the DataTable are translated, so the key looking up the "Field Name" needs to be translated when looking up information from them.

Fixes #10011.

Also adds an explicit label for the "Cancel" button as it was not translated (the label came from swal when not explicitly provided.)