### PR TITLE
[timepoint_list] Translates Timepoint list module to Japanese.

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -5,9 +5,18 @@
 # This file is distributed under the same license as the LORIS package.
 # Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
 #
-
 msgid ""
 msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 # Smarty template main.tpl strings
 msgid "LORIS"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -181,6 +181,12 @@ msgstr "フィードバック"
 msgid "Scans"
 msgstr "スキャン"
 
+msgid "Stage"
+msgstr "ステージ"
+
+msgid "Sent To DCC"
+msgstr "DCCに送信"
+
 msgid "Date of Birth"
 msgstr "生年月日"
 
@@ -228,3 +234,34 @@ msgstr "アップロード済み"
 
 msgid "Total"
 msgstr "合計"
+
+# Common timepoint and vist terms
+msgid "Not Started"
+msgstr "開始されていません"
+
+msgid "Screening"
+msgstr "スクリーニング"
+
+msgid "Visit"
+msgstr "訪問"
+
+msgid "Approval"
+msgstr "承認"
+
+msgid "Subject"
+msgstr "候補者"
+
+msgid "Recycling Bin"
+msgstr "リサイクルビン"
+
+msgid "Pass"
+msgstr "合格"
+
+msgid "Failure"
+msgstr "失敗"
+
+msgid "Withdrawal"
+msgstr "撤退"
+
+msgid "In Progress"
+msgstr "進行中"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -8,6 +8,16 @@
 
 msgid ""
 msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 # Smarty template main.tpl strings
 msgid "LORIS"

--- a/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
@@ -5,9 +5,18 @@
 # This file is distributed under the same license as the LORIS package.
 # Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
 #
-
 msgid ""
 msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 msgid "Timepoint List"
 msgstr "Lista de Puntos en el Tiempo"

--- a/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
@@ -5,6 +5,7 @@
 # This file is distributed under the same license as the LORIS package.
 # Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
 #
+
 msgid ""
 msgstr ""
 "Project-Id-Version: LORIS 27\n"
@@ -17,7 +18,70 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 
-# I am not sure if this is the right kanji for "survey" 
 msgid "Timepoint List"
 msgstr "タイムポイントリスト"
+
+msgid "Click to Open"
+msgstr "クリックして開く"
+
+msgid "Stage Status"
+msgstr "ステージステータス"
+
+msgid "Date of Stage"
+msgstr "ステージの日付"
+
+msgid "Imaging Scan Done"
+msgstr "画像スキャン完了"
+
+msgid "BVL QC"
+msgstr "行動品質管理"
+
+msgid "BVL Exclusion"
+msgstr "行動的排除"
+
+msgid "Registered By"
+msgstr "登録者"
+
+msgid "List of Visits (Time Points)"
+msgstr "訪問リスト（時点）"
+
+msgid "Create time point"
+msgstr "タイムポイントを作成"
+
+msgid "Candidate Info"
+msgstr "候補者情報"
+
+msgid "View Imaging datasets"
+msgstr "画像データセットを表示"
+
+msgid "Actions:"
+msgstr "アクション:"
+
+msgid "Derived Age"
+msgstr "派生年齢"
+
+msgid "EDC Age"
+msgstr "EDC時代"
+
+msgid "Biological Sex"
+msgstr "生物学的性別"
+
+msgid "You do not have access to any timepoints registered for this candidate."
+msgstr "この候補者に対して登録されたタイムポイントにアクセスできません。"
+
+msgid " y / "
+msgstr ""
+
+msgid " m"
+msgstr ""
+
+msgid "Visual"
+msgstr "ビジュアル"
+
+msgid "Hardcopy"
+msgstr "ハードコピー"
+
+msgid "Complete"
+msgstr "完了"

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -13,7 +13,7 @@
       {dgettext("timepoint_list", "Biological Sex")}
     </th>
     <th>
-      Project
+      {dgettext("loris", "Project")}
     </th>
     {foreach from=$candidate.DisplayParameters item=value key=name}
       <th>
@@ -111,7 +111,7 @@
                     {if $timePoints[timepoint].Scan_done == 'Y'}
                         {assign var="scan_done" value={dgettext("loris", "Yes")}}
                         <a href="{$baseurl|default}/imaging_browser/viewSession/?sessionID={$timePoints[timepoint].SessionID}" class="timepoint_list">
-                        {$scan_done}</a>
+                        {dgettext('loris', $scan_done)}</a>
                     {else}
                         {assign var="scan_done" value={dgettext("loris", "No")}}
                         {$scan_done}
@@ -131,7 +131,9 @@
 
             <td>
             {if $timePoints[timepoint].BVLQCStatus}
-                {dgettext("timepoint_list", $timePoints[timepoint].BVLQCType)}
+                {if $timePoints[timepoint].BVLQCType != ""}
+		    {dgettext("timepoint_list", $timePoints[timepoint].BVLQCType)}
+                {/if}
             {else}
                 <img src="{$baseurl|default}/images/delete.gif" border="0" />
             {/if}


### PR DESCRIPTION
Add Japanese translation strings for the timepoint_list module.

Also re-added the file headers and instead added a guard around the empty string before calling gettext. Gettext("") returns the file header by design (see: https://stackoverflow.com/questions/7610144/why-does-gettext-translate-an-empty-string-to-the-po-header-text) but also has important meta-data such as the number of plural forms or the character set. We may want to consider adding a wrapper around (d)(n)gettext to handle this more generally.

Also added a missing gettext around "Project" for the table header, which is already in the loris namespace.