### PR TITLE
[Multilingual] Simplify language imports

### DIFF
--- a/jsx/I18nSetup.js
+++ b/jsx/I18nSetup.js
@@ -1,19 +1,15 @@
 import i18n from 'i18next';
 import {initReactI18next} from 'react-i18next';
 
-import jaResources from '../locale/ja/LC_MESSAGES/loris.json';
-import hiResources from '../locale/hi/LC_MESSAGES/loris.json';
-import esResources from '../locale/es/LC_MESSAGES/loris.json';
-
 const resources = {
   ja: {
-    loris: jaResources,
+    loris: require('../locale/ja/LC_MESSAGES/loris.json'),
   },
   hi: {
-    loris: hiResources,
+    loris: require('../locale/hi/LC_MESSAGES/loris.json'),
   },
   es: {
-    loris: esResources,
+    loris: require('../es/LC_MESSAGES/loris.json'),
   },
 };
 

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -12,9 +12,6 @@ import OpenProfileForm from './openProfileForm';
 import i18n from 'I18nSetup';
 import {withTranslation} from 'react-i18next';
 
-import jaStrings from '../locale/ja/LC_MESSAGES/candidate_list.json';
-import hiStrings from '../locale/hi/LC_MESSAGES/candidate_list.json';
-
 /**
  * Candidate List
  *
@@ -407,8 +404,10 @@ CandidateListIndex.propTypes = {
 
 window.addEventListener('load', () => {
   const args = QueryString.get();
-  i18n.addResourceBundle('ja', 'candidate_list', jaStrings);
-  i18n.addResourceBundle('hi', 'candidate_list', hiStrings);
+  i18n.addResourceBundle(
+	  'ja', 'candidate_list', require('../locale/ja/LC_MESSAGES/candidate_list.json'));
+  i18n.addResourceBundle('hi', 'candidate_list', require('../locale/hi/LC_MESSAGES/candidate_list.json'));
+
 
 
   const CLIndex = withTranslation(

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -13,9 +13,6 @@ import UploadFileForm from './uploadFileForm';
 import AddPermissionForm from './addPermissionForm';
 import ManagePermissionsForm from './managePermissionsForm';
 
-import hiStrings from '../locale/hi/LC_MESSAGES/data_release.json';
-import jaStrings from '../locale/ja/LC_MESSAGES/data_release.json';
-
 /**
  * Data Release
  *
@@ -244,8 +241,10 @@ DataReleaseIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
-  i18n.addResourceBundle('ja', 'data_release', jaStrings);
-  i18n.addResourceBundle('hi', 'data_release', hiStrings);
+  i18n.addResourceBundle('ja', 'data_release', require('../locale/ja/LC_MESSAGES/data_release.json'));
+  i18n.addResourceBundle('hi', 'data_release', require('../locale/hi/LC_MESSAGES/data_release.json'));
+
+
   const Index = withTranslation(
     ['data_release', 'loris']
   )(DataReleaseIndex);

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -10,9 +10,6 @@ import FilterableDataTable from 'FilterableDataTable';
 
 import fetchDataStream from 'jslib/fetchDataStream';
 
-import hiStrings from '../locale/hi/LC_MESSAGES/datadict.json';
-import jaStrings from '../locale/ja/LC_MESSAGES/datadict.json';
-
 /**
  * Data Dictionary Page.
  *
@@ -239,8 +236,10 @@ DataDictIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
-  i18n.addResourceBundle('hi', 'datadict', hiStrings);
-  i18n.addResourceBundle('ja', 'datadict', jaStrings);
+  i18n.addResourceBundle('hi', 'datadict', require('../locale/hi/LC_MESSAGES/datadict.json'));
+  i18n.addResourceBundle('ja', 'datadict', require('../locale/ja/LC_MESSAGES/datadict.json'));
+
+
   const Index = withTranslation(
     ['datadict', 'loris']
   )(DataDictIndex);

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -9,9 +9,6 @@ import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import swal from 'sweetalert2';
 
-import hiStrings from '../locale/hi/LC_MESSAGES/dictionary.json';
-import jaStrings from '../locale/ja/LC_MESSAGES/dictionary.json';
-
 /**
  * Data Dictionary Page.
  *
@@ -357,8 +354,9 @@ DataDictIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
-  i18n.addResourceBundle('ja', 'dictionary', jaStrings);
-  i18n.addResourceBundle('hi', 'dictionary', hiStrings);
+  i18n.addResourceBundle('ja', 'dictionary', require('../locale/ja/LC_MESSAGES/dictionary.json'));
+  i18n.addResourceBundle('hi', 'dictionary', require('../locale/hi/LC_MESSAGES/dictionary.json'));
+
   const Index = withTranslation(
     ['dictionary', 'loris']
   )(DataDictIndex);

--- a/modules/statistics/jsx/WidgetIndex.js
+++ b/modules/statistics/jsx/WidgetIndex.js
@@ -12,7 +12,6 @@ import {useTranslation} from 'react-i18next';
 import '../css/WidgetIndex.css';
 
 import {setupCharts} from './widgets/helpers/chartBuilder';
-import jaStrings from '../locale/ja/LC_MESSAGES/statistics.json';
 
 /**
  * WidgetIndex - the main window.
@@ -26,7 +25,8 @@ const WidgetIndex = (props) => {
   const [modalChart, setModalChart] = useState(null);
   const {t, i18n} = useTranslation();
   useEffect( () => {
-    i18n.addResourceBundle('ja', 'statistics', jaStrings);
+
+    i18n.addResourceBundle('ja', 'statistics', require('../locale/ja/LC_MESSAGES/statistics.json'));
   }, []);
 
   // used by recruitment.js and studyprogression.js to display each chart.

--- a/modules/statistics/jsx/widgets/studyprogression.js
+++ b/modules/statistics/jsx/widgets/studyprogression.js
@@ -6,7 +6,6 @@ import Panel from 'Panel';
 import {QueryChartForm} from './helpers/queryChartForm';
 import {setupCharts} from './helpers/chartBuilder';
 import {useTranslation} from 'react-i18next';
-import jaStrings from '../../locale/ja/LC_MESSAGES/statistics.json';
 
 /**
  * StudyProgression - a widget containing statistics for study data.
@@ -21,7 +20,8 @@ const StudyProgression = (props) => {
   const [showFiltersRecruitment, setShowFiltersRecruitment] = useState(false);
   const [activeView, setActiveView] = useState(0);
   useEffect( () => {
-    i18n.addResourceBundle('ja', 'statistics', jaStrings);
+    i18n.addResourceBundle('ja', 'statistics', require('../../locale/ja/LC_MESSAGES/statistics.json'));
+
 
     // Re-set default state that depended on the translation
     let newdetails = {...chartDetails};

--- a/src/Middleware/Language.php
+++ b/src/Middleware/Language.php
@@ -78,7 +78,7 @@ class Language implements MiddlewareInterface, MiddlewareChainer
         $loris = $request->getAttribute("loris");
         $lang  = self::detectLocale($loris, $request);
         if ($lang !== null) {
-            \setlocale(LC_MESSAGES, $lang . '.utf8');
+            \setlocale(LC_ALL, $lang . '.utf8');
             return $this->next->process(
                 $request->withAttribute("locale", $lang),
                 $handler


### PR DESCRIPTION
The importing of a named variable for every language at the top of multilingual files, just to pass it to addResourceBundle is getting a little unwieldy.

Replace them with an inline require() at the addResourceBundle call site so that we don't need to pollute the import namespace for every language (and to make life easier if dialects are added such as en-CA and en-US).

Testing instructions: Nothing should be affected in LORIS. In particular, translations should still be translated.