### PR TITLE
[Phan] fix cs error

### DIFF
--- a/modules/login/php/logout.class.inc
+++ b/modules/login/php/logout.class.inc
@@ -14,7 +14,6 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Logout extends \LORIS\Http\Endpoint
 {
-
     /**
      * {@inheritDoc}
      *


### PR DESCRIPTION
"FILE: /home/runner/work/Loris/Loris/modules/login/php/logout.class.inc
FOUND 1 ERROR AFFECTING 1 LINE
 25 | ERROR | [x] Expected 0 blank lines before function; 1 found
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY"
