### PR TITLE
[Forms] Redirect on successful save

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -66,14 +66,15 @@ class NDB_Form extends NDB_Page
      * Attempts to validate the form (using the defined rules) and
      * saves the validated data into the database
      *
-     * @return void
-     * @access public
+     * @return bool
      */
-    function save()
+    public function save() : bool
     {
-        if ($this->form->validate()) {
-            $this->form->process([&$this, "_save"]);
-        }
+        if (!$this->form->validate()) {
+            return false;
+	}
+        $this->form->process([&$this, "_save"]);
+	return true;
     }
 
     /**
@@ -129,7 +130,9 @@ class NDB_Form extends NDB_Page
     {
         $this->setup();
         if ($request->getMethod() === "POST") {
-            $this->save();
+            if ($this->save()) {
+		    return new \LORIS\Http\Response\JSON\SeeOther($request->getURI());
+            }
         }
 
         return (new \LORIS\Http\Response())

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -72,9 +72,9 @@ class NDB_Form extends NDB_Page
     {
         if (!$this->form->validate()) {
             return false;
-	}
+        }
         $this->form->process([&$this, "_save"]);
-	return true;
+        return true;
     }
 
     /**
@@ -131,7 +131,7 @@ class NDB_Form extends NDB_Page
         $this->setup();
         if ($request->getMethod() === "POST") {
             if ($this->save()) {
-		    return new \LORIS\Http\Response\JSON\SeeOther($request->getURI());
+                return new \LORIS\Http\Response\JSON\SeeOther($request->getURI());
             }
         }
 


### PR DESCRIPTION
This updates the NDB_Form class to respond with a `303 See Other` after a successful page and redirect to the same page.

This (in addition to being a better practice) fixes problems where the page is rendered before changes that depend on the updated values are saved to the database.

In particular, when changing the language on the my_preferences page, it will now immediately take effect rather than only doing after after the next page load.

Blocked by #10031 