### PR TITLE
[instrument_list] Translates Instrument list module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ locales:
 	msgfmt -o modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.mo modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
 	msgfmt -o modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.mo modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
 	msgfmt -o modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.mo modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
+	msgfmt -o modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.mo modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
 	msgfmt -o modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.mo modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.po
 	msgfmt -o modules/instruments/locale/ja/LC_MESSAGES/instruments.mo modules/instruments/locale/ja/LC_MESSAGES/instruments.po
 	msgfmt -o modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.mo modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -86,7 +86,7 @@ msgstr ""
 #: modules/imaging_uploader/php/module.class.inc:54
 #: modules/mri_violations/php/module.class.inc:53
 msgid "Imaging"
-msgstr ""
+msgstr "Imágenes"
 
 #: modules/candidate_list/php/module.class.inc:76
 #: modules/new_profile/php/module.class.inc:50
@@ -110,7 +110,7 @@ msgstr ""
 
 # Common loris terms. Consider moving these to their own textdomain?
 msgid "TimePoint"
-msgstr ""
+msgstr "Punto en el tiempo"
 
 # Common select option labels
 msgid "Yes"
@@ -145,6 +145,12 @@ msgstr ""
 msgid "Project"
 msgstr "Projecto"
 
+msgid "Candidate Registration Project"
+msgstr "Projecto donde se registró al Candidato"
+
+msgid "Timepoint Project"
+msgstr "Punto en el tiempo del Projecto"
+
 msgid "Cohort"
 msgstr "Cohorte"
 
@@ -177,6 +183,9 @@ msgstr "Etapa"
 
 msgid "Sent To DCC"
 msgstr "Enviar a CCD"
+
+msgid "Reverse Send To DCC"
+msgstr "Revertir Enviar al CCD"
 
 msgid "Date of Birth"
 msgstr ""
@@ -259,3 +268,18 @@ msgstr "Retirado"
 
 msgid "In Progress"
 msgstr "En Progreso"
+
+msgid "Complete"
+msgstr "Completo"
+
+msgid "Instruments"
+msgstr "Instrumentos"
+
+msgid "None"
+msgstr "Ninguna"
+
+msgid "Partial"
+msgstr "Parcial"
+
+msgid "All"
+msgstr "Completa"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -145,6 +145,12 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
+msgid "Candidate Registration Project"
+msgstr ""
+
+msgid "Timepoint Project"
+msgstr ""
+
 msgid "Cohort"
 msgstr ""
 
@@ -176,6 +182,9 @@ msgid "Stage"
 msgstr ""
 
 msgid "Sent To DCC"
+msgstr ""
+
+msgid "Reverse Send To DCC"
 msgstr ""
 
 msgid "Date of Birth"
@@ -258,4 +267,22 @@ msgid "Withdrawal"
 msgstr ""
 
 msgid "In Progress"
+msgstr ""
+
+msgid "Complete"
+msgstr ""
+
+msgid "Instruments"
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Partial"
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Start"
 msgstr ""

--- a/modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
@@ -1,0 +1,70 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Instrument List"
+msgstr "Lista de Instrumentos"
+
+msgid "Instruments"
+msgstr "Instrumentos"
+
+msgid "Visit to Site"
+msgstr "Visita al Sitio"
+
+msgid "Within Optimal"
+msgstr "Dentro de lo óptimo"
+
+msgid "Within Permitted"
+msgstr "Dentro de permitido"
+
+msgid "Behavioural Battery of Instruments"
+msgstr "Batería de instrumentos de comportamiento"
+
+msgid "Data Entry"
+msgstr "Entrada de datos"
+
+msgid "Administration"
+msgstr "Administración"
+
+msgid "Double Data Entry Form"
+msgstr "Formulario de entrada de datos duplicado"
+
+msgid "Double Data Entry Status"
+msgstr "Estado del formulario de entrada de datos duplicado"
+
+msgid "Double Data Entry"
+msgstr "Entrada de datos duplicada"
+
+msgid "The battery has no registered instruments"
+msgstr "La batería no tiene instrumentos registrados"
+
+msgid "View Imaging data"
+msgstr "Ver datos de Imágenes"
+
+msgid "Send TimePoint"
+msgstr "Enviar Punto en el Tiempo"
+
+msgid "No actions"
+msgstr "No acciones"
+
+msgid "Stage: %s"
+msgstr "Etapa: %s"
+
+msgid "Start %s Stage"
+msgstr "Iniciar %s Etapa"

--- a/modules/instrument_list/locale/instrument_list.pot
+++ b/modules/instrument_list/locale/instrument_list.pot
@@ -21,3 +21,50 @@ msgstr ""
 msgid "Instrument List"
 msgstr ""
 
+msgid "Instruments"
+msgstr ""
+
+msgid "Visit to Site"
+msgstr ""
+
+msgid "Within Optimal"
+msgstr ""
+
+msgid "Within Permitted"
+msgstr ""
+
+msgid "Behavioural Battery of Instruments"
+msgstr ""
+
+msgid "Data Entry"
+msgstr ""
+
+msgid "Administration"
+msgstr ""
+
+msgid "Double Data Entry Form"
+msgstr ""
+
+msgid "Double Data Entry Status"
+msgstr ""
+
+msgid "Double Data Entry"
+msgstr ""
+
+msgid "The battery has no registered instruments"
+msgstr ""
+
+msgid "View Imaging data"
+msgstr ""
+
+msgid "Send TimePoint"
+msgstr ""
+
+msgid "No actions"
+msgstr ""
+
+msgid "Stage: %s"
+msgstr ""
+
+msgid "Start %s Stage"
+msgstr ""

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -309,7 +309,8 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $dob_year     = abs($current_date->diff($dob_date)->y);
             $dob_month    = abs($current_date->diff($dob_date)->m);
-            $dob_age      = $dob_year . " y / " . $dob_month . " m";
+            $dob_age      = $dob_year . dgettext("timepoint_list", " y / ")
+                . $dob_month . dgettext("timepoint_list", " m");
             $this->tpl_data['dob_age'] = $dob_age;
         }
         // EDC to EDC Age
@@ -319,7 +320,8 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $edc_year     = abs($current_date->diff($edc_date)->y);
             $edc_month    = abs($current_date->diff($edc_date)->m);
-            $edc_age      = $edc_year . " y / " . $edc_month . " m";
+            $edc_age      = $edc_year . dgettext("timepoint_list", " y / ")
+                . $edc_month . dgettext("timepoint_list", " m");
             $this->tpl_data['edc_age'] = $edc_age;
         }
     }

--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -1,17 +1,17 @@
-	<h3 class="controlPanelSection">Actions</h3>
+	<h3 class="controlPanelSection">{dgettext("timepoint_list", "Actions:")}</h3>
 	<ul class="controlPanel">
 	    	<li>
 		{if $access.next_stage}
                         <i class="fas fa-folder-open fa-sm" width="12" height="12"></i>&nbsp;<a
-				href="{$baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">Start {$next_stage} Stage</a>
+				href="{$baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">{sprintf(dgettext("instrument_list", "Start %s Stage"), dgettext("loris", $next_stage))}</a>
 {else}
-                        <small>(No actions)</small>
+                        <small>({dgettext("instrument_list", "No actions")})</small>
 {/if}
 	    	</li>
 
 	</ul>
 
-	<h3 class="controlPanelSection">Stage: {$current_stage}</h3>
+	<h3 class="controlPanelSection">{sprintf(dgettext("instrument_list", "Stage: %s"), dgettext("loris", $current_stage))}</h3>
 	<ul class="controlPanel fa-ul">
 		{section name=item loop=$status}
 		<li>
@@ -24,73 +24,73 @@
 					onclick="sendUpdate('/instrument_list/?candID={$candID}&sessionID={$sessionID}&setStageUpdate=' + '{$onclickValue}')"
 					style="cursor: pointer;"
 				>
-					{$status[item].label}
+					{dgettext("loris", $status[item].label)}
 				</a>
 			{else}
-                <span class="fa-li"><i class="{$status[item].icon|default:'far fa-square'}"></i></span>{$status[item].label}
+                <span class="fa-li"><i class="{$status[item].icon|default:'far fa-square'}"></i></span>{dgettext("loris", $status[item].label)}
 			{/if}
 		</li>
 		{/section}
 	</ul>
 
-	<h3 class="controlPanelSection">Send Time Point</h3>
+	<h3 class="controlPanelSection">{dgettext("instrument_list", "Send TimePoint")}</h3>
 	<ul class="controlPanel fa-ul">
 		<li>
 			{if $access.send_to_dcc===true}
     				{if $send_to_dcc.set_submitted=='Check'}
-                        		<span class="fa-li"><i class="{$send_to_dcc.icon|default:'far fa-square'}"></i></span><a href="{$baseurl}/timepoint_flag/check_timepoint_flag/?identifier={$sessionID}">{$send_to_dcc.reverse|default:"Send To DCC"}</a><br>
+                        		<span class="fa-li"><i class="{$send_to_dcc.icon|default:'far fa-square'}"></i></span><a href="{$baseurl}/timepoint_flag/check_timepoint_flag/?identifier={$sessionID}">{$send_to_dcc.reverse|default:dgettext("loris", "Sent To DCC")}</a><br>
 	    			{else}
 						<a
 							onclick="sendUpdate('/instrument_list/?candID={$candID}&sessionID={$sessionID}&setSubmitted={$send_to_dcc.set_submitted}')"
 							style="cursor: pointer;"
 						>
-							{$send_to_dcc.reverse|default:"Send To DCC"}
+							{dgettext("loris", $send_to_dcc.reverse)|default:dgettext("loris", "Sent To DCC")}
 						</a>
     				{/if}
 			{else}
-                        <span title='{$access.send_to_dcc_status_message}'><span class="fa-li"><i class="{$send_to_dcc.icon|default:'fas fa-times'}"></i></span>Send To DCC</span>
+                        <span title='{$access.send_to_dcc_status_message}'><span class="fa-li"><i class="{$send_to_dcc.icon|default:'fas fa-times'}"></i></span>{dgettext("loris", "Sent To DCC")}</span>
 			{/if}
 		</li>
 	</ul>
 
 
-	<h3 class="controlPanelSection">BVL QC Type</h3>
+	<h3 class="controlPanelSection">{dgettext("timepoint_list", "BVL QC")}</h3>
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_type_none.icon|default:'far fa-square'}"></i></span>
 			{if $bvl_qc_type_none.showlink|default}
-                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=">Not Done</a>
+                                <a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=">{dgettext("timepoint_list", "Not Done")}</a>
 			{else}
-                                                Not Done
+                                                {dgettext("timepoint_list", "Not Done")}
 			{/if}
 		</li>
 
 		<li>
 		          <span class="fa-li"><i class="{$bvl_qc_type_visual.icon|default:'far fa-square'}"></i></span>
 			{if $bvl_qc_type_visual.showlink|default}
-                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Visual">Visual</a>
+                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Visual">{dgettext("timepoint_list", "Visual")}</a>
 			{else}
-                                                Visual
+                                                {dgettext("timepoint_list", "Visual")}
 			{/if}
 		</li>
 		<li>
                 	<span class="fa-li"><i class="{$bvl_qc_type_hardcopy.icon|default:'far fa-square'}"></i></span>
 			{if $bvl_qc_type_hardcopy.showlink|default}
-                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Hardcopy">Hardcopy</a>
+                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Hardcopy">{dgettext("timepoint_list", "Hardcopy")}</a>
 			{else}
-                                                Hardcopy
+                                                {dgettext("timepoint_list", "Hardcopy")}
 			{/if}
 		</li>
 	</ul>
 
-	<h3 class="controlPanelSection">BVL QC Status</h3>
+	<h3 class="controlPanelSection">{dgettext("timepoint_list", "BVL QC Status")}</h3>
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_status_none.icon|default:'far fa-square'}"></i></span>
 			{if $bvl_qc_status_none.showlink|default}
-                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=">Not Done</a>
+                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=">{dgettext("timepoint_list", "Not Done")}</a>
 			{else}
-                                                Not Done
+                                                {dgettext("timepoint_list", "Not Done")}
 			{/if}
 		</li>
 
@@ -99,7 +99,7 @@
 			{if $bvl_qc_status_complete.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=Complete">Complete</a>
 			{else}
-                                                Complete
+                                                {dgettext("timepoint_list", "Complete")}
 			{/if}
 		</li>
 	</ul>

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -5,27 +5,27 @@
   <tr class="info">
     {assign var="DoB" value=$candidate->getDisplayDoB()}
     <th>
-      Derived Age
+      {dgettext("timepoint_list", "Derived Age")}
     </th>
     <th>
-        EDC Age
+      {dgettext("timepoint_list", "EDC Age")}
     </th>
     <th>
-      Biological Sex
+      {dgettext("timepoint_list", "Biological Sex")}
     </th>
     {if $display.ProjectTitle == $display.ProjectName && $display.ProjectName != ""}
       <th>
-        Project
+        {dgettext("loris", "Project")}
       </th>
     {else}
       {if $display.ProjectTitle != ""}
         <th>
-          Candidate Registration Project
+          {dgettext("loris", "Candidate Registration Project")}
         </th>
       {/if}
       {if $display.ProjectName != ""}
         <th>
-          Timepoint Project
+          {dgettext("loris", "Timepoint Project")}
         </th>
       {/if}
     {/if}
@@ -36,22 +36,22 @@
     {/foreach}
     {if $sessionID != ""}
       <th>
-        Visit Label
+        {dgettext("loris", "Visit Label")}
       </th>
       <th>
-        Visit to Site
+        {dgettext("instrument_list", "Visit to Site")}
       </th>
       <th>
-        Cohort
+        {dgettext("loris", "Cohort")}
       </th>
       <th>
-        MR Scan Done
+        {dgettext("timepoint_list", "Imaging Scan Done")}
       </th>
       <th>
-        Within Optimal
+        {dgettext("instrument_list", "Within Optimal")}
       </th>
       <th>
-        Within Permitted
+        {dgettext("instrument_list", "Within Permitted")}
       </th>
       {if $SupplementalSessionStatuses|default}
         {foreach from=$timePoint.status item=status key=name}
@@ -113,16 +113,16 @@
       </td>
       <td>
         {if $display.WindowInfo.Optimum|default}
-          Yes
+          {dgettext("loris", "Yes")}
         {else}
-          No
+          {dgettext("loris", "No")}
         {/if}
       </td>
       <td {if not $display.WindowInfo.Optimum|default}class="error"{/if}>
         {if $display.WindowInfo.Permitted|default}
-          Yes
+          {dgettext("loris", "Yes")}
         {else}
-          No
+          {dgettext("loris", "No")}
         {/if}
       </td>
       {if $SupplementalSessionStatuses|default}
@@ -142,20 +142,20 @@
     <thead>
     <tr class="info">
       <th nowrap="nowrap" colspan="3">
-        Stage
+        {dgettext("loris", "Stage")}
       </th>
       <th nowrap="nowrap" colspan="3">
-        Status
+        {dgettext("timepoint_list", "Stage Status")}
       </th>
       <th nowrap="nowrap" colspan="2">
-        Date
+        {dgettext("timepoint_list", "Date of Stage")}
       </th>
     </tr>
     </thead>
     <tbody>
     <tr>
       <td nowrap="nowrap" colspan="3">
-        Screening
+        {dgettext("loris", "Screening")}
       </td>
       <td nowrap="nowrap" colspan="3">
         {$display.Screening}
@@ -166,10 +166,12 @@
     </tr>
     <tr>
       <td nowrap="nowrap" colspan="3">
-        Visit
+        {dgettext("loris", "Visit")}
       </td>
       <td nowrap="nowrap" colspan="3">
-        {$display.Visit}
+        {if $display.Visit != ""}
+            {dgettext("loris", $display.Visit)}
+        {/if}
       </td>
       <td nowrap="nowrap" colspan="2">
         {$display.Date_visit}
@@ -177,7 +179,7 @@
     </tr>
     <tr>
       <td nowrap="nowrap" colspan="3">
-        Approval
+        {dgettext("loris", "Approval")}
       </td>
       <td nowrap="nowrap" colspan="3">
         {$display.Approval}
@@ -191,7 +193,7 @@
 </div>
 
 <!-- table title -->
-<h3>Behavioural Battery of Instruments</h3>
+<h3>{dgettext("instrument_list", "Behavioural Battery of Instruments")}</h3>
 
 <!-- table with list of instruments and links to open them -->
 <table class="table table-hover table-bordered dynamictable" cellpadding="2">
@@ -199,17 +201,17 @@
     <!-- print the sub group header row -->
     <thead>
     <tr class="info">
-	    <th>{$instrument_groups[group].title}
+	    <th>{dgettext("loris", $instrument_groups[group].title)}
 	       <!-- show the instruction only one time -->
 	       {if $smarty.section.group.iteration == 1}
-	       <br />(Click To Open)
+	       <br />({dgettext("timepoint_list", "Click to Open")})
 	       {/if}
 	    </th>
-	    <th>Data Entry</th>
-	    <th>Administration</th>
-	    <th>Feedback</th>
-	    <th>Double Data Entry Form</th>
-	    <th>Double Data Entry Status</th>
+	    <th>{dgettext("instrument_list", "Data Entry")}</th>
+	    <th>{dgettext("instrument_list", "Administration")}</th>
+	    <th>{dgettext("loris", "Feedback")}</th>
+	    <th>{dgettext("instrument_list", "Double Data Entry Form")}</th>
+	    <th>{dgettext("instrument_list", "Double Data Entry Status")}</th>
     </tr>
     </thead>
 	{section name=instrument loop=$instruments[group]}
@@ -218,29 +220,42 @@
 	    	<td>
                 <a href="{$baseurl|default}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].commentID}&sessionID={$sessionID}&candID={$candID}">
 	            {$instruments[group][instrument].fullName}</a></td>
-	    	<td>{$instruments[group][instrument].dataEntryStatus}</td>
-	    	<td>{$instruments[group][instrument].administrationStatus}</td>
+	    	<td>
+                    {if $instruments[group][instrument].dataEntryStatus != ""}
+                        {dgettext("loris", $instruments[group][instrument].dataEntryStatus)}</td>
+                    {/if}
+	    	<td>
+                    {if $instruments[group][instrument].administrationStatus != ""}
+                        {dgettext("loris", $instruments[group][instrument].administrationStatus)}
+                    {/if}
+                </td>
 	    	<td bgcolor="{$instruments[group][instrument].feedbackColor|default}">
-		    	{$instruments[group][instrument].feedbackStatus}
+                    {dgettext("timepoint_list", $instruments[group][instrument].feedbackStatus)}
 	        </td>
 			<td>
-				{if $instruments[group][instrument].isDdeEnabled }
-				    	<a href="{$baseurl|default}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].ddeCommentID}&sessionID={$sessionID}&candID={$candID}">Double Data Entry</a>
-			   {/if}&nbsp;
+                            {if $instruments[group][instrument].isDdeEnabled }
+				    	<a href="{$baseurl|default}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].ddeCommentID}&sessionID={$sessionID}&candID={$candID}">{dgettext("instrument_list", "Double Data Entry")}</a>
+                            {/if}&nbsp;
 			</td>
-			<td>{if $instruments[group][instrument].isDdeEnabled }{$instruments[group][instrument].ddeDataEntryStatus}{/if}&nbsp;</td>
+			<td>
+                            {if $instruments[group][instrument].isDdeEnabled && $instruments[group][instrument].ddeDataEntryStatus != "" }
+                                {dgettext("loris", $instruments[group][instrument].ddeDataEntryStatus)}
+                            {/if}&nbsp;
+                        </td>
 	   	</tr>
 	   </tbody>
 	{/section}
 {sectionelse}
-     <tr><td nowrap="nowrap">The battery has no registered instruments</td></tr>
+     <tr><td nowrap="nowrap">{dgettext("instrument_list", "The battery has no registered instruments")}</td></tr>
 {/section}
 </table>
 {if $imaging_browser_permission}
   <div class="col-xs-12 row">
   </div>
   <div class="col-xs-12 row">
-    <button class="btn btn-primary" onclick="location.href='{$baseurl|default}/imaging_browser/viewSession/?sessionID={$sessionID}'">View Imaging data</button>
+      <button class="btn btn-primary" onclick="location.href='{$baseurl|default}/imaging_browser/viewSession/?sessionID={$sessionID}'">
+          {dgettext("instrument_list", "View Imaging data")}
+      </button>
   </div>
 {/if}
 </div>

--- a/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
@@ -36,6 +36,9 @@ msgstr "Imagen de Scan hecha"
 msgid "BVL QC"
 msgstr "CC Conductual"
 
+msgid "BVL QC Status"
+msgstr "Estado del CC Conductual"
+
 msgid "BVL Exclusion"
 msgstr "Exclusión Conductual"
 
@@ -74,6 +77,9 @@ msgstr " a / "
 
 msgid " m"
 msgstr " m"
+
+msgid "Not Done"
+msgstr "No Hecha"
 
 msgid "Visual"
 msgstr "Visual"

--- a/modules/timepoint_list/locale/timepoint_list.pot
+++ b/modules/timepoint_list/locale/timepoint_list.pot
@@ -5,9 +5,18 @@
 # This file is distributed under the same license as the LORIS package.
 # Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
 #
-
 msgid ""
 msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 msgid "Timepoint List"
 msgstr ""
@@ -25,6 +34,9 @@ msgid "Imaging Scan Done"
 msgstr ""
 
 msgid "BVL QC"
+msgstr ""
+
+msgid "BVL QC Status"
 msgstr ""
 
 msgid "BVL Exclusion"
@@ -64,6 +76,9 @@ msgid " y / "
 msgstr ""
 
 msgid " m"
+msgstr ""
+
+msgid "Not Done"
 msgstr ""
 
 msgid "Visual"


### PR DESCRIPTION
- Translates Instrument list module
- Spanish language was use for demonstration purposes only. ( Also the only Spanish translations included in the loris.po file were the ones used in this module -- for simplicity and speeding the process)
- some entries were added to the general loris.pot file since they are used in other modules as well.
- Breadcrumb are not translated in this PR since they came from other two modules candidate_list and candidate_profile respectively