### PR TITLE
[Meta/Multilingual] Add wildcard target for .mo files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 all: node_modules locales VERSION vendor
 	npm run build
 
+%.mo: %.po
+	msgfmt -o $@ $<
+
 # If anything changes, re-generate the VERSION file
 VERSION: .
 	tools/gen-version.sh
@@ -133,55 +136,51 @@ locales:
 	msgfmt -o modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.mo modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
 
 
-acknowledgements:
+acknowledgements: modules/acknowledgements/locale/ja/LC_MESSAGES/acknowledgements.mo
 	target=acknowledgements npm run compile
 
 create_timepoint:
 	target=data_release npm run compile
 
-data_release:
-	msgfmt -o modules/data_release/locale/hi/LC_MESSAGES/data_release.mo modules/data_release/locale/hi/LC_MESSAGES/data_release.po
+data_release: modules/data_release/locale/hi/LC_MESSAGES/data_release.mo modules/data_release/locale/ja/LC_MESSAGES/data_release.mo
 	npx i18next-conv -l hi -s modules/data_release/locale/hi/LC_MESSAGES/data_release.po -t modules/data_release/locale/hi/LC_MESSAGES/data_release.json 
-	msgfmt -o modules/data_release/locale/ja/LC_MESSAGES/data_release.mo modules/data_release/locale/ja/LC_MESSAGES/data_release.po
 	npx i18next-conv -l ja -s modules/data_release/locale/ja/LC_MESSAGES/data_release.po -t modules/data_release/locale/ja/LC_MESSAGES/data_release.json 
 	target=data_release npm run compile
 
-instrument_manager:
+instrument_manager: modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.mo
 	target=instrument_manager npm run compile
 
-dataquery:
+dataquery: modules/dataquery/locale/ja/LC_MESSAGES/dataquery.mo
 	msgfmt -o modules/dataquery/locale/ja/LC_MESSAGES/dataquery.mo modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
 	target=dataquery npm run compile
 
-login:
+login: modules/login/locale/ja/LC_MESSAGES/login.mo
 	target=login npm run compile
 
-module_manager:
+module_manager: modules/module_manager/locale/ja/LC_MESSAGES/module_manager.mo
 	target=module_manager npm run compile
 
-mri_violations:
+mri_violations: modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.mo
 	target=mri_violations npm run compile
 
-issue_tracker:
+issue_tracker: modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.mo
 	target=issue_tracker npm run compile
 
-candidate_list:
-	msgfmt -o modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+candidate_list: modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.mo
 	npx i18next-conv -l ja -s modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po -t modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.json
-	msgfmt -o modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.mo modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
 	npx i18next-conv -l hi -s modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po -t modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.json
 	target=candidate_list npm run compile
 
-candidate_parameters:
+candidate_parameters: modules/candidate_parameters/locale/ja/LC_MESSAGES/candidate_parameters.mo
 	target=candidate_parameters npm run compile
 
-dashboard:
+dashboard: modules/dashboard/locale/ja/LC_MESSAGES/dashboard.mo
 	target=dashboard npm run compile
 
-publication:
+publication: modules/publication/locale/ja/LC_MESSAGES/publication.mo
 	target=publication npm run compile
 
-server_processes_manager:
+server_processes_manager: modules/server_processes_manager/locale/ja/LC_MESSAGES/server_processes_manager.mo
 	target=server_processes_manager npm run compile
 
 conflict_resolver:


### PR DESCRIPTION
This adds a new wildcard target to convert .po files to .mo files.

Each `make modulename` target is updated to have a dependency on the .mo files that it uses, rather than explicitly running msgfmt multiple times.

This means that when running `make modulename` it will only run the msgfmt command if the po file has changed.

`make locales` should also be updated to make building loris more efficient when doing development, but that it not done in this PR to avoid conflicts with other module PRs that are in progress. It will be done ina future PR.

This is a simplified version of #10003 that puts the infrastructure in place but should be less likely to cause conflicts.