### PR TITLE
[candidate_profile/imaging_browser] Fix Imaging QC Summary widget on candiate_profile

### DIFF
--- a/modules/imaging_browser/jsx/CandidateScanQCSummaryWidget.js
+++ b/modules/imaging_browser/jsx/CandidateScanQCSummaryWidget.js
@@ -72,7 +72,7 @@ function CandidateScanQCSummaryWidget(props) {
 CandidateScanQCSummaryWidget.propTypes = {
   Files: PropTypes.array,
   BaseURL: PropTypes.string,
-  VisitMap: PropTypes.array,
+  VisitMap: PropTypes.object,
 };
 
 /**

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -109,9 +109,6 @@ class Module extends \Module
             if (count($scansummary) === 0) {
                 return [];
             }
-            foreach ($scansummary as $summary) {
-                $summary['nfiles'] = (int )$summary['nfiles'];
-            }
             return [
                 new CandidateWidget(
                     "Imaging QC Summary",


### PR DESCRIPTION
This fixes 2 problems which were preventing the Imaging QC summary widget on the candidate_profile page from loading correctly:

1. The type of the VisitMap prop was incorrectly set to "array". It is an object. This was causing a javascript error.
2. iterator_to_array was called after it had already been iterated on in a foreach loop, resulting in the iterator_to_array call returning an empty array. However, the result of the loop was not used anywhere, so it is simply removed.