### PR TITLE
Add Japanese translation strings for instrument_list

### DIFF
--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -164,6 +164,12 @@ msgstr "モジュール"
 msgid "Project"
 msgstr "プロジェクト"
 
+msgid "Candidate Registration Project"
+msgstr "候補者登録プロジェクト"
+
+msgid "Timepoint Project"
+msgstr "タイムポイントプロジェクト"
+
 msgid "Cohort"
 msgid_plural "Cohorts"
 msgstr[0] "コホート"
@@ -194,6 +200,12 @@ msgstr "ステージ"
 
 msgid "Sent To DCC"
 msgstr "DCCに送信"
+
+msgid "Send To DCC"
+msgstr "DCCに送信"
+
+msgid "Reverse Send To DCC"
+msgstr "DCCへの逆送信"
 
 msgid "Date of Birth"
 msgstr "生年月日"
@@ -279,6 +291,36 @@ msgstr "撤退"
 
 msgid "In Progress"
 msgstr "進行中"
+
+msgid "Complete"
+msgstr "完了"
+
+msgid "Instruments"
+msgstr "楽器"
+
+msgid "None"
+msgstr "なし"
+
+msgid "Partial"
+msgstr "部分的"
+
+msgid "All"
+msgstr "全て"
+
+msgid "Data Entry"
+msgstr "データ入力"
+
+msgid "Administration"
+msgstr "管理"
+
+msgid "Double Data Entry Form"
+msgstr "二重データ入力フォーム"
+
+msgid "Double Data Entry Status"
+msgstr "二重データ入力ステータス"
+
+msgid "Double Data Entry"
+msgstr "二重データ入力"
 
 # Age related terms
 msgid "Age"

--- a/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
@@ -21,3 +21,33 @@ msgstr ""
 msgid "Instrument List"
 msgstr "楽器リスト"
 
+msgid "Visit to Site"
+msgstr "現場訪問"
+
+msgid "Within Optimal"
+msgstr "最適な範囲内で"
+
+msgid "Within Permitted"
+msgstr "許可された範囲内"
+
+msgid "Behavioural Battery of Instruments"
+msgstr "行動測定機器"
+
+msgid "The battery has no registered instruments"
+msgstr "バッテリーには登録された機器がありません"
+
+msgid "View Imaging data"
+msgstr "画像データを表示"
+
+msgid "Send TimePoint"
+msgstr "送信タイムポイント"
+
+msgid "No actions"
+msgstr "アクションなし"
+
+msgid "Stage: %s"
+msgstr "ステージ: %s"
+
+msgid "Start %s Stage"
+msgstr "%s ステージを開始"
+

--- a/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
@@ -77,6 +77,9 @@ msgstr ""
 msgid " m"
 msgstr ""
 
+msgid "Not Done"
+msgstr "未完了"
+
 msgid "Visual"
 msgstr "ビジュアル"
 


### PR DESCRIPTION
Adds machine generated translation strings for Japanese for the new template strings from #10033, so that we have one language which is fully up to date.