### PR TITLE
[Core] set intl.default_locale

### DIFF
--- a/src/Middleware/Language.php
+++ b/src/Middleware/Language.php
@@ -79,7 +79,12 @@ class Language implements MiddlewareInterface, MiddlewareChainer
         $lang  = self::detectLocale($loris, $request);
         if ($lang !== null) {
             \setlocale(LC_MESSAGES, $lang . '.utf8');
-	    ini_set('intl.default_locale', $lang);
+            // Set the default_locale for intl to match the user preference,
+            // so that date formatting works correctly.
+            // PHPCS complains about ini_set not being allowed, but there
+            // does not seem to be any other way to do this.
+            //phpcs:ignore
+            ini_set('intl.default_locale', $lang);
             return $this->next->process(
                 $request->withAttribute("locale", $lang),
                 $handler


### PR DESCRIPTION
The IntlDateFormatter in PHP uses the value of intl.default_locale, not \setlocale in order to decide on the formatting to use for dates when a null value/empty string is passed as the locale.

This explicitly sets it so that dates in the en-CA locale are formatted as YYYY-mm-dd instead of YYYY/mm/dd.

* Resolves -- a comment that @racostas made, I can't find an issue for it.
