### PR TITLE
[Multilingual -  LORIS general translations] Adding some missing keys to loris.pot and es/loris.pot

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -126,9 +126,28 @@ msgstr "Crear"
 msgid "N/A"
 msgstr "N/A"
 
+# Filters
+msgid "Selection Filter"
+msgstr "Selección de Filtros"
+
+msgid "Show Filters"
+msgstr "Mostrar Filtros"
+
+msgid "Hide Filters"
+msgstr "Ocultar Filtros"
+
+msgid "Clear Filters"
+msgstr "Limpiar Filtros"
+
+msgid "Show Advanced Filters"
+msgstr "Mostras filtros avanzados"
+
+msgid "Hide Advanced Filters"
+msgstr "Ocultar filtros avanzados"
+
 # Common swal labels
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 msgid "Success!"
 msgstr "Exitoso!"
@@ -210,12 +229,6 @@ msgstr "Tipo de Entidad"
 
 msgid "Scan Done"
 msgstr "Scan hecho"
-
-msgid "Show Advanced Filters"
-msgstr "Mostras filtros avanzados"
-
-msgid "Hide Advanced Filters"
-msgstr "Ocultar filtros avanzados"
 
 msgid "Language"
 msgstr "Lenguaje"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -123,14 +123,8 @@ msgstr "いいえ"
 msgid "Create"
 msgstr "作成する"
 
-msgid "Cancel"
-msgstr "取り消す"
-
 msgid "N/A"
 msgstr "適用できない"
-
-msgid "Success!"
-msgstr "成功！"
 
 # Filters
 msgid "Selection Filter"
@@ -144,6 +138,13 @@ msgstr "フィルターを非表示"
 
 msgid "Clear Filters"
 msgstr "フィルターをクリア"
+
+# Common swal labels
+msgid "Cancel"
+msgstr "取り消す"
+
+msgid "Success!"
+msgstr "成功！"
 
 # Common candidate terms
 msgid "PSCID"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -125,6 +125,25 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
+# Filters
+msgid "Selection Filter"
+msgstr ""
+
+msgid "Show Filters"
+msgstr ""
+
+msgid "Hide Filters"
+msgstr ""
+
+msgid "Clear Filters"
+msgstr ""
+
+msgid "Show Advanced Filters"
+msgstr ""
+
+msgid "Hide Advanced Filters"
+msgstr ""
+
 # Common swal labels
 msgid "Cancel"
 msgstr ""
@@ -207,12 +226,6 @@ msgid "Entity Type"
 msgstr ""
 
 msgid "Scan Done"
-msgstr ""
-
-msgid "Show Advanced Filters"
-msgstr ""
-
-msgid "Hide Advanced Filters"
 msgstr ""
 
 msgid "Language"


### PR DESCRIPTION
## Brief summary of changes
- There were some accidental translations that were not included in the `/locale/loris.pot` file (mostly referring to Datatable filters)
- This PR adds the missing keys to loris.pot 
- Also add the missing keys and translations to `locale/es/LC_MESSAGES/loris.po`
- Also mv some of the translations on `locale/ja/LC_MESSAGES/loris.po` for keeping consistency. 

### To test.
1. Please ensure que the filters translations for Databable are properly loading in Japanese and Spanish.
<img width="1294" height="350" alt="image" src="https://github.com/user-attachments/assets/53bd0246-2e9b-408f-9e02-8eac14152eb7" />
2. No other translations should be affected.