### PR TITLE
[user_accounts] Make examiner sites multiselect

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -451,6 +451,7 @@ class Edit_User extends \NDB_Form
                     ]
                 );
 
+                $examinerID = array_values($examinerID);
                 $examinerID = $examinerID[0];
 
                 //get existing sites for examiner
@@ -1256,26 +1257,20 @@ class Edit_User extends \NDB_Form
         //        Validate Examiner Status
         //======================================
         if ($editor->hasPermission('examiner_multisite')) {
-            $matched = false;
-            foreach (array_keys($values) as $k) {
-                if ($values['examiner_sites'] ?? null) {
-                    $matched = true;
-                    if ($values['examiner_radiologist'] == '') {
-                        $errors['examiner_group'] = "Please specify if examiner " .
-                            "is a radiologist";
+            if ($values['examiner_sites'] ?? null) {
+                if ($values['examiner_radiologist'] == '') {
+                    $errors['examiner_group'] = "Please specify if examiner " .
+                        "is a radiologist";
 
-                    }
-                    if ($values['examiner_radiologist'] !== ''
-                        && $values['examiner_pending'] == ''
-                    ) {
-                        $errors['examiner_group'] = "Please set pending " .
-                            "approval Yes or No";
-                    }
                 }
-            }
-            if (!$matched
-                && ($values['examiner_radiologist'] !== ''
-                || $values['examiner_pending'] ?? '' !== '')
+                if ($values['examiner_radiologist'] !== ''
+                    && $values['examiner_pending'] == ''
+                ) {
+                    $errors['examiner_group'] = "Please set pending " .
+                        "approval Yes or No";
+                }
+            } elseif ($values['examiner_radiologist'] !== ''
+                || $values['examiner_pending'] ?? '' !== ''
             ) {
                 $errors['examiner_sites'] = "Please select at least one examiner
                 site or clear the 'Examiner status' fields below (i.e.


### PR DESCRIPTION
## Brief summary of changes
This PR modifies the user accounts module to have a multi-select field for examiner sites instead of checkboxes. This way the full site names are listed and a user can see more clearly what sites they are selecting for an examiner. All other behaviour of examiner selection should remain the same. 

<img width="571" height="139" alt="image" src="https://github.com/user-attachments/assets/366764ff-82de-4e54-bfbd-f7ff676e0419" />

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to a user who is not an examiner yet. 
2. Check that the validation for examiner fields works: the examiner site field should be required if radiologist and/or pending is selected, and likewise the radiologist / pending field should be required if an examiner field is selected
3. Save the user with 1 or 2 examiner fields selected, as well as the radiologist / pending fields selected
4. Navigate away from the page, refresh, and go back to edit the user. Make sure the same sites are still displayed as selected
5. Remove one site and save the user. Navigate away, refresh, then come back. Make sure the site was properly removed
6. Repeat the above step to remove all sites (make sure to also unset the radiologist / pending values). Make sure the sites were properly removed.
7. Try editing a user from a user who has does not have access to all sites. Make sure that only the current  user's sites are displayed in the examiner sites multiselect, and make sure that no extra sites are added / removed for the examiner when edited. 

#### Link(s) to related issue(s)

* Resolves #9864
