### PR TITLE
[instrument_list] Add missing translation string

### DIFF
--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -101,7 +101,7 @@
 		<li>
                 	<span class="fa-li"><i class="{$bvl_qc_status_complete.icon|default:'far fa-square'}"></i></span>
 			{if $bvl_qc_status_complete.showlink|default}
-                        	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=Complete">Complete</a>
+                                <a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=Complete">{dgettext("timepoint_list", "Complete")}</a>
 			{else}
                                                 {dgettext("timepoint_list", "Complete")}
 			{/if}


### PR DESCRIPTION
When the bvl_qc_status_complete.showlink was true, the "Complete" string was not marked up as translated despite the string already being translated for the "false" case and it being the same string.

Add the missing dgettext call.