### PR TITLE
[redcap] Fix empty options REDCap to LINST

### DIFF
--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -302,6 +302,10 @@ class RedcapDictionaryRecord
     private function _optionsToLINST() : string
     {
         $dictionary = $this->select_choices;
+        if ($dictionary === null) {
+            return '';
+        }
+
         $dictionary = str_replace(' | | ', ' | ', $dictionary);
         if (str_starts_with($dictionary, '| ')) {
             $dictionary = substr($dictionary, 2);


### PR DESCRIPTION
Extracted from https://github.com/aces/Loris/pull/9472, which got merged in C-BIG.

Add a `null` check in the REDCap to LINST instrument options, to accommodate for empty options.