### PR TITLE
[i18n/meta] Update Makefile to only compile changed language files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ POFILES=locale/fr/LC_MESSAGES/loris.po \
 	modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po \
 	modules/create_timepoint/locale/es/LC_MESSAGES/create_timepoint.po \
 	modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po \
+	modules/brainbrowser/locale/hi/LC_MESSAGES/brainbrowser.po \
 	modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po \
 	modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po \
 	modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po \
@@ -101,7 +102,6 @@ POFILES=locale/fr/LC_MESSAGES/loris.po \
 	modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po \
 	modules/help_editor/locale/ja/LC_MESSAGES/help_editor.po \
 	modules/help_editor/locale/hi/LC_MESSAGES/help_editor.po
-
 MOFILES=$(patsubst %.po,%.mo,$(POFILES))
 I18NJSONFILES=$(patsubst %.po,%.json,$(POFILES))
 


### PR DESCRIPTION
Some tweaks to the Makefile language file generation:
1. Only run msgfmt or i18next-conv if the original .po file has changed
2. Ensure `make modulename` handles file generation the same way as `make locales`
3. Consistently generate the json files for all .po files, instead of doing it selectively as we need it.