### PR TITLE
[LINST] Fix loading of LINST instruments

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1029,8 +1029,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ]
         );
 
-
-        $allValues  = $this->getInstanceData();
+        $allValues       = $this->getInstanceData();
         $curr_examinerID = $allValues['Examiner'];
 
         list(


### PR DESCRIPTION
LINST instruments currently throw an exception because getExaminerNames is called to get a list of examiners to pass to addElement. However, getExaminerNames calls getField("Examiner") to get the default value. Since addElement hasn't been called yet, it throws an exception saying the field does not exist for the instrument.

This bypasses it by calling getInstanceData and getting the examiner key directly.