### PR TITLE
[candidate_profile] Fix loading of instrument list 

### DIFF
--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -123,11 +123,11 @@ class VisitSummary extends \NDB_Page
                 continue;
             }
 
-	    $rslt[$key] = [
-                'Test_name' => $row['Test_name'],
-                'CommentID' => $row['CommentID'],
+            $rslt[$key] = [
+                'Test_name'     => $row['Test_name'],
+                'CommentID'     => $row['CommentID'],
                 'NumOfConflict' => $row['NumOfConflict'],
-	    ];
+            ];
             if ($instrument === null) {
                 $rslt[$key]['Completion'] = 0;
             } else {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1029,7 +1029,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ]
         );
 
-        $allValues  = $this->getInstanceData();
+        $allValues       = $this->getInstanceData();
         $curr_examinerID = $allValues['Examiner'];
 
         list(


### PR DESCRIPTION
The instrument list after expanding a visit does not have all of
its data loaded, only the "Completion". This fixes the loading
so that the testname/completion/etc are loaded and clickable.