### PR TITLE
adjustments to elements in the candidate profile item page

### DIFF
--- a/jsx/CSSGrid/index.js
+++ b/jsx/CSSGrid/index.js
@@ -104,7 +104,9 @@ function CSSGrid(props) {
     style.alignSelf = 'stretch';
     return (
       <Card title={value.Title} id={cardID} key={cardID} style={style}
-        cardSize={pSize} collapsing={value.collapsing}>
+        cardSize={pSize} collapsing={value.collapsing}
+        maxHeight={value?.MaxHeight}
+      >
         {value.Content}
       </Card>
     );

--- a/jsx/CSSGrid/index.js
+++ b/jsx/CSSGrid/index.js
@@ -1,6 +1,7 @@
 import Card from 'Card';
 import React, {useState, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
+import './styles.css';
 
 /**
  * Create a three column grid of cards using a CSS grid.
@@ -51,13 +52,6 @@ function CSSGrid(props) {
     );
     setPanelHeights(heights);
   });
-  const grid = {
-    display: 'grid',
-    gridTemplateColumns: '33% 33% 33%',
-    gridAutoFlow: 'row dense',
-    gridRowGap: '1em',
-    rowGap: '1em',
-  };
 
   let orderedCards = [];
   for (let i = 0; i < props.Cards.length; i++) {
@@ -117,7 +111,7 @@ function CSSGrid(props) {
   });
 
   return (
-    <div ref={cardsRef} style={grid}>{cards}</div>
+    <div ref={cardsRef} className='CSSGrid'>{cards}</div>
   );
 }
 CSSGrid.propTypes = {

--- a/jsx/CSSGrid/index.js
+++ b/jsx/CSSGrid/index.js
@@ -105,7 +105,7 @@ function CSSGrid(props) {
     return (
       <Card title={value.Title} id={cardID} key={cardID} style={style}
         cardSize={pSize} collapsing={value.collapsing}
-        maxHeight={value?.MaxHeight}
+        maxHeight={value.MaxHeight}
       >
         {value.Content}
       </Card>

--- a/jsx/CSSGrid/styles.css
+++ b/jsx/CSSGrid/styles.css
@@ -1,0 +1,14 @@
+.CSSGrid {
+    display: grid; 
+    grid-template-columns: 33% 33% 33%;
+    grid-auto-flow: row dense; 
+    gap: 1rem;
+}
+
+@media (max-width: 576px) {
+    .CSSGrid {
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+    }
+}

--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -68,6 +68,7 @@ class Card extends Component {
           style={{overflow: 'auto'}}
           panelSize={this.props.cardSize}
           collapsing={this.props.collapsing}
+          maxHeight={this.props?.maxHeight}
         >
           <div
             onClick={this.handleClick}
@@ -94,6 +95,7 @@ Card.propTypes = {
   cardSize: PropTypes.string,
   children: PropTypes.node,
   collapsing: PropTypes.bool,
+  maxHeight: PropTypes.string,
 };
 
 Card.defaultProps = {

--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -68,7 +68,7 @@ class Card extends Component {
           style={{overflow: 'auto'}}
           panelSize={this.props.cardSize}
           collapsing={this.props.collapsing}
-          maxHeight={this.props?.maxHeight}
+          maxHeight={this.props.maxHeight}
         >
           <div
             onClick={this.handleClick}

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -163,7 +163,6 @@ Panel.defaultProps = {
   height: '100%',
   class: 'panel-primary',
   collapsing: true,
-  maxHeight: '85vh',
 };
 
 export default Panel;

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
+import { max } from 'd3';
 
 /**
  * Panel - a collapsible panel component with optional multiple views.
@@ -122,7 +123,7 @@ const Panel = (props) => {
    */
   return (
     <div className={`panel ${props.class}`}
-      style={{height: props.panelSize}}>
+      style={{height: props.panelSize, maxHeight: props.maxHeight}}>
       {panelHeading}
       <div id={props.id}
         className={props.collapsed ?
@@ -154,6 +155,7 @@ Panel.propTypes = {
   panelSize: PropTypes.string,
   style: PropTypes.object,
   children: PropTypes.node,
+  maxHeight: PropTypes.string,
 };
 Panel.defaultProps = {
   initCollapsed: false,
@@ -162,6 +164,7 @@ Panel.defaultProps = {
   height: '100%',
   class: 'panel-primary',
   collapsing: true,
+  maxHeight: '85vh',
 };
 
 export default Panel;

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -1,7 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
-import { max } from 'd3';
 
 /**
  * Panel - a collapsible panel component with optional multiple views.

--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -165,7 +165,7 @@ class CandidateInfo extends Component {
 
     const renderTerm = (label, value, info) => {
       const cardStyle = {
-        width: info.width || '6em',
+        width: info.width || 'unset',
         padding: '1rem 0',
         marginLeft: '0.5rem',
         marginRight: '0.5rem',

--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -166,9 +166,11 @@ class CandidateInfo extends Component {
     const renderTerm = (label, value, info) => {
       const cardStyle = {
         width: info.width || '6em',
-        padding: '1em',
-        marginLeft: '1ex',
-        marginRight: '1ex',
+        padding: '1rem 0',
+        marginLeft: '0.5rem',
+        marginRight: '0.5rem',
+        wordBreak: 'break-word',
+        flexGrow: 1,
       };
       let valueStyle = {};
       if (info.valueWhitespace) {

--- a/modules/candidate_profile/php/candidatewidget.class.inc
+++ b/modules/candidate_profile/php/candidatewidget.class.inc
@@ -29,15 +29,15 @@ class CandidateWidget implements \LORIS\GUI\Widget
     /**
      * Construct a dashboard widget with the specified properties.
      *
-     * @param string $title         The title of the card to display.
-     * @param string $jsurl         The URL containing the React component.
-     * @param string $componentname The React component name for this widget.
-     * @param array  $props         Additional React props to pass to the React
-     *                              component.
-     * @param ?int   $width         The width in the CSS grid.
-     * @param ?int   $height        The height in the CSS grid.
-     * @param ?int   $order         The order in the CSS grid.
-     * @param ?string $maxheight    The max-height of the panel
+     * @param string  $title         The title of the card to display.
+     * @param string  $jsurl         The URL containing the React component.
+     * @param string  $componentname The React component name for this widget.
+     * @param array   $props         Additional React props to pass to the React
+     *                               component.
+     * @param ?int    $width         The width in the CSS grid.
+     * @param ?int    $height        The height in the CSS grid.
+     * @param ?int    $order         The order in the CSS grid.
+     * @param ?string $maxheight     The max-height of the panel
      */
     public function __construct(
         string $title,

--- a/modules/candidate_profile/php/candidatewidget.class.inc
+++ b/modules/candidate_profile/php/candidatewidget.class.inc
@@ -24,6 +24,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
     private ?int $_width;
     private ?int $_height;
     private ?int $_order;
+    private ?string $_maxheight;
 
     /**
      * Construct a dashboard widget with the specified properties.
@@ -36,6 +37,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      * @param ?int   $width         The width in the CSS grid.
      * @param ?int   $height        The height in the CSS grid.
      * @param ?int   $order         The order in the CSS grid.
+     * @param ?string $maxheight    The max-height of the panel
      */
     public function __construct(
         string $title,
@@ -44,7 +46,8 @@ class CandidateWidget implements \LORIS\GUI\Widget
         array $props,
         ?int $width = null,
         ?int $height = null,
-        ?int $order = null
+        ?int $order = null,
+        ?string $maxheight = null
     ) {
         $this->_title         = $title;
         $this->_url           = $jsurl;
@@ -53,6 +56,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
         $this->_componentname = $componentname;
         $this->_props         = $props;
         $this->_order         = $order;
+        $this->_maxheight     = $maxheight;
     }
 
     /**
@@ -137,5 +141,15 @@ class CandidateWidget implements \LORIS\GUI\Widget
     public function getComponentProps() : array
     {
         return $this->_props;
+    }
+
+    /**
+     * Return the Card max-height.
+     *
+     * @return ?string
+     */
+    public function getMaxHeight() : ?string
+    {
+        return $this->_maxheight;
     }
 }

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -68,6 +68,7 @@ window.addEventListener('load', () => {
 		    {if $widget->getWidth()},Width: {$widget->getWidth()}{/if}
 		    {if $widget->getOrder()},Order: {$widget->getOrder()}{/if}
 		    {if $widget->getHeight()},Height: {$widget->getHeight()}{/if}
+		    {if $widget->getMaxHeight()},MaxHeight: "{$widget->getMaxHeight()}"{/if}
 		});
         } catch(err) {
              console.error(err);

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -135,15 +135,16 @@ class VisitInstrumentList extends Component {
     };
     flexcontainer.justifyContent = 'flex-start';
 
-    let center = {
+    let titleText = {
       display: 'flex',
-      width: '12%',
-      height: '100%',
+      width: '100%',
       alignItems: 'center',
-      justifyContent: 'center',
+      textAlign: 'left',
+      wordBreak: 'break-word',
+      padding: '1rem',
     };
 
-    const termstyle = {paddingLeft: '2em', paddingRight: '2em'};
+    const termstyle = {padding: '1rem 1.5em', flexGrow: 1};
 
     let instruments = null;
     if (!this.state.instruments) {
@@ -252,37 +253,38 @@ class VisitInstrumentList extends Component {
         onMouseLeave={this.toggleHover}
       >
         <div style={flexcontainer}>
-          <div style={{background: bg, width: '1%', height: '100%'}}>
-          </div>
-          <div style={center}>
-            <h4 style={{width: '100%', padding: 0, margin: 0}}>
-              <a href={this.props.BaseURL
-                            + '/instrument_list/?candID='
-                            + this.props.Candidate.Meta.CandID
-                            + '&sessionID='
-                            + this.props.VisitMap[this.props.Visit.Meta.Visit]}>
-                {this.props.Visit.Meta.Visit}
-              </a>
-            </h4>
-          </div>
-          <div>
-            <dl style={defliststyle}>
-              <div style={termstyle}>
-                <dt>Cohort</dt>
-                <dd>{this.props.Visit.Meta.Battery}</dd>
-              </div>
-              <div style={termstyle}>
-                <dt>Site</dt>
-                <dd>{this.props.Visit.Meta.Site}</dd>
-              </div>
-              {vdate}
-              {vage}
-              <div style={termstyle}>
-                <dt>Status</dt>
-                <dd>{vstatus}</dd>
-              </div>
-            </dl>
-            {instruments}
+          <div style={{background: bg, width: '1%', height: '100%'}}></div>
+          <div style={{width: '100%'}}>
+            <div style={titleText}>
+              <h4 style={{width: '100%', padding: 0, margin: 0}}>
+                <a href={this.props.BaseURL
+                        + '/instrument_list/?candID='
+                        + this.props.Candidate.Meta.CandID
+                        + '&sessionID='
+                        + this.props.VisitMap[this.props.Visit.Meta.Visit]}>
+                  {this.props.Visit.Meta.Visit}
+                </a>
+              </h4>
+            </div>
+            <div>
+              <dl style={defliststyle}>
+                <div style={termstyle}>
+                  <dt>Cohort</dt>
+                  <dd>{this.props.Visit.Meta.Battery}</dd>
+                </div>
+                <div style={termstyle}>
+                  <dt>Site</dt>
+                  <dd>{this.props.Visit.Meta.Site}</dd>
+                </div>
+                {vdate}
+                {vage}
+                <div style={termstyle}>
+                  <dt>Status</dt>
+                  <dd>{vstatus}</dd>
+                </div>
+              </dl>
+              {instruments}
+            </div>
           </div>
         </div>
       </div>

--- a/modules/media/jsx/CandidateMediaWidget.js
+++ b/modules/media/jsx/CandidateMediaWidget.js
@@ -13,7 +13,7 @@ function CandidateMediaWidget(props) {
   for (let i = 0; i < props.Files.length; i++) {
     const file = props.Files[i];
     files.push(
-      <a className="list-group-item" key={i}
+      <a className="list-group-item" style={{wordBreak: 'break-word'}} key={i}
         href={props.BaseURL
                     + '/media/files/'
                     + encodeURIComponent(file.Filename)}>

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -85,6 +85,8 @@ class Module extends \Module
                     [ 'Files' => iterator_to_array($media)],
                     1,
                     1,
+                    null,
+                    "85vh"
                 )
             ];
         }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -351,7 +351,7 @@ configs.push({
     MultiSelectDropdown: './jsx/MultiSelectDropdown.js',
     Breadcrumbs: './jsx/Breadcrumbs.js',
     PolicyButton: './jsx/PolicyButton.js',
-    CSSGrid: './jsx/CSSGrid.js',
+    CSSGrid: './jsx/CSSGrid',
     Help: './jsx/Help.js',
     ...getModulesEntries(),
   },


### PR DESCRIPTION
## Brief summary of changes

* Adjust visual elements of certain modules used in the candidate profile page to make them not break under small window width sizes and to use more of the available space.
* Defined a max height limit for the panel that can be customized via props.
* Adjusted viewing of panel widgets on screen size of 576px and bellow.

Solves issue: https://github.com/aces/CBIGR/issues/559
Example page: candidate_profile/587630/

Before:
<img width="383" height="450" alt="Screenshot 2025-10-31 at 11 20 23 AM" src="https://github.com/user-attachments/assets/e4bb4d27-3758-4fe0-926f-ebdf3597026f" />

After: 
<img width="354" height="351" alt="Screenshot 2025-10-31 at 11 20 54 AM" src="https://github.com/user-attachments/assets/7c52ec39-388d-430f-8614-269f6521d1a2" />


Before: 
<img width="209" height="138" alt="Screenshot 2025-10-31 at 11 45 23 AM" src="https://github.com/user-attachments/assets/a514f624-571d-40db-abb2-6c27d34cb18f" />

After: 
<img width="217" height="136" alt="Screenshot 2025-10-31 at 11 45 29 AM" src="https://github.com/user-attachments/assets/4c31e12f-ff17-4b64-b0af-996c7d2e21e7" />


Before:
<img width="714" height="190" alt="Screenshot 2025-10-31 at 11 23 08 AM" src="https://github.com/user-attachments/assets/986abc9e-4365-46a8-ae93-f71c3b4c6d61" />

After:
<img width="730" height="246" alt="Screenshot 2025-10-31 at 11 23 13 AM" src="https://github.com/user-attachments/assets/bbd3e922-05ce-46e5-b7c3-bacbcb1dff85" />


Before:
<img width="405" height="144" alt="Screenshot 2025-10-31 at 11 24 03 AM" src="https://github.com/user-attachments/assets/90a42e59-0ba5-4160-99d9-2401e0d51409" />

After: 
<img width="361" height="163" alt="Screenshot 2025-10-31 at 11 24 06 AM" src="https://github.com/user-attachments/assets/3d4298f3-d89b-47e6-b2cd-c365673f26c9" />


Before:
<img width="50%" height="1016" alt="Screenshot 2025-11-03 at 10 07 04 AM" src="https://github.com/user-attachments/assets/eb95218d-cdec-4835-a9ca-0bd6240cd14b" />

After:
<img width="50%" height="1016" alt="Screenshot 2025-11-03 at 10 07 20 AM" src="https://github.com/user-attachments/assets/c89cfb0a-53d2-40d8-8edf-78f71070d7f6" />


Before:
![chrome-capture-2025-11-03](https://github.com/user-attachments/assets/8d9972da-e7c1-463e-8885-baa826ef4597)
![chrome-capture-2025-11-03 (1)](https://github.com/user-attachments/assets/44eb381a-7015-4c7b-a51c-e3f2bab752a1)

After:
<img width="50%" height="1013" alt="image" src="https://github.com/user-attachments/assets/fef15944-b33a-4d51-a23b-b4eb161617df" />
<img width="1515" height="1059" alt="Screenshot 2025-11-03 at 10 19 25 AM" src="https://github.com/user-attachments/assets/7c9d1c56-083d-4750-839d-23c2e296499e" />

