### PR TITLE
[instruments/candidate_profile] Translate Behavioural Data widget on candidate profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ locales:
 	msgfmt -o modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.mo modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
 	msgfmt -o modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.mo modules/instrument_manager/locale/ja/LC_MESSAGES/instrument_manager.po
 	msgfmt -o modules/instruments/locale/ja/LC_MESSAGES/instruments.mo modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+	npx i18next-conv -l ja -s modules/instruments/locale/ja/LC_MESSAGES/instruments.po -t modules/instruments/locale/ja/LC_MESSAGES/instruments.json --compatibilityJSON v4
 	msgfmt -o modules/instruments/locale/es/LC_MESSAGES/instruments.mo modules/instruments/locale/es/LC_MESSAGES/instruments.po
 	msgfmt -o modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.mo modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
 	msgfmt -o modules/login/locale/ja/LC_MESSAGES/login.mo modules/login/locale/ja/LC_MESSAGES/login.po

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -187,6 +187,9 @@ msgstr "セッション"
 msgid "Date of registration"
 msgstr "入学日"
 
+msgid "Date Of Visit"
+msgstr "訪問日"
+
 msgid "Participant Status"
 msgstr "参加者ステータス"
 
@@ -336,8 +339,9 @@ msgstr "進行中"
 msgid "Complete"
 msgstr "完了"
 
-msgid "Instruments"
-msgstr "楽器"
+msgid "Instrument"
+msgid_plural "Instruments"
+msgstr[0] "楽器"
 
 msgid "None"
 msgstr "なし"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -192,6 +192,9 @@ msgstr ""
 msgid "Date of registration"
 msgstr ""
 
+msgid "Date Of Visit"
+msgstr ""
+
 msgid "Participant Status"
 msgstr ""
 
@@ -380,8 +383,9 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-msgid "Instruments"
-msgstr ""
+msgid "Instrument"
+msgid_plural "Instruments"
+msgstr[0] ""
 
 msgid "None"
 msgstr ""

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -1,5 +1,8 @@
 import React, {Component} from 'react';
+import {withTranslation} from 'react-i18next';
 import PropTypes from 'prop-types';
+import i18n from 'I18nSetup';
+import jaStrings from '../locale/ja/LC_MESSAGES/instruments.json';
 
 /**
  * A VisitInstrumentList is a type of React component which displays
@@ -17,6 +20,7 @@ class VisitInstrumentList extends Component {
    */
   constructor(props) {
     super(props);
+    i18n.addResourceBundle('ja', 'instruments', jaStrings);
     this.state = {
       expanded: false,
       hover: false,
@@ -47,10 +51,17 @@ class VisitInstrumentList extends Component {
     let vdate = new Date(visit);
     let years = vdate.getFullYear()-dobdate.getFullYear();
     let months = years*12 + vdate.getMonth() - dobdate.getMonth();
+
     if (months <= 36) {
-      return months + ' months old';
+      return this.props.t(
+        '{{months}} months old',
+        {ns: 'loris', months: months}
+      );
     }
-    return years + ' years old';
+    return this.props.t(
+      '{{years}} years old',
+      {ns: 'loris', years: years}
+    );
   }
 
   /**
@@ -86,6 +97,14 @@ class VisitInstrumentList extends Component {
    * @return {object} - The rendered JSX
    */
   render() {
+    const dateFormatter = new Intl.DateTimeFormat(
+      loris.user.langpref.replace('_', '-'),
+      {
+        style: 'short',
+        timeZone: 'UTC',
+
+      }
+    );
     let style = {
       marginRight: '0.5%',
       textAlign: 'center',
@@ -96,16 +115,18 @@ class VisitInstrumentList extends Component {
       backgroundColor: 'transparent',
     };
 
-    let vstatus = 'Not Started';
+    let vstatus = this.props.t('Not Started', {ns: 'loris'});
     let bg = '#ea9999';
+    const statusString = (s) => this.props.t(s, {ns: 'loris'})
+      + '—' + this.props.t(this.props.Visit.Stages[s].Status, {ns: 'loris'});
     if (this.props.Visit.Stages.Approval) {
-      vstatus = 'Approval - ' + this.props.Visit.Stages.Approval.Status;
+      vstatus = statusString('Approval');
       bg = '#b6d7a8';
     } else if (this.props.Visit.Stages.Visit) {
-      vstatus = 'Visit - ' + this.props.Visit.Stages.Visit.Status;
+      vstatus = statusString('Visit');
       bg = '#ffe599';
     } else if (this.props.Visit.Stages.Screening) {
-      vstatus = 'Screening - ' + this.props.Visit.Stages.Screening.Status;
+      vstatus = statusString('Screening');
       bg = '#f9cb9c';
     }
 
@@ -185,24 +206,30 @@ class VisitInstrumentList extends Component {
       if (this.state.instruments.length === 0) {
         instruments = (
           <div>
-            {'Visit has no registered instruments in test battery.'}
+            {this.props.t(
+              'Visit has no registered instruments in test battery.',
+              {ns: 'instruments'})
+            }
           </div>
         );
       } else {
         instruments = (<div>
-          <h5>Instruments</h5>
+          <h5>{this.props.t(
+            'Instrument',
+            {ns: 'loris', count: this.state.instruments.length}
+          )}</h5>
           <table
             className="table table-hover table-bordered"
             style={{width: '95%'}}
           >
             <thead>
               <tr>
-                <th>Instrument</th>
+                <th>{this.props.t('Instrument', {ns: 'loris', count: 1})}</th>
                 <th style={{textAlign: 'center'}}>
-                                        Completion
+                  {this.props.t('Completion', {ns: 'instruments'})}
                 </th>
                 <th style={{textAlign: 'center'}}>
-                                        Conflicts?
+                  {this.props.t('Conflicts?', {ns: 'instruments'})}
                 </th>
               </tr>
             </thead>
@@ -223,11 +250,13 @@ class VisitInstrumentList extends Component {
     let vage = null;
     if (this.props.Visit.Stages.Visit) {
       vdate = (<div style={termstyle}>
-        <dt>Date Of Visit</dt>
-        <dd>{this.props.Visit.Stages.Visit.Date}</dd>
+        <dt>{this.props.t('Date Of Visit', {ns: 'loris'})}</dt>
+        <dd>{dateFormatter.format(
+          new Date(this.props.Visit.Stages.Visit.Date)
+        )}</dd>
       </div>);
       vage = (<div style={termstyle}>
-        <dt>Age</dt>
+        <dt>{this.props.t('Age', {ns: 'loris'})}</dt>
         <dd>{this.calcAge(
           this.props.Candidate.Meta.DoB,
           this.props.Visit.Stages.Visit.Date
@@ -268,17 +297,17 @@ class VisitInstrumentList extends Component {
           <div>
             <dl style={defliststyle}>
               <div style={termstyle}>
-                <dt>Cohort</dt>
+                <dt>{this.props.t('Cohort', {ns: 'loris', count: 1})}</dt>
                 <dd>{this.props.Visit.Meta.Battery}</dd>
               </div>
               <div style={termstyle}>
-                <dt>Site</dt>
+                <dt>{this.props.t('Site', {ns: 'loris'})}</dt>
                 <dd>{this.props.Visit.Meta.Site}</dd>
               </div>
               {vdate}
               {vage}
               <div style={termstyle}>
-                <dt>Status</dt>
+                <dt>{this.props.t('Status', {ns: 'loris'})}</dt>
                 <dd>{vstatus}</dd>
               </div>
             </dl>
@@ -294,6 +323,7 @@ VisitInstrumentList.propTypes = {
   Candidate: PropTypes.object,
   Visit: PropTypes.object,
   VisitMap: PropTypes.object,
+  t: PropTypes.Func,
 };
 
-export default VisitInstrumentList;
+export default withTranslation(['instruments', 'loris'])(VisitInstrumentList);

--- a/modules/instruments/locale/instruments.pot
+++ b/modules/instruments/locale/instruments.pot
@@ -47,3 +47,15 @@ msgstr ""
 
 msgid "Top"
 msgstr ""
+
+msgid "Behavioural Data"
+msgstr ""
+
+msgid "Completion"
+msgstr ""
+
+msgid "Conflicts?"
+msgstr ""
+
+msgid "Visit has no registered instruments in test battery."
+msgstr ""

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -48,3 +48,14 @@ msgstr "サブテスト"
 msgid "Top"
 msgstr "トップ"
 
+msgid "Behavioural Data"
+msgstr "行動データ"
+
+msgid "Completion"
+msgstr "完了"
+
+msgid "Conflicts?"
+msgstr "衝突？"
+
+msgid "Visit has no registered instruments in test battery."
+msgstr "訪問にはテスト バッテリーに登録された機器がありません。"

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -154,7 +154,7 @@ class Module extends \Module
 
             return [
                 new \LORIS\candidate_profile\CandidateWidget(
-                    "Behavioural Data",
+                    dgettext("instruments", "Behavioural Data"),
                     $baseurl . "/instruments/js/CandidateInstrumentList.js",
                     'lorisjs.instruments.CandidateInstrumentList.default',
                     [],


### PR DESCRIPTION
This adds Japanese translations for the last remaining widget on the candidate profile page. The dates are also now formatted according to the user's locale.
