### PR TITLE
[dashboard/statistics] Fix loading of dashboard charts

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -82,7 +82,7 @@ class Charts extends \NDB_Page
         // when splitting the path, then there should be exactly 2 parts left,
         // "charts", and the endpoint requested.
         $url = ltrim(
-            $request->getAttribute("unhandledURI")->getURI()->getPath(),
+            $request->getAttribute("unhandledURI")->getPath(),
             '/'
         );
 


### PR DESCRIPTION
The charts do not currently load, because the URI class does not have a getURI() method. It is already a URI.