### PR TITLE
[dashboard] fix not load "Total recruitment by Age" and "Ethnicity at Screening"

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -82,7 +82,7 @@ class Charts extends \NDB_Page
         // when splitting the path, then there should be exactly 2 parts left,
         // "charts", and the endpoint requested.
         $url = ltrim(
-            $request->getAttribute("unhandledURI")->getURI()->getPath(),
+            $request->getAttribute("unhandledURI")->getPath(),
             '/'
         );
 


### PR DESCRIPTION
[dashborad] fix not load "Total recruitment by Age" and "Ethnicity at Screening"
before <img width="883" height="602" alt="截屏2025-11-03 下午12 54 53" src="https://github.com/user-attachments/assets/53adb578-0231-4a05-81de-eaf1a940c078" />
after 
<img width="861" height="317" alt="截屏2025-11-03 下午12 59 32" src="https://github.com/user-attachments/assets/369d5366-4652-41a0-a1db-8219a2e505c1" />
