### PR TITLE
[redcap] add functionality to parse decimal options

### DIFF
--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -318,9 +318,6 @@ class RedcapDictionaryRecord
         $index = 1; //Auto-index counter
         foreach ($choices as $choice) {
             $choice = trim($choice);
-            if (empty($choice)) {
-                continue;
-            }
 
             $matches = [];
 


### PR DESCRIPTION
******************************************
The REDcap "radio option" sometimes includes no index and, in thtis case, a decimal (float) causing redcap2linst show the following error:

PHP Fatal error:  Uncaught DomainException: Could not parse radio option: '0.01 ' in /var/www/loris/project/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc:316 Stack trace: #0 /var/www/loris/project/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc(268): LORIS\redcap\client\models\RedcapDictionaryRecord->_optionsToLINST() #1 /var/www/loris/project/tools/redcap2linst.php(74): LORIS\redcap\client\models\RedcapDictionaryRecord->toLINST() #2 {main} thrown in /var/www/loris/project/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc on line 316

the fetch was 0.01 | 0.05 | 0.10 | 0.15 without indices, But this code fixes it as shown in image 2 and LINST code below

<img width="1325" height="141" alt="Screenshot from 2025-10-26 13-04-38" src="https://github.com/user-attachments/assets/5727f574-68ed-4c32-9988-011b6ed11893" />

<img width="539" height="677" alt="Screenshot from 2025-10-26 14-11-36" src="https://github.com/user-attachments/assets/9ef55178-7fc1-4f7e-96de-8715a68c0419" />


selectmultiple{@}wppsi_47_critic_5{@}Critical Value Significance

Level{@}'1'=>'0.01'{-}'2'=>'0.05'{-}'3'=>'0.10'{-}'4'=>'0.15'`


- [ ] Have you updated related documentation?
Relevant documentation is the REDcap importer docs, which could be clarified to address this and other bugs that sometimes occur when interfacing with REDcap instance variances.

#### Testing instructions (if applicable)

Testing requires a redcap instance with an instrument containing this particular setting.

#### Link(s) to related issue(s)
This change replicates CBIGR PR #546 
* Resolves #  (Reference the issue this fixes, if any.) None
