### PR TITLE
[imaging_qc] {{pageCount}} rows displayed of {{totalCount}}. only shows the variable name.

### DIFF
--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import PropTypes from 'prop-types';
+// eslint-disable-next-line no-unused-vars
 import i18n from 'I18nSetup';
 /**
  * Imaging Quality Control React Component


### PR DESCRIPTION
https://github.com/aces/Loris/issues/10112
* Resolves #  (Reference the issue this fixes, if any.)
](react-i18next:: useTranslation: You will need to pass in an i18next instance by using initReactI18next)](react-i18next:: useTranslation: You will need to pass in an i18next instance by using initReactI18next)