### PR TITLE
[CI/redcap] Add REDCap module to PR autolabeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -170,6 +170,10 @@
 - changed-files:
   - any-glob-to-any-file: modules/publication/**
 
+"Module: redcap":
+- changed-files:
+  - any-glob-to-any-file: modules/redcap/**
+
 "Module: schedule_module":
 - changed-files:
   - any-glob-to-any-file: modules/schedule_module/**


### PR DESCRIPTION
## Description

Add the REDCap module to the GitHub Actions PR autolabeler.

## Commits

- First commit sorts the autolabeler modules by alphabetical order (it was kinda disordered before).
- Second commit adds the REDCap module to the list.