### PR TITLE
Dqt improvements

### DIFF
--- a/jsx/Form.d.ts
+++ b/jsx/Form.d.ts
@@ -162,6 +162,7 @@ type checkboxProps = {
     required?: boolean
     errorMessage?: string
     elementClass?: string
+    style?: object
     onUserInput?: (name: string, value: any) => void
 }
 /**

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2192,7 +2192,7 @@ export class CheckboxElement extends React.Component {
     }
 
     return (
-      <div className={elementClass}>
+      <div className={elementClass} style={this.props.style}>
         <div className="col-sm-12">
           <label htmlFor={this.props.id}>
             <div style={divStyle}>
@@ -2228,6 +2228,7 @@ CheckboxElement.propTypes = {
   errorMessage: PropTypes.string,
   elementClass: PropTypes.string,
   onUserInput: PropTypes.func,
+  style: PropTypes.object,
 };
 
 CheckboxElement.defaultProps = {
@@ -2238,6 +2239,7 @@ CheckboxElement.defaultProps = {
   offset: 'col-sm-offset-3',
   class: 'checkbox-inline',
   elementClass: 'checkbox-inline col-sm-offset-3',
+  style: {},
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2178,7 +2178,9 @@ export class CheckboxElement extends React.Component {
     let elementClass = this.props.class + ' ' + this.props.offset;
     const divStyle = this.props.class === 'checkbox-inline'
       ? {paddingRight: '5px'}
-      : {paddingRight: '5px', display: 'inline-block'};
+      : this.props.class === 'checkbox-flex' ?
+        {paddingRight: '5px', display: 'flex'}
+        : {paddingRight: '5px', display: 'inline-block'};
 
     // Add required asterix
     if (this.props.required) {
@@ -2194,7 +2196,10 @@ export class CheckboxElement extends React.Component {
     return (
       <div className={elementClass} style={this.props.style}>
         <div className="col-sm-12">
-          <label htmlFor={this.props.id}>
+          <label htmlFor={this.props.id}
+            style={
+              this.props.class === 'checkbox-flex'
+                ? {display: 'flex'} : {}}>
             <div style={divStyle}>
               <input
                 type="checkbox"
@@ -2204,6 +2209,9 @@ export class CheckboxElement extends React.Component {
                 required={this.props.required}
                 disabled={this.props.disabled}
                 onChange={this.handleChange}
+                style={
+                  this.props.class === 'checkbox-flex' ? {marginTop: '0'} : {}
+                }
               />
             </div>
             {errorMessage}

--- a/modules/dataquery/jsx/components/filterableselectgroup.tsx
+++ b/modules/dataquery/jsx/components/filterableselectgroup.tsx
@@ -19,6 +19,7 @@ type SelectGroup = {
  * @param {string?} props.placeholder - An optional placeholder value when no elements are selected
  * @param {object} props.groups - Groups to select the dropdown into
  * @param {function} props.mapGroupName - A mapper from backend to frontend name for groups
+ * @param {string?} props.label - Select input label
  * @returns {React.ReactElement} - The element
  */
 function FilterableSelectGroup(props: {
@@ -26,6 +27,7 @@ function FilterableSelectGroup(props: {
     placeholder?: string,
     groups: object,
     mapGroupName?: (module: string) => string,
+    label?: string,
 }) {
   const groups: SelectGroup[] = [];
   const placeholder = props.placeholder || 'Select a category';
@@ -70,19 +72,50 @@ function FilterableSelectGroup(props: {
   };
   return (
     <div>
-      <Select options={groups} onChange={selected}
-        menuPortalTarget={document.body}
-        styles={{menuPortal:
-                    /**
-                     * Add a z-index to ensure the element stays visible
-                     *
-                     * @param {object} base - the base CSS
-                     * @returns {object} - the new CSS with z-index added
-                     */
-                    (base) => ({...base, zIndex: 9999})}
-        }
-        placeholder={placeholder}
-      />
+      {props.label ?
+        <label style={{width: '100%', fontSize: '24px'}}>
+          {props.label}
+          <Select options={groups} onChange={selected}
+            menuPortalTarget={document.body}
+            styles={{menuPortal:
+                        /**
+                         * Add a z-index to ensure the element stays visible
+                         *
+                         * @param {object} base - the base CSS
+                         * @returns {object} - the new CSS with z-index added
+                         */
+                        (base) => ({...base, zIndex: 9999}),
+            valueContainer:
+                            /**
+                             * Adds appropriate zIndex to the react select's base CSS
+                             *
+                             * @param {object} base - The current CSS
+                             * @returns {object} New CSS with z-index added
+                             */
+                            (base) => ({
+                              ...base,
+                              fontSize: '14px',
+                              fontWeight: 400,
+                            }),
+            }}
+            placeholder={placeholder}
+          />
+        </label>
+        :
+        <Select options={groups} onChange={selected}
+          menuPortalTarget={document.body}
+          styles={{menuPortal:
+                      /**
+                       * Add a z-index to ensure the element stays visible
+                       *
+                       * @param {object} base - the base CSS
+                       * @returns {object} - the new CSS with z-index added
+                       */
+                      (base) => ({...base, zIndex: 9999})}
+          }
+          placeholder={placeholder}
+        />
+      }
     </div>
   );
 }

--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -340,6 +340,8 @@ function DefineFields(props: {
   let fieldList: React.ReactElement|null = null;
   if (props.category) {
     // Put into a short variable name for line length
+    const mCategories = props.allCategories.categories[props.module];
+    const cname = mCategories[props.category];
     let defaultVisits;
     if (props.defaultVisits) {
       const allVisits = props.allVisits.map((el) => {
@@ -418,7 +420,7 @@ function DefineFields(props: {
               <input onChange={setFilter}
                 className='form-control'
                 type="text"
-                placeholder="Search fields"
+                placeholder={`Search within ${cname}`}
                 aria-describedby="input-filter-addon"
                 value={activeFilter}
                 style={{borderRadius: '32px 0 0 32px'}}/>

--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -93,7 +93,7 @@ function QueryField(props: {
 
     if (props.selected) {
       visits = <div onClick={(e) => e.stopPropagation()}>
-        <h4>Visits</h4>
+        <h4 style={{fontSize: '16px'}}>Visits</h4>
         <Select options={selectOptions.map((visit: string): VisitOption => {
           return {value: visit, label: visit};
         })
@@ -108,13 +108,25 @@ function QueryField(props: {
         menuPortalTarget={document.body}
         styles={
           {menuPortal:
-                        /**
-                         * Adds appropriate zIndex to the react select's base CSS
-                         *
-                         * @param {object} base - The current CSS
-                         * @returns {object} New CSS with z-index added
-                         */
-                        (base) => ({...base, zIndex: 9999}),
+                            /**
+                             * Adds appropriate zIndex to the react select's base CSS
+                             *
+                             * @param {object} base - The current CSS
+                             * @returns {object} New CSS with z-index added
+                             */
+                            (base) => ({...base, zIndex: 9999}),
+          valueContainer:
+                            /**
+                             * Adds appropriate zIndex to the react select's base CSS
+                             *
+                             * @param {object} base - The current CSS
+                             * @returns {object} New CSS with z-index added
+                             */
+                            (base) => ({
+                              ...base,
+                              maxHeight: '150px',
+                              overflowY: 'auto',
+                            }),
           }
         }
         closeMenuOnSelect={false}
@@ -130,7 +142,8 @@ function QueryField(props: {
       style={{
         cursor: 'pointer',
         display: 'flex',
-        justifyContent: 'space-between',
+        flexDirection: 'column',
+        marginBottom: '4px',
       }}
       onClick={() => props.onFieldToggle(
         props.module,
@@ -139,7 +152,7 @@ function QueryField(props: {
         selectedVisits,
       )}>
       <dl>
-        <dt>{item}</dt>
+        <dt style={{fontSize: '18px'}}>{item}</dt>
         <dd>{value.description} {download}</dd>
       </dl>
       {visits}
@@ -327,8 +340,8 @@ function DefineFields(props: {
   let fieldList: React.ReactElement|null = null;
   if (props.category) {
     // Put into a short variable name for line length
-    const mCategories = props.allCategories.categories[props.module];
-    const cname = mCategories[props.category];
+    // const mCategories = props.allCategories.categories[props.module];
+    // const cname = mCategories[props.category];
     let defaultVisits;
     if (props.defaultVisits) {
       const allVisits = props.allVisits.map((el) => {
@@ -337,73 +350,109 @@ function DefineFields(props: {
       const selectedVisits = props.defaultVisits.map((el) => {
         return {value: el, label: el};
       });
-      defaultVisits = <div style={{paddingBottom: '1em', display: 'flex'}}>
-        <h4 style={{paddingRight: '1ex'}}>Default Visits</h4>
-        <Select options={allVisits}
-          isMulti
-          onChange={props.onChangeDefaultVisits}
-          placeholder='Select Visits'
-          menuPortalTarget={document.body}
-          styles={
-            {menuPortal:
-                            /**
-                             * Adds appropriate zIndex to the react select's base CSS
-                             *
-                             * @param {object} base - The current CSS
-                             * @returns {object} New CSS with z-index added
-                             */
-                            (base) => ({...base, zIndex: 9999}),
-            }
-          }
-          value={selectedVisits}
-          closeMenuOnSelect={false}
-        />
-        <div>
-          <CheckboxElement label='Sync with selected fields'
+      defaultVisits = <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        marginBottom: '16px'}}>
+        <div style={{marginBottom: '8px'}}>
+          <CheckboxElement label='Sync visit selection across all fields'
             name="syncVisits"
+            class=""
+            offset=""
             value={syncVisits}
+            style={{}}
             onUserInput={
               (name: string, value: boolean) => setSyncVisits(value)
             } />
         </div>
+        {syncVisits && <div style={{marginBottom: '16px'}}>
+          <Select options={allVisits}
+            isMulti
+            onChange={props.onChangeDefaultVisits}
+            placeholder='Select Visits'
+            menuPortalTarget={document.body}
+            styles={
+              {menuPortal:
+                              /**
+                               * Adds appropriate zIndex to the react select's base CSS
+                               *
+                               * @param {object} base - The current CSS
+                               * @returns {object} New CSS with z-index added
+                               */
+                              (base) => ({...base, zIndex: 9999}),
+              valueContainer:
+                              /**
+                               * Adds appropriate zIndex to the react select's base CSS
+                               *
+                               * @param {object} base - The current CSS
+                               * @returns {object} New CSS with z-index added
+                               */
+                              (base) => ({
+                                ...base,
+                                maxHeight: '200px',
+                                overflowY: 'auto',
+                              }),
+              }
+            }
+            value={selectedVisits}
+            closeMenuOnSelect={false}
+          /></div>}
       </div>;
     }
 
     fieldList = (<div>
-      <div style={{display: 'flex', flexWrap: 'wrap',
-        justifyContent: 'space-between'}}>
-        <h2>{cname} fields</h2>
-        <div style={{marginTop: '1em',
+      <div style={{display: 'flex', flexDirection: 'column',
+        marginTop: '32px'}}>
+        {/* <h2>{cname} fields</h2> */}
+        <div style={{
           display: 'flex',
           flexWrap: 'nowrap',
           flexDirection: 'column',
         }}>
           {defaultVisits}
-          <div className="input-group">
-            <input onChange={setFilter}
-              className='form-control'
-              type="text"
-              placeholder="Filter within category"
-              aria-describedby="input-filter-addon"
-              value={activeFilter} />
-            <span className="input-group-addon">
-              <span className="glyphicon glyphicon-search"/>
-            </span>
-          </div>
-          <div style={{margin: '1ex',
+          <div style={{
+            width: '100%',
             display: 'flex',
-            flexWrap: 'wrap',
-            flexDirection: 'row',
-            justifyContent: 'space-around',
-          }}>
-            <button type="button" className="btn btn-primary"
-              onClick={addAll}>
-                            Add all
-            </button>
-            <button type="button" className="btn btn-primary"
-              onClick={removeAll}>
-                            Remove all
-            </button>
+            marginBottom: '8px',
+            alignItems: 'center',
+            justifyContent: 'space-between'}}>
+            <div className="input-group"
+              style={{width: '50%', display: 'flex'}}>
+              <input onChange={setFilter}
+                className='form-control'
+                type="text"
+                placeholder="Filter within category"
+                aria-describedby="input-filter-addon"
+                value={activeFilter}
+                style={{borderRadius: '32px 0 0 32px'}}/>
+              <span className="input-group-addon"
+                style={{
+                  borderRadius: '0 32px 32px 0',
+                  height: '34px',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  padding: '0 20px',
+                }}
+                id="input-filter-addon">
+                <span className="glyphicon glyphicon-search"/>
+              </span>
+            </div>
+            <div style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              flexDirection: 'row',
+              justifyContent: 'space-around',
+            }}>
+              <button type="button" className="btn btn-primary"
+                onClick={addAll}>
+                              Add all
+              </button>
+              <button type="button" className="btn btn-primary"
+                onClick={removeAll}>
+                              Remove all
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -413,8 +462,8 @@ function DefineFields(props: {
 
   return (
     <div>
-      <div style={{display: 'flex', flexWrap: 'nowrap'}}>
-        <div style={{width: '80vw', padding: '1em'}}>
+      <div style={{display: 'flex', gap: '1rem', width: '100%'}}>
+        <div style={{width: 'calc(70% - 1rem/2)', padding: '1em'}}>
           <h1>Available Fields</h1>
           <FilterableSelectGroup groups={props.allCategories.categories}
             mapGroupName={(key) => props.allCategories.modules[key]}
@@ -423,27 +472,30 @@ function DefineFields(props: {
           {fieldList}
         </div>
         <div style={{
-          width: '20vw',
           padding: '1em',
           position: 'sticky',
           top: 0,
-          maxHeight: '90vh',
-          overflow: 'auto',
+          width: 'calc(30% - 1rem/2)',
         }}>
-          <div>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-end',
-              marginBottom: '1em',
-            }}>
-              <h2>Selected Fields</h2>
-              <div>
-                <button type="button" className="btn btn-primary"
-                  style={{marginBottom: 7}}
-                  onClick={props.onClearAll}>Clear</button>
-              </div>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            marginBottom: '1em',
+            flexWrap: 'wrap',
+          }}>
+            <h2>Selected Fields</h2>
+            <div>
+              <button type="button" className="btn btn-primary"
+                style={{marginBottom: 7}}
+                onClick={props.onClearAll}>Clear</button>
             </div>
+          </div>
+          <div style={{
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            maxHeight: '90vh',
+          }}>
             <SelectedFieldList
               selected={props.selected}
               removeField={props.removeField}
@@ -527,6 +579,7 @@ function SelectedFieldList(props: {
     const style: React.CSSProperties = {display: 'flex',
       flexWrap: 'nowrap' as const,
       cursor: 'grab',
+      gap: '4px',
       justifyContent: 'space-between'};
     if (removingIdx === i) {
       style.textDecoration = 'line-through' as const;
@@ -543,6 +596,7 @@ function SelectedFieldList(props: {
         fontStyle: 'italic',
         color: '#aaa',
         fontSize: '0.7em',
+        wordBreak: 'break-word' as const,
         marginLeft: 20,
       };
       fieldvisits = <dd style={style}>{item.visits.join(', ')}</dd>;
@@ -572,13 +626,17 @@ function SelectedFieldList(props: {
       onDrop={() => moveSelected()}
     >
       <div>
-        <dt>{item.field}</dt>
-        <dd style={{marginLeft: 20}}>{getDictionaryDescription(
-          item.module,
-          item.category,
-          item.field,
-          props.fulldictionary,
-        )}</dd>
+        <dt style={{wordBreak: 'break-word'}}>{item.field}</dt>
+        <dd style={{
+          marginLeft: 20,
+          wordBreak: 'break-word',
+        }}>
+          {getDictionaryDescription(
+            item.module,
+            item.category,
+            item.field,
+            props.fulldictionary
+          )}</dd>
         {fieldvisits}
       </div>
       <div

--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -493,7 +493,7 @@ function DefineFields(props: {
           <div style={{
             overflowY: 'auto',
             overflowX: 'hidden',
-            maxHeight: '90vh',
+            maxHeight: '80vh',
           }}>
             <SelectedFieldList
               selected={props.selected}

--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -340,8 +340,6 @@ function DefineFields(props: {
   let fieldList: React.ReactElement|null = null;
   if (props.category) {
     // Put into a short variable name for line length
-    // const mCategories = props.allCategories.categories[props.module];
-    // const cname = mCategories[props.category];
     let defaultVisits;
     if (props.defaultVisits) {
       const allVisits = props.allVisits.map((el) => {
@@ -403,7 +401,6 @@ function DefineFields(props: {
     fieldList = (<div>
       <div style={{display: 'flex', flexDirection: 'column',
         marginTop: '32px'}}>
-        {/* <h2>{cname} fields</h2> */}
         <div style={{
           display: 'flex',
           flexWrap: 'nowrap',
@@ -421,7 +418,7 @@ function DefineFields(props: {
               <input onChange={setFilter}
                 className='form-control'
                 type="text"
-                placeholder="Filter within category"
+                placeholder="Search fields"
                 aria-describedby="input-filter-addon"
                 value={activeFilter}
                 style={{borderRadius: '32px 0 0 32px'}}/>

--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -353,9 +353,9 @@ function DefineFields(props: {
         flexDirection: 'column',
         marginBottom: '16px'}}>
         <div style={{marginBottom: '8px'}}>
-          <CheckboxElement label='Sync visit selection across all fields'
+          <CheckboxElement label='Sync visit selection across selected fields'
             name="syncVisits"
-            class=""
+            class="checkbox-flex"
             offset=""
             value={syncVisits}
             style={{}}
@@ -430,6 +430,7 @@ function DefineFields(props: {
                   justifyContent: 'center',
                   alignItems: 'center',
                   padding: '0 20px',
+                  cursor: 'pointer',
                 }}
                 id="input-filter-addon">
                 <span className="glyphicon glyphicon-search"/>
@@ -461,10 +462,11 @@ function DefineFields(props: {
     <div>
       <div style={{display: 'flex', gap: '1rem', width: '100%'}}>
         <div style={{width: 'calc(70% - 1rem/2)', padding: '1em'}}>
-          <h1>Available Fields</h1>
           <FilterableSelectGroup groups={props.allCategories.categories}
             mapGroupName={(key) => props.allCategories.modules[key]}
             onChange={props.onCategoryChange}
+            label="Select a Field"
+            placeholder='Available options'
           />
           {fieldList}
         </div>
@@ -481,7 +483,7 @@ function DefineFields(props: {
             marginBottom: '1em',
             flexWrap: 'wrap',
           }}>
-            <h2>Selected Fields</h2>
+            <h2>Field Selection</h2>
             <div>
               <button type="button" className="btn btn-primary"
                 style={{marginBottom: 7}}

--- a/modules/dataquery/jsx/hooks/usequery.tsx
+++ b/modules/dataquery/jsx/hooks/usequery.tsx
@@ -47,7 +47,11 @@ type useQueryReturnType = [
  * @returns {useQueryReturnType} - A veritable plethora of actions and values
  */
 function useQuery(): useQueryReturnType {
-  const [fields, setFields] = useState<APIQueryField[]>([]);
+  const [fields, setFields] = useState<APIQueryField[]>([{
+    'module': 'candidate_parameters',
+    'category': 'Identifiers',
+    'field': 'PSCID',
+  }]);
   const [criteria, setCriteria] = useState<QueryGroup>(new QueryGroup('and'));
 
   /**

--- a/modules/dataquery/jsx/hooks/usequery.tsx
+++ b/modules/dataquery/jsx/hooks/usequery.tsx
@@ -47,11 +47,7 @@ type useQueryReturnType = [
  * @returns {useQueryReturnType} - A veritable plethora of actions and values
  */
 function useQuery(): useQueryReturnType {
-  const [fields, setFields] = useState<APIQueryField[]>([{
-    'module': 'candidate_parameters',
-    'category': 'Identifiers',
-    'field': 'PSCID',
-  }]);
+  const [fields, setFields] = useState<APIQueryField[]>([]);
   const [criteria, setCriteria] = useState<QueryGroup>(new QueryGroup('and'));
 
   /**

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -148,7 +148,7 @@ function NextSteps(props: {
           alignItems: 'center',
           justifyContent: 'center',
           gap: '1rem',
-          padding: '16px 3rem',
+          padding: expanded ? '16px 3rem 8px' : '16px 3rem',
           cursor: 'pointer',
           backgroundColor: '#fff',
         }}

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -148,6 +148,7 @@ function NextSteps(props: {
           gap: '1rem',
           padding: '0 3rem',
           cursor: 'pointer',
+          backgroundColor: '#fff',
         }}
         onClick={() => setExpanded(!expanded)}
       >

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -112,19 +112,20 @@ function NextSteps(props: {
   }
 
   const expandIcon = <i
-    style={{transform: 'scaleY(2)', fontSize: '2em'}}
+    style={{
+      fontSize: '2em',
+      rotate: expanded ? '270deg' : '90deg',
+      color: '#064785',
+    }}
     className='fas fa-chevron-left'
-    onClick={() => setExpanded(!expanded)}
   ></i>;
   const style = expanded ? {
     background: 'white',
-    padding: '0.5em',
-    paddingLeft: '2em',
+    padding: '1rem 2rem',
   } : {
-    display: 'none',
-    visibility: 'hidden' as const,
-    padding: '0.5em',
-    paddingLeft: '2em',
+    display: 'hidden',
+    padding: '0rem 2rem',
+    height: '0px',
   };
 
   return (
@@ -137,25 +138,31 @@ function NextSteps(props: {
       borderColor: 'black',
       // Fix the height size so it doesn't move when
       // expanded or collapsed
-      height: 120,
       // Make sure we're on top of the footer
       zIndex: 300,
     }}>
+      <div
+        style={{display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '1rem',
+          padding: '0 3rem',
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <h3 style={{marginTop: '10px'}}>Next Steps</h3>
+        {expandIcon}</div>
       <div style={{
         display: 'flex',
         alignItems: 'stretch',
-        height: 120,
-        paddingRight: '14px',
       }}>
         <div style={style}>
-          <h3>Next Steps</h3>
           <div style={{display: 'flex'}}>
             {steps}
           </div>
         </div>
-        <div
-          style={{alignSelf: 'center'}}
-        >{expandIcon}</div>
+
       </div>
     </div>
   );

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -122,10 +122,12 @@ function NextSteps(props: {
   const style = expanded ? {
     background: 'white',
     padding: '1rem 2rem',
+    width: '100%',
   } : {
     display: 'hidden',
     padding: '0rem 2rem',
     height: '0px',
+    width: '100%',
   };
 
   return (
@@ -157,9 +159,10 @@ function NextSteps(props: {
       <div style={{
         display: 'flex',
         alignItems: 'stretch',
+        backgroundColor: '#fff',
       }}>
         <div style={style}>
-          <div style={{display: 'flex'}}>
+          <div style={{display: 'flex', justifyContent: 'center', gap: '1rem'}}>
             {steps}
           </div>
         </div>

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -146,13 +146,13 @@ function NextSteps(props: {
           alignItems: 'center',
           justifyContent: 'center',
           gap: '1rem',
-          padding: '0 3rem',
+          padding: '16px 3rem',
           cursor: 'pointer',
           backgroundColor: '#fff',
         }}
         onClick={() => setExpanded(!expanded)}
       >
-        <h3 style={{marginTop: '10px'}}>Next Steps</h3>
+        <h3 style={{margin: '0'}}>Next Steps</h3>
         {expandIcon}</div>
       <div style={{
         display: 'flex',

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -842,7 +842,7 @@ function SingleQueryDisplay(props: {
         props.setNameModalID(query.QueryID);
       }} />;
     msg = <div>{desc}
-            &nbsp;{starredIcon}{sharedIcon}{loadIcon}{nameIcon}{pinIcon}
+            &nbsp;{loadIcon}{nameIcon}{starredIcon}{pinIcon}{sharedIcon}
     </div>;
   } else if (query.SharedBy) {
     const desc = query.Name
@@ -1009,7 +1009,7 @@ function LoadIcon(props: {
     title="Reload query"
     style={{cursor: 'pointer'}}
     className="fa-stack">
-    <i className="fas fa-sync fa-stack-1x"></i>
+    <i className="fas fa-play fa-stack-1x"></i>
   </span>;
 }
 
@@ -1032,7 +1032,7 @@ function ShareIcon(props: {
     title={props.title}
     onClick={props.onClick}>
     <i style={props.isShared ? {color: 'blue'} : {}}
-      className="fas fa-globe fa-stack-1x" />
+      className="fas fa-share fa-stack-1x" />
   </span>;
 }
 


### PR DESCRIPTION
## Brief summary of changes

### 1. Updated Next Steps component to be more visually understandable 
#### Open (old)
<img width="282" height="131" alt="image" src="https://github.com/user-attachments/assets/3eabb3fa-4e25-4a06-bcbd-97f65c42d3af" />

#### Closed (old)
<img width="80" height="134" alt="image" src="https://github.com/user-attachments/assets/81690e93-b087-4cdb-b2c7-9ca8874937d4" />

#### Open (updated)
<img width="384" height="130" alt="image" src="https://github.com/user-attachments/assets/6bc8cb1b-a403-417b-9ff6-d83dd1b8d68e" />

#### Closed (updated)
<img width="390" height="72" alt="image" src="https://github.com/user-attachments/assets/2bd890e7-9946-4eca-8df6-4f200738de49" />


### 2. Updated and Reordered Icons on Recent Queries Panel
- Updated execute query and share query with more standardly used icons
#### Previously
<img width="170" height="37" alt="image" src="https://github.com/user-attachments/assets/4bafbc30-1f59-4059-a872-e9aece2938fd" />

#### Updated
<img width="169" height="38" alt="image" src="https://github.com/user-attachments/assets/65a6be77-2d94-4c34-8e54-6cc0f8b6a57d" />


### 3. Increased amount of space allocated to the Field Selection / Selected Fields section

#### Previously
<img width="1101" height="194" alt="image" src="https://github.com/user-attachments/assets/061299e5-1748-4e45-9a1b-8f19b014581f" />

#### Updated
<img width="1086" height="161" alt="image" src="https://github.com/user-attachments/assets/09eac525-cb3e-49e2-ae1b-5f909e564f02" />

### 4. Made large amounts of text on Selected Fields / Field Selection section not break into horizontal scrolling

#### Previously
<img width="256" height="1003" alt="image" src="https://github.com/user-attachments/assets/bd094e82-dd36-493a-a525-14823134cea5" />

#### Updated
<img width="329" height="929" alt="image" src="https://github.com/user-attachments/assets/e5aff9f8-e1d8-41ef-9de3-2c59ca21f52f" />

### 5. Removed field that was selected by default
- In the local development environment it was causing a bug when clicking the sync fields checkbox and was breaking the page. It is not happening in demo.loris.ca/dataquery.
<img width="235" height="149" alt="image" src="https://github.com/user-attachments/assets/e41ac30b-b168-487a-b8a2-3fd749c33826" />

### 6. Updated placement of UI elements
- Removed redundant labels
- Updated the sync field label to make easier the understanding of what it does
- Updated Available Fields label to Select a Field to make more clear what the user needs to do
- Hid the previously named Default Visits dropdown field until the user clicks the Sync visit selection checkbox
- Height limited the Sync Visits selection box with a scrollbar so it won't take too much space when there are too many visits available
- Updated search box look to make it more distinct from the other selection fields
- Changed search box and add all / remove all button placement to better group them near the available fields and make their relation clearer 
- Updated selected field list item so that visual elements won't clash together under certain screen sizes or depending on the amount of text.
- Height limited the visit selection with a scrollbar within a selected field list item in the field list so it won't take too much vertical space when there are too many visits available
#### Previously
<img width="912" height="414" alt="image" src="https://github.com/user-attachments/assets/d2d1b098-4466-46cd-852c-e6151cc949a1" />

#### Updated
<img width="743" height="438" alt="image" src="https://github.com/user-attachments/assets/e37be435-0c99-407f-bc14-cf07283e58a9" />


#### Link(s) to related issue(s)
558: https://github.com/aces/CBIGR/issues/558
