### PR TITLE
[publication] Add Japanese, Fix data dictionary link in english, clean up template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,11 @@ locales:
 	msgfmt -o modules/next_stage/locale/es/LC_MESSAGES/next_stage.mo modules/next_stage/locale/es/LC_MESSAGES/next_stage.po
 	msgfmt -o modules/oidc/locale/ja/LC_MESSAGES/oidc.mo modules/oidc/locale/ja/LC_MESSAGES/oidc.po
 	msgfmt -o modules/publication/locale/ja/LC_MESSAGES/publication.mo modules/publication/locale/ja/LC_MESSAGES/publication.po
+	msgfmt -o modules/publication/locale/en/LC_MESSAGES/publication.mo modules/publication/locale/en/LC_MESSAGES/publication.po
 	msgfmt -o modules/publication/locale/hi/LC_MESSAGES/publication.mo modules/publication/locale/hi/LC_MESSAGES/publication.po
 	npx i18next-conv -l hi -s modules/publication/locale/hi/LC_MESSAGES/publication.po -t modules/publication/locale/hi/LC_MESSAGES/publication.json
+	npx i18next-conv -l ja -s modules/publication/locale/ja/LC_MESSAGES/publication.po -t modules/publication/locale/ja/LC_MESSAGES/publication.json
+	npx i18next-conv -l en -s modules/publication/locale/en/LC_MESSAGES/publication.po -t modules/publication/locale/en/LC_MESSAGES/publication.json
 	msgfmt -o modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.mo modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
 	msgfmt -o modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.mo modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.po
 	npx i18next-conv -l hi -s modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.po -t modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.json	

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -123,6 +123,9 @@ msgstr "はい"
 msgid "No"
 msgstr "いいえ"
 
+msgid "Browse"
+msgstr "ブラウズ"
+
 msgid "Create"
 msgstr "作成する"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -188,9 +188,6 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-msgid "Close"
-msgstr ""
-
 # Common candidate terms
 msgid "PSCID"
 msgstr ""

--- a/modules/publication/jsx/publicationIndex.js
+++ b/modules/publication/jsx/publicationIndex.js
@@ -9,6 +9,8 @@ import StaticDataTable from 'jsx/StaticDataTable';
 import i18n from 'I18nSetup';
 import {withTranslation} from 'react-i18next';
 import hiStrings from '../locale/hi/LC_MESSAGES/publication.json';
+import jaStrings from '../locale/ja/LC_MESSAGES/publication.json';
+import enStrings from '../locale/en/LC_MESSAGES/publication.json';
 import FilterableDataTable from 'FilterableDataTable';
 
 /**
@@ -93,7 +95,7 @@ class PublicationIndex extends React.Component {
       );
     }
 
-    let tabList = [{id: 'browse', label: t('Browse', {ns: 'publication'})}];
+    let tabList = [{id: 'browse', label: t('Browse', {ns: 'loris'})}];
     let proposalTab;
 
     if (loris.userHasPermission('publication_propose')) {
@@ -250,6 +252,8 @@ PublicationIndex.propTypes = {
 
 window.addEventListener('load', () => {
   i18n.addResourceBundle('hi', 'publication', hiStrings);
+  i18n.addResourceBundle('ja', 'publication', jaStrings);
+  i18n.addResourceBundle('en', 'publication', enStrings);
 
   const PubIndex = withTranslation(['publication'])(PublicationIndex);
 

--- a/modules/publication/jsx/viewProjectIndex.js
+++ b/modules/publication/jsx/viewProjectIndex.js
@@ -2,10 +2,14 @@ import {createRoot} from 'react-dom/client';
 import ViewProject from './viewProject';
 import i18n from 'I18nSetup';
 import hiStrings from '../locale/hi/LC_MESSAGES/publication.json';
+import jaStrings from '../locale/ja/LC_MESSAGES/publication.json';
+import enStrings from '../locale/en/LC_MESSAGES/publication.json';
 const args = QueryString.get(document.currentScript.src);
 
 document.addEventListener('DOMContentLoaded', () => {
   i18n.addResourceBundle('hi', 'publication', hiStrings);
+  i18n.addResourceBundle('ja', 'publication', jaStrings);
+  i18n.addResourceBundle('en', 'publication', enStrings);
   const viewProject = (
     <div className="page-edit-form">
       <div className="row">

--- a/modules/publication/locale/en/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/en/LC_MESSAGES/publication.po
@@ -1,0 +1,23 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "helpFindingVariables"
+msgstr "For help finding variables of interest, consult the <ddLink>Data Dictionary</ddLink>"
+

--- a/modules/publication/locale/hi/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/hi/LC_MESSAGES/publication.po
@@ -21,23 +21,11 @@ msgstr ""
 msgid "Publications"
 msgstr "प्रकाशन"
 
-msgid "Loading"
-msgstr "लोड हो रहा है"
-
-msgid "Browse"
-msgstr "ब्राउज़ करें"
-
 msgid "File to upload"
 msgstr "अपलोड करने के लिए फ़ाइल"
 
-msgid "Upload"
-msgstr "अपलोड करें"
-
 msgid "Are you sure?"
 msgstr "क्या आप सुनिश्चित हैं?"
-
-msgid "Cancel"
-msgstr "रद्द करें"
 
 msgid "Submit"
 msgstr "जमा करें"
@@ -123,17 +111,11 @@ msgstr "स्थिति"
 msgid "Reason for rejection"
 msgstr "अस्वीकृति का कारण"
 
-msgid "Pending"
-msgstr "लंबित"
-
 msgid "Approved"
 msgstr "स्वीकृत"
 
 msgid "Rejected"
 msgstr "अस्वीकृत"
-
-msgid "For help finding variables of interest, consult"
-msgstr "रुचि वाले वेरिएबल खोजने में सहायता के लिए, परामर्श करें"
 
 msgid "Date Proposed"
 msgstr "प्रस्तावित तिथि"
@@ -149,9 +131,6 @@ msgstr "परियोजना प्रस्ताव निर्मात�
 
 msgid "Published"
 msgstr "प्रकाशित"
-
-msgid "In Progress"
-msgstr "प्रगति पर"
 
 msgid "View Project"
 msgstr "परियोजना देखें"

--- a/modules/publication/locale/ja/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/ja/LC_MESSAGES/publication.po
@@ -20,3 +20,150 @@ msgstr ""
 
 msgid "Publications"
 msgstr "出版物"
+
+msgid "File to upload"
+msgstr "アップロードするファイル"
+
+msgid "Are you sure?"
+msgstr "本気ですか？"
+
+msgid "Submit"
+msgstr "提出する"
+
+msgid "Title"
+msgstr "タイトル"
+
+msgid "Year"
+msgstr "年"
+
+msgid "Authors"
+msgstr "著者"
+
+msgid "Journal"
+msgstr "ジャーナル"
+
+msgid "DOI"
+msgstr "デジタルオブジェクト識別子"
+
+msgid "Action"
+msgstr "アクション"
+
+msgid "Please fix any remaining form errors before submission"
+msgstr "提出前に残っているエラーを修正してください"
+
+msgid "Something went wrong!"
+msgstr "問題が発生しました。"
+
+msgid "Submission Successful!"
+msgstr "送信成功しました!"
+
+msgid "Propose a Project"
+msgstr "プロジェクトを提案する"
+
+msgid "Propose a new project"
+msgstr "新しいプロジェクトを提案する"
+
+msgid "Edit failed!"
+msgstr "編集に失敗しました!"
+
+msgid "Edit Successful!"
+msgstr "編集に成功しました!"
+
+msgid "Download"
+msgstr "ダウンロード"
+
+msgid "Citation"
+msgstr "引用"
+
+msgid "Version"
+msgstr "バージョン"
+
+msgid "Collaborators"
+msgstr "協力者"
+
+msgid "Keywords"
+msgstr "キーワード"
+
+msgid "Variables Of Interest"
+msgstr "関心のある変数"
+
+msgid "Description"
+msgstr "説明"
+
+msgid "Publishing Status"
+msgstr "出版状況"
+
+msgid "Date Published"
+msgstr "公開日"
+
+msgid "Link"
+msgstr "リンク"
+
+msgid "Lead Investigator"
+msgstr "主任研究者"
+
+msgid "Lead Investigator Email"
+msgstr "主任研究者のメールアドレス"
+
+msgid "Status"
+msgstr "状態"
+
+msgid "Reason for rejection"
+msgstr "拒否理由"
+
+msgid "Approved"
+msgstr "承認された"
+
+msgid "Rejected"
+msgstr "拒否されました"
+
+msgid "Date Proposed"
+msgstr "提案日"
+
+msgid "Approval Status"
+msgstr "承認ステータス"
+
+msgid "Project"
+msgstr "プロジェクト"
+
+msgid "Project Proposal Creator"
+msgstr "プロジェクト提案作成者"
+
+msgid "Published"
+msgstr "出版"
+
+msgid "View Project"
+msgstr "プロジェクトを見る"
+
+msgid "LORIS Users with Edit Permission"
+msgstr "編集権限を持つロリスユーザー"
+
+msgid "Type of Variables of Interest"
+msgstr "関心のある変数の種類"
+
+msgid "Propose Project"
+msgstr "プロジェクトを提案する"
+
+msgid "Send email notification?"
+msgstr "メール通知を送信しますか?"
+
+msgid "Add User"
+msgstr "ユーザーを追加"
+
+msgid "Add Collaborator"
+msgstr "共同編集者を追加"
+
+msgid "Add Keyword"
+msgstr "キーワードを追加"
+
+msgid "Add Variable of Interest"
+msgstr "関心のある変数を追加する"
+
+msgid "Publication Type"
+msgstr "出版の種類"
+
+msgid "Publication Version"
+msgstr "出版版"
+
+msgid "helpFindingVariables"
+msgstr "興味のある変数を見つけるには、<ddLink>データ辞書</ddLink>を参照してください。"

--- a/modules/publication/locale/publication.pot
+++ b/modules/publication/locale/publication.pot
@@ -21,22 +21,10 @@ msgstr ""
 msgid "Publications"
 msgstr ""
 
-msgid "Loading"
-msgstr ""
-
-msgid "Browse"
-msgstr ""
-
 msgid "File to upload"
 msgstr ""
 
-msgid "Upload"
-msgstr ""
-
 msgid "Are you sure?"
-msgstr ""
-
-msgid "Cancel"
 msgstr ""
 
 msgid "Submit"
@@ -123,9 +111,6 @@ msgstr ""
 msgid "Reason for rejection"
 msgstr ""
 
-msgid "Pending"
-msgstr ""
-
 msgid "Approved"
 msgstr ""
 
@@ -148,9 +133,6 @@ msgid "Project Proposal Creator"
 msgstr ""
 
 msgid "Published"
-msgstr ""
-
-msgid "In Progress"
 msgstr ""
 
 msgid "View Project"


### PR DESCRIPTION
This adds Japanese support to the publication module. The "For help finding variables" text was wrong in English because it was replaced by a key.

Clean up some pot strings that are from the loris.po and do not need to be in publication.po
