### PR TITLE
Dqt improvements  field selection

### DIFF
--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -443,7 +443,6 @@ function DefineFields(props: {
             flexWrap: 'wrap',
           }}>
             <h2>{t('Selected Fields', {ns: 'dataquery'})}</h2>
-            {/* <h2>Field Selection</h2> */}
             <div>
               <button type="button" className="btn btn-primary"
                 style={{marginBottom: 7}}


### PR DESCRIPTION
## Brief summary of changes

### Increased amount of space allocated to the Field Selection / Selected Fields section

#### Previously
<img width="1101" height="194" alt="image" src="https://github.com/user-attachments/assets/061299e5-1748-4e45-9a1b-8f19b014581f" />

#### Updated
<img width="1074" height="170" alt="image" src="https://github.com/user-attachments/assets/53e1a224-7824-49e3-97fe-dc2853c679ad" />

### Made large amounts of text on Selected Fields / Field Selection section not break into horizontal scrolling
#### Previously
<img width="256" height="1003" alt="image" src="https://github.com/user-attachments/assets/bd094e82-dd36-493a-a525-14823134cea5" />

#### Updated
<img width="329" height="929" alt="image" src="https://github.com/user-attachments/assets/e5aff9f8-e1d8-41ef-9de3-2c59ca21f52f" />

#### Link(s) to related issue(s)
558: https://github.com/aces/CBIGR/issues/558
