### PR TITLE
[tools] Bugfix for generate_candidate_externalids.php

### DIFF
--- a/tools/generate_candidate_externalids.php
+++ b/tools/generate_candidate_externalids.php
@@ -67,7 +67,8 @@ if ($config->getSetting('useExternalID') !== 'true') {
 $cands = $DB->pselect(
     "SELECT CandID, ExternalID, RegistrationCenterID as site,
     RegistrationProjectID as project
-    FROM candidate",
+    FROM candidate
+    WHERE Entity_type<>'Scanner'",
     []
 );
 
@@ -78,8 +79,8 @@ foreach ($cands as $cand) {
         continue;
     }
 
-    $site    = \Site::singleton($cand['site']);
-    $project = \Project::getProjectFromID($cand['project']);
+    $site    = \Site::singleton(new \CenterID($cand['site']));
+    $project = \Project::getProjectFromID(new \ProjectID($cand['project']));
 
     $externalID = (new \ExternalIDGenerator(
         $site->getSiteAlias(),


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the generate external IDs script to be runnable on 26 (mainly creating site and project objects). It also excludes scanners from the genration since the regular pipeline adding the scanners does it while bypassing the external ID generation (i.e. designed to be null)