### PR TITLE
[my_preferences] Fix checkbox display

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -694,7 +694,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements RequestHandlerInterface
         return $this->form->createElement(
             "advcheckbox",
             $field,
-            dgettext($this->name, $label),
+            !empty($label) ? dgettext($this->name, $label) : '',
             [],
             $attribs
         );


### PR DESCRIPTION
The checkboxes on the my_preferences page have an empty description.

This causes the po header to get dumped instead of the empty string when dgettext is called. Add a guard around it to fix the page.

#### Testing instructions (if applicable)

1. Go to my_preferences
2. See that the page renders properly and doesn't have inexplicable text beside the notifications checkboxes.