### PR TITLE
[multilingual] Translate "No result found." message

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -443,7 +443,7 @@ class DataTable extends Component {
             </div>
           </div>
           <div className='alert alert-info no-result-found-panel'>
-            <strong>No result found.</strong>
+            <strong>{this.props.t('No result found.', {ns: 'loris'})}</strong>
           </div>
         </div>
       );

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -496,7 +496,7 @@ class StaticDataTable extends Component {
     if (this.props.Data === null || this.props.Data.length === 0) {
       return (
         <div className='alert alert-info no-result-found-panel'>
-          <strong>No result found.</strong>
+          <strong>{this.props.t('No result found.', {ns: 'loris'})}</strong>
         </div>
       );
     }

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -344,6 +344,9 @@ msgid "View details"
 msgstr "詳細を表示"
 
 # Data table strings
+msgid "No result found."
+msgstr "結果が見つかりませんでした。"
+
 msgid "{{pageCount}} rows displayed of {{totalCount}}."
 msgstr "{{totalCount}}行中{{pageCount}}行を表示"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -355,6 +355,9 @@ msgid "View details"
 msgstr ""
 
 # Data table strings
+msgid "No result found."
+msgstr ""
+
 msgid "{{pageCount}} rows displayed of {{totalCount}}."
 msgstr ""
 


### PR DESCRIPTION
Add Translation for "No result found." for DataTable/StaticDataTable.

Fixes #10192.
