### PR TITLE
[dataquery] Improve internationalization of query run time

### DIFF
--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -15,6 +15,7 @@ import {FlattenedField, FlattenedQuery, VisitOption} from './types';
 import {useTranslation} from 'react-i18next';
 import 'I18nSetup';
 
+declare const loris: any;
 /**
  * Return the welcome tab for the DQT
  *
@@ -828,14 +829,24 @@ function SingleQueryDisplay(props: {
 
   let msg: React.ReactNode = null;
   if (query.RunTime) {
+    const dateFormatter = new Intl.DateTimeFormat(
+      loris.user.langpref.replace('_', '-'),
+      {
+        dateStyle: 'long',
+        timeStyle: 'medium',
+      }
+    );
+    const runTime = dateFormatter.format(new Date(query.RunTime));
+
+
     let desc = query.Name
       ? <span>
         <b>{query.Name}</b>
-             &nbsp;<i>{t('(Run at {{runTime}})', {ns: 'dataquery',
-          runTime: query.RunTime})}</i>
+             &nbsp;<i>{t('(Run on {{runTime}})', {ns: 'dataquery',
+          runTime: runTime})}</i>
       </span>
-      : <i>{t('You ran this query at {{runTime}}', {ns: 'dataquery',
-        runTime: query.RunTime})}</i>;
+      : <i>{t('You ran this query on {{runTime}}', {ns: 'dataquery',
+        runTime: runTime})}</i>;
     if (!props.includeRuns) {
       desc = query.Name
         ? <span>

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -410,10 +410,10 @@ msgstr ""
 msgid "Successfully loaded query."
 msgstr ""
 
-msgid "(Run at {{runTime}})"
+msgid "(Run on {{runTime}})"
 msgstr ""
 
-msgid "You ran this query at {{runTime}}"
+msgid "You ran this query on {{runTime}}"
 msgstr ""
 
 msgid "You ran this query"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -418,10 +418,10 @@ msgstr "क्वेरी लोड हो गई"
 msgid "Successfully loaded query."
 msgstr "क्वेरी सफलतापूर्वक लोड हो गई।"
 
-msgid "(Run at {{runTime}})"
+msgid "(Run on {{runTime}})"
 msgstr "(चलाया गया {{runTime}} पर)"
 
-msgid "You ran this query at {{runTime}}"
+msgid "You ran this query on {{runTime}}"
 msgstr "आपने यह क्वेरी {{runTime}} पर चलाई"
 
 msgid "You ran this query"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -405,10 +405,10 @@ msgstr "クエリが読み込まれました"
 msgid "Successfully loaded query."
 msgstr "クエリが正常に読み込まれました。"
 
-msgid "(Run at {{runTime}})"
+msgid "(Run on {{runTime}})"
 msgstr "({{runTime}} に実行)"
 
-msgid "You ran this query at {{runTime}}"
+msgid "You ran this query on {{runTime}}"
 msgstr "このクエリは {{runTime}} に実行されました"
 
 msgid "You ran this query"


### PR DESCRIPTION
This uses the Intl.DateTimeFormatter to improve the display of the query run time, in order to be locale sensitive to the user's locale.

Before: 
<img width="821" height="522" alt="eng_before" src="https://github.com/user-attachments/assets/369331eb-4f1e-4c61-840a-ddf4b230ff45" />
<img width="862" height="545" alt="ja_before" src="https://github.com/user-attachments/assets/4fa9cb69-f9f3-4234-a8ad-18d27d4270e6" />

After:
<img width="809" height="533" alt="eng_after" src="https://github.com/user-attachments/assets/a77342b9-14e4-49c0-a61d-8efc1087f557" />
<img width="811" height="608" alt="20251205_11h18m09s_grim" src="https://github.com/user-attachments/assets/7fe53d3b-c29d-4036-ae40-0283a8ea5945" />
