### PR TITLE
[instrument_builder] Add 2 missing translations to instrument_builder

### DIFF
--- a/modules/instrument_builder/locale/instrument_builder.pot
+++ b/modules/instrument_builder/locale/instrument_builder.pot
@@ -216,3 +216,6 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+

--- a/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
@@ -212,3 +212,9 @@ msgstr "質問名が重複しています"
 
 msgid "Top"
 msgstr "トップ"
+
+msgid "Browse"
+msgstr "ブラウズ"
+
+msgid "Delete"
+msgstr "消去"


### PR DESCRIPTION
Delete was in the Hindi but missing from the pot file (and therefore from the translated Japanese based on it.) Browse was missing from the Japanese.

Fixes #10204