### PR TITLE
[issue_tracker/other] Fix "File to upload" in issue_tracker and "Submit Attachment"

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -354,3 +354,7 @@ msgstr "{{months}} meses"
 
 msgid "{{years}} years old"
 msgstr "{{years}} años"
+
+msgid "File to upload"
+msgstr "Archivo para subir"
+

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -421,6 +421,9 @@ msgstr "Permission refusée"
 msgid "Unauthorized"
 msgstr "Non-autorisé"
 
+msgid "File to upload"
+msgstr "Sélectionner un fichier à téléverser"
+
 msgid "Submit"
 msgstr "Soumettre"
 

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -524,6 +524,9 @@ msgstr "लोड हो रहा है..."
 msgid "Permission denied"
 msgstr "अनुमति अस्वीकृत"
 
+msgid "File to upload"
+msgstr "अपलोड करने के लिए फ़ाइल"
+
 msgid "Please make sure files are not larger than {{maxFileSize}}"
 msgstr "कृपया सुनिश्चित करें कि फ़ाइलें {{maxFileSize}} से बड़ी न हों"
 

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -543,6 +543,12 @@ msgstr "許可が拒否されました"
 msgid "Unauthorized"
 msgstr "不正な"
 
+msgid "File to upload"
+msgstr "アップロードするファイル"
+
+msgid "Please make sure files are not larger than {{maxFileSize}}"
+msgstr "ファイルが {{maxFileSize}} を超えていないことを確認してください"
+
 msgid "Submit"
 msgstr "提出する"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -543,6 +543,8 @@ msgstr ""
 msgid "Unauthorized"
 msgstr ""
 
+msgid "File to upload"
+msgstr ""
 
 msgid "Please make sure files are not larger than {{maxFileSize}}"
 msgstr ""

--- a/modules/data_release/jsx/uploadFileForm.js
+++ b/modules/data_release/jsx/uploadFileForm.js
@@ -70,7 +70,7 @@ class UploadFileForm extends Component {
         />
         <FileElement
           name='file'
-          label={t('File to upload', {ns: 'data_release'})}
+          label={t('File to upload', {ns: 'loris'})}
           onUserInput={this.updateFormElement}
           required={true}
           value={this.state.formData.file}

--- a/modules/data_release/locale/data_release.pot
+++ b/modules/data_release/locale/data_release.pot
@@ -57,9 +57,6 @@ msgstr ""
 msgid "Version names will be saved as lowercase."
 msgstr ""
 
-msgid "File to upload"
-msgstr ""
-
 msgid "You must select a file to upload"
 msgstr ""
 

--- a/modules/data_release/locale/fr/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/fr/LC_MESSAGES/data_release.po
@@ -60,9 +60,6 @@ msgstr "Note"
 msgid "Version names will be saved as lowercase."
 msgstr "Les noms des versions seront enregistrés en minuscules."
 
-msgid "File to upload"
-msgstr "Sélectionner un fichier à téléverser"
-
 msgid "You must select a file to upload"
 msgstr "Vous devez sélectionner un fichier à téléverser."
 

--- a/modules/data_release/locale/hi/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/hi/LC_MESSAGES/data_release.po
@@ -54,9 +54,6 @@ msgstr "नोट"
 msgid "Version names will be saved as lowercase."
 msgstr "संस्करण नाम छोटे अक्षरों में सहेजे जाएंगे।"
 
-msgid "File to upload"
-msgstr "अपलोड करने के लिए फ़ाइल"
-
 msgid "You must select a file to upload"
 msgstr "आपको अपलोड करने के लिए एक फ़ाइल चुननी होगी"
 

--- a/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
@@ -54,9 +54,6 @@ msgstr "注記"
 msgid "Version names will be saved as lowercase."
 msgstr "バージョン名は小文字で保存されます"
 
-msgid "File to upload"
-msgstr "アップロードするファイル"
-
 msgid "You must select a file to upload"
 msgstr "アップロードするファイルを選択する必要があります"
 

--- a/modules/instrument_builder/locale/instrument_builder.pot
+++ b/modules/instrument_builder/locale/instrument_builder.pot
@@ -218,4 +218,3 @@ msgstr ""
 
 msgid "Delete"
 msgstr ""
-

--- a/modules/issue_tracker/jsx/attachments/uploadForm.js
+++ b/modules/issue_tracker/jsx/attachments/uploadForm.js
@@ -148,7 +148,7 @@ class IssueUploadAttachmentForm extends Component {
           >
             <FileElement
               name='file'
-              label={t('File to upload', {ns: 'issue_tracker'})}
+              label={t('File to upload', {ns: 'loris'})}
               value={this.state.formData.file}
               onUserInput={this.setFileUploadFormData}
               required={true}

--- a/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
@@ -333,9 +333,6 @@ msgstr "अपलोड सफल!"
 msgid "Upload error!"
 msgstr "अपलोड त्रुटि!"
 
-msgid "File to upload"
-msgstr "अपलोड करने के लिए फ़ाइल"
-
 msgid "Submit Attachment"
 msgstr "संलग्नक सबमिट करें"
 

--- a/modules/issue_tracker/locale/issue_tracker.pot
+++ b/modules/issue_tracker/locale/issue_tracker.pot
@@ -260,3 +260,5 @@ msgstr ""
 msgid "Last 3 Comments"
 msgstr ""
 
+msgid "Submit Attachment"
+msgstr ""

--- a/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
@@ -264,3 +264,6 @@ msgstr "ユーザーアカウント"
 msgid "Last 3 Comments"
 msgstr "最後の3つのコメント"
 
+msgid "Submit Attachment"
+msgstr "添付ファイルを送信"
+

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -223,7 +223,7 @@ class MediaUploadForm extends Component {
               id='mediaUploadEl'
               onUserInput={this.setFormData}
               ref='file'
-              label={t('File to upload', {ns: 'media'})}
+              label={t('File to upload', {ns: 'loris'})}
               required={true}
               value={this.state.formData.file}
             />

--- a/modules/media/locale/es/LC_MESSAGES/media.po
+++ b/modules/media/locale/es/LC_MESSAGES/media.po
@@ -113,9 +113,6 @@ msgstr "Fecha de administración"
 msgid "Document's Language"
 msgstr "Idioma del documento"
 
-msgid "File to upload"
-msgstr "Archivo para subir"
-
 msgid "Upload File"
 msgstr "Cargar archivo"
 

--- a/modules/media/locale/fr/LC_MESSAGES/media.po
+++ b/modules/media/locale/fr/LC_MESSAGES/media.po
@@ -113,9 +113,6 @@ msgstr "Date d'administration"
 msgid "Document's Language"
 msgstr "Langue du document"
 
-msgid "File to upload"
-msgstr "Fichier à télécharger"
-
 msgid "Upload File"
 msgstr "Télécharger le fichier"
 

--- a/modules/media/locale/hi/LC_MESSAGES/media.po
+++ b/modules/media/locale/hi/LC_MESSAGES/media.po
@@ -113,9 +113,6 @@ msgstr "प्रशासन की तारीख"
 msgid "Document's Language"
 msgstr "दस्तावेज़ की भाषा"
 
-msgid "File to upload"
-msgstr "अपलोड करने के लिए फ़ाइल"
-
 msgid "Upload File"
 msgstr "फ़ाइल अपलोड करें"
 

--- a/modules/media/locale/ja/LC_MESSAGES/media.po
+++ b/modules/media/locale/ja/LC_MESSAGES/media.po
@@ -116,9 +116,6 @@ msgstr "投与日"
 msgid "Document's Language"
 msgstr "ドキュメントの言語"
 
-msgid "File to upload"
-msgstr "アップロードするファイル"
-
 msgid "Upload File"
 msgstr "ファイルをアップロードする"
 

--- a/modules/media/locale/media.pot
+++ b/modules/media/locale/media.pot
@@ -113,9 +113,6 @@ msgstr ""
 msgid "Document's Language"
 msgstr ""
 
-msgid "File to upload"
-msgstr ""
-
 msgid "Upload File"
 msgstr ""
 

--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -258,7 +258,7 @@ class ProjectFormFields extends React.Component {
             name={fileName}
             id={'publicationUploadEl_' + i}
             onUserInput={this.props.setFileData}
-            label={t('File to upload', {ns: 'publication'})}
+            label={t('File to upload', {ns: 'loris'})}
             value={this.props.formData[fileName]}
           />
         </div>

--- a/modules/publication/locale/hi/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/hi/LC_MESSAGES/publication.po
@@ -21,9 +21,6 @@ msgstr ""
 msgid "Publications"
 msgstr "प्रकाशन"
 
-msgid "File to upload"
-msgstr "अपलोड करने के लिए फ़ाइल"
-
 msgid "Submit"
 msgstr "जमा करें"
 

--- a/modules/publication/locale/ja/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/ja/LC_MESSAGES/publication.po
@@ -21,9 +21,6 @@ msgstr ""
 msgid "Publications"
 msgstr "出版物"
 
-msgid "File to upload"
-msgstr "アップロードするファイル"
-
 msgid "Submit"
 msgstr "提出する"
 

--- a/modules/publication/locale/publication.pot
+++ b/modules/publication/locale/publication.pot
@@ -21,9 +21,6 @@ msgstr ""
 msgid "Publications"
 msgstr ""
 
-msgid "File to upload"
-msgstr ""
-
 msgid "Submit"
 msgstr ""
 


### PR DESCRIPTION
Add translation for "Submit Attachment" to issue tracker, move "File to upload" to the loris namespace and re-use translation across all modules.

Resolves #10205