### PR TITLE
[Meta] Hopefully fix readthedocs building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,12 @@ mkdocs:
   configuration: readthedocs/mkdocs.yml
   fail_on_warning: false
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: 3.7
+
 python:
-  version: 3.7
   install:
       - requirements: readthedocs/requirements.txt
 


### PR DESCRIPTION
RTD is failing with the error:
"Config file validation error Config validation error in build.os. Value build not found."

According to https://github.com/readthedocs/readthedocs.org/issues/11173 the solution is to add a build.os key.

I am not 100% certain that this will fix the error, but it makes the config file more in-line with the sample linked in the above issue.