### PR TITLE
[candidate_parameters] missing JSX imports on family tab

### DIFF
--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -1,5 +1,15 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import Loader from 'Loader';
+import swal from 'sweetalert2';
+import {
+  FormElement,
+  StaticElement,
+  ButtonElement,
+  DateElement,
+  SelectElement,
+} from 'jsx/Form';
+
 
 /**
  * Family info component

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -1,12 +1,9 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import Loader from 'Loader';
-import swal from 'sweetalert2';
 import {
   FormElement,
   StaticElement,
   ButtonElement,
-  DateElement,
   SelectElement,
 } from 'jsx/Form';
 


### PR DESCRIPTION
## Brief summary of changes

The Family tab currently does not load at all without this. in order for this error to show up, the useFamly configuration must be set to yes. the symptoms observed are a blank screen, fixed by these additions.

