### PR TITLE
[SQL] Fix MEGREFMAG physiological channel type name

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -432,7 +432,7 @@ INSERT INTO physiological_channel_type
   ('MEGMAG',           'MEG magnetometer'                                    ),
   ('MEGGRADAXIAL',     'MEG axial gradiometer'                               ),
   ('MEGGRADPLANAR',    'MEG planar gradiometer'                              ),
-  ('MEGGREFMAG',       'MEG reference magnetometer'                          ),
+  ('MEGREFMAG',        'MEG reference magnetometer'                          ),
   ('MEGREFGRADAXIAL',  'MEG reference axial gradiometer'                     ),
   ('MEGREFGRADPLANAR', 'MEG reference planar gradiometer'                    ),
   ('MEGOTHER',         'Any other type of MEG sensor'                        ),
@@ -762,4 +762,3 @@ CREATE TABLE `physiological_task_event_history` (
   CONSTRAINT `FK_physiological_task_event_modified_by_history`
     FOREIGN KEY (`ModifiedBy`) REFERENCES `users` (`ID`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-

--- a/SQL/New_patches/2026-01-10_fix-meg-ref-mag-channel-type.sql
+++ b/SQL/New_patches/2026-01-10_fix-meg-ref-mag-channel-type.sql
@@ -1,0 +1,1 @@
+UPDATE physiological_channel_type SET ChannelTypeName = 'MEGREFMAG' WHERE ChannelTypeName = 'MEGGREFMAG';

--- a/raisinbread/RB_files/RB_physiological_channel_type.sql
+++ b/raisinbread/RB_files/RB_physiological_channel_type.sql
@@ -14,7 +14,7 @@ INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `Channel
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (11,'MEGMAG','MEG magnetometer');
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (12,'MEGGRADAXIAL','MEG axial gradiometer');
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (13,'MEGGRADPLANAR','MEG planar gradiometer');
-INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (14,'MEGGREFMAG','MEG reference magnetometer');
+INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (14,'MEGREFMAG','MEG reference magnetometer');
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (15,'MEGREFGRADAXIAL','MEG reference axial gradiometer');
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (16,'MEGREFGRADPLANAR','MEG reference planar gradiometer');
 INSERT INTO `physiological_channel_type` (`PhysiologicalChannelTypeID`, `ChannelTypeName`, `ChannelDescription`) VALUES (17,'MEGOTHER','Any other type of MEG sensor');


### PR DESCRIPTION
There is a typo in the channel type name, see the [BIDS reference](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetoencephalography.html) for more information.
