### PR TITLE
Fix: Remove line breaks from REDCap HTML fields in LINST output

### DIFF
--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -241,7 +241,7 @@ class RedcapDictionaryRecord
     {
         $field_type  = $this->field_type;
         $field_name  = $this->field_name;
-        $field_label = str_replace("\n", "<br /><br />", $this->field_label);
+        $field_label = str_replace(["\r\n", "\r", "\n"], '', $this->field_label);
         $field_desc  = "$field_name{@}$field_label";
 
         //


### PR DESCRIPTION
## Brief summary of changes

Remove line breaks from REDCap HTML fields when generating LINST output. The [toLINST()](cci:1://file:///Users/Arnav/Documents/GSoC/Loris/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc:232:4-293:5) method now strips all newline characters (`\r\n`, `\r`, `\n`) from field labels to ensure each LINST field stays on a single line as required by the LINST specification.

#### Link(s) to related issue(s)

* Resolves #10238