### PR TITLE
[REDCap] Handle empty data gracefully in notifications endpoint (#9895)

### DIFF
--- a/modules/redcap/php/endpoints/notifications.class.inc
+++ b/modules/redcap/php/endpoints/notifications.class.inc
@@ -108,6 +108,12 @@ class Notifications extends Endpoint
             $data = json_decode((string) $request->getBody(), true);
         }
 
+        // Handle empty data gracefully (e.g., REDCap DET "Test" button sends
+        // empty data).
+        if ($data === null || $data === []) {
+            return new \LORIS\Http\Response();
+        }
+
         try {
             $received_datetime = new \DateTimeImmutable();
 


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a TypeError that occurred when REDCap sends empty data to the LORIS notifications endpoint, such as when using the "Test" button on the REDCap Data Entry Trigger (DET).

**Changes:**
- Added an early validation check in the [_handlePOST()](cci:1://file:///Users/Arnav/Documents/GSoC/Loris/modules/redcap/php/endpoints/notifications.class.inc:91:4-230:5) method to detect null or empty data
- Returns a graceful HTTP 200 response when empty data is received
- Prevents TypeError from being thrown when null is passed to `RedcapNotification::__construct()`

#### Link(s) to related issue(s)

* Resolves aces/Loris#9895