### PR TITLE
Fix: PSCID type for random generation in API projects endpoint (#9551)

### DIFF
--- a/modules/api/php/views/projects.class.inc
+++ b/modules/api/php/views/projects.class.inc
@@ -51,7 +51,9 @@ class Projects
 
         $PSCIDFormat = \Candidate::structureToPCRE($PSCID['structure'], "SITE");
 
-        $type = $PSCID['generation'] == 'sequential' ? 'auto' : 'prompt';
+        $type = in_array($PSCID['generation'], ['sequential', 'random'], true)
+            ? 'auto'
+            : 'prompt';
 
         $settings = [
             "useEDC" => $useEDC,


### PR DESCRIPTION
## Brief summary of changes

Updated the projects/ API endpoint to correctly report the `PSCID:Type` as `auto` when the generation method is set to `random`. Previously, the logic only considered `sequential` as `auto`, which caused `random` (another automatic generation method) to be incorrectly described as `prompt`.

#### Link(s) to related issue(s)

* Resolves #9551
