### PR TITLE
Fix: More explicit message for duplicate timepoint

### DIFF
--- a/modules/create_timepoint/locale/create_timepoint.pot
+++ b/modules/create_timepoint/locale/create_timepoint.pot
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Timepoint created."
 msgstr ""
 
-msgid "This visit label is not unique."
+msgid "A timepoint with these conditions (%s, %s, %s, %s) already exists."
 msgstr ""
 
 msgid "You must be affiliated with a site to create a timepoint."

--- a/modules/create_timepoint/locale/es/LC_MESSAGES/create_timepoint.po
+++ b/modules/create_timepoint/locale/es/LC_MESSAGES/create_timepoint.po
@@ -30,8 +30,8 @@ msgstr "No existen Etiquetas de Visita definidas para la combinación projecto: 
 msgid "Timepoint created."
 msgstr "Punto en el Tiempo creado."
 
-msgid "This visit label is not unique."
-msgstr "Esta etiqueta de Visita no es única"
+msgid "A timepoint with these conditions (%s, %s, %s, %s) already exists."
+msgstr "Ya existe un Punto en el Tiempo con estas condiciones (%s, %s, %s, %s)."
 
 msgid "You must be affiliated with a site to create a timepoint."
 msgstr "Debe estar affiliado a un Sitio para poder crear un Punto en el Tiempo."

--- a/modules/create_timepoint/locale/fr/LC_MESSAGES/create_timepoint.po
+++ b/modules/create_timepoint/locale/fr/LC_MESSAGES/create_timepoint.po
@@ -35,8 +35,8 @@ msgstr ""
 msgid "Timepoint created."
 msgstr "Temps d'acquisition créé."
 
-msgid "This visit label is not unique."
-msgstr "Cette visite n'est pas unique."
+msgid "A timepoint with these conditions (%s, %s, %s, %s) already exists."
+msgstr "Un temps d'acquisition avec ces conditions (%s, %s, %s, %s) existe déjà."
 
 msgid "You must be affiliated with a site to create a timepoint."
 msgstr "Vous devez être affilié à un site pour créer un temps d'acquisition."

--- a/modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po
+++ b/modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po
@@ -30,8 +30,8 @@ msgstr "プロジェクト {{project}} とコホート {{cohort}} の組み合�
 msgid "Timepoint created."
 msgstr "タイムポイント作成"
 
-msgid "This visit label is not unique."
-msgstr "この訪問ラベルは一意ではありません。"
+msgid "A timepoint with these conditions (%s, %s, %s, %s) already exists."
+msgstr "これらの条件 (%s, %s, %s, %s) を持つタイムポイントは既に存在します。"
 
 msgid "You must be affiliated with a site to create a timepoint."
 msgstr "タイムポイントを作成するには、サイトに所属している必要があります。"

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -359,9 +359,32 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
         //If the visitLabel is already in use then let the user pick another
         foreach ($timePointArray AS $used_name) {
             if (strcasecmp($visitName, $used_name) == 0) {
-                throw new \LorisException(
-                    dgettext("create_timepoint", "This visit label is not unique.")
+                // Get project name
+                $project     = \Project::getProjectFromID($projectID);
+                $projectName = $project->getName();
+
+                // Get cohort title
+                $factory        = \NDB_Factory::singleton();
+                $config         = $factory->config();
+                $cohortSettings = $config->getCohortSettings($cohortID);
+                $cohortTitle    = $cohortSettings['title'] ?? 'Unknown';
+
+                // Get participant PSCID
+                $pscid = $candidate->getPSCID();
+
+                $message = sprintf(
+                    dgettext(
+                        "create_timepoint",
+                        "A timepoint with these conditions (%s, %s, %s, %s) "
+                            . "already exists."
+                    ),
+                    $pscid,
+                    $projectName,
+                    $cohortTitle,
+                    $visitName
                 );
+
+                throw new \LorisException($message);
             }
         }
     }


### PR DESCRIPTION
## Brief summary of changes

Updated the error message displayed when attempting to create a duplicate timepoint to be more explicit and user-friendly.

**Before:**
```
This visit label is not unique.
```

**After:**
```
A timepoint with these conditions (PSCID, Project, Cohort, Visit) already exists.
```

The new message now includes:
- Participant PSCID
- Project name
- Cohort title
- Visit label

**Changes made:**
- Modified `TimePoint::isValidVisitLabel()` to construct a detailed error message
- Updated translation files (.pot, .po) for English, Spanish, French, and Japanese

#### Link(s) to related issue(s)

* Resolves #9776