### PR TITLE
[DQT] Fix Data Query Tool execution for BMI and MRI (#10129, #9772)

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -423,8 +423,8 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
                         }
                     }
                 }
-                yield "$iCandID" => $candData;
             }
+            yield "$iCandID" => $candData;
         }
     }
 }


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a critical bug in `InstrumentQueryEngine` that prevented queries from running successfully for certain instruments, specifically resolving issues with BMI (#10129) and MRI (#9772).

The root cause was a misplaced `yield` statement within the `_dataToIterator` method in `modules/instruments/php/instrumentqueryengine.class.inc`.

**The Bug:**
The `yield` statement was inside the inner `foreach` loop that iterates through selected fields. This caused the generator to yield a result **for every single field** being processed for a candidate. 

**The Fix:**
I moved the `yield` statement **outside** the inner loop. Now, the code correctly iterates through all requested fields to build the complete data array for a candidate *before* yielding it.


BMI Screenshot:
<img width="916" height="755" alt="Screenshot 2026-01-22 at 23 47 00" src="https://github.com/user-attachments/assets/5ab49885-0b1e-47f2-93c4-ea104da0b7c7" />

MRI Screenshot:
<img width="1095" height="750" alt="Screenshot 2026-01-22 at 23 48 09" src="https://github.com/user-attachments/assets/a0cd26db-0a4d-4179-88df-f582e343d27b" />

It's always satisfying when a single line change, literally moving one line down using whitespace simultaneously solves two separate issues! 


#### Link(s) to related issue(s)
* Resolves #10129 
#9772 