### PR TITLE
[DQT] Fix terminology and labels in Add Condition modal

### DIFF
--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -145,9 +145,11 @@ function AddFilterModal(props: {
     }
 
     criteriaSelect = <div>
-      <h3>{t('Criteria', {ns: 'dataquery'})}</h3>
+      <h4 style={{color: '#003d68', fontWeight: 'normal'}}>
+        {t('Criteria', {ns: 'dataquery'})}
+      </h4>
       <div style={{display: 'flex'}}>
-        <div style={{width: '20%'}}>
+        <div style={{width: '40%'}}>
           <FilterableSelectGroup groups={
             {'Operators': getOperatorOptions(fieldDictionary, t)}
           }
@@ -157,14 +159,15 @@ function AddFilterModal(props: {
           placeholder={t('Select an operator', {ns: 'dataquery'})}
           />
         </div>
-        <div style={{width: '80%'}}>{valueSelect}</div>
+        <div style={{width: '60%'}}>{valueSelect}</div>
       </div>
     </div>;
 
     if (fieldDictionary.scope == 'session' && fieldDictionary.visits) {
       visitSelect = <div onClick={(e) => e.stopPropagation()}>
-        <h3>{t('for at least one of the following visits',
-          {ns: 'dataquery'})}</h3>
+        <h4 style={{color: '#003d68', fontWeight: 'normal'}}>
+            {t('Visits', {ns: 'dataquery'})}
+        </h4>
         <VisitList
           t={t}
           options={fieldDictionary.visits}
@@ -282,7 +285,9 @@ function AddFilterModal(props: {
     }
     );
   return (
-    <Modal title={t('Add Condition', {ns: 'dataquery'})}
+    <Modal title={<span style={{color: '#003d68'}}>
+      {t('Add Condition', {ns: 'dataquery'})}
+    </span>}
       show={true}
       throwWarning={true}
       onClose={props.closeModal}
@@ -290,7 +295,6 @@ function AddFilterModal(props: {
       <div style={{width: '100%', padding: '1em'}}>
         <div style={{display: 'flex', width: '100%'}}>
           <div style={{width: '40%'}}>
-            <h3>{t('Category', {ns: 'dataquery', count: 1})}</h3>
             <FilterableSelectGroup
               groups={props.categories.categories}
               mapGroupName={(key) => props.categories.modules[key]}
@@ -304,8 +308,7 @@ function AddFilterModal(props: {
               }}
             />
           </div>
-          <div style={{width: '100%'}}>
-            <h3>{t('Field', {ns: 'dataquery', count: 1})}</h3>
+          <div style={{width: '60%'}}>
             {fieldSelect}
           </div>
         </div>
@@ -356,9 +359,9 @@ function getOperatorOptions(dict: FieldDictionary, t: any) {
     options = {
       'eq': '=',
       'neq': '≠',
-      'startsWith': t('starts with', {ns: 'dataquery'}),
-      'contains': t('contains', {ns: 'dataquery'}),
-      'endsWith': t('ends with', {ns: 'dataquery'}),
+      'startsWith': t('Starts With', {ns: 'dataquery'}),
+      'contains': t('Contains', {ns: 'dataquery'}),
+      'endsWith': t('Ends With', {ns: 'dataquery'}),
     };
   } else {
     // fall back to == and !=, valid for any type.

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -166,7 +166,7 @@ function AddFilterModal(props: {
     if (fieldDictionary.scope == 'session' && fieldDictionary.visits) {
       visitSelect = <div onClick={(e) => e.stopPropagation()}>
         <h4 style={{color: '#003d68', fontWeight: 'normal'}}>
-            {t('Visits', {ns: 'dataquery'})}
+          {t('Visits', {ns: 'dataquery'})}
         </h4>
         <VisitList
           t={t}
@@ -288,10 +288,10 @@ function AddFilterModal(props: {
     <Modal title={<span style={{color: '#003d68'}}>
       {t('Add Condition', {ns: 'dataquery'})}
     </span>}
-      show={true}
-      throwWarning={true}
-      onClose={props.closeModal}
-      onSubmit={submitPromise}>
+    show={true}
+    throwWarning={true}
+    onClose={props.closeModal}
+    onSubmit={submitPromise}>
       <div style={{width: '100%', padding: '1em'}}>
         <div style={{display: 'flex', width: '100%'}}>
           <div style={{width: '40%'}}>

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -282,15 +282,15 @@ function AddFilterModal(props: {
     }
     );
   return (
-    <Modal title={t('Add criteria', {ns: 'dataquery'})}
+    <Modal title={t('Add Condition', {ns: 'dataquery'})}
       show={true}
       throwWarning={true}
       onClose={props.closeModal}
       onSubmit={submitPromise}>
       <div style={{width: '100%', padding: '1em'}}>
-        <h3>{t('Field', {ns: 'dataquery', count: 1})}</h3>
         <div style={{display: 'flex', width: '100%'}}>
           <div style={{width: '40%'}}>
+            <h3>{t('Category', {ns: 'dataquery', count: 1})}</h3>
             <FilterableSelectGroup
               groups={props.categories.categories}
               mapGroupName={(key) => props.categories.modules[key]}
@@ -305,6 +305,7 @@ function AddFilterModal(props: {
             />
           </div>
           <div style={{width: '100%'}}>
+            <h3>{t('Field', {ns: 'dataquery', count: 1})}</h3>
             {fieldSelect}
           </div>
         </div>

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -165,9 +165,8 @@ function AddFilterModal(props: {
 
     if (fieldDictionary.scope == 'session' && fieldDictionary.visits) {
       visitSelect = <div onClick={(e) => e.stopPropagation()}>
-        <h4 style={{color: '#003d68', fontWeight: 'normal'}}>
-          {t('Visits', {ns: 'dataquery'})}
-        </h4>
+        <h3>{t('for at least one of the following visits',
+          {ns: 'dataquery'})}</h3>
         <VisitList
           t={t}
           options={fieldDictionary.visits}
@@ -359,9 +358,9 @@ function getOperatorOptions(dict: FieldDictionary, t: any) {
     options = {
       'eq': '=',
       'neq': '≠',
-      'startsWith': t('Starts With', {ns: 'dataquery'}),
-      'contains': t('Contains', {ns: 'dataquery'}),
-      'endsWith': t('Ends With', {ns: 'dataquery'}),
+      'startsWith': t('starts with', {ns: 'dataquery'}),
+      'contains': t('contains', {ns: 'dataquery'}),
+      'endsWith': t('ends with', {ns: 'dataquery'}),
     };
   } else {
     // fall back to == and !=, valid for any type.

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -250,9 +250,6 @@ msgstr ""
 msgid "No visits selected for criteria."
 msgstr ""
 
-msgid "Add criteria"
-msgstr ""
-
 msgid "Field"
 msgid_plural "Fields"
 msgstr[0] ""

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -373,9 +373,6 @@ msgstr "Visites non valides"
 msgid "No visits selected for criteria."
 msgstr "Aucune visite sélectionnée pour ces critères."
 
-msgid "Add criteria"
-msgstr "Ajouter critère"
-
 msgid "Field"
 msgid_plural "Fields"
 msgstr[0] "Champ"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -256,9 +256,6 @@ msgstr "अमान्य विज़िट"
 msgid "No visits selected for criteria."
 msgstr "मानदंड के लिए कोई विज़िट चयनित नहीं है।"
 
-msgid "Add criteria"
-msgstr "मानदंड जोड़ें"
-
 msgid "Field"
 msgid_plural "Fields"
 msgstr[0] "फ़ील्ड"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -259,9 +259,6 @@ msgstr "無効な訪問"
 msgid "No visits selected for criteria."
 msgstr "基準に該当する訪問が選択されていません。"
 
-msgid "Add criteria"
-msgstr "条件を追加する"
-
 msgid "Field"
 msgid_plural "Fields"
 msgstr[0] "分野"


### PR DESCRIPTION
## Brief summary of changes

- Renamed the modal title from "Add criteria" to "Add Condition" to match the button text.
- Added a clear **Category** label above the category dropdown.
- Ensured the **Field** label appears correctly above the field and not category dropdown. 

Original:
<img width="1254" height="426" alt="image" src="https://github.com/user-attachments/assets/9e5f1fe3-eb39-49b4-b104-a39779f3eb0f" />

Fixed:
<img width="1440" height="493" alt="Screenshot 2026-01-25 at 17 21 15" src="https://github.com/user-attachments/assets/e177aa03-6f13-4bf9-8655-f6979371a138" />

#### Link(s) to related issue(s)

* Resolves #10124
