### PR TITLE
[DQT] Fix: Improve "Add Condition" Modal Warning Logic and UX

### DIFF
--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -55,6 +55,10 @@ const Modal = ({
         showCancelButton: true,
         confirmButtonText: t('Proceed', {ns: 'loris'}),
         cancelButtonText: t('Cancel', {ns: 'loris'}),
+        reverseButtons: true,
+        focusCancel: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#888888',
       }).then((result) => result.value && onClose());
     } else {
       onClose(); // Close immediately if no warning

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -55,10 +55,6 @@ const Modal = ({
         showCancelButton: true,
         confirmButtonText: t('Proceed', {ns: 'loris'}),
         cancelButtonText: t('Cancel', {ns: 'loris'}),
-        reverseButtons: true,
-        focusCancel: true,
-        confirmButtonColor: '#3085d6',
-        cancelButtonColor: '#888888',
       }).then((result) => result.value && onClose());
     } else {
       onClose(); // Close immediately if no warning

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -111,6 +111,7 @@ function AddFilterModal(props: {
   const [op, setOp] = useState<Operators|null>(null);
   const [value, setValue] = useState<string|string[]>('');
   const [selectedVisits, setSelectedVisits] = useState<string[]|null>(null);
+  const [hasUserMadeSelection, setHasUserMadeSelection] = useState(false);
 
   const dropdownTitle = t('Field', {ns: 'dataquery', count: 99});
   if (props.displayedFields) {
@@ -129,6 +130,7 @@ function AddFilterModal(props: {
         setFieldname(fieldname);
         setOp(null);
         setValue('');
+        setHasUserMadeSelection(true);
         if (dict.visits) {
           setSelectedVisits(dict.visits);
         } else {
@@ -284,7 +286,7 @@ function AddFilterModal(props: {
   return (
     <Modal title={t('Add criteria', {ns: 'dataquery'})}
       show={true}
-      throwWarning={true}
+      throwWarning={hasUserMadeSelection}
       onClose={props.closeModal}
       onSubmit={submitPromise}>
       <div style={{width: '100%', padding: '1em'}}>
@@ -300,6 +302,7 @@ function AddFilterModal(props: {
                 setOp(null);
                 setValue('');
                 setSelectedVisits(null);
+                setHasUserMadeSelection(true);
                 props.onCategoryChange(module, category);
               }}
             />


### PR DESCRIPTION
## Brief summary of changes

*   **Fix Warning Logic**: The "Add Condition" modal now tracks active user selection state (`hasUserMadeSelection`), ensuring the exit warning only appears if data was actually entered in the current session.
*   **Fail-Safe UX**: Updated the modal to use safe defaults by making **Cancel** the primary and default action, positioning it first to reduce accidental confirmation.

<img width="1165" height="612" alt="Screenshot 2026-01-25 at 18 57 41" src="https://github.com/user-attachments/assets/73da1827-d587-47e9-a638-2e7b51af67e3" />

#### Link(s) to related issue(s)

* Resolves #10306