### PR TITLE
[image_uploader] Fix Clear Filters functionality in Imaging Uploader

### DIFF
--- a/jsx/FilterForm.js
+++ b/jsx/FilterForm.js
@@ -82,24 +82,22 @@ class FilterForm extends Component {
     React.Children.forEach(this.props.children, function(child, key) {
       // If child is a React component (i.e not a simple DOM element)
       if (React.isValidElement(child) &&
-        typeof child.type === 'function' &&
-        child.props.onUserInput
+        typeof child.type === 'function'
       ) {
         let callbackFunc = child.props.onUserInput;
-        let callbackName = callbackFunc.name;
-        let elementName = child.type.displayName;
+        let callbackName = callbackFunc ? callbackFunc.name : 'onUserInput';
+        let elementName = child.type.displayName || child.type.name;
         let queryFieldName = (child.props.name === 'candID') ?
           'candidateID' :
           child.props.name;
         let filterValue = this.queryString[queryFieldName];
         // If callback function was not set, set it to onElementUpdate() for form
         // elements and to clearFilter() for <ButtonElement type='reset'/>.
-        if (callbackName === 'onUserInput') {
-          if (elementName === 'ButtonElement' && child.props.type === 'reset') {
-            callbackFunc = this.clearFilter;
-          } else {
-            callbackFunc = this.onElementUpdate.bind(null, elementName);
-          }
+        // Always use clearFilter for reset buttons, regardless of passed callback
+        if (elementName === 'ButtonElement' && child.props.type === 'reset') {
+          callbackFunc = this.clearFilter;
+        } else if (callbackName === 'onUserInput') {
+          callbackFunc = this.onElementUpdate.bind(null, elementName);
         }
         // Pass onUserInput and value props to all children
         formChildren.push(React.cloneElement(child, {


### PR DESCRIPTION
## Brief summary of changes

- **Fixed Child Component Processing**: Updated `FilterForm.js` to correctly process child components that rely on `defaultProps` for their `onUserInput` callback.
- **Improved Reset Button Handling**: The logic for identifying the "Reset" button has been simplified and hardened. It now explicitly targets any `ButtonElement` with `type='reset'` to ensure the `clearFilter` handler is attached, regardless of whether a custom callback was passed from the parent. This resolves issues where passing a bound function would prevent the clear logic from activating.
- Added fallback logic for identifying component names (`displayName` vs `name`) to prevent potential errors with different component definitions.

### Verification
Verified that clicking "Clear Filters" now clears all filter fields (text inputs and dropdowns) and removes query parameters from the URL.

![Untitled](https://github.com/user-attachments/assets/1c4da168-f729-4155-a782-e85b3486361d)

#### Link(s) to related issue(s)

* Resolves #10208
