### PR TITLE
[NDB_BVL_Instrument] Conflict detecting fix

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2100,25 +2100,27 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // Load other instance data
         $otherData = $otherInstrument->getInstanceData();
 
+        $instrumentFields = array_keys($thisData + $otherData);
+
         // Create the return object data structure
         $diff = [];
 
         // Loop over this instance data
-        foreach ($thisData AS $key=>$value) {
-            if (!in_array($key, $this->_doubleDataEntryDiffIgnoreColumns)) {
-                if (($otherData[$key] ?? null) != $value) {
-                    $diff[] = [
-                        'TestName'       => $this->testName,
-                        'ExtraKeyColumn' => null,
-                        'ExtraKey1'      => ' ',
-                        'ExtraKey2'      => ' ',
-                        'FieldName'      => $key,
-                        'CommentId1'     => $this->getCommentID(),
-                        'Value1'         => $value,
-                        'CommentId2'     => $otherInstrument->getCommentID(),
-                        'Value2'         => $otherData[$key] ?? null,
-                    ];
-                }
+        foreach ($instrumentFields AS $key) {
+            if (!in_array($key, $this->_doubleDataEntryDiffIgnoreColumns)
+                && ($otherData[$key] ?? null) != ($thisData[$key] ?? null)
+            ) {
+                $diff[] = [
+                    'TestName'       => $this->testName,
+                    'ExtraKeyColumn' => null,
+                    'ExtraKey1'      => ' ',
+                    'ExtraKey2'      => ' ',
+                    'FieldName'      => $key,
+                    'CommentId1'     => $this->getCommentID(),
+                    'Value1'         => $thisData[$key] ?? null,
+                    'CommentId2'     => $otherInstrument->getCommentID(),
+                    'Value2'         => $otherData[$key] ?? null,
+                ];
             }
         }
 


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the "diff" function in NDB_BVL_Instrument.class.inc which is used for recreating conflicts. This function was reporting the difference between one instrument and another, but only doing so by considering the fields in the primary instrument. For SQL instruments this isn't a problem because the fields are determined by the SQL table. However, for JSON instruments this can result in conflicts going undetected because if a field is null it does not necessarily show up in getInstanceData, so it will not be considered.

The PR fixes the issue by checking values from a unique array of the keys from both the FDE and DDE (or from the primary and secondary instrument).

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. From this PR, run the recreate_conflcits.php script for a JSON instrument, and make sure there is a case where values are populated for DDE but not for FDE
2. Go to the conflict resolver and make sure there are conflicts for this case.

#### Link(s) to related issue(s)

* Resolves #NO ISSUE
