### PR TITLE
[electrophysiology_browser] Add CTF to electrophysiology browser supported file types

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -542,7 +542,27 @@ INSERT INTO ImagingFileTypes
   ('vsm',  'BrainStorm file format (EEG)'),
   ('edf',  'European data format (EEG)'),
   ('cnt',  'Neuroscan CNT data format (EEG)'),
+  ('ctf',  'CTF data format (MEG)'),
   ('archive', 'Archive file');
+
+CREATE TABLE `ephys_browser_file_type` (
+  `Type` varchar(12) NOT NULL PRIMARY KEY,
+  CONSTRAINT `FK_ephys_browser_file_type`
+    FOREIGN KEY (`Type`)
+    REFERENCES `ImagingFileTypes` (`type`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ephys_browser_file_type` (Type)
+VALUES
+  ('set'),
+  ('bdf'),
+  ('vhdr'),
+  ('vsm'),
+  ('edf'),
+  ('cnt'),
+  ('ctf'),
+  ('archive');
 
 -- Create `hed_schema` table
 CREATE TABLE `hed_schema` (

--- a/SQL/New_patches/2026-02-04_ephys_browser_file_type.sql
+++ b/SQL/New_patches/2026-02-04_ephys_browser_file_type.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `ephys_browser_file_type` (
+  `Type` varchar(12) NOT NULL PRIMARY KEY,
+  CONSTRAINT `FK_ephys_browser_file_type`
+    FOREIGN KEY (`Type`)
+    REFERENCES `ImagingFileTypes` (`type`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `ImagingFileTypes` (type, description) VALUES
+  ('ctf', 'CTF data format (MEG)');
+
+INSERT INTO `ephys_browser_file_type` (Type)
+VALUES
+  ('set'),
+  ('bdf'),
+  ('vhdr'),
+  ('vsm'),
+  ('edf'),
+  ('cnt'),
+  ('ctf'),
+  ('archive');

--- a/modules/electrophysiology_browser/README.md
+++ b/modules/electrophysiology_browser/README.md
@@ -34,6 +34,10 @@ electrophysiology_browser_view_site
 electrophysiology_browser_edit_annotations
  - This permission allows the user to add, edit, and delete annotations for raw or derived datasets
 
+## Configuration
+
+The electrophysiology browser displays the imaging file types present in the `ephys_browser_file_type` table.
+
 ## Download
 
 You can download all the files related to a recording (channel information,

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
@@ -41,7 +41,6 @@ class ElectrophysiologyBrowserRowProvisioner
      */
     function __construct(protected \LORIS\LorisInstance $loris)
     {
-
         parent::__construct(
             $loris,
             "SELECT
@@ -74,6 +73,7 @@ class ElectrophysiologyBrowserRowProvisioner
               s.CenterID                                AS CenterID,
               s.ProjectID                               AS ProjectID
             FROM physiological_file pf
+              JOIN ephys_browser_file_type ebft ON (ebft.Type=pf.FileType)
               LEFT JOIN session s   ON (s.ID=pf.SessionID)
               LEFT JOIN candidate c ON (c.ID=s.CandidateID)
               LEFT JOIN psc         ON (s.CenterID=psc.CenterID)
@@ -82,12 +82,6 @@ class ElectrophysiologyBrowserRowProvisioner
                 USING (PhysiologicalOutputTypeID)
             WHERE c.Active='Y'
               AND s.Active='Y'
-              AND pf.FileType IN (
-                SELECT type FROM ImagingFileTypes
-                WHERE
-                  description LIKE '%(EEG)'
-                  OR type = 'archive'
-              )
             GROUP BY SessionID",
             []
         );

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -14,6 +14,7 @@
  * @link       https://www.github.com/aces/Loris/
  */
 namespace LORIS\electrophysiology_browser;
+
 /**
  * Class module implements the basic LORIS module functionality
  *

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -155,19 +155,18 @@ class Sessions extends \NDB_Page
 
         $db = $this->loris->getDatabaseConnection();
 
-        $query = 'SELECT
+        $query = "SELECT
                 DISTINCT(pf.SessionID)
               FROM physiological_file pf
+                JOIN ephys_browser_file_type ebft ON (pf.FileType = ebft.Type)
                 LEFT JOIN session s ON (s.ID=pf.SessionID)
                 LEFT JOIN candidate c ON (c.ID=s.CandidateID)
                 LEFT JOIN psc ON (s.CenterID=psc.CenterID)
                 LEFT JOIN physiological_output_type pot
                   USING (PhysiologicalOutputTypeID)
               WHERE
-                s.Active = "Y"
-                AND pf.FileType IN ('.
-            '"bdf", "cnt", "edf", "set", "vhdr", "vsm", "archive"'.
-            ') ORDER BY pf.SessionID';
+                s.Active = 'Y'
+                ORDER BY pf.SessionID";
 
         $response = [];
 

--- a/modules/electrophysiology_browser/test/EEGBrowserIntegrationTest.php
+++ b/modules/electrophysiology_browser/test/EEGBrowserIntegrationTest.php
@@ -90,20 +90,6 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
             ]
         );
         $this->DB->insert(
-            "ImagingFileTypes",
-            [
-                'type'        => 'testType',
-                'description' => 'test%(EEG)'
-            ]
-        );
-        $this->DB->insert(
-            "ImagingFileTypes",
-            [
-                'type'        => 'testType2',
-                'description' => 'test2%(EEG)'
-            ]
-        );
-        $this->DB->insert(
             "physiological_output_type",
             [
                 'PhysiologicalOutputTypeID' => 22,
@@ -124,7 +110,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
                 'PhysiologicalOutputTypeID' => 22,
                 'InsertedByUser'            => 'Unit Tester',
                 'FilePath'                  => '/path/to/test/file',
-                'FileType'                  => 'testType'
+                'FileType'                  => 'set'
             ]
         );
         $this->DB->insert(
@@ -134,7 +120,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
                 'PhysiologicalOutputTypeID' => 23,
                 'InsertedByUser'            => 'Unit Tester',
                 'FilePath'                  => '/path/to/test/file2',
-                'FileType'                  => 'testType2'
+                'FileType'                  => 'ctf'
             ]
         );
     }
@@ -191,20 +177,6 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
             [
                 'PhysiologicalOutputTypeID' => 23,
                 'OutputTypeName'            => 'test2'
-            ]
-        );
-        $this->DB->delete(
-            "ImagingFileTypes",
-            [
-                'type'        => 'testType',
-                'description' => 'test%(EEG)'
-            ]
-        );
-        $this->DB->delete(
-            "ImagingFileTypes",
-            [
-                'type'        => 'testType2',
-                'description' => 'test2%(EEG)'
             ]
         );
         parent::tearDown();

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -994,7 +994,7 @@ class Utility
 
         $scan_types_DB = \NDB_Factory::singleton()->database()->pselect(
             "SELECT MriScanTypeID, MriScanTypeName
-             FROM mri_scan_type 
+             FROM mri_scan_type
              JOIN files USING (MriScanTypeID)",
             []
         );

--- a/raisinbread/RB_files/RB_ImagingFileTypes.sql
+++ b/raisinbread/RB_files/RB_ImagingFileTypes.sql
@@ -6,6 +6,7 @@ INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('bdf','Biosemi fi
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('bval','NIfTI DWI file with b-values');
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('bvec','NIfTI DWI file with b-vectors');
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('cnt','Neuroscan CNT data format (EEG)');
+INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('ctf','CTF data format (MEG)');
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('edf','European data format (EEG)');
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('grid_0','MNI BIC non-linear field for non-linear transformation');
 INSERT INTO `ImagingFileTypes` (`type`, `description`) VALUES ('json','JSON file');

--- a/raisinbread/RB_files/RB_ephys_browser_file_type.sql
+++ b/raisinbread/RB_files/RB_ephys_browser_file_type.sql
@@ -1,0 +1,13 @@
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `ephys_browser_file_type`;
+LOCK TABLES `ephys_browser_file_type` WRITE;
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('set');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('bdf');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('vhdr');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('vsm');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('edf');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('cnt');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('ctf');
+INSERT INTO `ephys_browser_file_type` (`Type`) VALUES ('archive');
+UNLOCK TABLES;
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
Partially addresses #10290 and #10308.

## Description

Add CTF (MEG) to the list of physiological file types displayed in the electrophysiology browser, using a new table that specifies the file types that should be displayed in the electrophysiology browser instead of a hard-coded logic.

## Details

The original code relied on `(EEG)` appearing in the file type description to know whether to display it or not in the EEG browser, which is a little problematic:
- I don´t think code logic should depend on a description field (which should be meant for humans).
- MEG is not EEG!

Instead, this PR adds the `ephys_browser_file_type` table that lists the file types that should be displayed in the electrophysiology browser.