### PR TITLE
[data_query] Support URIs in Longitudinal and Crossectional Views

### DIFF
--- a/modules/dqt/jsx/react.savedqueries.js
+++ b/modules/dqt/jsx/react.savedqueries.js
@@ -71,9 +71,6 @@ const ManageSavedQueryFilters = (props) => {
 const ManageSavedQueryRow = (props) => {
   const [fieldsVisible, setFields] = useState(null);
   const [filtersVisible, setFilters] = useState(null);
-  /**
-   *
-   */
   function publicquerydelete() {
     const id = props.Query['_id'];
     swal.fire({


### PR DESCRIPTION
## Summary
This PR resolves issues with the rendering of URI fields in the data query tool. Previously, URIs were concatenated into a single string with keys prepended (e.g., `link1=http://url1;link2=http://url2`), which made the download link invalid

## Changes
- **Data Mapping**: Updated the expansion logic to check `dictionary.type`. If the type is `URI`, the logic now bypasses the `key=value` concatenation to provide clean URL strings.
- **DisplayValue Component**: Refactored the `URI` case to handle semicolon-separated strings. The component now splits the input value and generates a separate, valid `<a>` tag for each individual URI to ensure correct browser navigation.

## Fixes
Resolves #9890