### PR TITLE
[RTD] Fix build on 27 branch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,12 @@ mkdocs:
   configuration: readthedocs/mkdocs.yml
   fail_on_warning: false
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.7
   install:
       - requirements: readthedocs/requirements.txt
 


### PR DESCRIPTION
Fix build of readthedocs on 27.0 branch by pulling in config from the main branch.