### PR TITLE
candidate_parameters: replace $.ajax with lorisFetch

### DIFF
--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -49,7 +49,7 @@ class CandidateInfo extends Component {
    */
   componentDidMount() {
     const {t} = this.props;
-    this.client.getJSON(this.props.dataURL)
+    this.client.getData(this.props.candID, this.props.tabName)
       .then((data) => {
         let formData = {
           flaggedCaveatemptor: data.flagged_caveatemptor,
@@ -393,8 +393,8 @@ class CandidateInfo extends Component {
   }
 }
 CandidateInfo.propTypes = {
-  dataURL: PropTypes.string,
-  tabName: PropTypes.string,
+  candID: PropTypes.string.isRequired,
+  tabName: PropTypes.string.isRequired,
   action: PropTypes.string,
   t: PropTypes.string.isRequired,
 };

--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -11,6 +11,7 @@ import {
   ButtonElement,
   TextareaElement,
 } from 'jsx/Form';
+import lorisFetch from 'jslib/lorisFetch';
 
 /**
  * Candiate info component
@@ -46,34 +47,34 @@ class CandidateInfo extends Component {
    */
   componentDidMount() {
     const {t} = this.props;
-    let that = this;
-    $.ajax(
-      this.props.dataURL,
-      {
-        dataType: 'json',
-        success: function(data) {
-          let formData = {
-            flaggedCaveatemptor: data.flagged_caveatemptor,
-            flaggedOther: data.flagged_other,
-            flaggedReason: data.flagged_reason,
-          };
+    lorisFetch(this.props.dataURL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('request_failed');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        let formData = {
+          flaggedCaveatemptor: data.flagged_caveatemptor,
+          flaggedOther: data.flagged_other,
+          flaggedReason: data.flagged_reason,
+        };
 
-          // Add parameter values to formData
-          Object.assign(formData, data.parameter_values);
+        // Add parameter values to formData
+        Object.assign(formData, data.parameter_values);
 
-          that.setState({
-            Data: data,
-            isLoaded: true,
-            formData: formData,
-          });
-        },
-        error: function(data, errorCode, errorMsg) {
-          that.setState({
-            error: t('An error occured while loading the page.', {ns: 'loris'}),
-          });
-        },
-      }
-    );
+        this.setState({
+          Data: data,
+          isLoaded: true,
+          formData: formData,
+        });
+      })
+      .catch(() => {
+        this.setState({
+          error: t('An error occured while loading the page.', {ns: 'loris'}),
+        });
+      });
   }
 
   /**
@@ -334,37 +335,43 @@ class CandidateInfo extends Component {
 
     formData.append('tab', this.props.tabName);
     formData.append('candID', this.state.Data.candID);
-    $.ajax(
-      {
-        type: 'POST',
-        url: self.props.action,
-        data: formData,
-        cache: false,
-        contentType: false,
-        processData: false,
-        success: function(data) {
+    lorisFetch(self.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
+        self.setState(
+          {
+            updateResult: 'success',
+          }
+        );
+        self.showAlertMessage();
+      })
+      .catch((err) => {
+        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
           self.setState(
             {
-              updateResult: 'success',
+              updateResult: 'error',
+              errorMessage: err.lorisMessage,
             }
           );
           self.showAlertMessage();
-        },
-        error: function(err) {
-          if (err.responseText !== '') {
-            let errorMessage = JSON.parse(err.responseText).message;
-            self.setState(
-              {
-                updateResult: 'error',
-                errorMessage: errorMessage,
-              }
-            );
-            self.showAlertMessage();
-          }
-        },
-
-      }
-    );
+        }
+      });
   }
 
   /**

--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -12,6 +12,7 @@ import {
   TextareaElement,
 } from 'jsx/Form';
 import CandidateParametersClient from './CandidateParametersClient';
+import lorisFetch from 'jslib/lorisFetch';
 
 /**
  * Candiate info component
@@ -330,8 +331,25 @@ class CandidateInfo extends Component {
 
     formData.append('tab', this.props.tabName);
     formData.append('candID', this.state.Data.candID);
-    this.client.postForm(self.props.action, formData)
-      .then(() => {
+    lorisFetch(self.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
         self.setState(
           {
             updateResult: 'success',
@@ -339,23 +357,12 @@ class CandidateInfo extends Component {
         );
         self.showAlertMessage();
       })
-      .catch(async (err) => {
-        let errorMessage = '';
-        if (err && err.response) {
-          try {
-            const text = await err.response.text();
-            if (text) {
-              errorMessage = JSON.parse(text).message || '';
-            }
-          } catch (parseError) {
-            errorMessage = '';
-          }
-        }
-        if (errorMessage !== '') {
+      .catch((err) => {
+        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
           self.setState(
             {
               updateResult: 'error',
-              errorMessage: errorMessage,
+              errorMessage: err.lorisMessage,
             }
           );
           self.showAlertMessage();

--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -11,7 +11,7 @@ import {
   ButtonElement,
   TextareaElement,
 } from 'jsx/Form';
-import lorisFetch from 'jslib/lorisFetch';
+import CandidateParametersClient from './CandidateParametersClient';
 
 /**
  * Candiate info component
@@ -36,6 +36,7 @@ class CandidateInfo extends Component {
       isLoaded: false,
       loadedData: 0,
     };
+    this.client = new CandidateParametersClient();
     this.setFormData = this.setFormData.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -47,13 +48,7 @@ class CandidateInfo extends Component {
    */
   componentDidMount() {
     const {t} = this.props;
-    lorisFetch(this.props.dataURL)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('request_failed');
-        }
-        return response.json();
-      })
+    this.client.getJSON(this.props.dataURL)
       .then((data) => {
         let formData = {
           flaggedCaveatemptor: data.flagged_caveatemptor,
@@ -335,25 +330,8 @@ class CandidateInfo extends Component {
 
     formData.append('tab', this.props.tabName);
     formData.append('candID', this.state.Data.candID);
-    lorisFetch(self.props.action, {
-      method: 'POST',
-      body: formData,
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          let errorMessage = '';
-          let text = await response.text();
-          if (text) {
-            try {
-              errorMessage = JSON.parse(text).message || '';
-            } catch (err) {
-              errorMessage = '';
-            }
-          }
-          let error = new Error('request_failed');
-          error.lorisMessage = errorMessage;
-          throw error;
-        }
+    this.client.postForm(self.props.action, formData)
+      .then(() => {
         self.setState(
           {
             updateResult: 'success',
@@ -361,12 +339,23 @@ class CandidateInfo extends Component {
         );
         self.showAlertMessage();
       })
-      .catch((err) => {
-        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
+      .catch(async (err) => {
+        let errorMessage = '';
+        if (err && err.response) {
+          try {
+            const text = await err.response.text();
+            if (text) {
+              errorMessage = JSON.parse(text).message || '';
+            }
+          } catch (parseError) {
+            errorMessage = '';
+          }
+        }
+        if (errorMessage !== '') {
           self.setState(
             {
               updateResult: 'error',
-              errorMessage: err.lorisMessage,
+              errorMessage: errorMessage,
             }
           );
           self.showAlertMessage();

--- a/modules/candidate_parameters/jsx/CandidateParameters.js
+++ b/modules/candidate_parameters/jsx/CandidateParameters.js
@@ -48,6 +48,7 @@ class CandidateParameters extends Component {
           <TabContent
             action={actionURL}
             dataURL={`${dataURL}&data=${tabList[key].id}`}
+            candID={this.props.candID}
             tabName={tabList[key].id}
           />
         </TabPane>
@@ -161,4 +162,3 @@ window.addEventListener('load', () => {
     </div>
   );
 });
-

--- a/modules/candidate_parameters/jsx/CandidateParametersClient.js
+++ b/modules/candidate_parameters/jsx/CandidateParametersClient.js
@@ -12,22 +12,19 @@ class CandidateParametersClient extends Http.Client {
   }
 
   /**
-   * Fetch JSON data from a module URL using Client#get.
+   * Fetch candidate tab JSON data.
    *
-   * @param {string} url
+   * @param {string} candID
+   * @param {string} tabName
    * @return {Promise<any>}
    */
-  getJSON(url) {
-    const parsedURL = new URL(url, window.location.origin);
-    const prefix = '/candidate_parameters/';
-    const subEndpoint = parsedURL.pathname.startsWith(prefix)
-      ? parsedURL.pathname.slice(prefix.length)
-      : parsedURL.pathname.replace(/^\/+/, '');
-    const query = new Http.Query();
-    parsedURL.searchParams.forEach((value, key) => {
-      query.addParam({field: key, value: value});
-    });
-    return this.setSubEndpoint(subEndpoint).get(query);
+  getData(candID, tabName) {
+    const query = new Http.Query()
+      .addParam({field: 'candID', value: candID})
+      .addParam({field: 'data', value: tabName});
+    return this
+      .setSubEndpoint('ajax/getData.php')
+      .get(query);
   }
 }
 

--- a/modules/candidate_parameters/jsx/CandidateParametersClient.js
+++ b/modules/candidate_parameters/jsx/CandidateParametersClient.js
@@ -1,0 +1,43 @@
+import {Http} from 'jslib';
+
+/**
+ * Candidate parameters JSON client.
+ */
+class CandidateParametersClient extends Http.Client {
+  /**
+   * @constructor
+   */
+  constructor() {
+    // Base path is required by the shared Client, but this module uses full URLs.
+    super('/candidate_parameters');
+  }
+
+  /**
+   * Fetch JSON data from a module URL.
+   *
+   * @param {string} url
+   * @return {Promise<any>}
+   */
+  getJSON(url) {
+    return this.fetchJSON(new URL(url, window.location.origin), {
+      method: 'GET',
+      headers: {'Accept': 'application/json'},
+    });
+  }
+
+  /**
+   * Submit form data and parse JSON response.
+   *
+   * @param {string} url
+   * @param {FormData} formData
+   * @return {Promise<any>}
+   */
+  postForm(url, formData) {
+    return this.fetchJSON(new URL(url, window.location.origin), {
+      method: 'POST',
+      body: formData,
+    });
+  }
+}
+
+export default CandidateParametersClient;

--- a/modules/candidate_parameters/jsx/CandidateParametersClient.js
+++ b/modules/candidate_parameters/jsx/CandidateParametersClient.js
@@ -8,35 +8,26 @@ class CandidateParametersClient extends Http.Client {
    * @constructor
    */
   constructor() {
-    // Base path is required by the shared Client, but this module uses full URLs.
     super('/candidate_parameters');
   }
 
   /**
-   * Fetch JSON data from a module URL.
+   * Fetch JSON data from a module URL using Client#get.
    *
    * @param {string} url
    * @return {Promise<any>}
    */
   getJSON(url) {
-    return this.fetchJSON(new URL(url, window.location.origin), {
-      method: 'GET',
-      headers: {'Accept': 'application/json'},
+    const parsedURL = new URL(url, window.location.origin);
+    const prefix = '/candidate_parameters/';
+    const subEndpoint = parsedURL.pathname.startsWith(prefix)
+      ? parsedURL.pathname.slice(prefix.length)
+      : parsedURL.pathname.replace(/^\/+/, '');
+    const query = new Http.Query();
+    parsedURL.searchParams.forEach((value, key) => {
+      query.addParam({field: key, value: value});
     });
-  }
-
-  /**
-   * Submit form data and parse JSON response.
-   *
-   * @param {string} url
-   * @param {FormData} formData
-   * @return {Promise<any>}
-   */
-  postForm(url, formData) {
-    return this.fetchJSON(new URL(url, window.location.origin), {
-      method: 'POST',
-      body: formData,
-    });
+    return this.setSubEndpoint(subEndpoint).get(query);
   }
 }
 

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -6,6 +6,7 @@ import swal from 'sweetalert2';
 
 import {VerticalTabs, TabPane} from 'Tabs';
 import Loader from 'Loader';
+import lorisFetch from 'jslib/lorisFetch';
 import {
   FormElement,
   StaticElement,
@@ -59,10 +60,14 @@ class ConsentStatus extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    $.ajax(this.props.dataURL, {
-      method: 'GET',
-      dataType: 'json',
-      success: (data) => {
+    lorisFetch(this.props.dataURL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('request_failed');
+        }
+        return response.json();
+      })
+      .then((data) => {
         let formData = {};
         let consents = data.consents;
         for (let cStatus in consents) {
@@ -98,14 +103,13 @@ class ConsentStatus extends Component {
           formData: formData,
           isLoaded: true,
         });
-      },
-      error: (error) => {
+      })
+      .catch((error) => {
         console.error(error);
         this.setState({
           error: true,
         });
-      },
-    });
+      });
   }
 
   /**
@@ -265,14 +269,20 @@ class ConsentStatus extends Component {
     // Disable submit button to prevent form resubmission
     this.setState({submitDisabled: true});
 
-    $.ajax({
-      type: 'POST',
-      url: this.props.action,
-      data: formData,
-      cache: false,
-      contentType: false,
-      processData: false,
-      success: (data) => {
+    lorisFetch(this.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = await response.text();
+          if (!errorMessage) {
+            errorMessage = t('Failed to update!', {ns: 'candidate_parameters'});
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
         swal.fire({
           title: t('Success!', {ns: 'loris'}),
           text: t('Update successful.', {ns: 'candidate_parameters'}),
@@ -287,12 +297,12 @@ class ConsentStatus extends Component {
           }
           );
         this.fetchData();
-      },
-      error: (error) => {
+      })
+      .catch((error) => {
         console.error(error);
         // Enable submit button for form resubmission
         this.setState({submitDisabled: false});
-        let errorMessage = error.responseText ||
+        let errorMessage = error.lorisMessage ||
           t('Failed to update!', {ns: 'candidate_parameters'});
         swal.fire({
           title: t('Error!', {ns: 'loris'}),
@@ -300,8 +310,7 @@ class ConsentStatus extends Component {
           type: 'error',
           confirmButtonText: t('OK', {ns: 'loris'}),
         });
-      },
-    });
+      });
   }
 
   /**

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -58,11 +58,11 @@ class ConsentStatus extends Component {
   }
 
   /**
-   * Retrieve data from the provided URL and save it in state
+   * Retrieve data and save it in state.
    */
   fetchData() {
     const {t} = this.props;
-    this.client.getJSON(this.props.dataURL)
+    this.client.getData(this.props.candID, this.props.tabName)
       .then((data) => {
         let formData = {};
         let consents = data.consents;
@@ -579,9 +579,9 @@ class ConsentStatus extends Component {
 }
 
 ConsentStatus.propTypes = {
-  dataURL: PropTypes.string.isRequired,
+  candID: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
-  tabName: PropTypes.string,
+  tabName: PropTypes.string.isRequired,
   t: PropTypes.string.isRequired,
 };
 

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -9,6 +9,7 @@ import {
   SelectElement,
 } from 'jsx/Form';
 import CandidateParametersClient from './CandidateParametersClient';
+import lorisFetch from 'jslib/lorisFetch';
 
 /**
  * Family info component
@@ -267,8 +268,25 @@ class FamilyInfo extends Component {
       familyMembers: familyMembers,
     });
 
-    this.client.postForm(this.props.action, formData)
-      .then(() => {
+    lorisFetch(this.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
         self.setState({
           updateResult: 'success',
           formData: {},
@@ -285,18 +303,8 @@ class FamilyInfo extends Component {
         // rerender components
         self.forceUpdate();
       })
-      .catch(async (err) => {
-        let errorMessage = '';
-        if (err && err.response) {
-          try {
-            const text = await err.response.text();
-            if (text) {
-              errorMessage = JSON.parse(text).message || '';
-            }
-          } catch (parseError) {
-            errorMessage = '';
-          }
-        }
+      .catch((err) => {
+        let errorMessage = err.lorisMessage || '';
         self.setState(
           {
             updateResult: 'error',
@@ -361,31 +369,37 @@ class FamilyInfo extends Component {
     formData.append('candID', this.state.Data.candID);
     formData.append('familyDCCID', candID);
 
-    this.client.postForm(this.props.action, formData)
-      .then(() => {
+    lorisFetch(this.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
         self.setState(
           {
             updateResult: 'success',
           });
         self.showAlertMessage();
       })
-      .catch(async (err) => {
-        let errorMessage = '';
-        if (err && err.response) {
-          try {
-            const text = await err.response.text();
-            if (text) {
-              errorMessage = JSON.parse(text).message || '';
-            }
-          } catch (parseError) {
-            errorMessage = '';
-          }
-        }
-        if (errorMessage !== '') {
+      .catch((err) => {
+        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
           self.setState(
             {
               updateResult: 'error',
-              errorMessage: errorMessage,
+              errorMessage: err.lorisMessage,
             });
           self.showAlertMessage();
         }

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -8,7 +8,7 @@ import {
   ButtonElement,
   SelectElement,
 } from 'jsx/Form';
-import lorisFetch from 'jslib/lorisFetch';
+import CandidateParametersClient from './CandidateParametersClient';
 
 /**
  * Family info component
@@ -29,6 +29,7 @@ class FamilyInfo extends Component {
       isLoaded: false,
       loadedData: 0,
     };
+    this.client = new CandidateParametersClient();
     this.setFormData = this.setFormData.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -42,13 +43,7 @@ class FamilyInfo extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    lorisFetch(this.props.dataURL)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('request_failed');
-        }
-        return response.json();
-      })
+    this.client.getJSON(this.props.dataURL)
       .then((data) => {
         this.setState({
           Data: data,
@@ -272,25 +267,8 @@ class FamilyInfo extends Component {
       familyMembers: familyMembers,
     });
 
-    lorisFetch(this.props.action, {
-      method: 'POST',
-      body: formData,
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          let errorMessage = '';
-          let text = await response.text();
-          if (text) {
-            try {
-              errorMessage = JSON.parse(text).message || '';
-            } catch (err) {
-              errorMessage = '';
-            }
-          }
-          let error = new Error('request_failed');
-          error.lorisMessage = errorMessage;
-          throw error;
-        }
+    this.client.postForm(this.props.action, formData)
+      .then(() => {
         self.setState({
           updateResult: 'success',
           formData: {},
@@ -307,8 +285,18 @@ class FamilyInfo extends Component {
         // rerender components
         self.forceUpdate();
       })
-      .catch((err) => {
-        let errorMessage = err.lorisMessage || '';
+      .catch(async (err) => {
+        let errorMessage = '';
+        if (err && err.response) {
+          try {
+            const text = await err.response.text();
+            if (text) {
+              errorMessage = JSON.parse(text).message || '';
+            }
+          } catch (parseError) {
+            errorMessage = '';
+          }
+        }
         self.setState(
           {
             updateResult: 'error',
@@ -373,37 +361,31 @@ class FamilyInfo extends Component {
     formData.append('candID', this.state.Data.candID);
     formData.append('familyDCCID', candID);
 
-    lorisFetch(this.props.action, {
-      method: 'POST',
-      body: formData,
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          let errorMessage = '';
-          let text = await response.text();
-          if (text) {
-            try {
-              errorMessage = JSON.parse(text).message || '';
-            } catch (err) {
-              errorMessage = '';
-            }
-          }
-          let error = new Error('request_failed');
-          error.lorisMessage = errorMessage;
-          throw error;
-        }
+    this.client.postForm(this.props.action, formData)
+      .then(() => {
         self.setState(
           {
             updateResult: 'success',
           });
         self.showAlertMessage();
       })
-      .catch((err) => {
-        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
+      .catch(async (err) => {
+        let errorMessage = '';
+        if (err && err.response) {
+          try {
+            const text = await err.response.text();
+            if (text) {
+              errorMessage = JSON.parse(text).message || '';
+            }
+          } catch (parseError) {
+            errorMessage = '';
+          }
+        }
+        if (errorMessage !== '') {
           self.setState(
             {
               updateResult: 'error',
-              errorMessage: err.lorisMessage,
+              errorMessage: errorMessage,
             });
           self.showAlertMessage();
         }

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -44,7 +44,7 @@ class FamilyInfo extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    this.client.getJSON(this.props.dataURL)
+    this.client.getData(this.props.candID, this.props.tabName)
       .then((data) => {
         this.setState({
           Data: data,
@@ -407,9 +407,8 @@ class FamilyInfo extends Component {
   }
 }
 FamilyInfo.propTypes = {
-  dataURL: PropTypes.string,
-  tabName: PropTypes.string,
-  candID: PropTypes.string,
+  tabName: PropTypes.string.isRequired,
+  candID: PropTypes.string.isRequired,
   action: PropTypes.string,
   t: PropTypes.string.isRequired,
 };

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -10,6 +10,7 @@ import {
   TextareaElement,
   ButtonElement,
 } from 'jsx/Form';
+import lorisFetch from 'jslib/lorisFetch';
 
 /**
  * Participant status component
@@ -48,50 +49,36 @@ class ParticipantStatus extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    let that = this;
-    $.ajax(
-      this.props.dataURL,
-      {
-        dataType: 'json',
-        xhr: function() {
-          let xhr = new window.XMLHttpRequest();
-          xhr.addEventListener(
-            'progress',
-            function(evt) {
-              that.setState(
-                {
-                  loadedData: evt.loaded,
-                }
-              );
-            }
-          );
-          return xhr;
-        },
-        success: function(data) {
-          let formData = {};
-          formData.participantStatus = data.participantStatus;
-          formData.participantSuboptions = data.participantSuboptions;
-          formData.reasonSpecify = data.reasonSpecify;
+    lorisFetch(this.props.dataURL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('request_failed');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        let formData = {};
+        formData.participantStatus = data.participantStatus;
+        formData.participantSuboptions = data.participantSuboptions;
+        formData.reasonSpecify = data.reasonSpecify;
 
-          that.setState(
-            {
-              Data: data,
-              formData: formData,
-              isLoaded: true,
-            }
-          );
-        },
-        error: function(data, errorCode, errorMsg) {
-          that.setState(
-            {
-              error: t('An error occured while loading the page.',
-                {ns: 'loris'}
-              ),
-            }
-          );
-        },
-      }
-    );
+        this.setState(
+          {
+            Data: data,
+            formData: formData,
+            isLoaded: true,
+          }
+        );
+      })
+      .catch(() => {
+        this.setState(
+          {
+            error: t('An error occured while loading the page.',
+              {ns: 'loris'}
+            ),
+          }
+        );
+      });
   }
 
   /**
@@ -297,37 +284,44 @@ class ParticipantStatus extends Component {
 
     formData.append('tab', this.props.tabName);
     formData.append('candID', this.state.Data.candID);
-    $.ajax(
-      {
-        type: 'POST',
-        url: self.props.action,
-        data: formData,
-        cache: false,
-        contentType: false,
-        processData: false,
-        success: function(data) {
+    lorisFetch(self.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
+        self.setState(
+          {
+            updateResult: 'success',
+          }
+        );
+        self.showAlertMessage();
+        self.fetchData();
+      })
+      .catch((err) => {
+        if (err.lorisMessage !== undefined && err.lorisMessage !== '') {
           self.setState(
             {
-              updateResult: 'success',
+              updateResult: 'error',
+              errorMessage: err.lorisMessage,
             }
           );
           self.showAlertMessage();
-          self.fetchData();
-        },
-        error: function(err) {
-          if (err.responseText !== '') {
-            let errorMessage = JSON.parse(err.responseText).message;
-            self.setState(
-              {
-                updateResult: 'error',
-                errorMessage: errorMessage,
-              }
-            );
-            self.showAlertMessage();
-          }
-        },
-      }
-    );
+        }
+      });
   }
 
   /**

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -51,7 +51,7 @@ class ParticipantStatus extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    this.client.getJSON(this.props.dataURL)
+    this.client.getData(this.props.candID, this.props.tabName)
       .then((data) => {
         let formData = {};
         formData.participantStatus = data.participantStatus;
@@ -343,8 +343,8 @@ class ParticipantStatus extends Component {
   }
 }
 ParticipantStatus.propTypes = {
-  dataURL: PropTypes.string,
-  tabName: PropTypes.string,
+  candID: PropTypes.string.isRequired,
+  tabName: PropTypes.string.isRequired,
   action: PropTypes.string,
   t: PropTypes.string.isRequired,
 };

--- a/modules/candidate_parameters/jsx/ProbandInfo.js
+++ b/modules/candidate_parameters/jsx/ProbandInfo.js
@@ -12,6 +12,7 @@ import {
   DateElement,
   TextareaElement,
 } from 'jsx/Form';
+import lorisFetch from 'jslib/lorisFetch';
 
 /**
  * Proband Info Component.
@@ -57,10 +58,14 @@ class ProbandInfo extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    $.ajax(this.props.dataURL, {
-      method: 'GET',
-      dataType: 'json',
-      success: (data) => {
+    lorisFetch(this.props.dataURL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('request_failed');
+        }
+        return response.json();
+      })
+      .then((data) => {
         const formData = {
           ProbandSex: data.ProbandSex,
           ProbandDoB: data.ProbandDoB,
@@ -76,15 +81,14 @@ class ProbandInfo extends Component {
           isLoaded: true,
           sexOptions: data.sexOptions,
         });
-      },
-      error: (error) => {
+      })
+      .catch(() => {
         this.setState({
           error: t('An error occurred when loading the form!',
             {ns: 'candidate_parameters'}
           ),
         });
-      },
-    });
+      });
   }
 
   /**
@@ -158,31 +162,40 @@ class ProbandInfo extends Component {
 
     formData.append('tab', this.props.tabName);
     formData.append('candID', this.state.Data.candID);
-    $.ajax({
-      type: 'POST',
-      url: this.props.action,
-      data: formData,
-      cache: false,
-      contentType: false,
-      processData: false,
-      success: (data) => {
+    lorisFetch(this.props.action, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          let errorMessage = '';
+          let text = await response.text();
+          if (text) {
+            try {
+              errorMessage = JSON.parse(text).message || '';
+            } catch (err) {
+              errorMessage = '';
+            }
+          }
+          let error = new Error('request_failed');
+          error.lorisMessage = errorMessage;
+          throw error;
+        }
         this.setState({
           updateResult: 'success',
         });
         this.showAlertMessage();
         this.fetchData();
-      },
-      error: (error) => {
-        if (error.responseText !== '') {
-          let errorMessage = JSON.parse(error.responseText).message;
+      })
+      .catch((error) => {
+        if (error.lorisMessage !== undefined && error.lorisMessage !== '') {
           this.setState({
             updateResult: 'error',
-            errorMessage: errorMessage,
+            errorMessage: error.lorisMessage,
           });
           this.showAlertMessage();
         }
-      },
-    });
+      });
   }
 
   /**

--- a/modules/candidate_parameters/jsx/ProbandInfo.js
+++ b/modules/candidate_parameters/jsx/ProbandInfo.js
@@ -60,7 +60,7 @@ class ProbandInfo extends Component {
    */
   fetchData() {
     const {t} = this.props;
-    this.client.getJSON(this.props.dataURL)
+    this.client.getData(this.props.candID, this.props.tabName)
       .then((data) => {
         const formData = {
           ProbandSex: data.ProbandSex,
@@ -377,9 +377,9 @@ class ProbandInfo extends Component {
 }
 
 ProbandInfo.propTypes = {
-  dataURL: PropTypes.string.isRequired,
+  candID: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
-  tabName: PropTypes.string,
+  tabName: PropTypes.string.isRequired,
   t: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
## Summary
Replace `$.ajax` calls with `lorisFetch` in `candidate_parameters`.

## Why
This removes jQuery AJAX usage in this module for issue #4213.

## Scope
Only AJAX replacement in this module. No unrelated jQuery refactors.

## Dependency
Depends on #10333 .

## Verification
`git grep '\$\.ajax'` is clean for touched files.
