### PR TITLE
statistics: replace $.ajax with lorisFetch

### DIFF
--- a/modules/statistics/js/form_stats_MRI.js
+++ b/modules/statistics/js/form_stats_MRI.js
@@ -1,4 +1,5 @@
 /*global document, $*/
+var lorisFetch = window.lorisFetch || fetch;
 $('#selectall').click(
     function(event) {
         if(this.checked) {
@@ -45,14 +46,19 @@ function updateMRITab() {
         }
     );
 
-    var request = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_MRI/?dynamictabs=dynamictabs&MRIProject=' + (MRIProject==null ? "" : MRIProject.value) + '&MRIsite=' + MRIsite.value + '&Scans=' + scanArray,
-            type: 'GET',
-            data: 'html',
-            success: function(response) {
-                $('#mri').html(response);
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_MRI/?dynamictabs=dynamictabs&MRIProject=' +
+        (MRIProject==null ? "" : MRIProject.value) + '&MRIsite=' + MRIsite.value +
+        '&Scans=' + scanArray,
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(response) {
+            $('#mri').html(response);
+        });
 }

--- a/modules/statistics/js/form_stats_behavioural.js
+++ b/modules/statistics/js/form_stats_behavioural.js
@@ -1,17 +1,22 @@
 /*global document, $, window, scrollContent*/
+var lorisFetch = window.lorisFetch || fetch;
 function updateBehaviouralTab() {
     var BehaviouralProject = document.getElementById("BehaviouralProject");
-    var request            = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_behavioural/?dynamictabs=dynamictabs&BehaviouralProject=' + (BehaviouralProject==null ? "" : BehaviouralProject.value),
-            type: 'GET',
-            data: 'html',
-            success: function (response) {
-                $('#data_entry').html(response);
-                $(".dynamictable").DynamicTable();
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_behavioural/?dynamictabs=dynamictabs&BehaviouralProject=' +
+        (BehaviouralProject==null ? "" : BehaviouralProject.value),
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(response) {
+            $('#data_entry').html(response);
+            $(".dynamictable").DynamicTable();
+        });
 }
 function checkOverflow() {
     'use strict';

--- a/modules/statistics/js/form_stats_demographic.js
+++ b/modules/statistics/js/form_stats_demographic.js
@@ -1,17 +1,24 @@
 /*global document, $*/
+var lorisFetch = window.lorisFetch || fetch;
 function updateDemographicTab() {
     var DemographicSite       = document.getElementById("DemographicSite");
     var DemographicProject    = document.getElementById("DemographicProject");
     var DemographicInstrument = document.getElementById("DemographicInstrument");
-    var request = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_demographic/?dynamictabs=dynamictabs&DemographicSite=' + DemographicSite.value + '&DemographicProject=' + (DemographicProject==null ? "" : DemographicProject.value)+'&DemographicInstrument='+DemographicInstrument.value,
-            type: 'GET',
-            data: 'html',
-            success: function(response) {
-                $('#demographics').html(response);
-                $(".dynamictable").DynamicTable();
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_demographic/?dynamictabs=dynamictabs&DemographicSite=' +
+        DemographicSite.value + '&DemographicProject=' +
+        (DemographicProject==null ? "" : DemographicProject.value) +
+        '&DemographicInstrument=' + DemographicInstrument.value,
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(response) {
+            $('#demographics').html(response);
+            $(".dynamictable").DynamicTable();
+        });
 }

--- a/modules/statistics/js/table_statistics.js
+++ b/modules/statistics/js/table_statistics.js
@@ -1,4 +1,5 @@
 /*global document, $*/
+var lorisFetch = window.lorisFetch || fetch;
 $('#showVL').click(
     function(event) {
         if(this.checked) {
@@ -21,48 +22,61 @@ function updateDemographicInstrument() {
     var DemographicSite       = document.getElementById("DemographicSite");
     var DemographicInstrument = document.getElementById("DemographicInstrument");
 
-    var request = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_demographic/?dynamictabs=dynamictabs&DemographicSite=' + DemographicSite.value + '&DemographicInstrument=' + DemographicInstrument.value,
-            type: 'GET',
-            data: 'html',
-            success: function(page){
-                $('#demographics').html(page);
-                $(".dynamictable").DynamicTable();
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_demographic/?dynamictabs=dynamictabs&DemographicSite=' +
+        DemographicSite.value + '&DemographicInstrument=' + DemographicInstrument.value,
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(page){
+            $('#demographics').html(page);
+            $(".dynamictable").DynamicTable();
+        });
 }
 
 function updateBehaviouralInstrument() {
     var BehaviouralSite       = document.getElementById("BehaviouralSite");
     var BehaviouralInstrument = document.getElementById("BehaviouralInstrument");
     var BehaviouralProject    = document.getElementById("BehaviouralProject");
-    var request = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_behavioural/?dynamictabs=dynamictabs&BehaviouralSite=' + BehaviouralSite.value + '&BehaviouralInstrument=' + (BehaviouralProject==null ? "" : BehaviouralProject.value) + '&BehaviouralProject=' + BehaviouralProject.value,
-            type: 'GET',
-            data: 'html',
-            success: function(page) {
-                $('#data_entry').html(page);
-                $(".dynamictable").DynamicTable();
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_behavioural/?dynamictabs=dynamictabs&BehaviouralSite=' +
+        BehaviouralSite.value + '&BehaviouralInstrument=' +
+        (BehaviouralProject==null ? "" : BehaviouralProject.value) +
+        '&BehaviouralProject=' + BehaviouralProject.value,
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(page) {
+            $('#data_entry').html(page);
+            $(".dynamictable").DynamicTable();
+        });
 }
 function updateMRITable() {
     var selectedMRI_TYPE = document.getElementById("mri_type");
     var MRIProject       = document.getElementById("MRIProject");
-    var request          = $.ajax(
-        {
-            url: loris.BaseURL + '/statistics/stats_MRI/?dynamictabs=dynamictabs&mri_type=' + selectedMRI_TYPE.value +
-            '&MRIProject=' + (MRIProject==null ? "" : MRIProject.value),
-            type: 'GET',
-            data: 'html',
-            success: function(page) {
-                $('#mri').html(page);
-                $(".dynamictable").DynamicTable();
+    lorisFetch(
+        loris.BaseURL + '/statistics/stats_MRI/?dynamictabs=dynamictabs&mri_type=' +
+        selectedMRI_TYPE.value + '&MRIProject=' + (MRIProject==null ? "" : MRIProject.value),
+        {credentials: 'same-origin'}
+    )
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('request_failed');
             }
-        }
-    );
+            return response.text();
+        })
+        .then(function(page) {
+            $('#mri').html(page);
+            $(".dynamictable").DynamicTable();
+        });
 }


### PR DESCRIPTION
## Summary
Replace `$.ajax` calls with `lorisFetch` in `statistics`.

## Why
This removes jQuery AJAX usage in this module for issue #4213.

## Scope
Only AJAX replacement in this module. No unrelated jQuery refactors.

## Dependency
Depends on PR #10333 .

## Verification
`git grep '\$\.ajax'` is clean for touched files.
