### PR TITLE
[DQT] Fix Default Visits Dropdown Filtering

### DIFF
--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -234,7 +234,8 @@ function DefineFields(props: {
   // When viewing a category, only show visits where that category has data
   const availableVisits = useMemo(() => {
     // If no category is displayed, show all visits
-    if (!props.displayedFields || Object.keys(props.displayedFields).length === 0) {
+    if (!props.displayedFields ||
+        Object.keys(props.displayedFields).length === 0) {
       return props.allVisits;
     }
 


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the issue where the Default Visits dropdown would display all visits regardless of the category selected.
The dropdown now correctly filters visits based on the currently displayed category (e.g., selecting AOSI shows only its valid visits).

- Updated logic to filter visits based on the currently displayed category instead of selected fields.
- Added logic to automatically update default visits when switching categories.

**Original:** V4-V6 do not exist but still selected by default. 
<img width="740" height="435" alt="Screenshot 2026-02-07 at 18 26 46" src="https://github.com/user-attachments/assets/c98b04b6-9dae-4029-9385-9afb7032278d" />


**Final Demo Video:**

https://github.com/user-attachments/assets/a08071a2-d87f-485d-8051-b8ab6c2233ae




#### Link(s) to related issue(s)

* Resolves #9833