### PR TITLE
[core/api] Fix EEG recording channels sampling frequency PHP type

### DIFF
--- a/php/libraries/RecordingChannels.class.inc
+++ b/php/libraries/RecordingChannels.class.inc
@@ -28,7 +28,7 @@ class RecordingChannels
     private ?string $_channeltypedescription;
     private ?string $_channelstatus;
     private ?string $_statusdescription;
-    private ?string $_samplingfrequency;
+    private ?int    $_samplingfrequency;
     private ?string $_lowcutoff;
     private ?string $_highcutoff;
     private ?string $_manualflag;
@@ -46,7 +46,7 @@ class RecordingChannels
      * @param ?string $channeltypedescription Channel Type Description
      * @param ?string $channelstatus          Channel Status
      * @param ?string $statusdescription      Status Description
-     * @param ?string $samplingfrequency      Sampling Frequency
+     * @param ?int    $samplingfrequency      Sampling Frequency
      * @param ?string $lowcutoff              Low Cutoff
      * @param ?string $highcutoff             High Cutoff
      * @param ?string $manualflag             Manual Flag
@@ -62,7 +62,7 @@ class RecordingChannels
         ?string $channeltypedescription,
         ?string $channelstatus,
         ?string $statusdescription,
-        ?string $samplingfrequency,
+        ?int    $samplingfrequency,
         ?string $lowcutoff,
         ?string $highcutoff,
         ?string $manualflag,
@@ -150,9 +150,9 @@ class RecordingChannels
     /**
      * Accessor for sampling frequency
      *
-     * @return ?string
+     * @return ?int
      */
-    public function getSamplingFrequency(): ?string
+    public function getSamplingFrequency(): ?int
     {
         return $this->_samplingfrequency;
     }


### PR DESCRIPTION
## Problem

The [LORIS API documentation](https://demo.loris.ca/api_docs/#/Electrophysiology/get_candidates__candid___visit__recordings__filename__channels) as well as the [LORIS SQL schema](https://github.com/aces/Loris/blob/ebcc5d9a42719441d5ce8125021f7a80b41b564c/SQL/0000-00-05-ElectrophysiologyTables.sql#L125) specify that the EEG recording channel frequency is an integer, however that field is a string in the PHP code.

This is not too problematic for our EEG demonstration files ([they all have `null` sampling frequencies](https://demo.loris.ca/api/v0.0.3/candidates/300166/V1/recordings/sub-OTT166_ses-V1_task-faceO_eeg.edf/channels)) but it results in a 500 type error when that sampling frequency is specified.

## Solution

Use an integer instead of a string, it fixes the 500 error and respects the API documentation.