### PR TITLE
[SQL/electrophysiology] Fix physiological event sample SQL type

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -302,7 +302,7 @@ CREATE TABLE `physiological_task_event` (
   `Channel`                  TEXT             DEFAULT NULL,
   `EventCode`                INT(10)          DEFAULT NULL,
   `EventValue`               varchar(255)     DEFAULT NULL,
-  `EventSample`              decimal(11,6)    DEFAULT NULL,
+  `EventSample`              INT(10)          DEFAULT NULL,
   `EventType`                VARCHAR(50)      DEFAULT NULL,
   `TrialType`                VARCHAR(255)     DEFAULT NULL,
   `ResponseTime`             TIME             DEFAULT NULL,

--- a/SQL/New_patches/2026-02-12_fix-physio-event-sample-type.sql
+++ b/SQL/New_patches/2026-02-12_fix-physio-event-sample-type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `physiological_task_event` MODIFY COLUMN `EventSample` int(10) DEFAULT NULL;


### PR DESCRIPTION
## Problem

In the LORIS database schema, the `EventSample` field currently has a `decimal(11, 6)` type, which can represent decimal values up to 100,000.

I have some files for MPN that have event sample values up to 300,000, so a higher maximum is clearly needed. After digging more into it, it appears that this field is not a standard BIDS field, but that it is rather a field produced by MNE-BIDS (this will need to be documented on the Python side). In my dataset, and as well as the ~~inexistant~~ very sparse documentation that I could find, it actually seems to me that this value should always be an integer:
https://github.com/mne-tools/mne-bids/blob/5dac732153c071a85d25d5dd0f3d7fde7d15bf2b/mne_bids/write.py#L516-L521
> The event onset time in *number of sampling points*. First sample is 0.

https://github.com/mne-tools/mne-bids/blob/5dac732153c071a85d25d5dd0f3d7fde7d15bf2b/mne_bids/read.py#L601
The documented values uses integers rather than decimals.

Moreover, I ran the following query on Raisinbread and C-BIG and did not find any decimal value:
```sql
SELECT 
    SUM(CASE WHEN EventSample IS NULL THEN 1 ELSE 0 END) as rows_null,
    SUM(CASE WHEN EventSample IS NOT NULL AND EventSample != FLOOR(EventSample) THEN 1 ELSE 0 END) as rows_with_decimals,
    SUM(CASE WHEN EventSample IS NOT NULL AND EventSample = FLOOR(EventSample) THEN 1 ELSE 0 END) as rows_with_integers
FROM physiological_task_event;
```

## Solution

Change the `EventSample` column type from `DECIMAL(11, 6)` to `INT(10)`.