### PR TITLE
[Configuration] Fix: Decouple Visit Window Columns from SupplementalSessionStatus Config

### DIFF
--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -47,19 +47,21 @@
       <th>
         {dgettext("timepoint_list", "Imaging Scan Done")}
       </th>
+    {if $display.WindowInfo.WindowDefined|default}
       <th>
         {dgettext("instrument_list", "Within Optimal")}
       </th>
       <th>
         {dgettext("instrument_list", "Within Permitted")}
       </th>
-      {if $SupplementalSessionStatuses|default}
+    {/if}
+    {if $SupplementalSessionStatuses|default}
         {foreach from=$timePoint.status item=status key=name}
           <th>
             {$name}
           </th>
         {/foreach}
-      {/if}
+    {/if}
     {/if}
   </tr>
   </thead>
@@ -122,6 +124,7 @@
             <img alt="Data Missing" src="{$baseurl|default}/images/help2.gif" border=0>
         {/if}
       </td>
+    {if $display.WindowInfo.WindowDefined|default}
       <td>
         {if $display.WindowInfo.Optimum|default}
           {dgettext("loris", "Yes")}
@@ -136,13 +139,14 @@
           {dgettext("loris", "No")}
         {/if}
       </td>
-      {if $SupplementalSessionStatuses|default}
+    {/if}
+    {if $SupplementalSessionStatuses|default}
         {foreach from=$display.status item=status}
           <td>
             {$status}
           </td>
         {/foreach}
-      {/if}
+    {/if}
     {/if}
   </tr>
   </tbody>

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -211,25 +211,27 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
                 }
                 $this->_timePointInfo['status'][$row['Name']] = $row['Value'];
             }
-            $this->_timePointInfo['WindowInfo'] = $db->pSelectRow(
-                "SELECT DATEDIFF(s.Date_visit, c.DoB) as AgeDays,
-                        DATEDIFF(s.Date_visit, c.DoB) BETWEEN
-                            w.OptimumMinDays
-                            AND w.OptimumMaxDays as Optimum,
-                        (DATEDIFF(s.Date_visit, c.DoB) BETWEEN
-                            w.WindowMinDays AND w.WindowMaxDays
-                        ) as Permitted
-                    FROM session s
-                        JOIN candidate c ON c.ID=s.CandidateID
-                        JOIN Visit_Windows w ON (
-                            LOWER(w.Visit_label)=LOWER(s.Visit_label)
-                        )
-                    WHERE s.ID=:sessionID",
-                [":sessionID" => $sessionID]
-            );
-
         }
 
+        $this->_timePointInfo['WindowInfo'] = $db->pSelectRow(
+            "SELECT (w.WindowMinDays IS NOT NULL
+                     OR w.OptimumMinDays IS NOT NULL)
+                        as WindowDefined,
+                    DATEDIFF(s.Date_visit, c.DoB) as AgeDays,
+                    DATEDIFF(s.Date_visit, c.DoB) BETWEEN
+                        w.OptimumMinDays
+                        AND w.OptimumMaxDays as Optimum,
+                    (DATEDIFF(s.Date_visit, c.DoB) BETWEEN
+                        w.WindowMinDays AND w.WindowMaxDays
+                    ) as Permitted
+                FROM session s
+                    JOIN candidate c ON c.ID=s.CandidateID
+                    JOIN Visit_Windows w ON (
+                        LOWER(w.Visit_label)=LOWER(s.Visit_label)
+                    )
+                WHERE s.ID=:sessionID",
+            [":sessionID" => $sessionID]
+        );
     }
 
     /**

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -58,12 +58,14 @@
       <th>
         {dgettext("timepoint_list", "Imaging Scan Done")}
       </th>
+      {if $display.WindowInfo.WindowDefined|default}
       <th>
         {dgettext("instrument_list", "Within Optimal")}
       </th>
       <th>
         {dgettext("instrument_list", "Within Permitted")}
       </th>
+      {/if}
       {if $SupplementalSessionStatuses }
         {foreach from=$timePoint.status item=status key=name}
           <th>
@@ -123,6 +125,7 @@
             <img alt="Data Missing" src="{$baseurl|default}/images/help2.gif" border=0>
         {/if}
       </td>
+      {if $display.WindowInfo.WindowDefined|default}
       <td>
         {if $display.WindowInfo.Optimum|default}
           {dgettext("loris", "Yes")}
@@ -137,6 +140,7 @@
           {dgettext("loris", "No")}
         {/if}
       </td>
+      {/if}
       {if $SupplementalSessionStatuses|default}
         {foreach from=$timePoint.status item=status}
           <td>


### PR DESCRIPTION
## Brief summary of changes

The "Within Optimal" and "Within Permitted" columns in the instrument list were incorrectly tied to the "Use Supplemental Session Status" configuration setting. When this setting was disabled, the columns would either disappear or display "No" even when visit windows were properly defined in the database, causing confusion about data completeness.

Additionally, the individual instrument pages (e.g., AOSI, MRI) always displayed these columns unconditionally, showing "No" even when no visit windows were defined at all.

### Backend (`TimePoint.class.inc`)
- Moved the `WindowInfo` SQL query **outside** the `SupplementalSessionStatus` configuration check, making visit window data always available when defined
- Added a computed `WindowDefined` boolean flag to clearly indicate when visit windows exist in the database

### Frontend Templates
- **`menu_instrument_list.tpl`**: Updated conditional logic to check `WindowDefined` instead of the config flag
- **`instrument_html.tpl`**: Added conditional display logic (previously missing) to hide columns when no windows are defined

### Result
- Columns now appear **only when** `Visit_Windows` table defines ranges for the visit
- Yes/No values are computed based on the candidate's age relative to the defined windows
- Configuration setting no longer affects this functionality

## Testing

### 1. Configuration Independence
- Toggled "Use Supplemental Session Status" between "Yes" and "No"
- **Result**: Visit window columns remain unchanged (decoupled from config)

### 2. Null Windows (Default State)
- **Test**: I verified that the default `Visit_Windows` table has no ranges defined (NULL) for visit `V3`:
```sql
SELECT WindowMinDays, OptimumMinDays FROM Visit_Windows WHERE Visit_label='V3';
-- Result: NULL, NULL
```
- **Result**: DCC090 → V3 shows **no "Within Optimal/Permitted" columns**
<img width="1322" height="758" alt="Screenshot 2026-02-12 at 19 23 52" src="https://github.com/user-attachments/assets/3bf4f639-daf4-4cd3-b10c-8eb2d140df87" />

### 3. Defined Windows → "No" Result
Set narrow window (100 days) to force "outside range" result:
```sql
UPDATE Visit_Windows SET WindowMinDays=0, WindowMaxDays=100, 
  OptimumMinDays=0, OptimumMaxDays=100 WHERE Visit_label='V2';
```
- **Result**: DCC090 → V2 (age 3,728 days) shows **"No"** for both columns

<img width="1322" height="756" alt="Screenshot 2026-02-12 at 19 23 36" src="https://github.com/user-attachments/assets/166c250e-da22-4d4e-b967-628c92066e0b" />


### 4. Defined Windows → "Yes" Result
Set wide window (10,000 days) to include candidate:
```sql
UPDATE Visit_Windows SET WindowMinDays=0, WindowMaxDays=10000, 
  OptimumMinDays=0, OptimumMaxDays=10000 WHERE Visit_label='V1';
```
- **Result**: DCC090 → V1 (age 4,372 days) shows **"Yes"** for both columns

<img width="1321" height="759" alt="Screenshot 2026-02-12 at 19 23 06" src="https://github.com/user-attachments/assets/93ee35a8-50a4-4ee6-b9a6-77c17aa657ae" />

#### Link(s) to related issue(s)
* Resolves #10230 