### PR TITLE
[DQT] Fix random scroll jump when deleting selected fields

### DIFF
--- a/modules/dataquery/jsx/definefields.tsx
+++ b/modules/dataquery/jsx/definefields.tsx
@@ -600,7 +600,8 @@ function SelectedFieldList(props: {
         onMouseEnter={() => setRemovingIdx(i)}
         onMouseLeave={() => setRemovingIdx(null)}>
         <i
-          className="fas fa-trash-alt" onClick={() => {
+          className="fas fa-trash-alt" onClick={(e) => {
+            e.stopPropagation();
             removeField(item);
             setRemovingIdx(null);
           }}


### PR DESCRIPTION
## Brief summary of changes

Added `e.stopPropagation()` to the delete click handler.

### Testing 

Before:

https://github.com/user-attachments/assets/e071af03-fefa-4c48-8b99-621642943efa



After:

https://github.com/user-attachments/assets/705e69db-c591-451e-8f14-fd4aa326806b



#### Link(s) to related issue(s)
* Resolves #10122
