### PR TITLE
[statistics-imaging stats] Fix: Imaging Statistics fatal type error in stats_mri

### DIFF
--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -397,30 +397,32 @@ class Stats_MRI extends \NDB_Form
         $scanDoneExists = false;
         if ($DB->columnExists('mri_parameter_form', $MRI_Type . "_Scan_Done")) {
             $scanDoneExists = true;
-            $result         = $DB->pselect(
-                "SELECT s.CohortID,
-                    s.CenterID,
-                    s.Visit_label as VLabel,
-                    $CaseStatement as Subcat,
-                    COUNT(*) as val
-                FROM mri_parameter_form m
-                    JOIN flag f USING (CommentID)
-                    JOIN session s ON (f.SessionID=s.ID)
-                    JOIN candidate c ON (c.ID=s.CandidateID)
-                WHERE s.Current_stage <> 'Recycling Bin'
-                    AND f.Administration <> 'None'
-                    AND s.Active='Y'
-                    AND c.Active='Y'
-                    AND f.CommentID NOT LIKE 'DDE%'
-                    AND s.CenterID <> '1'
+            $result         = iterator_to_array(
+                $DB->pselect(
+                    "SELECT s.CohortID,
+                        s.CenterID,
+                        s.Visit_label as VLabel,
+                        $CaseStatement as Subcat,
+                        COUNT(*) as val
+                    FROM mri_parameter_form m
+                        JOIN flag f USING (CommentID)
+                        JOIN session s ON (f.SessionID=s.ID)
+                        JOIN candidate c ON (c.ID=s.CandidateID)
+                    WHERE s.Current_stage <> 'Recycling Bin'
+                        AND f.Administration <> 'None'
+                        AND s.Active='Y'
+                        AND c.Active='Y'
+                        AND f.CommentID NOT LIKE 'DDE%'
+                        AND s.CenterID <> '1'
 		    AND s.CenterID IN (" . $sitesString . ")
-                    $suproject_query
-                    $Param_Project
-                GROUP BY Subcat,
-                    s.CohortID,
-                    s.CenterID,
-                    s.Visit_label",
-                $bigTable_params
+                        $suproject_query
+                        $Param_Project
+                    GROUP BY Subcat,
+                        s.CohortID,
+                        s.CenterID,
+                        s.Visit_label",
+                    $bigTable_params
+                )
             );
         }
 
@@ -663,4 +665,3 @@ class Stats_MRI extends \NDB_Form
         );
     }
 }
-


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the error on `Reports -> Statistics -> Imaging Statistics`.

`Stats_MRI::renderStatsTable()` requires argument `$data` to be an array, but a `LORIS\Database\Query` object was being passed from `setup()`.

Updated `modules/statistics/php/stats_mri.class.inc` to convert the `pselect()` result to an array using `iterator_to_array(...)` before passing it to `renderStatsTable()`.

#### Testing

Before:
<img width="1198" height="715" alt="Screenshot 2026-02-13 at 13 13 41" src="https://github.com/user-attachments/assets/05750a79-c497-41df-8f18-eb3a3e5b9f08" />


After:
<img width="1204" height="751" alt="Screenshot 2026-02-13 at 13 03 22" src="https://github.com/user-attachments/assets/b805f5f3-9b48-44d8-8621-1087a3042c61" />

#### Link(s) to related issue(s)

* Resolves #10272
