### PR TITLE
[core] Make DataInstance extend AccessibleResource

### DIFF
--- a/modules/acknowledgements/php/acknowledgementrow.class.inc
+++ b/modules/acknowledgements/php/acknowledgementrow.class.inc
@@ -50,6 +50,13 @@ class AcknowledgementRow implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return true;

--- a/modules/acknowledgements/php/acknowledgementrow.class.inc
+++ b/modules/acknowledgements/php/acknowledgementrow.class.inc
@@ -49,4 +49,9 @@ class AcknowledgementRow implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return true;
+    }
 }

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -102,6 +102,13 @@ class CandidatesRow implements \LORIS\Data\DataInstance,
         return $this->_projectid;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -101,4 +101,12 @@ class CandidatesRow implements \LORIS\Data\DataInstance,
         }
         return $this->_projectid;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -107,6 +107,13 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance,
         return $this->_entitytype === 'Scanner';
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -106,4 +106,12 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance,
     {
         return $this->_entitytype === 'Scanner';
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/api/php/models/projectinstrumentsrow.class.inc
+++ b/modules/api/php/models/projectinstrumentsrow.class.inc
@@ -119,4 +119,9 @@ class ProjectInstrumentsRow implements \LORIS\Data\DataInstance
         }
         return $obj;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return true;
+    }
 }

--- a/modules/api/php/models/projectinstrumentsrow.class.inc
+++ b/modules/api/php/models/projectinstrumentsrow.class.inc
@@ -120,6 +120,13 @@ class ProjectInstrumentsRow implements \LORIS\Data\DataInstance
         return $obj;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return true;

--- a/modules/api/php/models/projectrecordingsrow.class.inc
+++ b/modules/api/php/models/projectrecordingsrow.class.inc
@@ -91,4 +91,12 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
     {
         return intval($this->_centerid);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/api/php/models/projectrecordingsrow.class.inc
+++ b/modules/api/php/models/projectrecordingsrow.class.inc
@@ -92,6 +92,13 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
         return intval($this->_centerid);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/api/php/models/sitesrow.class.inc
+++ b/modules/api/php/models/sitesrow.class.inc
@@ -56,4 +56,12 @@ class SitesRow implements DataInstance, SiteHaver
     {
         return \CenterID::singleton($this->_id);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/api/php/models/sitesrow.class.inc
+++ b/modules/api/php/models/sitesrow.class.inc
@@ -57,6 +57,13 @@ class SitesRow implements DataInstance, SiteHaver
         return \CenterID::singleton($this->_id);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/battery_manager/php/test.class.inc
+++ b/modules/battery_manager/php/test.class.inc
@@ -106,6 +106,13 @@ class Test implements
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/battery_manager/php/test.class.inc
+++ b/modules/battery_manager/php/test.class.inc
@@ -105,4 +105,12 @@ class Test implements
             'Active'                 => $this->row['active']          ?? null,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -164,4 +164,12 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
             'feedback_status' => $this->_feedback_status,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -165,6 +165,13 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -148,4 +148,12 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
             'commentID'         => $this->_commentID,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -149,6 +149,13 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -157,6 +157,13 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -156,4 +156,12 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
             'commentID'       => $this->_commentID,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/biobank/php/container.class.inc
+++ b/modules/biobank/php/container.class.inc
@@ -559,6 +559,13 @@ class Container implements
         return json_encode($this);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/biobank/php/container.class.inc
+++ b/modules/biobank/php/container.class.inc
@@ -558,4 +558,12 @@ class Container implements
     {
         return json_encode($this);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/biobank/php/log.class.inc
+++ b/modules/biobank/php/log.class.inc
@@ -191,5 +191,12 @@ class Log implements \JsonSerializable, \LORIS\Data\DataInstance
     {
         return json_encode($this);
     }
-}
 
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
+}

--- a/modules/biobank/php/log.class.inc
+++ b/modules/biobank/php/log.class.inc
@@ -192,6 +192,13 @@ class Log implements \JsonSerializable, \LORIS\Data\DataInstance
         return json_encode($this);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/biobank/php/pool.class.inc
+++ b/modules/biobank/php/pool.class.inc
@@ -497,5 +497,12 @@ class Pool implements
     {
         return json_encode($this);
     }
-}
 
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
+}

--- a/modules/biobank/php/pool.class.inc
+++ b/modules/biobank/php/pool.class.inc
@@ -498,6 +498,13 @@ class Pool implements
         return json_encode($this);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/biobank/php/shipment.class.inc
+++ b/modules/biobank/php/shipment.class.inc
@@ -268,6 +268,13 @@ class Shipment implements
         return json_encode($this);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/biobank/php/shipment.class.inc
+++ b/modules/biobank/php/shipment.class.inc
@@ -267,5 +267,12 @@ class Shipment implements
     {
         return json_encode($this);
     }
-}
 
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
+}

--- a/modules/biobank/php/specimen.class.inc
+++ b/modules/biobank/php/specimen.class.inc
@@ -713,4 +713,12 @@ class Specimen implements
     {
         return json_encode($this);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/biobank/php/specimen.class.inc
+++ b/modules/biobank/php/specimen.class.inc
@@ -714,6 +714,13 @@ class Specimen implements
         return json_encode($this);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -80,4 +80,12 @@ class CandidateListRow implements \LORIS\Data\DataInstance,
     {
         return $this->ProjectID;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -81,6 +81,13 @@ class CandidateListRow implements \LORIS\Data\DataInstance,
         return $this->ProjectID;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -98,6 +98,13 @@ class ResolvedDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->projectid);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/conflict_resolver/php/models/resolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/resolveddto.class.inc
@@ -97,4 +97,12 @@ class ResolvedDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->projectid);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -94,6 +94,13 @@ class UnresolvedDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->projectid);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/conflict_resolver/php/models/unresolveddto.class.inc
+++ b/modules/conflict_resolver/php/models/unresolveddto.class.inc
@@ -93,4 +93,12 @@ class UnresolvedDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->projectid);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/data_release/php/datareleaserow.class.inc
+++ b/modules/data_release/php/datareleaserow.class.inc
@@ -50,6 +50,13 @@ class DataReleaseRow implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return true;

--- a/modules/data_release/php/datareleaserow.class.inc
+++ b/modules/data_release/php/datareleaserow.class.inc
@@ -49,4 +49,9 @@ class DataReleaseRow implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return true;
+    }
 }

--- a/modules/datadict/php/datadictrow.class.inc
+++ b/modules/datadict/php/datadictrow.class.inc
@@ -50,4 +50,10 @@ class DataDictRow implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasPermission('data_dict_view')
+            || $user->hasPermission('data_dict_edit');
+    }
 }

--- a/modules/datadict/php/datadictrow.class.inc
+++ b/modules/datadict/php/datadictrow.class.inc
@@ -51,6 +51,13 @@ class DataDictRow implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasPermission('data_dict_view')

--- a/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
@@ -77,6 +77,13 @@ class DICOMArchiveRowWithoutSession implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         if ($this->createdBy()->getId() === $user->getId()) {

--- a/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc
@@ -76,4 +76,14 @@ class DICOMArchiveRowWithoutSession implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        if ($this->createdBy()->getId() === $user->getId()) {
+            return true;
+        }
+
+        return $user->hasPermission('dicom_archive_view_allsites')
+            || $user->hasPermission('dicom_archive_nosessionid');
+    }
 }

--- a/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
@@ -114,6 +114,13 @@ class DICOMArchiveRowWithSession implements \LORIS\Data\DataInstance,
         return $this->CreatedBy;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowwithsession.class.inc
@@ -113,4 +113,12 @@ class DICOMArchiveRowWithSession implements \LORIS\Data\DataInstance,
     {
         return $this->CreatedBy;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/document_repository/php/docreporow.class.inc
+++ b/modules/document_repository/php/docreporow.class.inc
@@ -70,4 +70,12 @@ class DocRepoRow implements
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/document_repository/php/docreporow.class.inc
+++ b/modules/document_repository/php/docreporow.class.inc
@@ -71,6 +71,13 @@ class DocRepoRow implements
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
@@ -80,6 +80,13 @@ class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance,
         return $this->ProjectID;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
@@ -79,4 +79,12 @@ class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance,
     {
         return $this->ProjectID;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
@@ -193,6 +193,13 @@ class ElectrophysioFile implements \LORIS\Data\DataInstance
         return '';
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         $sessionID = $this->getParameter('SessionID');

--- a/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
+++ b/modules/electrophysiology_browser/php/models/electrophysiofile.class.inc
@@ -192,4 +192,28 @@ class ElectrophysioFile implements \LORIS\Data\DataInstance
     {
         return '';
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        $sessionID = $this->getParameter('SessionID');
+        if ($sessionID === '') {
+            return false;
+        }
+
+        try {
+            $timepoint = \NDB_Factory::singleton()->timepoint(
+                new \SessionID($sessionID)
+            );
+        } catch (\Throwable) {
+            return false;
+        }
+
+        return (
+            $user->hasPermission('electrophysiology_browser_view_allsites')
+            || (
+                $user->hasCenter($timepoint->getCenterID())
+                && $user->hasPermission('electrophysiology_browser_view_site')
+            )
+        ) && $user->hasProject($timepoint->getProject()->getId());
+    }
 }

--- a/modules/electrophysiology_uploader/php/electrophysiologyuploaderrow.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiologyuploaderrow.class.inc
@@ -67,4 +67,12 @@ class ElectrophysiologyUploaderRow
     {
         return $this->ProjectID;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/electrophysiology_uploader/php/electrophysiologyuploaderrow.class.inc
+++ b/modules/electrophysiology_uploader/php/electrophysiologyuploaderrow.class.inc
@@ -68,6 +68,13 @@ class ElectrophysiologyUploaderRow
         return $this->ProjectID;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/examiner/php/examinerrow.class.inc
+++ b/modules/examiner/php/examinerrow.class.inc
@@ -82,6 +82,13 @@ class ExaminerRow implements
         return $row;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/examiner/php/examinerrow.class.inc
+++ b/modules/examiner/php/examinerrow.class.inc
@@ -81,4 +81,12 @@ class ExaminerRow implements
         }
         return $row;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -259,6 +259,13 @@ class CnvDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->_projectID);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -258,4 +258,12 @@ class CnvDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->_projectID);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/filesdto.class.inc
+++ b/modules/genomic_browser/php/models/filesdto.class.inc
@@ -96,6 +96,13 @@ class FilesDTO implements DataInstance
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasAnyPermission(

--- a/modules/genomic_browser/php/models/filesdto.class.inc
+++ b/modules/genomic_browser/php/models/filesdto.class.inc
@@ -95,4 +95,14 @@ class FilesDTO implements DataInstance
             'Notes'            => $this->_Notes,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasAnyPermission(
+            [
+                'genomic_browser_view_allsites',
+                'genomic_browser_view_site',
+            ]
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/gwasdto.class.inc
+++ b/modules/genomic_browser/php/models/gwasdto.class.inc
@@ -114,4 +114,14 @@ class GwasDTO implements DataInstance
             'Pvalue'       => $this->_Pvalue,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasAnyPermission(
+            [
+                'genomic_browser_view_allsites',
+                'genomic_browser_view_site',
+            ]
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/gwasdto.class.inc
+++ b/modules/genomic_browser/php/models/gwasdto.class.inc
@@ -115,6 +115,13 @@ class GwasDTO implements DataInstance
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasAnyPermission(

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -322,4 +322,12 @@ class MethylationDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->_projectID);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -323,6 +323,13 @@ class MethylationDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->_projectID);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -158,4 +158,12 @@ class ProfileDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->_projectID);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -159,6 +159,13 @@ class ProfileDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->_projectID);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -309,4 +309,12 @@ class SnpDTO implements DataInstance, SiteHaver
     {
         return \ProjectID::singleton($this->_projectID);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -310,6 +310,13 @@ class SnpDTO implements DataInstance, SiteHaver
         return \ProjectID::singleton($this->_projectID);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/help_editor/php/helprow.class.inc
+++ b/modules/help_editor/php/helprow.class.inc
@@ -51,6 +51,13 @@ class HelpRow implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasPermission('context_help');

--- a/modules/help_editor/php/helprow.class.inc
+++ b/modules/help_editor/php/helprow.class.inc
@@ -50,4 +50,9 @@ class HelpRow implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasPermission('context_help');
+    }
 }

--- a/modules/imaging_browser/php/imagingbrowserrow.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrow.class.inc
@@ -89,6 +89,13 @@ class ImagingBrowserRow implements \LORIS\Data\DataInstance,
         return $this->DBRow['entityType'] === 'Scanner';
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/imaging_browser/php/imagingbrowserrow.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrow.class.inc
@@ -88,4 +88,12 @@ class ImagingBrowserRow implements \LORIS\Data\DataInstance,
     {
         return $this->DBRow['entityType'] === 'Scanner';
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/instrument_manager/php/instrumentrow.class.inc
+++ b/modules/instrument_manager/php/instrumentrow.class.inc
@@ -339,4 +339,9 @@ class InstrumentRow implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasAnyPermission(Instrument_Manager::PERMISSIONS);
+    }
 }

--- a/modules/instrument_manager/php/instrumentrow.class.inc
+++ b/modules/instrument_manager/php/instrumentrow.class.inc
@@ -340,6 +340,13 @@ class InstrumentRow implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasAnyPermission(Instrument_Manager::PERMISSIONS);

--- a/modules/issue_tracker/php/issuerow.class.inc
+++ b/modules/issue_tracker/php/issuerow.class.inc
@@ -68,6 +68,13 @@ class IssueRow implements
         return $this->Module;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/modules/issue_tracker/php/issuerow.class.inc
+++ b/modules/issue_tracker/php/issuerow.class.inc
@@ -67,4 +67,12 @@ class IssueRow implements
     {
         return $this->Module;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -59,4 +59,15 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
             'mime_type'   => $this->mime_type,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasAnyPermission(
+            [
+                'issue_tracker_all_issue',
+                'issue_tracker_own_issue',
+                'issue_tracker_site_issue',
+            ]
+        );
+    }
 }

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -60,6 +60,13 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasAnyPermission(

--- a/modules/media/php/mediafile.class.inc
+++ b/modules/media/php/mediafile.class.inc
@@ -89,6 +89,13 @@ class MediaFile implements \LORIS\Data\DataInstance,
         return 0;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/media/php/mediafile.class.inc
+++ b/modules/media/php/mediafile.class.inc
@@ -88,4 +88,12 @@ class MediaFile implements \LORIS\Data\DataInstance,
         }
         return 0;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/module_manager/php/modulerow.class.inc
+++ b/modules/module_manager/php/modulerow.class.inc
@@ -62,4 +62,9 @@ class ModuleRow implements \LORIS\Data\DataInstance
             'Active'   => $this->Active,
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasPermission('module_manager_edit');
+    }
 }

--- a/modules/module_manager/php/modulerow.class.inc
+++ b/modules/module_manager/php/modulerow.class.inc
@@ -63,6 +63,13 @@ class ModuleRow implements \LORIS\Data\DataInstance
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasPermission('module_manager_edit');

--- a/modules/mri_violations/php/mriviolation.class.inc
+++ b/modules/mri_violations/php/mriviolation.class.inc
@@ -59,4 +59,23 @@ class MRIViolation implements \LORIS\Data\DataInstance
         }
         return \ProjectID::singleton(intval($this->DBRow['Project']));
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        if ($user->hasPermission('violated_scans_view_allsites')) {
+            return true;
+        }
+
+        $center = $this->getCenterID();
+        if ($center !== null && !$user->hasCenter($center)) {
+            return false;
+        }
+
+        $project = $this->getProjectID();
+        if ($project !== null && !$user->hasProject($project)) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/modules/mri_violations/php/mriviolation.class.inc
+++ b/modules/mri_violations/php/mriviolation.class.inc
@@ -60,6 +60,13 @@ class MRIViolation implements \LORIS\Data\DataInstance
         return \ProjectID::singleton(intval($this->DBRow['Project']));
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         if ($user->hasPermission('violated_scans_view_allsites')) {

--- a/modules/mri_violations/php/protocolcheckviolation.class.inc
+++ b/modules/mri_violations/php/protocolcheckviolation.class.inc
@@ -44,4 +44,14 @@ class ProtocolCheckViolation implements \LORIS\Data\DataInstance
         }
         return \CenterID::singleton($this->DBRow['CenterID']);
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        if ($user->hasPermission('violated_scans_view_allsites')) {
+            return true;
+        }
+
+        $center = $this->getCenterID();
+        return $center === null || $user->hasCenter($center);
+    }
 }

--- a/modules/mri_violations/php/protocolcheckviolation.class.inc
+++ b/modules/mri_violations/php/protocolcheckviolation.class.inc
@@ -45,6 +45,13 @@ class ProtocolCheckViolation implements \LORIS\Data\DataInstance
         return \CenterID::singleton($this->DBRow['CenterID']);
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         if ($user->hasPermission('violated_scans_view_allsites')) {

--- a/modules/mri_violations/php/protocolviolation.class.inc
+++ b/modules/mri_violations/php/protocolviolation.class.inc
@@ -32,6 +32,13 @@ class ProtocolViolation implements \LORIS\Data\DataInstance
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasAnyPermission(

--- a/modules/mri_violations/php/protocolviolation.class.inc
+++ b/modules/mri_violations/php/protocolviolation.class.inc
@@ -31,4 +31,14 @@ class ProtocolViolation implements \LORIS\Data\DataInstance
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasAnyPermission(
+            [
+                'violated_scans_view_allsites',
+                'violated_scans_view_ownsite',
+            ]
+        );
+    }
 }

--- a/modules/schedule_module/php/schedulerow.class.inc
+++ b/modules/schedule_module/php/schedulerow.class.inc
@@ -127,6 +127,13 @@ class ScheduleRow implements \LORIS\Data\DataInstance,
         return $this->ProjectID;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/schedule_module/php/schedulerow.class.inc
+++ b/modules/schedule_module/php/schedulerow.class.inc
@@ -126,4 +126,12 @@ class ScheduleRow implements \LORIS\Data\DataInstance,
     {
         return $this->ProjectID;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -80,6 +80,13 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance,
         return $this->ProjectID;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -79,4 +79,12 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance,
     {
         return $this->ProjectID;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -63,6 +63,13 @@ class UserAccountRow implements
         return $this->DBRow;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(

--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -62,4 +62,12 @@ class UserAccountRow implements
     {
         return $this->DBRow;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerAndProjectMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/php/libraries/CohortData.class.inc
+++ b/php/libraries/CohortData.class.inc
@@ -73,6 +73,13 @@ class CohortData implements DataInstance
         ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return $user->hasPermission('config');

--- a/php/libraries/CohortData.class.inc
+++ b/php/libraries/CohortData.class.inc
@@ -72,4 +72,9 @@ class CohortData implements DataInstance
             "RecruitmentTarget" => $this->recruitmentTarget
         ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return $user->hasPermission('config');
+    }
 }

--- a/src/Data/DataInstance.php
+++ b/src/Data/DataInstance.php
@@ -27,6 +27,8 @@ namespace LORIS\Data;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-interface DataInstance extends \JsonSerializable
+interface DataInstance extends
+    \JsonSerializable,
+    \LORIS\StudyEntities\AccessibleResource
 {
 }

--- a/src/Data/Filters/AccessibleResourceFilter.php
+++ b/src/Data/Filters/AccessibleResourceFilter.php
@@ -36,14 +36,6 @@ class AccessibleResourceFilter implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        if (!($resource instanceof \LORIS\StudyEntities\AccessibleResource)) {
-            if ($this->defaultReturn === null) {
-                throw new \LorisException(
-                    "Resource is not an AccessibleResource instance"
-                );
-            }
-            return $this->defaultReturn;
-        }
         return $resource->isAccessibleBy($user);
     }
 }

--- a/src/Data/Models/DicomTarDTO.php
+++ b/src/Data/Models/DicomTarDTO.php
@@ -119,4 +119,9 @@ class DicomTarDTO implements \LORIS\Data\DataInstance
                 'series'      => $series,
                ];
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return true;
+    }
 }

--- a/src/Data/Models/DicomTarDTO.php
+++ b/src/Data/Models/DicomTarDTO.php
@@ -68,6 +68,7 @@ class DicomTarDTO implements \LORIS\Data\DataInstance
     {
         return $this->tarname;
     }
+
     /**
      * Accessor for ArchiveLocation
      *
@@ -120,6 +121,13 @@ class DicomTarDTO implements \LORIS\Data\DataInstance
                ];
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return true;

--- a/src/Data/Models/ImageDTO.php
+++ b/src/Data/Models/ImageDTO.php
@@ -173,4 +173,12 @@ class ImageDTO implements
     {
         return $this->entitytype === 'Scanner';
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/src/Data/Models/ImageDTO.php
+++ b/src/Data/Models/ImageDTO.php
@@ -47,14 +47,14 @@ class ImageDTO implements
     /**
      * Constructor
      *
-     * @param ?int    $fileid              The FileID
-     * @param ?string $filename            The image filename
-     * @param ?string $filelocation        The image location
-     * @param ?string $outputtype          The output type
-     * @param ?string $acquisitionprotocol The aquisition protocol
-     * @param ?string $filetype            The file type
+     * @param ?int      $fileid              The FileID
+     * @param ?string   $filename            The image filename
+     * @param ?string   $filelocation        The image location
+     * @param ?string   $outputtype          The output type
+     * @param ?string   $acquisitionprotocol The aquisition protocol
+     * @param ?string   $filetype            The file type
      * @param \CenterID $centerid            The image session's centerid
-     * @param ?string $entitytype          The image candidate's entity_type
+     * @param ?string   $entitytype          The image candidate's entity_type
      */
     public function __construct(
         ?int $fileid,
@@ -174,6 +174,13 @@ class ImageDTO implements
         return $this->entitytype === 'Scanner';
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/src/Data/Models/MRIUploadDTO.php
+++ b/src/Data/Models/MRIUploadDTO.php
@@ -167,4 +167,9 @@ class MRIUploadDTO implements \LORIS\Data\DataInstance
     {
         return $this->toJSON();
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return true;
+    }
 }

--- a/src/Data/Models/MRIUploadDTO.php
+++ b/src/Data/Models/MRIUploadDTO.php
@@ -168,6 +168,13 @@ class MRIUploadDTO implements \LORIS\Data\DataInstance
         return $this->toJSON();
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return true;

--- a/src/Data/Models/RecordingDTO.php
+++ b/src/Data/Models/RecordingDTO.php
@@ -163,4 +163,12 @@ class RecordingDTO implements
     {
         return $this->centerid;
     }
+
+    public function isAccessibleBy(\User $user): bool
+    {
+        return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(
+            $user,
+            $this
+        );
+    }
 }

--- a/src/Data/Models/RecordingDTO.php
+++ b/src/Data/Models/RecordingDTO.php
@@ -47,14 +47,14 @@ class RecordingDTO implements
     /**
      * Constructor
      *
-     * @param ?int    $fileid              The FileID
-     * @param ?string $filename            The image filename
-     * @param ?string $filelocation        The image location
-     * @param ?string $outputtype          The output type
-     * @param ?string $acquisitionmodality The aquisition modality
-     * @param ?string $filetype            The file type
+     * @param ?int      $fileid              The FileID
+     * @param ?string   $filename            The image filename
+     * @param ?string   $filelocation        The image location
+     * @param ?string   $outputtype          The output type
+     * @param ?string   $acquisitionmodality The aquisition modality
+     * @param ?string   $filetype            The file type
      * @param \CenterID $centerid            The image session's centerid
-     * @param ?string $entitytype          The image candidate's entity_type
+     * @param ?string   $entitytype          The image candidate's entity_type
      */
     public function __construct(
         ?int $fileid,
@@ -164,6 +164,13 @@ class RecordingDTO implements
         return $this->centerid;
     }
 
+    /**
+     * Check whether a user can access this data instance.
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
     public function isAccessibleBy(\User $user): bool
     {
         return \LORIS\StudyEntities\DataInstanceAccess::centerMatch(

--- a/src/StudyEntities/DataInstanceAccess.php
+++ b/src/StudyEntities/DataInstanceAccess.php
@@ -26,7 +26,12 @@ final class DataInstanceAccess
     {
         $centerData = self::getMethodValue(
             $resource,
-            ['getCenterIDs', 'getCenterIds', 'getCenterID', 'getCenterId']
+            [
+             'getCenterIDs',
+             'getCenterIds',
+             'getCenterID',
+             'getCenterId',
+            ]
         );
         if (!$centerData['found']) {
             return false;
@@ -61,7 +66,12 @@ final class DataInstanceAccess
     ): bool {
         $projectData = self::getMethodValue(
             $resource,
-            ['getProjectIDs', 'getProjectIds', 'getProjectID', 'getProjectId']
+            [
+             'getProjectIDs',
+             'getProjectIds',
+             'getProjectID',
+             'getProjectId',
+            ]
         );
         if (!$projectData['found']) {
             return false;
@@ -130,13 +140,22 @@ final class DataInstanceAccess
         foreach ($methods as $method) {
             if (method_exists($resource, $method)) {
                 try {
-                    return ['found' => true, 'value' => $resource->$method()];
+                    return [
+                            'found' => true,
+                            'value' => $resource->$method(),
+                           ];
                 } catch (\Throwable) {
-                    return ['found' => false, 'value' => null];
+                    return [
+                            'found' => false,
+                            'value' => null,
+                           ];
                 }
             }
         }
-        return ['found' => false, 'value' => null];
+        return [
+                'found' => false,
+                'value' => null,
+               ];
     }
 
     /**

--- a/src/StudyEntities/DataInstanceAccess.php
+++ b/src/StudyEntities/DataInstanceAccess.php
@@ -1,0 +1,231 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\StudyEntities;
+
+/**
+ * Utility helpers for DataInstance access checks.
+ */
+final class DataInstanceAccess
+{
+    /**
+     * Utility class.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Return true if the user has at least one matching center on the resource.
+     *
+     * @param \User  $user     User whose access is being checked.
+     * @param object $resource Data resource with center getters.
+     *
+     * @return bool
+     */
+    public static function centerMatch(\User $user, object $resource): bool
+    {
+        $centerData = self::getMethodValue(
+            $resource,
+            ['getCenterIDs', 'getCenterIds', 'getCenterID', 'getCenterId']
+        );
+        if (!$centerData['found']) {
+            return false;
+        }
+
+        $centers = self::normalizeCenters($centerData['value']);
+        if (count($centers) === 0) {
+            return false;
+        }
+
+        foreach ($centers as $center) {
+            if ($user->hasCenter($center)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true if the user has at least one matching project on the resource.
+     *
+     * @param \User  $user             User whose access is being checked.
+     * @param object $resource         Data resource with project getters.
+     * @param bool   $allowNullProject Whether null project means accessible.
+     *
+     * @return bool
+     */
+    public static function projectMatch(
+        \User $user,
+        object $resource,
+        bool $allowNullProject = false
+    ): bool {
+        $projectData = self::getMethodValue(
+            $resource,
+            ['getProjectIDs', 'getProjectIds', 'getProjectID', 'getProjectId']
+        );
+        if (!$projectData['found']) {
+            return false;
+        }
+
+        if ($projectData['value'] === null) {
+            return $allowNullProject;
+        }
+
+        $value = $projectData['value'];
+        if (!is_iterable($value)) {
+            $project = self::normalizeProject($value);
+            return $project !== null && $user->hasProject($project);
+        }
+
+        $projects = [];
+        foreach ($value as $project) {
+            if ($project === null && $allowNullProject) {
+                return true;
+            }
+            $normalized = self::normalizeProject($project);
+            if ($normalized !== null) {
+                $projects[] = $normalized;
+            }
+        }
+        if (count($projects) === 0) {
+            return false;
+        }
+
+        foreach ($projects as $project) {
+            if ($user->hasProject($project)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true if center and project access checks both pass.
+     *
+     * @param \User  $user             User whose access is being checked.
+     * @param object $resource         Data resource.
+     * @param bool   $allowNullProject Whether null project means accessible.
+     *
+     * @return bool
+     */
+    public static function centerAndProjectMatch(
+        \User $user,
+        object $resource,
+        bool $allowNullProject = false
+    ): bool {
+        return self::centerMatch($user, $resource)
+            && self::projectMatch($user, $resource, $allowNullProject);
+    }
+
+    /**
+     * Try calling the first existing method from a list of method names.
+     *
+     * @param object   $resource Object to read from.
+     * @param string[] $methods  Candidate method names.
+     *
+     * @return array{found: bool, value: mixed}
+     */
+    private static function getMethodValue(object $resource, array $methods): array
+    {
+        foreach ($methods as $method) {
+            if (method_exists($resource, $method)) {
+                try {
+                    return ['found' => true, 'value' => $resource->$method()];
+                } catch (\Throwable) {
+                    return ['found' => false, 'value' => null];
+                }
+            }
+        }
+        return ['found' => false, 'value' => null];
+    }
+
+    /**
+     * Normalize a center payload to a list of CenterID objects.
+     *
+     * @param mixed $value Center payload.
+     *
+     * @return \CenterID[]
+     */
+    private static function normalizeCenters(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if ($value instanceof \CenterID) {
+            return [$value];
+        }
+
+        if (!is_iterable($value)) {
+            $center = self::normalizeCenter($value);
+            return $center === null ? [] : [$center];
+        }
+
+        $centers = [];
+        foreach ($value as $center) {
+            $normalized = self::normalizeCenter($center);
+            if ($normalized !== null) {
+                $centers[] = $normalized;
+            }
+        }
+        return $centers;
+    }
+
+    /**
+     * Normalize one center value.
+     *
+     * @param mixed $center Center value.
+     *
+     * @return ?\CenterID
+     */
+    private static function normalizeCenter(mixed $center): ?\CenterID
+    {
+        if ($center instanceof \CenterID) {
+            return $center;
+        }
+        if (is_int($center)) {
+            try {
+                return \CenterID::singleton($center);
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+        if (is_string($center) && ctype_digit($center)) {
+            try {
+                return \CenterID::singleton((int) $center);
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalize one project value.
+     *
+     * @param mixed $project Project value.
+     *
+     * @return ?\ProjectID
+     */
+    private static function normalizeProject(mixed $project): ?\ProjectID
+    {
+        if ($project instanceof \ProjectID) {
+            return $project;
+        }
+        if (is_int($project)) {
+            try {
+                return \ProjectID::singleton($project);
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+        if (is_string($project) && ctype_digit($project)) {
+            try {
+                return \ProjectID::singleton((int) $project);
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/test/unittests/DataInstanceAccessTest.php
+++ b/test/unittests/DataInstanceAccessTest.php
@@ -5,15 +5,24 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for DataInstanceAccess helper methods.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class DataInstanceAccessTest extends TestCase
 {
     /**
+     * Verify center matching works with a single center getter.
+     *
      * @return void
      */
     public function testCenterMatchWithSingleCenter(): void
     {
         $resource = new class () {
+            /**
+             * Return center for this fake resource.
+             *
+             * @return \CenterID
+             */
             public function getCenterID(): \CenterID
             {
                 return \CenterID::singleton(1);
@@ -33,12 +42,16 @@ class DataInstanceAccessTest extends TestCase
     }
 
     /**
+     * Verify center matching succeeds when one center matches in a list.
+     *
      * @return void
      */
     public function testCenterMatchWithMultipleCenters(): void
     {
         $resource = new class () {
             /**
+             * Return center IDs for the anonymous test resource.
+             *
              * @return int[]
              */
             public function getCenterIDs(): array
@@ -59,11 +72,18 @@ class DataInstanceAccessTest extends TestCase
     }
 
     /**
+     * Verify project matching accepts scalar project IDs.
+     *
      * @return void
      */
     public function testProjectMatchWithScalarProject(): void
     {
         $resource = new class () {
+            /**
+             * Return project for this fake resource.
+             *
+             * @return int
+             */
             public function getProjectID(): int
             {
                 return 3;
@@ -83,11 +103,18 @@ class DataInstanceAccessTest extends TestCase
     }
 
     /**
+     * Verify allowNullProject behavior for null project IDs.
+     *
      * @return void
      */
     public function testProjectMatchHandlesNullProjectByFlag(): void
     {
         $resource = new class () {
+            /**
+             * Return null project for this fake resource.
+             *
+             * @return ?\ProjectID
+             */
             public function getProjectID(): ?\ProjectID
             {
                 return null;
@@ -105,16 +132,28 @@ class DataInstanceAccessTest extends TestCase
     }
 
     /**
+     * Verify combined center/project matching requires both checks.
+     *
      * @return void
      */
     public function testCenterAndProjectMatchRequiresBoth(): void
     {
         $resource = new class () {
+            /**
+             * Return center for this fake resource.
+             *
+             * @return \CenterID
+             */
             public function getCenterID(): \CenterID
             {
                 return \CenterID::singleton(1);
             }
 
+            /**
+             * Return project for this fake resource.
+             *
+             * @return \ProjectID
+             */
             public function getProjectID(): \ProjectID
             {
                 return \ProjectID::singleton(2);
@@ -128,10 +167,14 @@ class DataInstanceAccessTest extends TestCase
         $user->method('hasCenter')->willReturn(true);
         $user->method('hasProject')->willReturn(false);
 
-        $this->assertFalse(DataInstanceAccess::centerAndProjectMatch($user, $resource));
+        $this->assertFalse(
+            DataInstanceAccess::centerAndProjectMatch($user, $resource)
+        );
     }
 
     /**
+     * Verify missing center/project getters fail closed.
+     *
      * @return void
      */
     public function testMissingGettersReturnFalse(): void
@@ -151,16 +194,28 @@ class DataInstanceAccessTest extends TestCase
     }
 
     /**
+     * Verify invalid scalar IDs fail closed.
+     *
      * @return void
      */
     public function testInvalidScalarIdentifiersReturnFalse(): void
     {
         $resource = new class () {
+            /**
+             * Return invalid center value for this fake resource.
+             *
+             * @return string
+             */
             public function getCenterID(): string
             {
                 return 'invalid-center';
             }
 
+            /**
+             * Return invalid project value for this fake resource.
+             *
+             * @return string
+             */
             public function getProjectID(): string
             {
                 return 'invalid-project';
@@ -176,15 +231,24 @@ class DataInstanceAccessTest extends TestCase
 
         $this->assertFalse(DataInstanceAccess::centerMatch($user, $resource));
         $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource));
-        $this->assertFalse(DataInstanceAccess::centerAndProjectMatch($user, $resource));
+        $this->assertFalse(
+            DataInstanceAccess::centerAndProjectMatch($user, $resource)
+        );
     }
 
     /**
+     * Verify thrown getter exceptions fail closed.
+     *
      * @return void
      */
     public function testThrowingGetterReturnsFalse(): void
     {
         $resource = new class () {
+            /**
+             * Throw to simulate broken accessor implementation.
+             *
+             * @return ?\ProjectID
+             */
             public function getProjectID(): ?\ProjectID
             {
                 throw new \RuntimeException('broken getter');

--- a/test/unittests/DataInstanceAccessTest.php
+++ b/test/unittests/DataInstanceAccessTest.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types=1);
+
+use LORIS\StudyEntities\DataInstanceAccess;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DataInstanceAccess helper methods.
+ */
+class DataInstanceAccessTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testCenterMatchWithSingleCenter(): void
+    {
+        $resource = new class () {
+            public function getCenterID(): \CenterID
+            {
+                return \CenterID::singleton(1);
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasCenter'])
+            ->getMock();
+        $user->expects($this->once())
+            ->method('hasCenter')
+            ->with(\CenterID::singleton(1))
+            ->willReturn(true);
+
+        $this->assertTrue(DataInstanceAccess::centerMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCenterMatchWithMultipleCenters(): void
+    {
+        $resource = new class () {
+            /**
+             * @return int[]
+             */
+            public function getCenterIDs(): array
+            {
+                return [5, 7];
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasCenter'])
+            ->getMock();
+        $user->expects($this->exactly(2))
+            ->method('hasCenter')
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $this->assertTrue(DataInstanceAccess::centerMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testProjectMatchWithScalarProject(): void
+    {
+        $resource = new class () {
+            public function getProjectID(): int
+            {
+                return 3;
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasProject'])
+            ->getMock();
+        $user->expects($this->once())
+            ->method('hasProject')
+            ->with(\ProjectID::singleton(3))
+            ->willReturn(true);
+
+        $this->assertTrue(DataInstanceAccess::projectMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testProjectMatchHandlesNullProjectByFlag(): void
+    {
+        $resource = new class () {
+            public function getProjectID(): ?\ProjectID
+            {
+                return null;
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasProject'])
+            ->getMock();
+        $user->expects($this->never())->method('hasProject');
+
+        $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource));
+        $this->assertTrue(DataInstanceAccess::projectMatch($user, $resource, true));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCenterAndProjectMatchRequiresBoth(): void
+    {
+        $resource = new class () {
+            public function getCenterID(): \CenterID
+            {
+                return \CenterID::singleton(1);
+            }
+
+            public function getProjectID(): \ProjectID
+            {
+                return \ProjectID::singleton(2);
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasCenter', 'hasProject'])
+            ->getMock();
+        $user->method('hasCenter')->willReturn(true);
+        $user->method('hasProject')->willReturn(false);
+
+        $this->assertFalse(DataInstanceAccess::centerAndProjectMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingGettersReturnFalse(): void
+    {
+        $resource = new class () {
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasCenter', 'hasProject'])
+            ->getMock();
+        $user->expects($this->never())->method('hasCenter');
+        $user->expects($this->never())->method('hasProject');
+
+        $this->assertFalse(DataInstanceAccess::centerMatch($user, $resource));
+        $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testInvalidScalarIdentifiersReturnFalse(): void
+    {
+        $resource = new class () {
+            public function getCenterID(): string
+            {
+                return 'invalid-center';
+            }
+
+            public function getProjectID(): string
+            {
+                return 'invalid-project';
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasCenter', 'hasProject'])
+            ->getMock();
+        $user->expects($this->never())->method('hasCenter');
+        $user->expects($this->never())->method('hasProject');
+
+        $this->assertFalse(DataInstanceAccess::centerMatch($user, $resource));
+        $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource));
+        $this->assertFalse(DataInstanceAccess::centerAndProjectMatch($user, $resource));
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowingGetterReturnsFalse(): void
+    {
+        $resource = new class () {
+            public function getProjectID(): ?\ProjectID
+            {
+                throw new \RuntimeException('broken getter');
+            }
+        };
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasProject'])
+            ->getMock();
+        $user->expects($this->never())->method('hasProject');
+
+        $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource));
+        $this->assertFalse(DataInstanceAccess::projectMatch($user, $resource, true));
+    }
+}

--- a/test/unittests/DataInstanceBehaviorTest.php
+++ b/test/unittests/DataInstanceBehaviorTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/../../modules/mri_violations/php/mriviolation.class.inc';
+require_once __DIR__ . '/../../modules/mri_violations/php/protocolcheckviolation.class.inc';
+require_once __DIR__ . '/../../modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc';
+
+use LORIS\dicom_archive\DICOMArchiveRowWithoutSession;
+use LORIS\mri_violations\MRIViolation;
+use LORIS\mri_violations\ProtocolCheckViolation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Targeted behaviour tests for custom DataInstance access implementations.
+ */
+class DataInstanceBehaviorTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testMRIViolationAccessibleWithMatchingCenterAndProject(): void
+    {
+        $resource = new MRIViolation(
+            [
+                'Site'    => 1,
+                'Project' => 2,
+            ]
+        );
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasPermission', 'hasCenter', 'hasProject'])
+            ->getMock();
+        $user->method('hasPermission')->willReturn(false);
+        $user->method('hasCenter')->willReturn(true);
+        $user->method('hasProject')->willReturn(true);
+
+        $this->assertTrue($resource->isAccessibleBy($user));
+    }
+
+    /**
+     * @return void
+     */
+    public function testMRIViolationDeniedOnCenterMismatchWithoutAllSites(): void
+    {
+        $resource = new MRIViolation(
+            [
+                'Site'    => 1,
+                'Project' => 2,
+            ]
+        );
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasPermission', 'hasCenter', 'hasProject'])
+            ->getMock();
+        $user->method('hasPermission')->willReturn(false);
+        $user->method('hasCenter')->willReturn(false);
+        $user->expects($this->never())->method('hasProject');
+
+        $this->assertFalse($resource->isAccessibleBy($user));
+    }
+
+    /**
+     * @return void
+     */
+    public function testProtocolCheckViolationAllowsNullCenter(): void
+    {
+        $resource = new ProtocolCheckViolation(['CenterID' => null]);
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['hasPermission', 'hasCenter'])
+            ->getMock();
+        $user->method('hasPermission')->willReturn(false);
+        $user->expects($this->never())->method('hasCenter');
+
+        $this->assertTrue($resource->isAccessibleBy($user));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDicomWithoutSessionAccessibleByCreator(): void
+    {
+        $creator = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->getMock();
+        $creator->method('getId')->willReturn(9);
+
+        $resource = new DICOMArchiveRowWithoutSession([], $creator);
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'hasPermission'])
+            ->getMock();
+        $user->method('getId')->willReturn(9);
+        $user->expects($this->never())->method('hasPermission');
+
+        $this->assertTrue($resource->isAccessibleBy($user));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDicomWithoutSessionAccessibleByPermission(): void
+    {
+        $creator = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->getMock();
+        $creator->method('getId')->willReturn(3);
+
+        $resource = new DICOMArchiveRowWithoutSession([], $creator);
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'hasPermission'])
+            ->getMock();
+        $user->method('getId')->willReturn(11);
+        $user->method('hasPermission')->willReturnMap(
+            [
+                ['dicom_archive_view_allsites', true],
+                ['dicom_archive_nosessionid', false],
+            ]
+        );
+
+        $this->assertTrue($resource->isAccessibleBy($user));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDicomWithoutSessionDeniedWithoutCreatorOrPermissions(): void
+    {
+        $creator = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->getMock();
+        $creator->method('getId')->willReturn(3);
+
+        $resource = new DICOMArchiveRowWithoutSession([], $creator);
+
+        $user = $this->getMockBuilder(\User::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'hasPermission'])
+            ->getMock();
+        $user->method('getId')->willReturn(11);
+        $user->method('hasPermission')->willReturn(false);
+
+        $this->assertFalse($resource->isAccessibleBy($user));
+    }
+}

--- a/test/unittests/DataInstanceBehaviorTest.php
+++ b/test/unittests/DataInstanceBehaviorTest.php
@@ -1,8 +1,11 @@
 <?php declare(strict_types=1);
 
-require_once __DIR__ . '/../../modules/mri_violations/php/mriviolation.class.inc';
-require_once __DIR__ . '/../../modules/mri_violations/php/protocolcheckviolation.class.inc';
-require_once __DIR__ . '/../../modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc';
+require_once __DIR__
+    . '/../../modules/mri_violations/php/mriviolation.class.inc';
+require_once __DIR__
+    . '/../../modules/mri_violations/php/protocolcheckviolation.class.inc';
+require_once __DIR__
+    . '/../../modules/dicom_archive/php/dicomarchiverowwithoutsession.class.inc';
 
 use LORIS\dicom_archive\DICOMArchiveRowWithoutSession;
 use LORIS\mri_violations\MRIViolation;
@@ -11,10 +14,14 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Targeted behaviour tests for custom DataInstance access implementations.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class DataInstanceBehaviorTest extends TestCase
 {
     /**
+     * Verify MRI violations allow matching center/project access.
+     *
      * @return void
      */
     public function testMRIViolationAccessibleWithMatchingCenterAndProject(): void
@@ -38,6 +45,8 @@ class DataInstanceBehaviorTest extends TestCase
     }
 
     /**
+     * Verify MRI violations deny center mismatch without all-sites permission.
+     *
      * @return void
      */
     public function testMRIViolationDeniedOnCenterMismatchWithoutAllSites(): void
@@ -61,6 +70,8 @@ class DataInstanceBehaviorTest extends TestCase
     }
 
     /**
+     * Verify protocol check violations allow rows with null center.
+     *
      * @return void
      */
     public function testProtocolCheckViolationAllowsNullCenter(): void
@@ -78,6 +89,8 @@ class DataInstanceBehaviorTest extends TestCase
     }
 
     /**
+     * Verify DICOM no-session rows are accessible by their creator.
+     *
      * @return void
      */
     public function testDicomWithoutSessionAccessibleByCreator(): void
@@ -101,6 +114,8 @@ class DataInstanceBehaviorTest extends TestCase
     }
 
     /**
+     * Verify DICOM no-session rows are accessible via explicit permissions.
+     *
      * @return void
      */
     public function testDicomWithoutSessionAccessibleByPermission(): void
@@ -129,6 +144,8 @@ class DataInstanceBehaviorTest extends TestCase
     }
 
     /**
+     * Verify DICOM no-session rows are denied without creator/permission.
+     *
      * @return void
      */
     public function testDicomWithoutSessionDeniedWithoutCreatorOrPermissions(): void

--- a/test/unittests/DataInstanceContractTest.php
+++ b/test/unittests/DataInstanceContractTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates the DataInstance contract is consistently implemented.
+ */
+class DataInstanceContractTest extends TestCase
+{
+    /**
+     * Ensure DataInstance extends AccessibleResource.
+     *
+     * @return void
+     */
+    public function testDataInstanceExtendsAccessibleResource(): void
+    {
+        $interfaces = class_implements(\LORIS\Data\DataInstance::class);
+        $this->assertContains(
+            \LORIS\StudyEntities\AccessibleResource::class,
+            $interfaces
+        );
+    }
+
+    /**
+     * Ensure each DataInstance class declares isAccessibleBy with a bool return.
+     *
+     * @return void
+     */
+    public function testAllDataInstancesDeclareIsAccessibleBy(): void
+    {
+        $files = $this->getDataInstanceFiles();
+        $this->assertNotEmpty($files, 'No DataInstance classes found');
+
+        $pattern = '/public\\s+function\\s+isAccessibleBy\\s*\\(\\s*\\\\User\\s+\\$user\\s*\\)\\s*:\\s*bool/s';
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
+            $this->assertNotFalse($contents, "Unable to read file: $file");
+            $this->assertMatchesRegularExpression(
+                $pattern,
+                $contents,
+                "Missing required isAccessibleBy signature in $file"
+            );
+        }
+    }
+
+    /**
+     * Discover PHP files containing DataInstance implementations.
+     *
+     * @return string[]
+     */
+    private function getDataInstanceFiles(): array
+    {
+        $roots = [
+            __DIR__ . '/../../src',
+            __DIR__ . '/../../php',
+            __DIR__ . '/../../modules',
+        ];
+
+        $matches = [];
+        $classPattern = '/class\\s+\\w+(?:\\s+extends\\s+[\\w\\\\]+)?\\s+implements[\\s\\S]{0,250}?DataInstance[\\s\\S]{0,120}?\\{/s';
+
+        foreach ($roots as $root) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($root)
+            );
+            foreach ($iterator as $file) {
+                $extension = strtolower($file->getExtension());
+                if (
+                    !$file->isFile()
+                    || !in_array($extension, ['php', 'inc'], true)
+                ) {
+                    continue;
+                }
+
+                $path = $file->getPathname();
+                $contents = file_get_contents($path);
+                if ($contents === false) {
+                    continue;
+                }
+                if (preg_match($classPattern, $contents) === 1) {
+                    $matches[] = $path;
+                }
+            }
+        }
+
+        sort($matches);
+        return $matches;
+    }
+}

--- a/test/unittests/DataInstanceContractTest.php
+++ b/test/unittests/DataInstanceContractTest.php
@@ -4,6 +4,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Validates the DataInstance contract is consistently implemented.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class DataInstanceContractTest extends TestCase
 {
@@ -28,10 +30,11 @@ class DataInstanceContractTest extends TestCase
      */
     public function testAllDataInstancesDeclareIsAccessibleBy(): void
     {
-        $files = $this->getDataInstanceFiles();
+        $files = $this->_getDataInstanceFiles();
         $this->assertNotEmpty($files, 'No DataInstance classes found');
 
-        $pattern = '/public\\s+function\\s+isAccessibleBy\\s*\\(\\s*\\\\User\\s+\\$user\\s*\\)\\s*:\\s*bool/s';
+        $pattern = '/public\\s+function\\s+isAccessibleBy\\s*\\('
+            . '\\s*\\\\User\\s+\\$user\\s*\\)\\s*:\\s*bool/s';
         foreach ($files as $file) {
             $contents = file_get_contents($file);
             $this->assertNotFalse($contents, "Unable to read file: $file");
@@ -48,7 +51,7 @@ class DataInstanceContractTest extends TestCase
      *
      * @return string[]
      */
-    private function getDataInstanceFiles(): array
+    private function _getDataInstanceFiles(): array
     {
         $roots = [
             __DIR__ . '/../../src',
@@ -56,8 +59,9 @@ class DataInstanceContractTest extends TestCase
             __DIR__ . '/../../modules',
         ];
 
-        $matches = [];
-        $classPattern = '/class\\s+\\w+(?:\\s+extends\\s+[\\w\\\\]+)?\\s+implements[\\s\\S]{0,250}?DataInstance[\\s\\S]{0,120}?\\{/s';
+        $matches      = [];
+        $classPattern = '/class\\s+\\w+(?:\\s+extends\\s+[\\w\\\\]+)?\\s+'
+            . 'implements[\\s\\S]{0,250}?DataInstance[\\s\\S]{0,120}?\\{/s';
 
         foreach ($roots as $root) {
             $iterator = new RecursiveIteratorIterator(
@@ -65,14 +69,13 @@ class DataInstanceContractTest extends TestCase
             );
             foreach ($iterator as $file) {
                 $extension = strtolower($file->getExtension());
-                if (
-                    !$file->isFile()
+                if (!$file->isFile()
                     || !in_array($extension, ['php', 'inc'], true)
                 ) {
                     continue;
                 }
 
-                $path = $file->getPathname();
+                $path     = $file->getPathname();
                 $contents = file_get_contents($path);
                 if ($contents === false) {
                     continue;


### PR DESCRIPTION
## Brief summary of changes

1. Updated the `DataInstance` contract to extend both `\JsonSerializable` and `\LORIS\StudyEntities\AccessibleResource`, making `isAccessibleBy(\User): bool` mandatory for all implementers.
2. Simplified `src/Data/Filters/AccessibleResourceFilter.php` by removing the runtime `instanceof AccessibleResource` guard and calling `isAccessibleBy()` directly.
3. Added `src/StudyEntities/DataInstanceAccess.php` to centralize common center/project access checks (including getter variants and scalar ID normalization with fail-closed behavior).
4. Added `isAccessibleBy()` implementations for all previously missing `DataInstance` classes, using shared helper logic for standard cases and explicit custom logic for exceptions (e.g., MRI violations, protocol-check violations, DICOM no-session rows, permission-gated DTOs).
5. Added coverage with new unit tests for:
  i. contract enforcement (`DataInstanceContractTest`)
  ii. helper behavior (`DataInstanceAccessTest`)
  iii. custom exception behavior (`DataInstanceBehaviorTest`)

#### Testing instructions (if applicable)
1. Run:
   `docker compose run -T --rm unit-tests vendor/bin/phpunit --configuration test/phpunit.xml test/unittests/DataInstanceContractTest.php test/unittests/DataInstanceAccessTest.php test/unittests/DataInstanceBehaviorTest.php`
6. Result: targeted Docker unit tests for contract + helper + exception-path behavior passed: `OK (16 tests, 139 assertions)`

#### Link(s) to related issue(s)

* Resolves #9511
