### PR TITLE
Add PHP 8.5 support, remove 8.3 from tests

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.4', '8.5']
         apiversion: ['v0.0.3', 'v0.0.4-dev']
     steps:
     - uses: actions/checkout@v4
@@ -220,7 +220,7 @@ jobs:
         fail-fast: false
         matrix:
             testsuite: ['integration']
-            php: ['8.3', '8.4']
+            php: ['8.4', '8.5']
             ci_node_index: [0,1,2,3]
 
             include:
@@ -228,13 +228,13 @@ jobs:
             - ci_node_total: 4
 
             - testsuite: 'static'
-              php: '8.3'
+              php: '8.4'
             - testsuite: 'unit'
-              php: '8.3'
+              php: '8.4'
             - testsuite: 'static'
-              php: '8.4'
+              php: '8.5'
             - testsuite: 'unit'
-              php: '8.4'
+              php: '8.5'
 
     steps:
     - uses: actions/checkout@v4

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -43,15 +43,11 @@ return [
         "test"
     ],
     'exclude_file_list' => [
-        'vendor/squizlabs/php_codesniffer/tests/Core/Tokenizer/DoubleQuotedStringTest.inc'
+        'vendor/squizlabs/php_codesniffer/tests/Core/Tokenizer/DoubleQuotedStringTest.inc',
+	'vendor/squizlabs/php_codesniffer/tests/Core/Tokenizers/PHP/OtherContextSensitiveKeywordsTest.inc',
     ],
     "exclude_analysis_directory_list" => [
         "vendor"
-    ],
-    "autoload_internal_extension_signatures" => [
-        // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,
-        // because Phan disables xdebug by default.
-        "xdebug"     => "vendor/phan/phan/.phan/internal_stubs/xdebug.phan_php",
     ],
     "plugins" => [
         "UnreachableCodePlugin",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev" : {
         "squizlabs/php_codesniffer" : "^3.5",
         "phpunit/phpunit" : "12.5.8",
-        "phan/phan": "^5.0",
+        "phan/phan": "^6.0",
         "phpstan/phpstan": "^1.4",
         "slevomat/coding-standard": "^6.4",
         "php-webdriver/webdriver" : "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da47d12add28cd287870782f73699245",
+    "content-hash": "4a2807b3bd33717057d85c1d0a01a18a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.359.1",
+            "version": "3.379.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "40543e3993fc5094094ac9f9bdc4434bf81cca2d"
+                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/40543e3993fc5094094ac9f9bdc4434bf81cca2d",
-                "reference": "40543e3993fc5094094ac9f9bdc4434bf81cca2d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
+                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
                 "shasum": ""
             },
             "require": {
@@ -84,24 +84,23 @@
                 "guzzlehttp/psr7": "^2.4.5",
                 "mtdowling/jmespath.php": "^2.8.0",
                 "php": ">=8.1",
-                "psr/http-message": "^1.0 || ^2.0"
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
             },
             "require-dev": {
                 "andrewsville/php-token-reflection": "^1.4",
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
-                "ext-pcntl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^v6.4.0 || ^v7.1.0",
                 "yoast/phpunit-polyfills": "^2.0"
             },
             "suggest": {
@@ -109,6 +108,7 @@
                 "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
                 "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
                 "ext-sockets": "To use client-side monitoring"
             },
             "type": "library",
@@ -135,11 +135,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.359.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.379.0"
             },
-            "time": "2025-10-29T20:13:06+00:00"
+            "time": "2026-04-13T18:11:10+00:00"
         },
         {
             "name": "bjeavons/zxcvbn-php",
@@ -215,16 +215,16 @@
         },
         {
             "name": "chillerlan/php-qrcode",
-            "version": "5.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chillerlan/php-qrcode.git",
-                "reference": "390393e97a6e42ccae0e0d6205b8d4200f7ddc43"
+                "reference": "7b66282572fc14075c0507d74d9837dab25b38d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chillerlan/php-qrcode/zipball/390393e97a6e42ccae0e0d6205b8d4200f7ddc43",
-                "reference": "390393e97a6e42ccae0e0d6205b8d4200f7ddc43",
+                "url": "https://api.github.com/repos/chillerlan/php-qrcode/zipball/7b66282572fc14075c0507d74d9837dab25b38d6",
+                "reference": "7b66282572fc14075c0507d74d9837dab25b38d6",
                 "shasum": ""
             },
             "require": {
@@ -235,7 +235,7 @@
             "require-dev": {
                 "chillerlan/php-authenticator": "^4.3.1 || ^5.2.1",
                 "ext-fileinfo": "*",
-                "phan/phan": "^5.5.1",
+                "phan/phan": "^5.5.2",
                 "phpcompatibility/php-compatibility": "10.x-dev",
                 "phpmd/phpmd": "^2.15",
                 "phpunit/phpunit": "^9.6",
@@ -304,20 +304,20 @@
                     "type": "Ko-Fi"
                 }
             ],
-            "time": "2025-09-19T17:30:27+00:00"
+            "time": "2025-11-23T23:51:44+00:00"
         },
         {
             "name": "chillerlan/php-settings-container",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/chillerlan/php-settings-container.git",
-                "reference": "95ed3e9676a1d47cab2e3174d19b43f5dbf52681"
+                "reference": "a0a487cbf5344f721eb504bf0f59bada40c381b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/95ed3e9676a1d47cab2e3174d19b43f5dbf52681",
-                "reference": "95ed3e9676a1d47cab2e3174d19b43f5dbf52681",
+                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/a0a487cbf5344f721eb504bf0f59bada40c381b7",
+                "reference": "a0a487cbf5344f721eb504bf0f59bada40c381b7",
                 "shasum": ""
             },
             "require": {
@@ -325,11 +325,13 @@
                 "php": "^8.1"
             },
             "require-dev": {
+                "phan/phan": "^5.5.2",
                 "phpmd/phpmd": "^2.15",
-                "phpstan/phpstan": "^1.11",
-                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpstan/phpstan": "^2.1.31",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
                 "phpunit/phpunit": "^10.5",
-                "squizlabs/php_codesniffer": "^3.10"
+                "slevomat/coding-standard": "^8.22",
+                "squizlabs/php_codesniffer": "^4.0"
             },
             "type": "library",
             "autoload": {
@@ -354,7 +356,8 @@
                 "Settings",
                 "configuration",
                 "container",
-                "helper"
+                "helper",
+                "property hook"
             ],
             "support": {
                 "issues": "https://github.com/chillerlan/php-settings-container/issues",
@@ -370,20 +373,20 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2024-07-16T11:13:48+00:00"
+            "time": "2026-03-20T21:10:52+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v7.0.2",
+            "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "5645b43af647b6947daac1d0f659dd1fbe8d3b65"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5645b43af647b6947daac1d0f659dd1fbe8d3b65",
-                "reference": "5645b43af647b6947daac1d0f659dd1fbe8d3b65",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
             "require": {
@@ -391,6 +394,7 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -430,37 +434,37 @@
                 "php"
             ],
             "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v7.0.2"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
             },
-            "time": "2025-12-16T22:17:28+00:00"
+            "time": "2026-04-01T20:38:03+00:00"
         },
         {
             "name": "google/recaptcha",
-            "version": "1.3.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/google/recaptcha.git",
-                "reference": "56522c261d2e8c58ba416c90f81a4cd9f2ed89b9"
+                "reference": "8c021a6df19c49f1ddfae3ee0c28ccffe381db25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/google/recaptcha/zipball/56522c261d2e8c58ba416c90f81a4cd9f2ed89b9",
-                "reference": "56522c261d2e8c58ba416c90f81a4cd9f2ed89b9",
+                "url": "https://api.github.com/repos/google/recaptcha/zipball/8c021a6df19c49f1ddfae3ee0c28ccffe381db25",
+                "reference": "8c021a6df19c49f1ddfae3ee0c28ccffe381db25",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.14",
-                "php-coveralls/php-coveralls": "^2.5",
-                "phpunit/phpunit": "^10"
+                "friendsofphp/php-cs-fixer": "^3.94",
+                "php-coveralls/php-coveralls": "^2.9",
+                "phpunit/phpunit": "^13"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-main": "1.4.x-dev"
                 }
             },
             "autoload": {
@@ -485,7 +489,7 @@
                 "issues": "https://github.com/google/recaptcha/issues",
                 "source": "https://github.com/google/recaptcha"
             },
-            "time": "2025-06-26T22:21:57+00:00"
+            "time": "2026-03-20T13:27:02+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -698,16 +702,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -723,6 +727,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -794,7 +799,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -810,7 +815,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1689,17 +1694,170 @@
             "time": "2024-09-25T14:21:43+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "name": "symfony/filesystem",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -1751,7 +1909,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -1771,7 +1929,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         }
     ],
     "packages-dev": [
@@ -1998,6 +2156,58 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
+            },
+            "time": "2026-01-12T21:07:10+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
             "source": {
@@ -2073,51 +2283,6 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
-            "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "shasum": ""
-            },
-            "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AdvancedJsonRpc\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Felix Becker",
-                    "email": "felix.b@outlook.com"
-                }
-            ],
-            "description": "A more advanced JSONRPC implementation",
-            "support": {
-                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
-            },
-            "time": "2021-06-11T22:34:44+00:00"
-        },
-        {
             "name": "guzzlehttp/streams",
             "version": "3.0.0",
             "source": {
@@ -2171,51 +2336,6 @@
             },
             "abandoned": true,
             "time": "2014-10-12T19:18:40+00:00"
-        },
-        {
-            "name": "microsoft/tolerant-php-parser",
-            "version": "v0.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/microsoft/tolerant-php-parser.git",
-                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/3eccfd273323aaf69513e2f1c888393f5947804b",
-                "reference": "3eccfd273323aaf69513e2f1c888393f5947804b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.15"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Microsoft\\PhpParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rob Lourens",
-                    "email": "roblou@microsoft.com"
-                }
-            ],
-            "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "support": {
-                "issues": "https://github.com/microsoft/tolerant-php-parser/issues",
-                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.1.2"
-            },
-            "time": "2022-10-05T17:30:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2279,16 +2399,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.5.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
                 "shasum": ""
             },
             "require": {
@@ -2324,9 +2444,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
             },
-            "time": "2024-09-08T10:13:13+00:00"
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2388,39 +2508,42 @@
         },
         {
             "name": "phan/phan",
-            "version": "5.5.2",
+            "version": "6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "25d7e8d185a4c78e7423c188fb28bba5dbde20c1"
+                "reference": "ebaecc75c999c51f7e649625b383ca8e95b45bc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/25d7e8d185a4c78e7423c188fb28bba5dbde20c1",
-                "reference": "25d7e8d185a4c78e7423c188fb28bba5dbde20c1",
+                "url": "https://api.github.com/repos/phan/phan/zipball/ebaecc75c999c51f7e649625b383ca8e95b45bc7",
+                "reference": "ebaecc75c999c51f7e649625b383ca8e95b45bc7",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^1.4|^2.0|^3.0",
                 "composer/xdebug-handler": "^2.0|^3.0",
+                "danog/advanced-json-rpc": "^3.0.4",
                 "ext-filter": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "felixfbecker/advanced-json-rpc": "^3.0.4",
-                "microsoft/tolerant-php-parser": "0.1.2",
                 "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0|^4.0|^5.0",
-                "php": "^7.2.0|^8.0.0",
-                "sabre/event": "^5.1.3",
-                "symfony/console": "^3.2|^4.0|^5.0|^6.0|^7.0",
+                "phan/tolerant-php-parser": "v0.2.0",
+                "phan/var_representation_polyfill": "^0.1.4",
+                "php": "^8.1.0",
+                "sabre/event": "^5.1.3|^6.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
                 "symfony/polyfill-mbstring": "^1.11.0",
-                "symfony/polyfill-php80": "^1.20.0",
-                "tysonandre/var_representation_polyfill": "^0.0.2|^0.1.0"
+                "symfony/string": "^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "microsoft/tolerant-php-parser": "*"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.0"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
-                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.0.1+ is needed, 1.0.16+ is recommended.",
+                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.1.3+ is needed.",
                 "ext-iconv": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
                 "ext-igbinary": "Improves performance of polyfill when ext-ast is unavailable",
                 "ext-mbstring": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
@@ -2434,6 +2557,9 @@
             ],
             "type": "project",
             "autoload": {
+                "files": [
+                    "src/Phan/bootstrap/polyfills.php"
+                ],
                 "psr-4": {
                     "Phan\\": "src/Phan"
                 }
@@ -2462,9 +2588,113 @@
             ],
             "support": {
                 "issues": "https://github.com/phan/phan/issues",
-                "source": "https://github.com/phan/phan/tree/5.5.2"
+                "source": "https://github.com/phan/phan/tree/6.0.5"
             },
-            "time": "2025-10-04T18:04:38+00:00"
+            "time": "2026-03-27T15:41:19+00:00"
+        },
+        {
+            "name": "phan/tolerant-php-parser",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phan/phan-tolerant.git",
+                "reference": "199a81a43531cea4872893f10adc3eefcacacea9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phan/phan-tolerant/zipball/199a81a43531cea4872893f10adc3eefcacacea9",
+                "reference": "199a81a43531cea4872893f10adc3eefcacacea9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Microsoft\\PhpParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Lourens",
+                    "email": "roblou@microsoft.com"
+                }
+            ],
+            "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
+            "support": {
+                "issues": "https://github.com/phan/phan-tolerant/issues",
+                "source": "https://github.com/phan/phan-tolerant/tree/v0.2.0"
+            },
+            "time": "2025-10-29T19:20:13+00:00"
+        },
+        {
+            "name": "phan/var_representation_polyfill",
+            "version": "0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phan/var_representation_polyfill",
+                "reference": "6673325fb4343899af4564d9f6984b1fbe077e9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phan/var_representation_polyfill/zipball/6673325fb4343899af4564d9f6984b1fbe077e9d",
+                "reference": "6673325fb4343899af4564d9f6984b1fbe077e9d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.2.0|^8.0.0"
+            },
+            "provide": {
+                "ext-var_representation": "*"
+            },
+            "require-dev": {
+                "phan/phan": "^5.4.1",
+                "phpunit/phpunit": "^8.5.0"
+            },
+            "suggest": {
+                "ext-var_representation": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/var_representation.php"
+                ],
+                "psr-4": {
+                    "VarRepresentation\\": "src/VarRepresentation"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tyson Andre"
+                }
+            ],
+            "description": "Polyfill for var_representation: convert a variable to a string in a way that fixes the shortcomings of var_export",
+            "keywords": [
+                "var_export",
+                "var_representation"
+            ],
+            "time": "2026-01-28T23:32:31+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2590,12 +2820,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-webdriver/php-webdriver.git",
-                "reference": "898f0be8267680fbf962e371ea39b7f7f6411bdb"
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/898f0be8267680fbf962e371ea39b7f7f6411bdb",
-                "reference": "898f0be8267680fbf962e371ea39b7f7f6411bdb",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/ac0662863aa120b4f645869f584013e4c4dba46a",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a",
                 "shasum": ""
             },
             "require": {
@@ -2604,7 +2834,7 @@
                 "ext-zip": "*",
                 "php": "^7.3 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.12",
-                "symfony/process": "^5.0 || ^6.0 || ^7.0"
+                "symfony/process": "^5.0 || ^6.0 || ^7.0 || ^8.0"
             },
             "replace": {
                 "facebook/webdriver": "*"
@@ -2617,10 +2847,10 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpunit/phpunit": "^9.3",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/var-dumper": "^5.0 || ^6.0 || ^7.0"
+                "symfony/var-dumper": "^5.0 || ^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
-                "ext-SimpleXML": "For Firefox profile creation"
+                "ext-simplexml": "For Firefox profile creation"
             },
             "default-branch": true,
             "type": "library",
@@ -2649,7 +2879,7 @@
                 "issues": "https://github.com/php-webdriver/php-webdriver/issues",
                 "source": "https://github.com/php-webdriver/php-webdriver/tree/main"
             },
-            "time": "2025-02-24T19:21:58+00:00"
+            "time": "2025-12-28T23:57:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2871,11 +3101,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.32",
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
-                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -2920,20 +3150,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T10:16:31+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.5",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a25bde1f8f83849f441ef5713c6466e470872a71",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -2988,7 +3218,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -3008,7 +3238,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T04:53:32+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3427,25 +3657,28 @@
         },
         {
             "name": "sabre/event",
-            "version": "5.1.7",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/event.git",
-                "reference": "86d57e305c272898ba3c28e9bd3d65d5464587c2"
+                "reference": "70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/event/zipball/86d57e305c272898ba3c28e9bd3d65d5464587c2",
-                "reference": "86d57e305c272898ba3c28e9bd3d65d5464587c2",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7",
+                "reference": "70525d519b6fbd8e2cbef4e0dbe69c9d4a3e2db7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
-                "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.6"
             },
             "type": "library",
             "autoload": {
@@ -3489,7 +3722,7 @@
                 "issues": "https://github.com/sabre-io/event/issues",
                 "source": "https://github.com/fruux/sabre-event"
             },
-            "time": "2024-08-27T11:23:05+00:00"
+            "time": "2024-09-06T10:14:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3562,16 +3795,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.5",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c284f55811f43d555e51e8e5c166ac40d3e33c63",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
@@ -3630,7 +3863,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -3650,7 +3883,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-08T04:43:00+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3779,16 +4012,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.4",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
@@ -3803,7 +4036,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -3831,7 +4064,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -3851,7 +4084,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-15T07:05:40+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4451,16 +4684,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.4",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -4477,11 +4710,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -4531,7 +4759,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-05T05:47:09+00:00"
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -4587,47 +4815,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.5",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7"
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
-                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b66d385dc58f69652e56f78a4184615e3f2b7f7",
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4661,7 +4881,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.5"
+                "source": "https://github.com/symfony/console/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4681,103 +4901,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-14T15:46:26+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
                 "shasum": ""
             },
             "require": {
@@ -4826,7 +4963,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -4846,11 +4983,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4911,7 +5048,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -4934,105 +5071,21 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-01-02T08:10:11+00:00"
-        },
-        {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -5060,7 +5113,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5080,20 +5133,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
@@ -5147,7 +5200,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -5159,42 +5212,46 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.4",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f96476035142921000338bad71e5247fbc138872"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
-                "reference": "f96476035142921000338bad71e5247fbc138872",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5233,7 +5290,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.4"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5253,7 +5310,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:36:48+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5304,68 +5361,6 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
-        },
-        {
-            "name": "tysonandre/var_representation_polyfill",
-            "version": "0.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TysonAndre/var_representation_polyfill.git",
-                "reference": "e9116c2c352bb0835ca428b442dde7767c11ad32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TysonAndre/var_representation_polyfill/zipball/e9116c2c352bb0835ca428b442dde7767c11ad32",
-                "reference": "e9116c2c352bb0835ca428b442dde7767c11ad32",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.2.0|^8.0.0"
-            },
-            "provide": {
-                "ext-var_representation": "*"
-            },
-            "require-dev": {
-                "phan/phan": "^5.4.1",
-                "phpunit/phpunit": "^8.5.0"
-            },
-            "suggest": {
-                "ext-var_representation": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "0.1.3-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/var_representation.php"
-                ],
-                "psr-4": {
-                    "VarRepresentation\\": "src/VarRepresentation"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tyson Andre"
-                }
-            ],
-            "description": "Polyfill for var_representation: convert a variable to a string in a way that fixes the shortcomings of var_export",
-            "keywords": [
-                "var_export",
-                "var_representation"
-            ],
-            "support": {
-                "issues": "https://github.com/TysonAndre/var_representation_polyfill/issues",
-                "source": "https://github.com/TysonAndre/var_representation_polyfill/tree/0.1.3"
-            },
-            "time": "2022-08-31T12:59:22+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5437,5 +5432,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -34,38 +34,6 @@ bind_textdomain_codeset("loris", 'UTF-8');
 bindtextdomain("loris", __DIR__ . '/../locale');
 textdomain("loris");
 
-// TODO: Remove this code once PHP 8.4 becomes the minimal PHP version in LORIS.
-if (version_compare(PHP_VERSION, '8.4', '<')) {
-    // @phan-file-suppress PhanRedefineFunctionInternal
-
-    // phpcs:ignore
-    if (!function_exists('array_any')) {
-        // phpcs:ignore
-        function array_any(array $array, callable $callback): bool
-        {
-            foreach ($array as $key => $value) {
-                if ($callback($value, $key)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-    // phpcs:ignore
-    if (!function_exists('array_find')) {
-        // phpcs:ignore
-        function array_find(array $array, callable $callback)
-        {
-            foreach ($array as $key => $value) {
-                if ($callback($value, $key)) {
-                    return $value;
-                }
-            }
-            return null;
-        }
-    }
-}
-
 // FIXME: The code in NDB_Client should mostly be replaced by middleware.
 $client = new \NDB_Client;
 $client->initialize();

--- a/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
@@ -46,7 +46,7 @@ class Dicom extends Endpoint implements \LORIS\Middleware\ETagCalculator
      * A cache of the endpoint results, so that it doesn't need to be
      * recalculated for the ETag and handler.
      *
-     * @var ResponseInterface
+     * @var \Psr\Http\Message\MessageInterface
      */
     private $_cache;
 

--- a/modules/api_docs/test/APIDocsTestIntegrationTest.php
+++ b/modules/api_docs/test/APIDocsTestIntegrationTest.php
@@ -33,18 +33,17 @@ class APIDocsTestIntegrationTest extends \LorisIntegrationTest
     {
         $this->setupPermissions(['api_docs']);
         $this->safeGet($this->url . "/api_docs");
-        $selectOptions = null;
         try {
             $selectOptions = $this->safeFindElement(
                 WebDriverBy::cssSelector("select")
             );
+            $this->assertNotEmpty($selectOptions);
         } catch (\Facebook\WebDriver\Exception\NoSuchElementException $e) {
             $content = $this->safeFindElement(
                 WebDriverBy::id("lorisworkspace")
             );
             $this->fail('Can`t find select element. Found: ' . $content->getText());
         }
-        $this->assertNotEmpty($selectOptions);
     }
 
     /**

--- a/modules/biobank/php/containercontroller.class.inc
+++ b/modules/biobank/php/containercontroller.class.inc
@@ -76,9 +76,10 @@ class ContainerController
     {
         $this->_validatePermission('view');
         $containers  = [];
-        $this->dao   = $this->dao
+        $dao         = $this->dao
             ->filter(new \LORIS\Data\Filters\UserSiteMatch());
-        $containerIt = $this->dao->execute($this->user);
+        $containerIt = $dao->execute($this->user);
+
         foreach ($containerIt as $id => $container) {
             $containers[$id] = $container;
         }

--- a/modules/biobank/php/poolcontroller.class.inc
+++ b/modules/biobank/php/poolcontroller.class.inc
@@ -35,7 +35,7 @@ class PoolController
      *
      * @var \Database $db
      * @var \User     $user
-     * @var PoolDAO   $dao
+     * @var PoolDAO $dao
      * @var \LORIS\LorisInstance $loris
      */
     private $db, $user, $dao, $loris;
@@ -51,7 +51,7 @@ class PoolController
         $this->loris = $loris;
         $this->db    = $loris->getDatabaseConnection();
         $this->user  = $user;
-        $this->dao   = $this->_getDataProvisioner();
+        $this->dao   = new PoolDAO($this->loris);
     }
 
     /**
@@ -63,7 +63,10 @@ class PoolController
     {
         $this->_validatePermission('view');
         $pools  = [];
-        $poolIt = $this->dao->execute($this->user);
+        $poolIt = $this->dao
+            ->filter(new \LORIS\Data\Filters\UserSiteMatch())
+            ->filter(new \LORIS\Data\Filters\UserProjectMatch())
+            ->execute($this->user);
         foreach ($poolIt as $id => $pool) {
             $pools[$id] = $pool;
         }
@@ -88,21 +91,6 @@ class PoolController
         $pool = (new Pool())->fromArray($poolArray);
         $this->validateInstance($pool);
         return $this->dao->saveInstance($pool);
-    }
-
-    /**
-     * Treats the Pool DAO as a Provisioner that can be iterated through to
-     * provide the permissible Pool Objects for the current User
-     *
-     * @return \LORIS\Data\Provisioner
-     */
-    private function _getDataProvisioner() : \LORIS\Data\Provisioner
-    {
-        $dao = new PoolDAO($this->loris);
-        $dao = $dao
-            ->filter(new \LORIS\Data\Filters\UserSiteMatch())
-            ->filter(new \LORIS\Data\Filters\UserProjectMatch());
-        return $dao;
     }
 
     /**

--- a/modules/biobank/php/specimencontroller.class.inc
+++ b/modules/biobank/php/specimencontroller.class.inc
@@ -65,11 +65,12 @@ class SpecimenController
     public function getInstances() : array
     {
         $this->_validatePermission('view');
-        $specimens  = [];
-        $this->dao  = $this->dao
+        $specimens = [];
+
+        $dao        = $this->dao
             ->filter(new \LORIS\Data\Filters\UserSiteMatch())
             ->filter(new \LORIS\Data\Filters\UserProjectMatch());
-        $specimenIt = $this->dao->execute($this->user);
+        $specimenIt = $dao->execute($this->user);
         foreach ($specimenIt as $id => $specimen) {
             $specimens[$id] = $specimen;
         }

--- a/modules/candidate_parameters/test/candidateQueryEngineTest.php
+++ b/modules/candidate_parameters/test/candidateQueryEngineTest.php
@@ -29,7 +29,6 @@ use LORIS\Data\Query\Criteria\Substring;
  */
 class CandidateQueryEngineTest extends TestCase
 {
-
     protected \LORIS\candidate_parameters\CandidateQueryEngine $engine;
     protected $factory;
     protected $config;
@@ -112,9 +111,13 @@ class CandidateQueryEngineTest extends TestCase
             [__DIR__ . "/../../"]
         );
 
-        $this->engine = $lorisinstance->getModule(
+        $engine = $lorisinstance->getModule(
             'candidate_parameters'
         )->getQueryEngines()[0];
+
+        assert($engine instanceof \LORIS\candidate_parameters\CandidateQueryEngine);
+
+        $this->engine = $engine;
     }
 
     /**

--- a/modules/conflict_resolver/test/ConflictResolverTestIntegrationTest.php
+++ b/modules/conflict_resolver/test/ConflictResolverTestIntegrationTest.php
@@ -11,7 +11,6 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
-use Facebook\WebDriver\WebDriverSelect;
 use Facebook\WebDriver\WebDriverBy;
  require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
@@ -230,6 +229,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
             'rewrite later'
         );
          //set canID 475906 to resolved
+        /*
         $this->safeGet(
             $this->url .
             "/conflict_resolver/?CandID=475906&instrument=radiology_review"
@@ -246,5 +246,6 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         )->getText();
          // 4 means there are 4 records under this site.
         $this->assertStringContainsString("of 575", $bodyText);
+        */
     }
 }

--- a/modules/dataquery/php/query.class.inc
+++ b/modules/dataquery/php/query.class.inc
@@ -35,7 +35,7 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
      * Construct a Query object
      *
      * @param \LORIS\LorisInstance $loris     The LORIS Instance
-     * @param int                  $queryID   The Query ID
+     * @param ?int                 $queryID   The Query ID
      * @param ?array               $query     The serialized form of
      *                                        the query
      * @param ?string              $name      The query name
@@ -47,7 +47,7 @@ class Query implements \LORIS\StudyEntities\AccessibleResource,
      */
     public function __construct(
         protected \LORIS\LorisInstance $loris,
-        public readonly int $queryID,
+        public readonly ?int $queryID,
         ?array $query=null,
         public ?string $name=null,
         protected ?string $adminname=null,

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -259,6 +259,9 @@ class ViewDetails extends \NDB_Form
             ['tid' => $this->tpl_data['archive']['TarchiveID']]
         )['IsPhantom'] ?? null;
 
+        // This shouldn't happen, but without it phan doesn't realize
+        // that patientname is part of the array
+        assert(isset($this->tpl_data['archive']['PatientName']));
         if ($isPhantom === 'Y') {
             $isValid = preg_match(
                 "/$legoPhanRegex/",

--- a/modules/electrophysiology_browser/test/EEGBrowserIntegrationTest.php
+++ b/modules/electrophysiology_browser/test/EEGBrowserIntegrationTest.php
@@ -538,6 +538,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->markTestSkipped(
             'rewrite later'
         );
+        /*
         $this->safeGet($this->url . "/electrophysiology_browser/sessions/999999");
         $link = self::$nextLink;
         $this->safeClick(WebDriverBy::cssSelector($link));
@@ -553,6 +554,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
 
         $this->safeClick(WebDriverBy::cssSelector(self::$prevLink));
         $this->assertStringContainsString("166", $this->webDriver->getCurrentURL());
+        */
     }
 
     /**

--- a/modules/imaging_browser/test/ImagingBrowserTestIntegrationTest.php
+++ b/modules/imaging_browser/test/ImagingBrowserTestIntegrationTest.php
@@ -712,6 +712,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Skipping tests until Travis and React get along better'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
         $this->webDriver->navigate()->refresh();
@@ -728,6 +729,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString("View Session", $bodyText);
+	*/
 
         // Selected link tested in the next test
     }
@@ -747,6 +749,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             'Links are broken, Redmine 9576'
         );
 
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
 
@@ -802,6 +805,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector('#table-header-left tbody td:nth-child(5)')
         )->getText();
         $this->assertStringContainsString("Test Site AOL", $SiteText1);
+	 */
     }
 
     /**
@@ -836,6 +840,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Currently awaiting redmine 9385'
         );
+	/*
         $this->setupPermissions(array('imaging_browser_view_allsites'));
         $this->webDriver->navigate()->refresh();
         $this->safeGet(
@@ -861,6 +866,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::xPath('//*[@id="page"]/div/div[1]/a/label')
         )->getText();
         $this->assertStringContainsString("Brainbrowser", $BreadCrumbText);
+	 */
     }
 
     /**
@@ -874,6 +880,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Skipping tests until Travis and React get along better'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
         $this->safeGet(
@@ -954,6 +961,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::Name("visit_status")
         )->getText();
         $this->assertStringContainsString("Fail", $QCStatusVisit);
+	 */
     }
 
     /**
@@ -967,6 +975,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Skipping tests until Travis and React get along better'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
         $this->webDriver->navigate()->refresh();
@@ -995,6 +1004,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::xPath('//*[@id="lorisworkspace"]/div[1]/div/div/div[1]')
         )->getText();
         $this->assertStringContainsString("Selection Filter", $SelectionFilter);
+	 */
     }
 
     /******** C ********/
@@ -1017,6 +1027,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'React components can not be tested'
         );
+	/*
 
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
@@ -1154,6 +1165,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("body")
         )->getText();
         $this->assertStringContainsString("Mri Violations", $breadcrumbText);
+	 */
     }
 
     /**
@@ -1188,6 +1200,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Popup windows can not be tested'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(array('imaging_browser_view_allsites'));
         $this->webDriver->navigate()->refresh();
@@ -1217,6 +1230,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         )->getText();
         $this->assertStringContainsString("Click here to close this window", $newWindowText);
         $this->webDriver->switchTo()->window($diff[1])->close();
+	 */
     }
 
     /******** D ********/
@@ -1230,6 +1244,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'Skipping tests until Travis and React get along better'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(
             array(
@@ -1278,6 +1293,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         );
 
         $this->webDriver->switchTo()->window($diff[1])->close();
+	 */
     }
 
     /******** E ********/
@@ -1291,6 +1307,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $this->markTestSkipped(
             'React components can not be tested'
         );
+	/*
         // Setting permissions to view all sites to view all datasets
         $this->setupPermissions(
             array(
@@ -1342,6 +1359,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         );
 
         $this->webDriver->switchTo()->window($diff[1])->close();
+	 */
     }
 }
 ?>

--- a/modules/imaging_browser/test/ImagingQueryEngineTest.php
+++ b/modules/imaging_browser/test/ImagingQueryEngineTest.php
@@ -21,7 +21,6 @@ use LORIS\Data\Query\Criteria\Substring;
  */
 class ImagingQueryEngineTest extends TestCase
 {
-
     protected \LORIS\imaging_browser\QueryEngine $engine;
     protected $factory;
     protected $config;
@@ -205,9 +204,11 @@ class ImagingQueryEngineTest extends TestCase
             [__DIR__ . "/../../"]
         );
 
-        $this->engine = $lorisinstance->getModule(
+        $engine = $lorisinstance->getModule(
             'imaging_browser'
         )->getQueryEngines()[0];
+        assert($engine instanceof \LORIS\imaging_browser\QueryEngine);
+        $this->engine = $engine;
     }
 
     /**

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -484,7 +484,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         //////// for "new" scans //////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
         $updateFile = isset($args['values']['overwrite'])
-            ? (boolean) $args['values']['overwrite'] : false;
+            ? (bool) $args['values']['overwrite'] : false;
         $id         = $db->pselectOne(
             "SELECT
                 IF (InsertionComplete=0 AND
@@ -558,7 +558,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $pname      = '';
         $IsPhantom  = $args['values']['IsPhantom'];
         $updateFile = isset($args['values']['overwrite'])
-            ? (boolean) $args['values']['overwrite'] : false;
+            ? (bool) $args['values']['overwrite'] : false;
         ///////////////////////////////////////////////////////////////////////
         ///////////////If empty get it using User class////////////////////////
         ///////////////////////////////////////////////////////////////////////

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -142,7 +142,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             );
         }
         foreach ($reporter_expanded as $r_row) {
-            $reporters[$r_row['Real_name'] ?? ''] = $r_row['Real_name'] ?? 'Unknown';
+            $reporters[$r_row['Real_name']] = $r_row['Real_name'];
         }
 
         //assignees
@@ -156,7 +156,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             []
         );
         foreach ($assignee_expanded as $a_row) {
-            $assignees[$a_row['Real_name'] ?? ''] = $a_row['Real_name'] ?? 'Unknown';
+            $assignees[$a_row['Real_name']] = $a_row['Real_name'];
         }
 
         $modules = array_reduce(

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -142,7 +142,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             );
         }
         foreach ($reporter_expanded as $r_row) {
-            $reporters[$r_row['Real_name']] = $r_row['Real_name'];
+            $reporters[$r_row['Real_name'] ?? ''] = $r_row['Real_name'] ?? 'Unknown';
         }
 
         //assignees
@@ -156,7 +156,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             []
         );
         foreach ($assignee_expanded as $a_row) {
-            $assignees[$a_row['Real_name']] = $a_row['Real_name'];
+            $assignees[$a_row['Real_name'] ?? ''] = $a_row['Real_name'] ?? 'Unknown';
         }
 
         $modules = array_reduce(

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -53,6 +53,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
                 'UserID'     => 'TestUser',
                 'First_name' => 'Test',
                 'Last_name'  => 'User',
+		'Real_name'  => 'Test User'
             ]
         );
         $this->DB->insert(

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -53,7 +53,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
                 'UserID'     => 'TestUser',
                 'First_name' => 'Test',
                 'Last_name'  => 'User',
-		'Real_name'  => 'Test User'
+                'Real_name'  => 'Test User'
             ]
         );
         $this->DB->insert(

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -160,8 +160,6 @@ class Issue_TrackerTest extends LorisIntegrationTest
     function testClearFormIssueTracker()
     {
         $this->safeGet($this->url . "/issue_tracker/");
-	// FIXME: Remove this
-	sleep(1);
         $titleElement = $this->safeFindElement(
             WebDriverBy::Name("title")
         );

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -159,7 +159,9 @@ class Issue_TrackerTest extends LorisIntegrationTest
      */
     function testClearFormIssueTracker()
     {
-         $this->safeGet($this->url . "/issue_tracker/");
+        $this->safeGet($this->url . "/issue_tracker/");
+	// FIXME: Remove this
+	sleep(1);
         $titleElement = $this->safeFindElement(
             WebDriverBy::Name("title")
         );

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -342,8 +342,8 @@ function getUploadFields()
         $visit = $record["Visit_label"];
         $pscid = $record["PSCID"];
 
-        if (!isset($sessionData[$pscid]['instruments'][$visit])) {
-            $sessionData[$pscid]['instruments'][$visit] = [];
+        if (!isset($sessionData[$pscid]['instruments'][$visit ?? ''])) {
+            $sessionData[$pscid]['instruments'][$visit ?? ''] = [];
         }
         if (!isset($sessionData[$pscid]['instruments']['all'])) {
             $sessionData[$pscid]['instruments']['all'] = [];
@@ -449,7 +449,7 @@ function toSelect($options, $item, $item2)
     }
 
     foreach (array_keys($options) as $key) {
-        $selectOptions[$options[$key][$optionsValue]] = $options[$key][$item];
+        $selectOptions[$options[$key][$optionsValue] ?? ''] = $options[$key][$item];
     }
 
     return $selectOptions;

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1623,7 +1623,7 @@ class Database implements LoggerAwareInterface
     public function setBuffering(bool $buffered): void
     {
         if ($this->_PDO->setAttribute(
-            \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY,
+            \PDO\Mysql::ATTR_USE_BUFFERED_QUERY,
             $buffered
         ) == false
         ) {

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -541,13 +541,13 @@ class NDB_Page extends \LORIS\Http\Endpoint implements
      * Adds a group (array of elements created by $this->create*
      * wrappers) to the current page.
      *
-     * @param array  $elements  The group of elements to add to the page
-     * @param string $name      The name to give this group
-     * @param string $label     A label to attach to the group
-     * @param string $delimiter The separator to use between group elements
-     * @param ?array $options   An optional array to include prefix_wrapper and
-     *                          postfix_wrapper strings - html that will be
-     *                          placed before and after the group html
+     * @param array   $elements  The group of elements to add to the page
+     * @param string  $name      The name to give this group
+     * @param ?string $label     A label to attach to the group
+     * @param string  $delimiter The separator to use between group elements
+     * @param ?array  $options   An optional array to include prefix_wrapper and
+     *                           postfix_wrapper strings - html that will be
+     *                           placed before and after the group html
      *
      * @return void
      *
@@ -560,7 +560,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements
         $this->form->addGroup(
             $elements,
             $name,
-            !empty($label) ? dgettext($this->name, $label) : null,
+            !empty($label) ? dgettext($this->name, $label) : '',
             $delimiter,
             $options
         );

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -87,7 +87,7 @@ class Project implements \JsonSerializable
             );
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
-            $project->_recruitmentTarget = (integer) $projectData['recTarget'];
+            $project->_recruitmentTarget = (int) $projectData['recTarget'];
 
             self::$_instances[$projectName] = $project;
         }
@@ -520,7 +520,7 @@ class Project implements \JsonSerializable
             );
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
-            $project->_recruitmentTarget = (integer)$projectData['recTarget'];
+            $project->_recruitmentTarget = (int)$projectData['recTarget'];
 
             self::$_instances[$projectData['name']] = $project;
             $projects[] = $project;

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -183,7 +183,7 @@ class Settings
         $configVal = $this->_config->getSetting($settingName);
 
         if (is_bool($configVal) || is_numeric($configVal)) {
-            return (boolean)$configVal;
+            return (bool)$configVal;
         }
 
         if (is_string($configVal) && strtolower($configVal) == "true") {

--- a/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
@@ -122,7 +122,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "examiner_location",
             "Examiner location",
             array(
-                null               => '',
+                "" => '',
                 "examiner"         => "Examiner",
                 "in_room_observer" => "In-Room Observer",
                 "behind_mirror"    => "Behind Mirror",
@@ -172,7 +172,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
         );
 
         $q1_opts = array(
-            null           => "",
+            "" 	           => "",
             0              => "0 = Pass",
             1              => "1 = Delayed/Interupted",
             2              => "2 = Partial or No Tracking",
@@ -190,7 +190,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
         }
 
         $q1_opts_2 = array(
-            null => '',
+            ""   => '',
             0    => "0 = Smoothly tracks",
             1    => "1 = Delayed or interrupted",
             2    => "2 = Partial",
@@ -219,7 +219,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
                 "q2_disengagement_of_attention_press_$press",
                 "Press #$press",
                 array(
-                    null           => "",
+                    ""             => "",
                     0              => "0 = Pass (<1 sec)",
                     1              => "1 = Delayed (1-2 sec)",
                     2              => "2 = Stuck (>2 sec)",
@@ -232,7 +232,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "q2_disengagement_of_attention_score_override",
             "Override score (required):",
             array(
-                null => '',
+                ""   => '',
                 0    => "0 = Immediately moves attention",
                 1    => "1 = Delayed movement of attention",
                 2    => "2 = Fails to move attention",
@@ -264,7 +264,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
                     "q3_orients_to_name_press_{$press}_trial_{$trial}",
                     "Press #$press, Trial #$trial $parents",
                     array(
-                        null                          => "",
+                        ""                            => "",
                         "orients_with_eye_contact"    => "Orients with eye contact",
                         "orients_without_eye_contact" => "Orients without eye contact",
                         "fail_to_orient"              => "Fail to orient",
@@ -277,7 +277,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "q3_orients_to_name_score_override",
             "Override score (required):",
             array(
-                null => '',
+                ""   => '',
                 0    => "0 = Orients",
                 1    => "1 = Inconsistent orienting",
                 2    => "2 = Does not orient",
@@ -302,7 +302,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "q4_differential_response_to_facial_emotion",
             "Score: ",
             array(
-                null           => "",
+                ""             => "",
                 0              => "0 = Clear change",
                 1              => "1 = Questionable change",
                 2              => "2 = Does not show change",
@@ -327,7 +327,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "q5_anticipatory_response",
             "Score: ",
             array(
-                null           => "",
+                ""             => "",
                 0              => "0 = Clear anticipatory response",
                 1              => "1 = Subtle/Questionable response",
                 2              => "2 = Only during game or routine",
@@ -372,7 +372,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
                     "q6_imitation_of_actions_act_{$activity}_att_{$attempt}",
                     "",
                     array(
-                        null           => "",
+                        ""             => "",
                         0              => "0 = Clear imitation",
                         1              => "1 = Equivocal imitation",
                         2              => "2 = Does not imitate",
@@ -406,7 +406,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "q6_imitation_of_actions_score_override",
             "Override score (required):",
             array(
-                null => '',
+                ""   => '',
                 0    => "0 = Clear imitation",
                 1    => "1 = Equivocal imitation",
                 2    => "2 = Does not imitate",
@@ -454,7 +454,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
         );
         //answer arrays
         $zeroOneTwoThree = array(
-            null           => "",
+            ""             => "",
             0              => "0",
             1              => "1",
             2              => "2",
@@ -463,14 +463,14 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
             "not_answered" => "Not Answered",
         );
         $zeroTwo         = array(
-            null           => "",
+            ""             => "",
             0              => "0",
             2              => "2",
             8              => "8 = Not Applicable",
             "not_answered" => "Not Answered",
         );
         $zeroOneTwo      = array(
-            null           => "",
+            ""             => "",
             0              => "0",
             1              => "1",
             2              => "2",

--- a/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
@@ -126,7 +126,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         // Questions
 
         $yesNoOptions = array(
-                         null  => "",
+                         ""    => "",
                          "yes" => "Yes",
                          "no"  => "No",
                         );
@@ -157,7 +157,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         // Questions
 
         $yesNoOptions = array(
-                         null  => "",
+                         ""    => "",
                          "yes" => "Yes",
                          "no"  => "No",
                         );
@@ -197,7 +197,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         // Questions
 
         $yesNoOptions = array(
-                         null  => "",
+                         ""    => "",
                          "yes" => "Yes",
                          "no"  => "No",
                         );
@@ -254,7 +254,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         // Questions
 
         $yesNoOptions = array(
-                         null  => "",
+                         ""    => "",
                          "yes" => "Yes",
                          "no"  => "No",
                         );
@@ -338,7 +338,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         }
 
         $concussionOptions = array(
-                              null              => "",
+                              ""                => "",
                               "headaches"       => "Headaches",
                               "dizziness"       => "Dizziness",
                               "memory_problems" => "Memory problems",

--- a/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
@@ -132,7 +132,7 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
         );
 
         $typesOfData = array(
-            null                => '',
+            ''                  => '',
             'participant'       => 'Participant',
             'human_phantom'     => 'Human Phantom',
             'geometric_phantom' => 'Geometric Phantom',
@@ -148,7 +148,7 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
         $query    = "SELECT Name, CenterID FROM psc";
         $db       = \NDB_Factory::singleton()->database();
         $sitesRaw = $db->pselect($query, array());
-        $sites    = array(null => '');
+        $sites    = array('' => '');
         foreach ($sitesRaw as $i) {
             $sites[$i['CenterID']] = $i['Name'];
         }
@@ -184,7 +184,7 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
         );
 
         $acquiredOptions = array(
-            null      => '',
+            ''        => '',
             'yes'     => dgettext("loris", 'Yes'),
             'partial' => dgettext($this->name, 'Partial'),
             'no'      => dgettext("loris", 'No'),

--- a/raisinbread/instruments/NDB_BVL_Instrument_radiology_review.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_radiology_review.class.inc
@@ -58,20 +58,20 @@ class NDB_BVL_Instrument_radiology_review extends NDB_BVL_Instrument
         $this->_addMetadataFields();
 
         $yes_no_option = [
-            null           => "",
+            ""             => "",
             "no"           => "No",
             "yes"          => "Yes",
             "not_answered" => "Not Answered",
         ];
         $normal_option = [
-            null           => "",
+            ""             => "",
             "normal"       => "Normal",
             "abnormal"     => "Abnormal",
             "atypical"     => "Atypical",
             "not_answered" => "Not Answered",
         ];
         $exclusionaryOrNot = [
-            null               => "",
+            ""                 => "",
             "exclusionary"     => "Exclusionary",
             "non_exclusionary" => "Non-Exclusionary",
             "not_answered"     => "Not Answered",

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  php = pkgs.php84.withExtensions ({ enabled, all }:
+  php = pkgs.php85.withExtensions ({ enabled, all }:
     enabled ++ [ all.ast ]);
 in
 pkgs.mkShell {
-  buildInputs = with pkgs; [ php git nodejs php84Packages.composer gettext webpack-cli typescript ];
+  buildInputs = with pkgs; [ php git nodejs php85Packages.composer gettext webpack-cli typescript ];
   shellHook =
     ''
        php -v;

--- a/src/Security/OTP/HOTP.php
+++ b/src/Security/OTP/HOTP.php
@@ -52,6 +52,6 @@ class HOTP
     public function getCode(int $counter, int $len) : string
     {
         $dec = $this->getTruncatedDecimal($counter);
-        return str_pad(strval($dec % pow(10, $len)), $len, "0", STR_PAD_LEFT);
+        return str_pad(strval($dec % ( int)pow(10, $len)), $len, "0", STR_PAD_LEFT);
     }
 }

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -150,13 +150,6 @@ abstract class LorisIntegrationTest extends TestCase
 
             $this->login("UnitTester", $this->validPassword);
         }
-
-        if (extension_loaded('xdebug')
-            && function_exists("xdebug_start_code_coverage")
-        ) {
-            xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
-        }
-
     }
 
     /**

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -532,6 +532,7 @@ class CandidateTest extends TestCase
     public function testGetListOfVisitLabels()
     {
         $this->markTestSkipped("Test is incomplete");
+        /*
         $this->_setUpTestDoublesForSelectCandidate();
 
         $selectReturns = [
@@ -552,6 +553,7 @@ class CandidateTest extends TestCase
 
         $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->assertEquals($expected, $this->_candidate->getListOfVisitLabels());
+        */
 
     }
 

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -1352,6 +1352,7 @@ class Database_Test extends TestCase
         $this->markTestIncomplete(
             "This test calls a private method, making it fail for now"
         );
+        /*
         $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->getAllMethodsExcept(['insertIgnore']))
             ->getMock();
@@ -1364,6 +1365,7 @@ class Database_Test extends TestCase
 
         '@phan-var \Database $stub';
         $stub->insertIgnore($table, $set);
+        */
     }
 
     /**

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -60,7 +60,6 @@ class LorisForms_Test extends TestCase
     {
         if (!isset($this->form->form[$el])) {
             $this->fail("Element $el does not exist");
-            return;
         }
         $this->assertEquals(
             $this->form->form[$el]['type'],
@@ -82,7 +81,6 @@ class LorisForms_Test extends TestCase
     {
         if (!isset($this->form->form[$el])) {
             $this->fail("Element $el does not exist");
-            return;
         }
         $this->assertEquals(
             $this->form->form[$el]['label'],
@@ -107,7 +105,6 @@ class LorisForms_Test extends TestCase
     {
         if (!isset($this->form->form[$el])) {
             $this->fail("Element $el does not exist");
-            return;
         }
 
         if (is_array($attribValue)) {

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -152,7 +152,6 @@ class NDB_BVL_Instrument_Test extends TestCase
         // set by the instrument constructor,
         // if PHPunit hadn't disabled the constructor
         $ref = new \ReflectionProperty(get_class($instrument), 'loris');
-        $ref->setAccessible(true);
         $ref->setValue(
             $instrument,
             new \LORIS\LorisInstance(
@@ -1621,7 +1620,6 @@ class NDB_BVL_Instrument_Test extends TestCase
         // set by the instrument constructor,
         // if PHPunit hadn't disabled the constructor
         $ref = new \ReflectionProperty(get_class($otherInstrument), 'loris');
-        $ref->setAccessible(true);
         $ref->setValue(
             $otherInstrument,
             new \LORIS\LorisInstance(
@@ -2018,7 +2016,6 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_factoryForDB->setConfig($this->_config);
 
         $ref = new \ReflectionProperty(get_class($this->_instrument), 'loris');
-        $ref->setAccessible(true);
         $ref->setValue(
             $this->_instrument,
             new \LORIS\LorisInstance(

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -696,6 +696,7 @@ class NDB_PageTest extends TestCase
     public function testDisplayWithFormFrozen()
     {
         $this->markTestIncomplete("This test is incomplete!");
+        /*
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
         '@phan-var \NDB_Config $configMock';
         $factory = NDB_Factory::singleton();
@@ -707,6 +708,7 @@ class NDB_PageTest extends TestCase
             ->willReturn("fetch was called!");
         $this->_page->form->freeze();
         $this->assertEquals("fetch was called!", $this->_page->display());
+        */
     }
 
     /**

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -314,8 +314,14 @@ class UserTest extends TestCase
         parent::setUp();
         $this->_factory = \NDB_Factory::singleton();
         $this->_factory->reset();
-        $this->_configMock = $this->_factory->Config(CONFIG_XML);
-        $this->_dbMock     = $this->_factory->database();
+
+        $mockdb     = $this->_factory->database();
+        $mockconfig = $this->_factory->Config(CONFIG_XML);
+        '@phan-var \Database&PHPUnit\Framework\MockObject\MockObject $mockdb';
+        '@phan-var \NDB_Config&PHPUnit\Framework\MockObject\MockObject $mockconfig';
+
+        $this->_configMock = $mockconfig;
+        $this->_dbMock     = $mockdb;
 
         $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
         $mockdb     = $this->getMockBuilder('Database')->getMock();

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -173,7 +173,7 @@ class UtilityTest extends TestCase
         parent::setUp();
 
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        '@phan-var \NDB_Config $configMock';
+        '@phan-var \NDB_Config \NDB_Config&PHPUnit\Framework\MockObject\MockObject $configMock';
         $this->_configMock = $configMock;
         $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
 

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -173,7 +173,8 @@ class UtilityTest extends TestCase
         parent::setUp();
 
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        '@phan-var \NDB_Config \NDB_Config&PHPUnit\Framework\MockObject\MockObject $configMock';
+
+        '@phan-var \NDB_Config \NDB_Config&PHPUnit\Framework\MockObject\MockObject $configMock'; // phpcs:ignore
         $this->_configMock = $configMock;
         $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
 

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -141,6 +141,7 @@ class VisitTest extends TestCase
     function testAllVisit()
     {
         $this->markTestSkipped("Test Will be restored after Visit class revamp");
+        /*
 
         $visits = $this->visitController->getAllVisits();
         $this->assertEquals(
@@ -148,6 +149,7 @@ class VisitTest extends TestCase
             $visits,
             "the name of the visit does not match value in DB"
         );
+        */
     }
 
     /**
@@ -160,6 +162,7 @@ class VisitTest extends TestCase
     function testVisitsProjects()
     {
         $this->markTestSkipped("Test Will be restored after Visit class revamp");
+        /*
 
         $visits = $this->visitController->getVisitsProjectCohort();
         $this->assertEquals(
@@ -167,6 +170,7 @@ class VisitTest extends TestCase
             $visits,
             "the project cohort relation does not match value in DB"
         );
+        */
     }
 
     /**
@@ -179,6 +183,7 @@ class VisitTest extends TestCase
     function testGetVisitsByName()
     {
         $this->markTestSkipped("Test Will be restored after Visit class revamp");
+        /*
 
         $visit_result = new \Loris\Visit('V1');
         $visits       = $this->visitController->getVisitsByName("V1");
@@ -186,6 +191,7 @@ class VisitTest extends TestCase
             [$visit_result],
             $visits
         );
+        */
     }
 
     /**

--- a/tools/configuration_check.php
+++ b/tools/configuration_check.php
@@ -14,7 +14,7 @@ use \LORIS\Http\Client;
 use \LORIS\Http\Request;
 
 // XXX These must be updated manually in future releases.
-define('MINIMUM_PHP_VERSION', '8.3');
+define('MINIMUM_PHP_VERSION', '8.4');
 define('MINIMUM_APACHE_VERSION', '2.4');
 define('MINIMUM_MYSQL_VERSION', '5.7');
 define('MINIMUM_MARIADB_VERSION', '10.3');

--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -18,36 +18,6 @@ set_include_path(
     __DIR__."/../php/libraries:"
 );
 
-// TODO: Remove this code once PHP 8.4 becomes the minimal PHP version in LORIS.
-if (version_compare(PHP_VERSION, '8.4', '<')) {
-    // phpcs:ignore
-    if (!function_exists('array_any')) {
-        // phpcs:ignore
-        function array_any(array $array, callable $callback): bool
-        {
-            foreach ($array as $key => $value) {
-                if ($callback($value, $key)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-    // phpcs:ignore
-    if (!function_exists('array_find')) {
-        // phpcs:ignore
-        function array_find(array $array, callable $callback)
-        {
-            foreach ($array as $key => $value) {
-                if ($callback($value, $key)) {
-                    return $value;
-                }
-            }
-            return null;
-        }
-    }
-}
-
 require_once __DIR__ . "/../vendor/autoload.php";
 $configFile = __DIR__."/../project/config.xml";
 $client     = new NDB_Client();


### PR DESCRIPTION
PHP 8.5 is out and we officially support the latest 2 versions of PHP, so change the tests from 8.3 and 8.4 to 8.4 and 8.5.

Had to fix a few deprecation warnings, but otherwise poking around seemed to mostly work.