### PR TITLE
Update Python config file name configuration

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -298,7 +298,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "scout" FROM ConfigSettings cs W
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/issue_tracker" FROM ConfigSettings WHERE Name="issue_tracker_url";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'prod' FROM ConfigSettings cs WHERE cs.Name="mriConfigFile";
-INSERT INTO Config (ConfigID, Value) SELECT ID, 'database_config.py' FROM ConfigSettings cs WHERE cs.Name="mriPythonConfigFile";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 'config.py' FROM ConfigSettings cs WHERE cs.Name="mriPythonConfigFile";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'environment' FROM ConfigSettings cs WHERE cs.Name="EnvironmentFile";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'flair' FROM ConfigSettings WHERE Name="compute_snr_modalities";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 't1'    FROM ConfigSettings WHERE Name="compute_snr_modalities";

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -1,4 +1,4 @@
-/*M!999999\- enable the sandbox mode */ 
+/*M!999999\- enable the sandbox mode */
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `Config`;
 LOCK TABLES `Config` WRITE;
@@ -98,7 +98,7 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (116,116,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (117,117,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (118,118,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (119,119,'');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (120,120,'database_config.py');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (120,120,'config.py');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (121,125,'false');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (122,126,'0');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (126,129,'365');


### PR DESCRIPTION
## Problem

Since https://github.com/aces/Loris-MRI/pull/1313 (will be in the LORIS-MRI 29 release), the default LORIS Python configuration file has been renamed from `database_config.py` to `config.py`, but the default configuration value has not been updated yet.

## Solution

Update the default Python configuration file name in the LORIS database so that new installations work by default. There is no SQL patch for existing installations as it should be up to them to decide whether they rename their Python configuration file or not.