### PR TITLE
[SQL/electrophysiology] Fix physiological event response time SQL type

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -305,7 +305,7 @@ CREATE TABLE `physiological_task_event` (
   `EventSample`              decimal(11,6)    DEFAULT NULL,
   `EventType`                VARCHAR(50)      DEFAULT NULL,
   `TrialType`                VARCHAR(255)     DEFAULT NULL,
-  `ResponseTime`             TIME             DEFAULT NULL,
+  `ResponseTime`             decimal(11,6)    DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalTaskEventID`),
   KEY `FK_event_file` (`EventFileID`),
   INDEX idx_pte_EventValue (`EventValue`),

--- a/SQL/New_patches/2026-02-12_fix-physio-event-response-time.sql
+++ b/SQL/New_patches/2026-02-12_fix-physio-event-response-time.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `physiological_task_event` MODIFY COLUMN `ResponseTime` decimal(11,6) DEFAULT NULL;


### PR DESCRIPTION
This PR changes to the `physiological_task_event.ResponseTime` field from the `TIME` type more practical / BIDS-accurate `DECIMAL` type (the former being mostly used for times of the day).

See the motivation in this Slack message:
> In the LORIS SQL schema, we use a TIME type to store BIDS event response times, which stores them in a hh:mm:ss:12346 format. Although the MariaDB and MySQL documentation both say that this is possible, I find it a little awkward, and would prefer to use a DECIMAL type for this data.
https://mariadb.com/docs/server/reference/data-types/date-and-time-data-types/time
> 
> Reasoning:
> 
> These values are read from the events.tsv file, and are given as (possibly decimal) seconds rather than hours/minutes/seconds.
> I do not expect us to use / manipulate / display this data in a hh:mm:ss format, I think we shouls say "the participant took 70 seconds to react" rather than ¨the participant took 1min 10 to react".
> This translate badly to the Python time type, which is exclusively for times of the day. This can be overriden, but I feel like we should just fix the schema directly in the database.

I tested that the patch correctly converts values from `TIME` to `DECIMAL`. It also appears that the former type does not correctly handle decimal values (milliseconds...):
```
MariaDB [LORIS]> UPDATE physiological_task_event SET ResponseTime = "00:01:10.5" WHERE PhysiologicalTaskEventID = 1;
Query OK, 10 rows affected (0.005 sec)
Rows matched: 10  Changed: 10  Warnings: 0

MariaDB [LORIS]> SELECT PhysiologicalTaskEventID, ResponseTime FROM physiological_task_event WHERE PhysiologicalTaskEventID = 1;
+--------------------------+--------------+
| PhysiologicalTaskEventID | ResponseTime |
+--------------------------+--------------+
|                        1 | 00:01:10     |
+--------------------------+--------------+
10 rows in set (0.001 sec)

MariaDB [LORIS]> SOURCE SQL/New_patches/2026-02-12_fix-physio-event-response-time.sql
Query OK, 16190 rows affected (0.082 sec)              
Records: 16190  Duplicates: 0  Warnings: 0

MariaDB [LORIS]> SELECT PhysiologicalTaskEventID, ResponseTime FROM physiological_task_event WHERE PhysiologicalTaskEventID = 1;
+--------------------------+--------------+
| PhysiologicalTaskEventID | ResponseTime |
+--------------------------+--------------+
|                        1 |   110.000000 |
+--------------------------+--------------+
10 rows in set (0.007 sec)

MariaDB [LORIS]> UPDATE physiological_task_event SET ResponseTime = 110.5 WHERE PhysiologicalTaskEventID = 1;
Query OK, 10 rows affected (0.004 sec)
Rows matched: 10  Changed: 10  Warnings: 0

MariaDB [LORIS]> SELECT PhysiologicalTaskEventID, ResponseTime FROM physiological_task_event LIMIT 10;
+--------------------------+--------------+
| PhysiologicalTaskEventID | ResponseTime |
+--------------------------+--------------+
|                        1 |   110.500000 |
+--------------------------+--------------+
10 rows in set (0.007 sec)
```