### PR TITLE
[Email] Add attachment functionality

### DIFF
--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -55,7 +55,8 @@ class Email
         string $from = '',
         string $cc = '',
         string $bcc = '',
-        string $type="text/plain"
+        string $type="text/plain",
+        array  $atachments = []
     ): bool {
         $config   =& NDB_Config::singleton();
         $defaults = $config->getSetting('mail');
@@ -69,7 +70,6 @@ class Email
         }
         // build header
         $headers  = "MIME-Version: 1.0\n";
-        $headers .= "Content-type: $type; charset = UTF-8\n";
         $headers .= "Reply-to: $reply_to\n";
         $headers .= "From: $from\n";
         $headers .= "Return-Path: $from\n";
@@ -105,11 +105,57 @@ class Email
         // get rid of the subject from the message body
         $message = preg_replace('/^Subject: .*/', '', $message);
 
+        // Set attachment settings in body if there are any
+        if (!empty($attachments)) {
+
+            // boundary to seaprate MIME parts
+            $boundary = bin2hex(random_bytes(16));
+
+            // For attachments, use multipart 
+            $headers .= "Content-Type: multipart/mixed; boundary=\"$boundary\"\r\n";
+
+            // In first part add charset / encoding since content-type in header
+            // is indicating multi-part
+            $body  = "--$boundary\r\n";
+            $body .= "Content-Type: $type; charset=UTF-8\r\n";
+            $body .= "Content-Transfer-Encoding: 8bit\r\n\r\n";
+
+            // Add email message
+            $body .= $message . "\r\n";
+
+            foreach ($attachments as $file) {
+
+                if (!file_exists($file['path'])) {
+                    continue;
+                }
+
+                // Use chunk_split for proper line length
+                $fileContent = chunk_split(
+                    base64_encode(file_get_contents($file['path']))
+                );
+
+                $filename = $file['name'] ?? basename($file['path']);
+                $filetype = $file['type'] ?? 'application/octet-stream';
+
+                // Add part for each file attachment
+                $body .= "--$boundary\r\n";
+                $body .= "Content-Type: $filetype; name=\"$filename\"\r\n";
+                $body .= "Content-Disposition: attachment; filename=\"$filename\"\r\n";
+                $body .= "Content-Transfer-Encoding: base64\r\n\r\n";
+                $body .= $fileContent . "\r\n";
+            }
+
+            $body .= "--$boundary--";
+        } else {
+            $headers .= "Content-type: $type; charset=UTF-8\r\n";
+            $body = $message;
+        }
+
         // send the email
         return mail(
             $to,
             $match[1],
-            preg_replace("/(?<!\r)\n/s", "\n", $message),
+            preg_replace("/(?<!\r)\n/s", "\n", $body),
             $headers
         );
     }

--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -35,14 +35,15 @@ class Email
      * Every template MUST BEGIN with "Subject: subject text". Put new
      * templates in the subfolder "email" of the Smarty templates folder.
      *
-     * @param string $to       email address to send email to
-     * @param string $template template to use for email content
-     * @param array  $tpl_data template's data for smarty binding
-     * @param string $reply_to optional email header
-     * @param string $from     optional email header
-     * @param string $cc       optional email header
-     * @param string $bcc      optional email header
-     * @param string $type     optional defaults to plain text
+     * @param string $to          email address to send email to
+     * @param string $template    template to use for email content
+     * @param array  $tpl_data    template's data for smarty binding
+     * @param string $reply_to    optional email header
+     * @param string $from        optional email header
+     * @param string $cc          optional email header
+     * @param string $bcc         optional email header
+     * @param string $type        optional defaults to plain text
+     * @param array  $attachments optional files to attach
      *
      * @return bool The result of PHP mail().
      * @access public
@@ -56,7 +57,7 @@ class Email
         string $cc = '',
         string $bcc = '',
         string $type="text/plain",
-        array  $atachments = []
+        array  $attachments = []
     ): bool {
         $config   =& NDB_Config::singleton();
         $defaults = $config->getSetting('mail');
@@ -111,7 +112,7 @@ class Email
             // boundary to seaprate MIME parts
             $boundary = bin2hex(random_bytes(16));
 
-            // For attachments, use multipart 
+            // For attachments, use multipart
             $headers .= "Content-Type: multipart/mixed; boundary=\"$boundary\"\r\n";
 
             // In first part add charset / encoding since content-type in header
@@ -124,23 +125,32 @@ class Email
             $body .= $message . "\r\n";
 
             foreach ($attachments as $file) {
+                if (!$file instanceof \SplFileInfo) {
+                    throw new \Exception(
+                        "Invalid attachment provided. " .
+                        "Expected instance of SplFileInfo."
+                    );
+                }
+                $filePath = $file->getRealPath();
+                $filename = $file->getFilename();
+                $filetype = mime_content_type($filePath);
 
-                if (!file_exists($file['path'])) {
-                    continue;
+                if (!file_exists($filePath)) {
+                    throw new \Exception(
+                        "Email attachment file not found: {$filePath}"
+                    );
                 }
 
                 // Use chunk_split for proper line length
                 $fileContent = chunk_split(
-                    base64_encode(file_get_contents($file['path']))
+                    base64_encode(file_get_contents($filePath))
                 );
-
-                $filename = $file['name'] ?? basename($file['path']);
-                $filetype = $file['type'] ?? 'application/octet-stream';
 
                 // Add part for each file attachment
                 $body .= "--$boundary\r\n";
                 $body .= "Content-Type: $filetype; name=\"$filename\"\r\n";
-                $body .= "Content-Disposition: attachment; filename=\"$filename\"\r\n";
+                $body .=
+                    "Content-Disposition: attachment; filename=\"$filename\"\r\n";
                 $body .= "Content-Transfer-Encoding: base64\r\n\r\n";
                 $body .= $fileContent . "\r\n";
             }
@@ -148,7 +158,7 @@ class Email
             $body .= "--$boundary--";
         } else {
             $headers .= "Content-type: $type; charset=UTF-8\r\n";
-            $body = $message;
+            $body     = $message;
         }
 
         // send the email


### PR DESCRIPTION
## Brief summary of changes
This PR adds to the Email.class.inc library file to be able to add attachments to emails sent by LORIS. 

This is done by detecting whether an array of attachments was added, and if so, changing the Content-Type to multi-part and adding each attachment individually.  If no attachments are passed as an argument, then the Email class continues as it did before.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Add a 9th argument to an Email::send function somewhere in LORIS with a full filepath passed through
2. Have the email sent to your own address, and make sure that the attachment is added to the sent email properly
3. Try sending an email like normal without an attachment, and make sure that that works as usual.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
