### PR TITLE
[htdocs] Update savecsv.js to save with utf-8 encoding

### DIFF
--- a/htdocs/js/workers/savecsv.js
+++ b/htdocs/js/workers/savecsv.js
@@ -33,7 +33,9 @@ self.addEventListener('message', function(e) {
     );
     content += '"' + row.join('","') + '"\r\n';
   }
-  contentBlob = new Blob([content], {type: 'text/csv'});
+  contentBlob = new Blob(['\uFEFF' + content], {
+    type: 'text/csv;charset=utf-8;',
+  });
   // fs = saveAs(contentBlob, "data.csv");
   // fs = new FileSaverSync(contentBlob, "data.csv");
   self.postMessage({cmd: 'SaveCSV', message: contentBlob});


### PR DESCRIPTION
## Brief summary of changes

Updated `htdocs/js/workers/savecsv.js` to:
- prepend `\uFEFF` to CSV content
- use Blob type `text/csv;charset=utf-8;`

I did not test this since the change is minimal and straightforward. 

#### Link(s) to related issue(s)

* Resolves #10378
