### PR TITLE
[FilesUploadHandler] Add preliminary check for path traversal

### DIFF
--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -157,11 +157,21 @@ class FilesUploadHandler implements RequestHandlerInterface
                 );
             }
 
+            $filename = $file->getClientFilename();
+
+            if (str_contains($filename, "/") === true
+                || str_contains($filename, "..") === true
+            ) {
+                return new \LORIS\Http\Response\JSON\Forbidden(
+                    'Path traversal not allowed'
+                );
+            }
+
             /* basename() is used here to prevent path traversal characters
              * from being used.
              */
             $targetPath = $this->uploadDirectory->getPathname() . '/' . basename(
-                $file->getClientFilename()
+                $filename
             );
 
             /* If file exists, set response code to 'Conflict' unless the


### PR DESCRIPTION
The FilesUploadHandler uses `basename` on the client filename in order to ensure the user can not escape the configured path by uploading a filename containing ../../ (web browsers will generally just provide the filename, but a malicious attacker can try and escape the path.)

However, there is still a theoretical possibility that a caller to FilesUploadHandler does something such as insert the unsanitized value into the database, which can then be misused indirectly.

This adds a preliminary check to ensure the filename provided does not look like a path so that an error is returned and the caller (hopefully) does not do anything with the value if it has anything that looks like a path character. The basename check is maintained.
