### PR TITLE
[redcap] strip html and non-breaking space from field label

### DIFF
--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -242,9 +242,12 @@ class RedcapDictionaryRecord
         $field_type  = $this->field_type;
         $field_name  = $this->field_name;
         $field_label = str_replace(["\r\n", "\r", "\n"], '', $this->field_label);
+        $field_label = strip_tags($this->field_label);
+        $field_label = str_replace("\xc2\xa0", ' ', $field_label);
+        $field_label = preg_replace('/\s+/', ' ', $field_label);
+        $field_label = trim($field_label);
         $field_desc  = "$field_name{@}$field_label";
 
-        //
         switch ($field_type) {
         case 'text':
             // text maps directly to LORIS

--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -242,7 +242,10 @@ class RedcapDictionaryRecord
         $field_type  = $this->field_type;
         $field_name  = $this->field_name;
         $field_label = str_replace(["\r\n", "\r", "\n"], '', $this->field_label);
-        $field_label = strip_tags($this->field_label);
+        // strip HTML-related content
+        $field_label = strip_tags($field_label);
+        // replace the non-breaking space \xao
+        // and \xc2, the first byte of its UTF-8 encoding
         $field_label = str_replace("\xc2\xa0", ' ', $field_label);
         $field_label = preg_replace('/\s+/', ' ', $field_label);
         $field_label = trim($field_label);

--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -244,8 +244,8 @@ class RedcapDictionaryRecord
         $field_label = str_replace(["\r\n", "\r", "\n"], '', $this->field_label);
         // strip HTML-related content
         $field_label = strip_tags($field_label);
-        // replace the non-breaking space \xao
-        // and \xc2, the first byte of its UTF-8 encoding
+        // replace the non-breaking space in unicode-encoding (\xao)
+        // and UTF-8 encoding (\xc2)
         $field_label = str_replace("\xc2\xa0", ' ', $field_label);
         $field_label = preg_replace('/\s+/', ' ', $field_label);
         $field_label = trim($field_label);


### PR DESCRIPTION
## Brief summary of changes

Sometimes, a REDcap instance is set up with HTML elements to facilitate user experience. This html is transferred to LINST.


This PR Removes html from LINST during redcap2linst import and
also removes non-breaking space

See the html tags at the bottom of this image:
1.
<img width="491" height="217" alt="Screenshot from 2025-11-10 15-38-11" src="https://github.com/user-attachments/assets/6d6a3c09-f62e-475b-b1f4-0b5851f996b0" />

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
