### PR TITLE
[elecrophysiology_browser] Fix session link keying in translated UI

### DIFF
--- a/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
@@ -77,6 +77,8 @@ class ElectrophysiologyBrowserIndex extends Component {
     const style = '';
     let result = <td className={style}>{cell}</td>;
     const {t} = this.props;
+    const sessionIDKey = t('SessionID', {ns: 'electrophysiology_browser'});
+    const sessionID = row[sessionIDKey] || row.SessionID;
     switch (column) {
     case t('Links', {ns: 'electrophysiology_browser'}):
       let cellTypes = cell.split(',');
@@ -85,7 +87,7 @@ class ElectrophysiologyBrowserIndex extends Component {
       for (let i = 0; i < cellTypes.length; i += 1) {
         cellLinks.push(<a key={i} href={loris.BaseURL +
               '/electrophysiology_browser/sessions/' +
-              row.SessionID + '?outputType=' +
+              sessionID + '?outputType=' +
               cellTypes[i]}>
           {cellTypes[i]}
         </a>);
@@ -97,7 +99,7 @@ class ElectrophysiologyBrowserIndex extends Component {
       if (cellTypes.length > 1) {
         cellLinks.push(<a key="all" href={loris.BaseURL +
             '/electrophysiology_browser/sessions/' +
-            row.SessionID}>
+            sessionID}>
           {t('all types', {ns: 'electrophysiology_browser'})}
         </a>);
       }


### PR DESCRIPTION
## Brief summary of changes
- Fixed EEG Browser session link generation to avoid `/sessions/undefined` in translated views.
- Resolved session ID using the translated `SessionID` column key with fallback to `row.SessionID`.

https://github.com/user-attachments/assets/8f307e35-b75f-4a82-80c4-61de68c9ccef

#### Link(s) to related issue(s)

* Resolves #10388
