### PR TITLE
[dataquery + login] Translate Terms of Use menu label and popup text

### DIFF
--- a/jsx/PolicyButton.js
+++ b/jsx/PolicyButton.js
@@ -8,6 +8,76 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Swal from 'sweetalert2';
+import 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
+const DATAQUERY_DEFAULT_CONTENT =
+  'By using this Data Query Tool, you acknowledge that you know it is ' +
+  'in beta and may not work as expected. You also agree to use it ' +
+  'responsibly and not to misuse the data.';
+const LOGIN_DEFAULT_CONTENT =
+  'By using this LORIS instance you acknowledge that you know it is ' +
+  'filled with test data, and not real user data.';
+
+const POLICY_TRANSLATION_MSGIDS = Object.freeze({
+  dataquery_example: Object.freeze({
+    HeaderButtonText: 'Terms of Use',
+    SwalTitle: 'Terms of Use',
+    AcceptButtonText: 'Yes, I accept',
+    DeclineButtonText: 'Decline',
+    Content: DATAQUERY_DEFAULT_CONTENT,
+  }),
+  login_example: Object.freeze({
+    HeaderButtonText: 'Terms of Use',
+    SwalTitle: 'Terms of Use',
+    AcceptButtonText: 'Accept',
+    Content: LOGIN_DEFAULT_CONTENT,
+  }),
+});
+
+/**
+ * Return the canonical literal msgid for a known policy field.
+ *
+ * @param {object} policy - Policy object from backend.
+ * @param {string} field - Backend policy field name.
+ * @return {string|null} canonical msgid or null if unknown.
+ */
+const getPolicyMsgid = (policy, field) => {
+  if (!policy
+    || typeof policy.PolicyName !== 'string'
+    || policy.PolicyName === ''
+  ) {
+    return null;
+  }
+  const policyTranslations = POLICY_TRANSLATION_MSGIDS[policy.PolicyName];
+  if (!policyTranslations || !policyTranslations[field]) {
+    return null;
+  }
+  return policyTranslations[field];
+};
+
+/**
+ * Translate known policy text while preserving literal fallback.
+ *
+ * @param {object} policy - Policy object from backend.
+ * @param {string} field - Backend policy field name.
+ * @param {string|undefined|null} fallbackText - Raw backend value.
+ * @param {function|undefined} t - i18n translate function from withTranslation.
+ * @return {string|undefined|null} Translated or fallback text.
+ */
+const translatePolicyField = (policy, field, fallbackText, t) => {
+  if (typeof fallbackText !== 'string' || fallbackText === '') {
+    return fallbackText;
+  }
+  const msgid = getPolicyMsgid(policy, field);
+  if (msgid === null || typeof t !== 'function') {
+    return fallbackText;
+  }
+  return t(
+    msgid,
+    {ns: 'loris', defaultValue: fallbackText}
+  );
+};
 
 /**
  * PolicyButton Component
@@ -21,39 +91,57 @@ import Swal from 'sweetalert2';
  * @param {string} [props.buttonText] - Optional text for the button.
  * @param {boolean} [props.anon] - Optional flag to indicate if the user is anonymous.
  * @param {function} [props.callback] - Optional callback function to execute after the policy decision.
+ * @param {function} [props.t] - Translate function from withTranslation.
  */
-const PolicyButton = ({
+const PolicyButtonComponent = ({
   onClickPolicy,
   popUpPolicy,
   buttonStyle,
   buttonText,
   anon=false,
   callback=() => {},
+  t,
 }) => {
   if (popUpPolicy && popUpPolicy.needsRenewal) {
-    fireSwal(popUpPolicy);
+    fireSwal(popUpPolicy, undefined, undefined, t);
   }
   if (onClickPolicy) {
+    const headerButtonText = translatePolicyField(
+      onClickPolicy,
+      'HeaderButtonText',
+      onClickPolicy.HeaderButtonText,
+      t
+    );
     return <a
       className="hidden-xs hidden-sm"
       id="on-click-policy-button"
       style={{...buttonStyle}}
       href="#"
       onClick={() => {
-        fireSwal(onClickPolicy, anon, callback);
+        fireSwal(onClickPolicy, anon, callback, t);
       }}
     >
-      {buttonText || onClickPolicy.HeaderButtonText}
+      {buttonText || headerButtonText}
     </a>;
   }
 };
 
-const fireSwal = (policy, anon, callback) => {
+const fireSwal = (policy, anon=false, callback=() => {}, t) => {
   Swal.fire({
-    title: policy.SwalTitle,
-    html: policy.Content,
-    confirmButtonText: policy.AcceptButtonText,
-    cancelButtonText: policy.DeclineButtonText,
+    title: translatePolicyField(policy, 'SwalTitle', policy.SwalTitle, t),
+    html: translatePolicyField(policy, 'Content', policy.Content, t),
+    confirmButtonText: translatePolicyField(
+      policy,
+      'AcceptButtonText',
+      policy.AcceptButtonText,
+      t
+    ),
+    cancelButtonText: translatePolicyField(
+      policy,
+      'DeclineButtonText',
+      policy.DeclineButtonText,
+      t
+    ),
     showCancelButton: policy.DeclineButtonText,
     allowOutsideClick: false,
   }).then((decision) => {
@@ -82,15 +170,18 @@ const fireSwal = (policy, anon, callback) => {
   });
 };
 
-PolicyButton.propTypes = {
+PolicyButtonComponent.propTypes = {
   onClickPolicy: PropTypes.shape({
+    PolicyName: PropTypes.string,
+    HeaderButtonText: PropTypes.string,
     SwalTitle: PropTypes.string.isRequired,
     Content: PropTypes.string.isRequired,
     AcceptButtonText: PropTypes.string.isRequired,
     DeclineButtonText: PropTypes.string.isRequired,
-  }).isRequired,
-  onClickPolicy: PropTypes.object.isRequired,
+  }),
   popUpPolicy: PropTypes.shape({
+    PolicyName: PropTypes.string,
+    HeaderButtonText: PropTypes.string,
     needsRenewal: PropTypes.bool,
     SwalTitle: PropTypes.string,
     Content: PropTypes.string,
@@ -101,8 +192,11 @@ PolicyButton.propTypes = {
   buttonText: PropTypes.string,
   anon: PropTypes.bool,
   callback: PropTypes.func,
+  t: PropTypes.func,
 };
+
+const PolicyButton = withTranslation('loris')(PolicyButtonComponent);
 
 window.PolicyButton = PolicyButton;
 
-export {PolicyButton, fireSwal};
+export {PolicyButton, PolicyButtonComponent, fireSwal, translatePolicyField};

--- a/locale/en/LC_MESSAGES/loris.po
+++ b/locale/en/LC_MESSAGES/loris.po
@@ -133,6 +133,25 @@ msgstr "Submit"
 msgid "Proceed"
 msgstr "Proceed"
 
+# Policy text
+msgid "Terms of Use"
+msgstr "Terms of Use"
+
+msgid "Yes, I accept"
+msgstr "Yes, I accept"
+
+msgid "Decline"
+msgstr "Decline"
+
+msgid "Accept"
+msgstr "Accept"
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+
 # Common candidate terms
 msgid "PSCID"
 msgstr "PSCID"

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -164,6 +164,25 @@ msgstr "Cancelar"
 msgid "Success!"
 msgstr "Exitoso!"
 
+# Policy text
+msgid "Terms of Use"
+msgstr "Términos de uso"
+
+msgid "Yes, I accept"
+msgstr "Sí, acepto"
+
+msgid "Decline"
+msgstr "Rechazar"
+
+msgid "Accept"
+msgstr "Aceptar"
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr "Al utilizar esta herramienta de consulta de datos, usted reconoce que está en versión beta y que puede no funcionar como se espera. También acepta usarla de manera responsable y no hacer un uso indebido de los datos."
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr "Al utilizar esta instancia de LORIS, usted reconoce que contiene datos de prueba y no datos reales de usuarios."
+
 # Common candidate terms
 msgid "PSCID"
 msgstr "SCPID"

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -204,6 +204,25 @@ msgstr "Réussi!"
 msgid "Close"
 msgstr "Fermer"
 
+# Policy text
+msgid "Terms of Use"
+msgstr "Conditions d'utilisation"
+
+msgid "Yes, I accept"
+msgstr "Oui, j'accepte"
+
+msgid "Decline"
+msgstr "Refuser"
+
+msgid "Accept"
+msgstr "Accepter"
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr "En utilisant cet outil de requête de données, vous reconnaissez qu'il est en version bêta et peut ne pas fonctionner comme prévu. Vous acceptez aussi de l'utiliser de manière responsable et de ne pas faire mauvais usage des données."
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr "En utilisant cette instance LORIS, vous reconnaissez qu'elle contient des données de test et non des données réelles d'utilisateurs."
+
 # Common candidate terms
 msgid "PSCID"
 msgstr "PSCID"

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -226,6 +226,25 @@ msgstr "सहेजा जा रहा है"
 msgid "Leaving the form will result in the loss of any information entered."
 msgstr "फॉर्म छोड़ने पर दर्ज की गई सभी जानकारी खो जाएगी।"
 
+# Policy text
+msgid "Terms of Use"
+msgstr "उपयोग की शर्तें"
+
+msgid "Yes, I accept"
+msgstr "हाँ, मैं स्वीकार करता/करती हूँ"
+
+msgid "Decline"
+msgstr "अस्वीकार करें"
+
+msgid "Accept"
+msgstr "स्वीकार करें"
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr "इस डेटा क्वेरी टूल का उपयोग करके, आप स्वीकार करते हैं कि यह बीटा संस्करण में है और संभव है कि अपेक्षित रूप से काम न करे। आप यह भी सहमत हैं कि आप इसका जिम्मेदारी से उपयोग करेंगे और डेटा का दुरुपयोग नहीं करेंगे।"
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr "इस LORIS इंस्टेंस का उपयोग करके, आप स्वीकार करते हैं कि इसमें वास्तविक उपयोगकर्ता डेटा नहीं बल्कि परीक्षण डेटा भरा हुआ है।"
+
 # Common candidate terms
 msgid "PSCID"
 msgstr "पीएससीआईडी"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -196,6 +196,25 @@ msgstr "成功！"
 msgid "Close"
 msgstr "近い"
 
+# Policy text
+msgid "Terms of Use"
+msgstr "利用規約"
+
+msgid "Yes, I accept"
+msgstr "はい、同意します"
+
+msgid "Decline"
+msgstr "拒否する"
+
+msgid "Accept"
+msgstr "同意する"
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr "このデータクエリツールを使用することで、あなたはこれがベータ版であり、期待どおりに動作しない可能性があることを認めます。また、データを責任を持って使用し、不適切に利用しないことに同意します。"
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr "このLORISインスタンスを使用することで、これには実データではなくテストデータが含まれていることを認めます。"
+
 # Common candidate terms
 msgid "PSCID"
 msgstr "プロジェクト識別子"
@@ -564,4 +583,3 @@ msgstr "データセット"
 # For react-select <Select> noOptionsMessage prop
 msgid "No options"
 msgstr "オプションなし"
-

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -200,6 +200,25 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+# Policy text
+msgid "Terms of Use"
+msgstr ""
+
+msgid "Yes, I accept"
+msgstr ""
+
+msgid "Decline"
+msgstr ""
+
+msgid "Accept"
+msgstr ""
+
+msgid "By using this Data Query Tool, you acknowledge that you know it is in beta and may not work as expected. You also agree to use it responsibly and not to misuse the data."
+msgstr ""
+
+msgid "By using this LORIS instance you acknowledge that you know it is filled with test data, and not real user data."
+msgstr ""
+
 # Common candidate terms
 msgid "PSCID"
 msgstr ""


### PR DESCRIPTION
## Brief summary of changes
- Updated shared policy rendering so Terms of Use is localized consistently across both login and dataquery views.
- Refactored `PolicyButton` to use `withTranslation('loris')` and literal `t(...)` msgids for default policy entries (`dataquery_example`, `login_example`).
- Added translation coverage for the policy nav label, popup title, popup body, and accept/decline button text.
- Preserved safe fallback behavior: unmapped policy names/fields continue to display backend-provided text unchanged.
- Added translation entries for all supported UI languages (en, fr, ja, hi, es).

I do not have experience with Spanish or Japanese, so a strict review will be required for these translations.
Please let me know whatever changes required, and I'll be happy to incorporate them!

### Screenshots

Dataquery Tool:
<img width="1108" height="659" alt="Screenshot 2026-03-06 at 01 08 04" src="https://github.com/user-attachments/assets/d80519d0-2616-475e-a02b-653a143990af" />
<img width="1118" height="631" alt="Screenshot 2026-03-06 at 01 10 44" src="https://github.com/user-attachments/assets/4d473336-ac51-400f-b8cb-3867edf6a0fc" />
<img width="1110" height="643" alt="Screenshot 2026-03-06 at 01 07 44" src="https://github.com/user-attachments/assets/7abb54e4-d273-4456-b1ea-0476d9088697" />


Login Page:
<img width="1109" height="677" alt="Screenshot 2026-03-06 at 01 08 17" src="https://github.com/user-attachments/assets/eac6747d-9618-44bd-9532-1c3b40628ca8" />
<img width="1107" height="600" alt="Screenshot 2026-03-06 at 01 08 45" src="https://github.com/user-attachments/assets/fe7cc174-b33b-4c03-8a5e-8cfce39e0908" />
<img width="1108" height="593" alt="Screenshot 2026-03-06 at 01 08 59" src="https://github.com/user-attachments/assets/bfa9f8e3-c4fb-4391-b395-81a40261d068" />

#### Link(s) to related issue(s)

* Resolves #10263

