### PR TITLE
[document_repository] Fix swal translation coverage

### DIFF
--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -10,6 +10,7 @@ import {
 } from 'jsx/Form';
 import i18n from 'I18nSetup';
 import {withTranslation} from 'react-i18next';
+import translateKnownBackendError from './translateKnownBackendError';
 
 import hiStrings from '../locale/hi/LC_MESSAGES/document_repository.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/document_repository.json';
@@ -154,6 +155,7 @@ class DocCategoryForm extends React.Component {
    * Uploads the file to the server
    */
   uploadFile() {
+    const {t} = this.props;
     // Set form data and upload the media file
     let formData = this.state.formData;
     let formObj = new FormData();
@@ -178,19 +180,41 @@ class DocCategoryForm extends React.Component {
           this.setState({
             formData: {}, // reset form data after successful file upload
           });
-          swal.fire('Category Successfully Added!',
-            '', 'success');
+          swal.fire({
+            title: t(
+              'Category added successfully!',
+              {ns: 'document_repository'}
+            ),
+            text: '',
+            type: 'success',
+            confirmButtonText: t('OK', {ns: 'loris'}),
+          });
         } else {
           resp.json().then((data) => {
-            swal.fire('Could not add category!',
-              data.error, 'error');
+            const backendError = data && data.error ? data.error : '';
+            const errorMessage = backendError
+              ? translateKnownBackendError(backendError, t)
+              : t(
+                'Please report the issue or contact your administrator',
+                {ns: 'document_repository'}
+              );
+            swal.fire({
+              title: t('Could not add category!', {ns: 'document_repository'}),
+              text: errorMessage,
+              type: 'error',
+              confirmButtonText: t('OK', {ns: 'loris'}),
+            });
           }).catch((error) => {
             console.error(error);
-            swal.fire(
-              'Unknown Error!',
-              'Please report the issue or contact your administrator.',
-              'error'
-            );
+            swal.fire({
+              title: t('Error', {ns: 'document_repository'}),
+              text: t(
+                'Please report the issue or contact your administrator',
+                {ns: 'document_repository'}
+              ),
+              type: 'error',
+              confirmButtonText: t('OK', {ns: 'loris'}),
+            });
           });
         }
       });

--- a/modules/document_repository/jsx/deleteCategoryForm.js
+++ b/modules/document_repository/jsx/deleteCategoryForm.js
@@ -8,6 +8,7 @@ import {
 } from 'jsx/Form';
 import {withTranslation} from 'react-i18next';
 import i18n from 'I18nSetup';
+import translateKnownBackendError from './translateKnownBackendError';
 
 import hiStrings from '../locale/hi/LC_MESSAGES/document_repository.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/document_repository.json';
@@ -159,16 +160,23 @@ class DeleteDocCategoryForm extends React.Component {
         } else {
           msg = t('Delete error!', {ns: 'document_repository'});
         }
+        const translatedMsg = translateKnownBackendError(msg, t);
         this.setState({
-          errorMessage: msg,
+          errorMessage: translatedMsg,
         });
-        swal.fire(msg, '', 'error');
+        swal.fire({
+          title: translatedMsg,
+          text: '',
+          type: 'error',
+          confirmButtonText: t('OK', {ns: 'loris'}),
+        });
         console.error(msg);
       } else {
         swal.fire({
           text: t('Delete Successful!', {ns: 'document_repository'}),
           title: '',
           type: 'success',
+          confirmButtonText: t('OK', {ns: 'loris'}),
         }).then(function() {
           window.location.assign('/document_repository');
         });
@@ -176,11 +184,17 @@ class DeleteDocCategoryForm extends React.Component {
     }).catch( (error) => {
       let msg = error.message ? error.message : t('Delete error!',
         {ns: 'document_repository'});
+      const translatedMsg = translateKnownBackendError(msg, t);
       this.setState({
-        errorMessage: msg,
+        errorMessage: translatedMsg,
         uploadProgress: -1,
       });
-      swal.fire(msg, '', 'error');
+      swal.fire({
+        title: translatedMsg,
+        text: '',
+        type: 'error',
+        confirmButtonText: t('OK', {ns: 'loris'}),
+      });
       console.error(error);
     });
   }

--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -216,7 +216,7 @@ class DocIndex extends React.Component {
         swal.fire({
           title: t('Are you sure?', {ns: 'loris'}),
           text: t('You won\'t be able to revert this!',
-            {ns: 'loris'}),
+            {ns: 'document_repository'}),
           type: 'warning',
           showCancelButton: true,
           confirmButtonColor: '#3085d6',
@@ -234,8 +234,13 @@ class DocIndex extends React.Component {
             }).then((resp) => resp.json())
               .then(()=>{
                 location.reload();
-                swal.fire(t('Delete Successful!',
-                  {ns: 'document_repository'}), '', 'success');
+                swal.fire({
+                  title: t('Delete Successful!',
+                    {ns: 'document_repository'}),
+                  text: '',
+                  type: 'success',
+                  confirmButtonText: t('OK', {ns: 'loris'}),
+                });
               });
           }
         });

--- a/modules/document_repository/jsx/editForm.js
+++ b/modules/document_repository/jsx/editForm.js
@@ -193,7 +193,15 @@ class DocEditForm extends React.Component {
     })
       .then((resp) => resp.json())
       .then(()=>{
-        swal.fire('Updated Successful!', '', 'success');
+        swal.fire({
+          title: this.props.t(
+            'File updated successfully!',
+            {ns: 'document_repository'}
+          ),
+          text: '',
+          type: 'success',
+          confirmButtonText: this.props.t('OK', {ns: 'loris'}),
+        });
         this.fetchData();
       });
   }

--- a/modules/document_repository/jsx/translateKnownBackendError.js
+++ b/modules/document_repository/jsx/translateKnownBackendError.js
@@ -1,0 +1,26 @@
+const KNOWN_BACKEND_ERROR_MSGIDS = Object.freeze({
+  'Duplicate category name under same parent folder.':
+    'Duplicate category name under same parent folder.',
+  'Can not delete non-empty category':
+    'Can not delete non-empty category',
+});
+
+/**
+ * Translate known backend error bodies while preserving raw fallback text.
+ *
+ * @param {string} message - Backend-provided error body.
+ * @param {function} t - i18n translate function.
+ * @return {string} Translated text for known messages or raw fallback.
+ */
+const translateKnownBackendError = (message, t) => {
+  if (typeof message !== 'string' || message === '') {
+    return message;
+  }
+  const msgid = KNOWN_BACKEND_ERROR_MSGIDS[message];
+  if (!msgid || typeof t !== 'function') {
+    return message;
+  }
+  return t(msgid, {ns: 'document_repository', defaultValue: message});
+};
+
+export default translateKnownBackendError;

--- a/modules/document_repository/locale/document_repository.pot
+++ b/modules/document_repository/locale/document_repository.pot
@@ -87,6 +87,12 @@ msgstr ""
 msgid "Category added successfully!"
 msgstr ""
 
+msgid "Could not add category!"
+msgstr ""
+
+msgid "Duplicate category name under same parent folder."
+msgstr ""
+
 msgid "Error"
 msgstr ""
 
@@ -138,6 +144,9 @@ msgstr ""
 msgid "Delete error!"
 msgstr ""
 
+msgid "Can not delete non-empty category"
+msgstr ""
+
 msgid "Delete Successful!"
 msgstr ""
 
@@ -160,6 +169,9 @@ msgid "Date Uploaded"
 msgstr ""
 
 msgid "Edit"
+msgstr ""
+
+msgid "Delete"
 msgstr ""
 
 msgid "Delete File"

--- a/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
@@ -93,6 +93,12 @@ msgstr "Parent"
 msgid "Category added successfully!"
 msgstr "Catégorie ajoutée avec succès !"
 
+msgid "Could not add category!"
+msgstr "Impossible d'ajouter la catégorie !"
+
+msgid "Duplicate category name under same parent folder."
+msgstr "Nom de catégorie en double sous le même dossier parent."
+
 msgid "Error"
 msgstr "Erreur"
 
@@ -154,6 +160,9 @@ msgstr "Supprimer une catégorie"
 msgid "Delete error!"
 msgstr "Supprimer l'erreur !"
 
+msgid "Can not delete non-empty category"
+msgstr "Impossible de supprimer une catégorie non vide"
+
 #, fuzzy
 msgid "Delete Successful!"
 msgstr "Suppression réussie !"
@@ -179,6 +188,9 @@ msgstr "Date de téléversement"
 
 msgid "Edit"
 msgstr "Modifier"
+
+msgid "Delete"
+msgstr "Supprimer"
 
 msgid "Delete File"
 msgstr "Supprimer le fichier"

--- a/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
@@ -89,6 +89,12 @@ msgstr "मूल"
 msgid "Category added successfully!"
 msgstr "श्रेणी सफलतापूर्वक जोड़ी गई!"
 
+msgid "Could not add category!"
+msgstr "श्रेणी नहीं जोड़ी जा सकी!"
+
+msgid "Duplicate category name under same parent folder."
+msgstr "एक ही मूल फ़ोल्डर के अंतर्गत श्रेणी का नाम डुप्लिकेट है।"
+
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -140,6 +146,9 @@ msgstr "एक श्रेणी हटाएँ"
 msgid "Delete error!"
 msgstr "हटाने में त्रुटि!"
 
+msgid "Can not delete non-empty category"
+msgstr "रिक्त न होने वाली श्रेणी को हटाया नहीं जा सकता"
+
 msgid "Delete Successful!"
 msgstr "हटाना सफल रहा!"
 
@@ -160,6 +169,9 @@ msgstr "अपलोड की तारीख"
 
 msgid "Edit"
 msgstr "संपादित करें"
+
+msgid "Delete"
+msgstr "हटाएँ"
 
 msgid "Delete File"
 msgstr "फ़ाइल हटाएँ"

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -87,6 +87,12 @@ msgstr "親"
 msgid "Category added successfully!"
 msgstr "カテゴリが正常に追加されました。"
 
+msgid "Could not add category!"
+msgstr "カテゴリを追加できませんでした!"
+
+msgid "Duplicate category name under same parent folder."
+msgstr "同じ親フォルダ内に同じカテゴリ名があります。"
+
 msgid "Error"
 msgstr "エラー"
 
@@ -138,6 +144,9 @@ msgstr "カテゴリを削除する"
 msgid "Delete error!"
 msgstr "削除エラー!"
 
+msgid "Can not delete non-empty category"
+msgstr "空でないカテゴリは削除できません"
+
 msgid "Delete Successful!"
 msgstr "削除に成功しました!"
 
@@ -161,6 +170,9 @@ msgstr "アップロード日"
 
 msgid "Edit"
 msgstr "編集"
+
+msgid "Delete"
+msgstr "削除"
 
 msgid "Delete File"
 msgstr "ファイルを削除"


### PR DESCRIPTION
## Brief summary of changes
This PR fixes untranslated `document_repository` swal dialogs by removing hardcoded English text, correcting a namespace mismatch, and localizing known backend error messages shown in popups.

- Updated add-category, delete-category, edit-entry, and delete-file swals to use `t(...)` translations.
- Fixed delete confirmation text lookup by switching `"You won't be able to revert this!"` to the `document_repository` namespace.
- Added translation mapping for known backend errors (`Duplicate category name under same parent folder.`, `Can not delete non-empty category`) with raw-text fallback for unknown messages.
- Added missing translation keys and entries for `fr`, `hi`, and `ja` (with English msgid fallback), including `Delete` and category error strings.
- Added translated `OK` confirm button text in the affected swals.

Since I don't have experience with Japanese, a strict review will be required for its translations.
Please let me know whatever changes required and I'll incorporate them. 


### Screenshots

<img width="1004" height="486" alt="Screenshot 2026-03-06 at 12 43 09" src="https://github.com/user-attachments/assets/a9a43be0-666a-433f-a414-0811bee439db" />
<img width="1054" height="469" alt="Screenshot 2026-03-06 at 12 43 26" src="https://github.com/user-attachments/assets/d0d7fceb-833a-4ed2-93dd-4d4a624794aa" />
<img width="1047" height="492" alt="Screenshot 2026-03-06 at 13 14 00" src="https://github.com/user-attachments/assets/3f7376e6-665e-42f9-b453-1a83f792cfcd" />
<img width="1415" height="575" alt="Screenshot 2026-03-06 at 13 14 47" src="https://github.com/user-attachments/assets/8c4a29fb-de19-4e3d-9211-84aed880a83b" />
<img width="1058" height="475" alt="Screenshot 2026-03-06 at 12 43 49" src="https://github.com/user-attachments/assets/cc26d798-26e9-4d89-8ec5-71d5d090616f" />
<img width="1003" height="462" alt="Screenshot 2026-03-06 at 12 44 17" src="https://github.com/user-attachments/assets/6309fc4a-6dfa-4d0a-bf07-5b29c271c772" />
<img width="1414" height="582" alt="Screenshot 2026-03-06 at 13 15 00" src="https://github.com/user-attachments/assets/28c2ed4d-6465-4823-83e2-94720ce69f5b" />

#### Link(s) to related issue(s)

* Resolves #10280 #10215