### PR TITLE
[dictionary] "Cohorts" filter label translation

### DIFF
--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -331,7 +331,7 @@ class DataDictIndex extends Component {
         },
       },
       {
-        label: t('Cohorts', {ns: 'loris'}),
+        label: t('Cohort', {ns: 'loris', count: 1}),
         show: true,
         filter: {
           name: 'Cohorts',


### PR DESCRIPTION
## Brief summary of changes

Resolved the untranslated Dictionary “Cohorts” filter label by using the existing localized `Cohort` key, without changing filter behaviour.

<img width="1057" height="581" alt="image" src="https://github.com/user-attachments/assets/a89e4e59-f258-4322-9e74-281221b596b6" />

#### Link(s) to related issue(s)

* Resolves #10271