### PR TITLE
[dataquery] Show self-shared queries in Shared Queries panel

### DIFF
--- a/modules/dataquery/jsx/hooks/usesharedqueries.tsx
+++ b/modules/dataquery/jsx/hooks/usesharedqueries.tsx
@@ -99,10 +99,9 @@ type SharedQueriesType = [
 /**
  * React hook to load recent and shared queries from the server
  *
- * @param {string} username - The username accessing the module
  * @returns {array} - [{queries}, reload function(), {queryActions}]
  */
-function useSharedQueries(username: string): SharedQueriesType {
+function useSharedQueries(): SharedQueriesType {
   const [recentQueries, setRecentQueries] = useState<FlattenedQuery[]>([]);
   const [sharedQueries, setSharedQueries] = useState<FlattenedQuery[]>([]);
   const [topQueries, setTopQueries] = useState<FlattenedQuery[]>([]);
@@ -138,27 +137,10 @@ function useSharedQueries(username: string): SharedQueriesType {
               convertedtop.push(flattened);
             }
             if (query.Public == true) {
-              // If we're the only person who shared it, don't show it in our
-              // shared queries.
-              // If other people shared it too, then remove ourselves from the
-              // "shared by" list in the Shared Queries panel.
-              if (query.SharedBy.length == 1
-                            && query.SharedBy[0] == username
-              ) {
-                // don't include
-              } else {
-                // filter
-                query.SharedBy = query.SharedBy.filter(
-                  (item: string) => {
-                    return item != username;
-                  }
-                );
-                // Make a new copy to avoid mutating the version used by other
-                // tabs
-                const flattened2: FlattenedQuery
-                            = query2flattened(query);
-                convertedshared.push(flattened2);
-              }
+              // Include all public queries, including ones shared by the
+              // current user, so shared queries are consistent with the
+              // Recent Queries "Shared Only" filter.
+              convertedshared.push(flattened);
             }
           });
         }

--- a/modules/dataquery/jsx/index.tsx
+++ b/modules/dataquery/jsx/index.tsx
@@ -72,20 +72,18 @@ function useActiveCategory(
  * @param {object} props - React props
  * @param {any} props.t - useTranslation
  * @param {boolean} props.queryAdmin - true if the current user has permission to administer study queries
- * @param {string} props.username - The user accessing the app
  *
  * @returns {React.ReactElement} - The main page of the app
  */
 function DataQueryApp(props: {
     t: any,
     queryAdmin: boolean,
-    username: string
 }) {
   const [activeTab, setActiveTab] = useState('Info');
   useBreadcrumbs(activeTab, setActiveTab);
 
   const [queries, reloadQueries, queryActions]
-        = useSharedQueries(props.username);
+        = useSharedQueries();
 
   const visits = useVisits();
 
@@ -267,7 +265,6 @@ window.addEventListener('load', () => {
   root.render(
     <Index
       queryAdmin={loris.userHasPermission('dataquery_admin')}
-      username={loris.user.username}
     />,
   );
 });


### PR DESCRIPTION
## Brief summary of changes

- Included queries shared by the current user in the Shared Queries panel.
- Removed the self-share filtering logic so Shared Queries matches Recent Queries with `Shared Only` enabled.
- Removed the now-unused `username` hook parameter.

https://github.com/user-attachments/assets/239545db-b269-4186-b537-7e7dfe9586e2



#### Link(s) to related issue(s)

* Resolves #9902