### PR TITLE
[document_repository] Breadcrumb translation

### DIFF
--- a/modules/document_repository/php/edit.class.inc
+++ b/modules/document_repository/php/edit.class.inc
@@ -45,12 +45,14 @@ class Edit extends \NDB_Page
      */
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
-        $label = ucwords(str_replace('_', ' ', $this->name));
         return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb($label, "/$this->name"),
             new \LORIS\Breadcrumb(
-                'Edit',
-                "/" . $_GET['lorispath']
+                dgettext('document_repository', 'Document Repository'),
+                "/$this->name"
+            ),
+            new \LORIS\Breadcrumb(
+                dgettext('document_repository', 'Edit'),
+                "/$this->name/$this->page"
             )
         );
     }


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the untranslated breadcrumbs on the Document Repository edit page.

- Updated the breadcrumb labels to use existing `document_repository` gettext translations instead of derived and hardcoded English text.
- Replaced the invalid `lorispath` breadcrumb link with the standard edit-page route.


<img width="963" height="558" alt="Screenshot 2026-03-07 at 00 35 35" src="https://github.com/user-attachments/assets/dc62147d-680f-42da-9fea-0b70ae86018b" />
 
<img width="928" height="551" alt="Screenshot 2026-03-07 at 00 34 54" src="https://github.com/user-attachments/assets/3bac055a-6f1f-42df-a8e4-f327840a1757" />

<img width="934" height="572" alt="Screenshot 2026-03-07 at 00 35 02" src="https://github.com/user-attachments/assets/ff413954-4958-487e-b44e-b6885fa8e8aa" />

<img width="964" height="570" alt="Screenshot 2026-03-07 at 00 35 14" src="https://github.com/user-attachments/assets/1c508126-1b0a-49d7-88a7-92b51c5d0cc2" />

#### Link(s) to related issue(s)
* Resolves #10278
