### PR TITLE
[SQL/physiological] Remove physiological file dummy date default

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -29,7 +29,7 @@ CREATE TABLE `physiological_file` (
   `SessionID`                 INT(10)    UNSIGNED  NOT NULL,
   `InsertTime`                TIMESTAMP            NOT NULL      DEFAULT CURRENT_TIMESTAMP,
   `FileType`                  VARCHAR(12)          DEFAULT NULL,
-  `AcquisitionTime`           DATETIME             DEFAULT '1970-01-01 00:00:01',
+  `AcquisitionTime`           DATETIME             DEFAULT NULL,
   `InsertedByUser`            VARCHAR(50)          NOT NULL,
   `FilePath`                  VARCHAR(255)         NOT NULL,
   `Index`                     INT(5)               DEFAULT NULL,

--- a/SQL/New_patches/2026-03-13_fix-physio-file-default-date.sql
+++ b/SQL/New_patches/2026-03-13_fix-physio-file-default-date.sql
@@ -1,0 +1,8 @@
+-- Modify AcquisitionTime column to allow NULL and remove the dummy default
+ALTER TABLE `physiological_file`
+MODIFY COLUMN `AcquisitionTime` DATETIME DEFAULT NULL;
+
+-- Update any existing records that still have the dummy date to NULL
+UPDATE `physiological_file`
+SET `AcquisitionTime` = NULL
+WHERE `AcquisitionTime` = '1970-01-01 00:00:01';


### PR DESCRIPTION
## Problem

The `physiological_table` field is nullable, yet it uses a dummy date as a default. Although the imaging scripts seem to always put a date manually, a dummy date is a bad practice as it is harder to be sure whether a date is real or not.

## Solution

Just use `NULL` as a default instead.

## Testing

Ran the patch in Raisinbread and checked that nothing bad happened.