### PR TITLE
Profiler reference fix

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -17,6 +17,7 @@
  * @link     https://www.github.com/aces/Loris/
  */
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . "/../php/libraries/Profiler.php";
 
 // We don't want PHP to automatically add cache control headers unless
 // we explicitly generate them in the request response. (This needs


### PR DESCRIPTION
## Brief summary of changes

Fix on missing Profiler ref.

## Edit 

After re-checking install, some files seem to have been missing during `make dev`.
I ran the install with node `v18.20.8`, and had this error, when I ran it with node `v20.20.1`, this error was not present anymore. @driusan any idea why?
