### PR TITLE
[candidate_parameters] Add date precision field for DoD

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -159,7 +159,7 @@ CREATE TABLE `candidate` (
   `ExternalID` varchar(255) DEFAULT NULL,
   `DoB` date DEFAULT NULL,
   `DoD` date DEFAULT NULL,
-  `DoD_precision` enum('known_year_month','known_year','unknown') DEFAULT NULL,
+  `DoD_precision` enum('known_full','known_year_month','known_year','unknown') DEFAULT NULL,
   `EDC` date DEFAULT NULL,
   `Sex` varchar(255) DEFAULT NULL,
   `RegistrationCenterID` integer unsigned NOT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -159,6 +159,7 @@ CREATE TABLE `candidate` (
   `ExternalID` varchar(255) DEFAULT NULL,
   `DoB` date DEFAULT NULL,
   `DoD` date DEFAULT NULL,
+  `DoD_precision` enum('known_year_month','known_year','unknown') DEFAULT NULL,
   `EDC` date DEFAULT NULL,
   `Sex` varchar(255) DEFAULT NULL,
   `RegistrationCenterID` integer unsigned NOT NULL,

--- a/SQL/New_patches/2026-03-17-DoD-precision-field.sql
+++ b/SQL/New_patches/2026-03-17-DoD-precision-field.sql
@@ -1,2 +1,2 @@
 ALTER TABLE candidate
-ADD COLUMN DoD_precision enum('known_year_month','known_year','unknown') DEFAULT NULL AFTER DoD;
+ADD COLUMN DoD_precision enum('known_full','known_year_month','known_year','unknown') DEFAULT NULL AFTER DoD;

--- a/SQL/New_patches/2026-03-17-DoD-precision-field.sql
+++ b/SQL/New_patches/2026-03-17-DoD-precision-field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE candidate
+ADD COLUMN DoD_precision enum('known_year_month','known_year','unknown') DEFAULT NULL AFTER DoD;

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -630,14 +630,20 @@ function editCandidateDOB(\Database $db): void
 function editCandidateDOD(\Database $db): void
 {
     $candID       = new CandID($_POST['candID']);
-    $dod          = new DateTime($_POST['dod']);
+    $dod          = array_key_exists('dod', $_POST) ?
+        new DateTime($_POST['dod']) : null;
+    $precision    = $_POST['dod_precision'];
     $strippedDate = null;
     $dodString    = null;
 
-    if (!$dod) {
+    if (!$dod && $precision !== 'unknown') {
         throw new \LorisException('Date not valid.');
     }
+    if (!$precision) {
+        throw new \LorisException('Date of Death precision must be specified.');
+    }
 
+    $updateData = [];
     if (!empty($dod)) {
         $config    = \NDB_Config::singleton();
         $dodFormat = $config->getSetting('dodFormat');
@@ -646,10 +652,17 @@ function editCandidateDOD(\Database $db): void
         } else {
             $dodString = $dod->format('Y-m-d');
         }
+        $updateData['DoD'] = $strippedDate ?? $dodString;
+    } else {
+        $updateData['DoD'] = null;
+    }
+
+    if ($precision) {
+        $updateData['DoD_precision'] = $precision;
         $db->update(
             'candidate',
-            ['DoD' => $strippedDate ?? $dodString],
-            ['ID' => $candID->__toString()]
+            $updateData,
+            ['CandID' => $candID->__toString()]
         );
     }
 }

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -586,7 +586,13 @@ function getDODFields(): array
     $db     = \NDB_Factory::singleton()->database();
 
     $candidateData = $db->pselectRow(
-        'SELECT PSCID,DoD, DoB FROM candidate where CandID =:candid',
+        'SELECT
+            PSCID,
+            DoD,
+            DoD_precision,
+            DoB
+        FROM candidate
+        WHERE CandID =:candid',
         ['candid' => $candID]
     );
     if ($candidateData === null) {
@@ -614,11 +620,12 @@ function getDODFields(): array
     $dob = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
 
     $result = [
-        'pscid'     => $candidateData['PSCID'],
-        'candID'    => $candID->__toString(),
-        'dod'       => $dod,
-        'dob'       => $dob,
-        'dodFormat' => $config->getSetting('dodFormat'),
+        'pscid'         => $candidateData['PSCID'],
+        'candID'        => $candID->__toString(),
+        'dod'           => $dod,
+        'dob'           => $dob,
+        'dod_precision' => $candidateData['DoD_precision'],
+        'dodFormat'     => $config->getSetting('dodFormat'),
     ];
     return $result;
 }

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -91,6 +91,12 @@ class CandidateDOB extends Component {
     }
 
     let dateFormat = this.state.data.dobFormat;
+
+    let dobValue = this.state.formData.dob || '';
+    if (dateFormat == 'Ym' && this.state.formData.dob) {
+      dobValue = dobValue.slice(0, 7);
+    }
+
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dob_edit')) {
@@ -126,7 +132,7 @@ class CandidateDOB extends Component {
           <DateElement
             label={t('DoB', {ns: 'loris'})}
             name='dob'
-            dateFormat={dateFormat}
+            dateFormat={dobValue}
             value={this.state.formData.dob}
             onUserInput={this.setFormData}
             disabled={disabled}

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -9,6 +9,7 @@ import {
   StaticElement,
   DateElement,
   ButtonElement,
+  SelectElement,
 } from 'jsx/Form';
 
 /**
@@ -95,6 +96,12 @@ class CandidateDOD extends Component {
       disabled = false;
       updateButton = <ButtonElement label={t('Update', {ns: 'loris'})}/>;
     }
+    let precisionOptions = {
+      'known_year_month' : t('Known year and month'),
+      'known_year' : t('Known year'),
+      'unknown' : t('Unknown date'),
+    };
+    let required = this.state.formData.dod_precision != 'unknown';
 
     return (
       <div className='row'>
@@ -121,14 +128,23 @@ class CandidateDOD extends Component {
             }
             class='form-control-static text-danger bg-danger col-sm-10'
           />
+          <SelectElement
+            label={t('Precision of date:')}
+            name='dod_precision'
+            options={precisionOptions}
+            value={this.state.formData.dod_precision}
+            onUserInput={this.setFormData}
+            disabled={disabled}
+            required={true}
+          />
           <DateElement
             label={t('Date Of Death:', {ns: 'candidate_parameters'})}
             name='dod'
             dateFormat={dateFormat}
             value={this.state.formData.dod}
             onUserInput={this.setFormData}
-            disabled={disabled}
-            required={true}
+            disabled={disabled || !required}
+            required={required}
           />
           {updateButton}
         </FormElement>
@@ -194,7 +210,6 @@ class CandidateDOD extends Component {
     }
 
     formObject.append('tab', this.props.tabName);
-
     fetch(this.props.action, {
       method: 'POST',
       cache: 'no-cache',

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -65,7 +65,13 @@ class CandidateDOD extends Component {
    * @param {*} value
    */
   setFormData(formElement, value) {
-    let formData = this.state.formData;
+    let formData = {...this.state.formData};
+
+    // Clear the DOD if indicated as unknown
+    if (formElement === 'dod_precision' && value === 'unknown') {
+      formData.dod = '';
+    }
+
     formData[formElement] = value;
     this.setState({
       formData: formData,
@@ -89,19 +95,29 @@ class CandidateDOD extends Component {
       return <Loader/>;
     }
 
-    let dateFormat = this.state.data.dodFormat;
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dod_edit')) {
       disabled = false;
       updateButton = <ButtonElement label={t('Update', {ns: 'loris'})}/>;
     }
+
     let precisionOptions = {
-      'known_year_month' : t('Known year and month'),
-      'known_year' : t('Known year'),
-      'unknown' : t('Unknown date'),
+      'known_year_month': t('I know the year and month of death'),
+      'known_year': t('I know the year of death'),
+      'unknown': t('I do not know the date of death'),
     };
+
     let required = this.state.formData.dod_precision != 'unknown';
+
+    let dateFormat = this.state.data.dodFormat;
+
+    let dodValue = this.state.formData.dod || '';
+    if (dateFormat == 'Ymd') {
+      precisionOptions['known_full'] = t('I know the full date of death');
+    } else if (dateFormat == 'Ym' && this.state.formData.dod) {
+      dodValue = dodValue.slice(0, 7);
+    }
 
     return (
       <div className='row'>

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -157,7 +157,7 @@ class CandidateDOD extends Component {
             label={t('Date Of Death:', {ns: 'candidate_parameters'})}
             name='dod'
             dateFormat={dateFormat}
-            value={this.state.formData.dod}
+            value={dodValue}
             onUserInput={this.setFormData}
             disabled={disabled || !required}
             required={required}

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -227,3 +227,18 @@ msgstr ""
 
 msgid "Comments: "
 msgstr ""
+
+msgid "I know the year and month of death"
+msgstr ""
+
+msgid "I know the year of death"
+msgstr ""
+
+msgid "I do not know the date of death"
+msgstr ""
+
+msgid "I know the full date of death"
+msgstr ""
+
+msgid "Precision of date:"
+msgstr ""


### PR DESCRIPTION
## Brief summary of changes
This PR adds a field to indicate the precision of DoD known as discussed in the LORIS meeting. 

The options for precision are "Known year and month", "Known year" and "Unknown Date". If "Unknown date" is selected, the date field should not be entered.

#### Testing instructions (if applicable)

1. Go to candidate parameters for a participant to update the DoD
2. Make sure you can not save without a precision selected
3. If "Unknown date" is selected, make sure you can not fill out a date / the date is not required.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
