### PR TITLE
[user_accounts] Lock user account page when editing own accounts

### DIFF
--- a/modules/user_accounts/locale/user_accounts.pot
+++ b/modules/user_accounts/locale/user_accounts.pot
@@ -197,3 +197,12 @@ msgstr ""
 
 msgid "This email address is already in use"
 msgstr ""
+
+msgid "You cannot edit your own account settings"
+msgstr ""
+
+msgid "To change your email or password, go to \"My Preferences\""
+msgstr ""
+
+msgid "For any other changes, contact an administrator"
+msgstr ""

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -191,6 +191,14 @@ class Edit_User extends \NDB_Form
      */
     function _process($values)
     {
+        if ($this->_isEditingOwnAccount()) {
+            error_log(
+                "[user_accounts] Blocked self-edit attempt for user: "
+                . $this->identifier
+            );
+            return;
+        }
+
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
         $config  = $factory->config();
@@ -646,6 +654,7 @@ class Edit_User extends \NDB_Form
         if (!empty($matches[1])) {
             $this->identifier = $matches[1];
         }
+        $this->tpl_data['isSelfEdit'] = $this->_isEditingOwnAccount();
         $response = parent::handle($request);
         if (!empty($this->redirect)) {
             return $response
@@ -1105,6 +1114,9 @@ class Edit_User extends \NDB_Form
 
         // unique key and password rules
         $this->form->addFormRule([&$this, '_validateEditUser']);
+
+        // Expose self-edit flag to the Smarty template.
+        $this->tpl_data['isSelfEdit'] = $this->_isEditingOwnAccount();
     }
 
     /**

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -24,6 +24,17 @@
         </div>
     </div>
     <h3>{dgettext("user_accounts", "Add/Edit User")}</h3>
+
+    {if $isSelfEdit}
+    <div class="alert alert-warning" role="alert">
+        {dgettext("user_accounts", "You cannot edit your own account settings.")}
+        {dgettext("user_accounts", "To change your email or password, go to \"My Preferences\".")}
+        {dgettext("user_accounts", "For any other changes, contact an administrator.")}
+    </div>
+    {/if}
+
+    <fieldset {if $isSelfEdit}disabled="disabled"{/if}>
+
 	    {if $form.errors.UserID_Group|default}
         <div class="row form-group has-error">
         {else}
@@ -494,9 +505,11 @@
     </div>
 </div>
 </div>
+    </fieldset>
+
 <div class="row form-group form-inline">
    <div class="col-sm-2">
-      <input class="btn btn-sm btn-primary" name="fire_away" value="{dgettext("loris", "Save")}" type="submit" />
+      <input class="btn btn-sm btn-primary" name="fire_away" value="{dgettext("loris", "Save")}" type="submit" {if $isSelfEdit}disabled="disabled"{/if}/>
   </div>
   <div class="col-sm-2">
     <input class="btn btn-sm btn-primary" value="{dgettext("loris", "Reset")}" type="reset"/>

--- a/modules/user_accounts/test/UserAccountsIntegrationTest.php
+++ b/modules/user_accounts/test/UserAccountsIntegrationTest.php
@@ -39,10 +39,10 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     private const UNITTESTER_EMAIL     = 'tester@example.com';
     private const UNITTESTER_EMAIL_NEW = 'newemail@example.com';
     // Admin user details
-    private const ADMIN_USERNAME  = 'admin';
-    private const ADMIN_REALNAME  = 'Admin account';
-    private const ADMIN_EMAIL     = 'admin@example.com';
-    private const ADMIN_EMAIL_NEW = 'tester@example.com';
+    private const ADMIN_USERNAME         = 'admin';
+    private const ADMIN_REALNAME         = 'Admin account';
+    private const ADMIN_EMAIL            = 'admin@example.com';
+    private const ADMIN_EMAIL_NEW        = 'tester@example.com';
     private const UNITTESTERTWO_USERNAME = 'UnitTesterTwo';
     private const UNITTESTERTWO_EMAIL    = 'tester2@example.com';
 

--- a/modules/user_accounts/test/UserAccountsIntegrationTest.php
+++ b/modules/user_accounts/test/UserAccountsIntegrationTest.php
@@ -43,6 +43,8 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     private const ADMIN_REALNAME  = 'Admin account';
     private const ADMIN_EMAIL     = 'admin@example.com';
     private const ADMIN_EMAIL_NEW = 'tester@example.com';
+    private const UNITTESTERTWO_USERNAME = 'UnitTesterTwo';
+    private const UNITTESTERTWO_EMAIL    = 'tester2@example.com';
 
     private $_name        = 'input[name="username"]';
     private $_site        = 'select[name="site"]';
@@ -213,38 +215,36 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function testUserAccountEdits()
     {
-        // Test changing first name
+        // Test changing first name on another user
         $this->_verifyUserModification(
-            'UnitTester',
+            self::UNITTESTERTWO_USERNAME,
             'First_name',
             'NewFirst'
         );
-        // Test changing last name
+        // Test changing last name on another user
         $this->_verifyUserModification(
-            'UnitTester',
+            self::UNITTESTERTWO_USERNAME,
             'Last_name',
             'NewLast'
         );
-        // Test changing 'Active' status
+        // Test changing 'Active' status on another user
         $this->_verifyUserModification(
-            'UnitTesterTwo',
+            self::UNITTESTERTWO_USERNAME,
             'Active',
             'No'
         );
-        // Test changing Email
+        // Test changing Email on another user
         $this->_verifyUserModification(
-            'UnitTester',
+            self::UNITTESTERTWO_USERNAME,
             'Email',
             'newemail@example.com'
         );
-        // Test changing Approval status
+        // Test changing Approval status on another user
         $this->_verifyUserModification(
-            'UnitTesterTwo',
+            self::UNITTESTERTWO_USERNAME,
             'Pending_approval',
             'No'
         );
-        //TODO:add test case to ensure pending_approval
-        //DOES NOT show up on UnitTester since logged in user is UnitTester
     }
 
     /**
@@ -373,6 +373,43 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     }
 
     /**
+     * Verifies that when a user opens their own account page the form is
+     * entirely read-only: a warning banner is shown, all editable fields are
+     * disabled, and the Save button is disabled.
+     *
+     * @return void
+     */
+    function testSelfEditFormIsReadOnly(): void
+    {
+        $this->_accessUser(self::UNITTESTER_USERNAME);
+
+        // Warning message must be visible
+        $this->assertStringContainsString(
+            'You cannot edit your own account settings',
+            $this->getBody()
+        );
+
+        // Core fields must be disabled (fieldset-level disabled propagates to
+        // descendants; isEnabled() reflects the effective disabled state)
+        foreach (['First_name', 'Last_name', 'Email'] as $fieldName) {
+            $this->assertFalse(
+                $this->safeFindElement(
+                    WebDriverBy::Name($fieldName)
+                )->isEnabled(),
+                "Expected field '$fieldName' to be disabled when editing own account"
+            );
+        }
+
+        // Save button must be disabled (it carries an explicit disabled attr)
+        $this->assertNotNull(
+            $this->safeFindElement(
+                WebDriverBy::Name('fire_away')
+            )->getAttribute('disabled'),
+            'Expected Save button to be disabled when editing own account'
+        );
+    }
+
+    /**
      * Ensures that the user cannot set their password to be the same value
      * as their email address.
      *
@@ -380,17 +417,16 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function testPasswordMustNotEqualEmail(): void
     {
-        // Make sure the user's email is set to a known value. This will also
-        // load the page.
+        // Set UnitTesterTwo's email to a known value first.
         $this->_verifyUserModification(
-            self::UNITTESTER_USERNAME,
+            self::UNITTESTERTWO_USERNAME,
             'Email',
             self::UNITTESTER_EMAIL_NEW
         );
 
         // Try changing the password to the same value.
         $this->_sendPasswordValues(
-            self::UNITTESTER_USERNAME,
+            self::UNITTESTERTWO_USERNAME,
             self::UNITTESTER_EMAIL_NEW
         );
         // This text comes from the class constants in Edit User
@@ -408,7 +444,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         // Send two different random strings to the password and confirm
         // password values.
         $this->_sendPasswordValues(
-            self::UNITTESTER_USERNAME,
+            self::UNITTESTERTWO_USERNAME,
             \Utility::randomString(),
             \Utility::randomString()
         );
@@ -427,13 +463,13 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $newPassword = \Utility::randomString();
         // Change the user's password to $newPassword
         $this->_sendPasswordValues(
-            self::UNITTESTER_USERNAME,
+            self::UNITTESTERTWO_USERNAME,
             $newPassword
         );
         // Change the password again using the same value. This should cause
         // and error.
         $this->_sendPasswordValues(
-            self::UNITTESTER_USERNAME,
+            self::UNITTESTERTWO_USERNAME,
             $newPassword
         );
         // This text comes from the class constants in Edit User


### PR DESCRIPTION
#### Testing instructions (if applicable)

1. Go to Admin-->User Accounts-->click on the user account(email) you shouldn't edit any field in that page.

#### Link(s) to related issue(s)

- Related to: https://github.com/aces/Loris/issues/10422
