### PR TITLE
Fix for bvl_feedback security vulnerability

### DIFF
--- a/modules/bvl_feedback/ajax/bvl_panel_ajax.php
+++ b/modules/bvl_feedback/ajax/bvl_panel_ajax.php
@@ -19,7 +19,17 @@
 namespace LORIS\bvl_feedback;
 use \LORIS\StudyEntities\Candidate\CandID;
 
-$username = \User::singleton()->getUsername();
+$user = \User::singleton();
+if (!$user->hasPermission('bvl_feedback')) {
+    header("HTTP/1.1 403 Forbidden");
+    header("Content-Type: text/plain");
+    exit(
+        "You do not have valid permissions for this
+         operation."
+    );
+}
+
+$username = $user->getUsername();
 $data     = \Utility::parseFormData($_POST);
 
 if (isset($data['candID']) && !empty($data['candID'])) {


### PR DESCRIPTION
This PR adds permission checks in LORIS bvl_feedback module for all ajax directory script invocations. This prevents users from accessing, modifying, or deleting feedback if they are not allowed to do so.