### PR TITLE
[electrophysiology_browser] Fix French translation

### DIFF
--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -499,7 +499,8 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-msgid "%s Channel Count"  # Channel Type (ex: EEG, ECG)
+# Channel Type (ex: EEG, ECG)
+msgid "%s Channel Count"
 msgstr ""
 
 msgid "Reference"

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -624,9 +624,9 @@ msgstr "Détails de l’événement"
 msgid "Sampling Frequency"
 msgstr "Fréquence d'échantillonnage"
 
-#, fuzzy
-msgid "%s Channel Count\"  # Channel Type (ex: EEG, ECG"
-msgstr "%s Nombre de canaux » # Type de canal (ex. : EEG, ECG"
+# Channel Type (ex: EEG, ECG)
+msgid "%s Channel Count"
+msgstr "Nombre canaux %s"
 
 msgid "Reference"
 msgstr "Référence"


### PR DESCRIPTION
## Brief summary of changes

Fixed the malformed inline comment in .pot that broke the French msgid.

`"%s Channel Count"` now resolves to `"Nombre canaux %s"` instead of falling back to English.

<img width="1026" height="659" alt="Screenshot 2026-04-21 at 12 44 22" src="https://github.com/user-attachments/assets/12d584ca-0a5d-4fee-abb4-f9b0dbe88312" />

#### Link(s) to related issue(s)

* Resolves #10279