### PR TITLE
[electrophysiology_uploader] Fix translations

### DIFF
--- a/modules/electrophysiology_uploader/jsx/ElectrophysiologyUploader.js
+++ b/modules/electrophysiology_uploader/jsx/ElectrophysiologyUploader.js
@@ -75,7 +75,7 @@ function ElectrophysiologyUploader(props) {
     <>
       <div className="alert alert-warning" role="alert">
         <strong>{t('LORIS 26 Beta Note:',
-          {ns: 'electrophysiology_uploader'})}</strong>
+          {ns: 'electrophysiology_uploader'})}</strong>{' '}
         {t('Files uploaded in this module will not be viewable'+
           ' in the Electrophysiology Browser module. ' +
            'This feature is under construction for the next release. ' +

--- a/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
+++ b/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
@@ -86,3 +86,7 @@ msgstr ""
 
 msgid "Uploaded By"
 msgstr ""
+
+# upload.class.inc
+msgid "File not found."
+msgstr ""

--- a/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
@@ -24,7 +24,7 @@ msgstr "Téléverseur d'électrophysiologie"
 
 #, fuzzy
 msgid "LORIS 26 Beta Note:"
-msgstr "LORIS 26 Beta Remarque:"
+msgstr "LORIS 26 Beta Remarque :"
 
 msgid ""
 "Files uploaded in this module will not be viewable in the Electrophysiology "

--- a/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
@@ -24,7 +24,7 @@ msgstr "Téléverseur d'électrophysiologie"
 
 #, fuzzy
 msgid "LORIS 26 Beta Note:"
-msgstr "LORIS 26 Beta Remarque :"
+msgstr "LORIS 26 Beta Remarque:"
 
 msgid ""
 "Files uploaded in this module will not be viewable in the Electrophysiology "
@@ -93,7 +93,7 @@ msgid "Submission error!"
 msgstr "Erreur de soumission!"
 
 msgid "Upload Location"
-msgstr "Emplacement de téléversement"
+msgstr "Emplacement du téléversement"
 
 msgid "Upload ID"
 msgstr "ID de téléversement"
@@ -106,3 +106,7 @@ msgstr "Statut"
 
 msgid "Uploaded By"
 msgstr "Téléverser par"
+
+# upload.class.inc
+msgid "File not found."
+msgstr "Fichier introuvable."

--- a/modules/electrophysiology_uploader/php/upload.class.inc
+++ b/modules/electrophysiology_uploader/php/upload.class.inc
@@ -84,7 +84,7 @@ class Upload extends \NDB_Page
 
         if (empty($file)) {
             return new \LORIS\Http\Response\JSON\NotFound(
-                "File not found."
+                dgettext('electrophysiology_uploader', 'File not found.')
             );
         }
 


### PR DESCRIPTION
## Brief summary of changes

Fixed the colon formatting issue across all languages.
Changed "de" → "du" in French as per suggestion.
<img width="1440" height="730" alt="Screenshot 2026-04-21 at 14 18 16" src="https://github.com/user-attachments/assets/84f3eb52-a46e-403d-8bfa-c2d68ff24d45" />

<br />

Added French translation for the `"File not found."` 404 response.
<img width="456" height="75" alt="Screenshot 2026-04-21 at 14 21 00" src="https://github.com/user-attachments/assets/a623a1b4-8b89-4240-836d-df93a0630628" />

<br />

I also tried doing the same for Hindi and Japanese, but non-ASCII characters are escaped as `\uXXXX`, so left it out of this PR for now. 
<img width="638" height="107" alt="Screenshot 2026-04-21 at 14 20 52" src="https://github.com/user-attachments/assets/67241be0-ad98-4596-b169-064be94b3d07" />

#### Link(s) to related issue(s)
* Resolves #10282