### PR TITLE
[candidate_list] Translate options for "Sex"

### DIFF
--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -122,6 +122,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 throw new \Exception("Unhandled DoB format: $this->dobFormat");
             }
         }
+        $row['Sex'] = isset($row['Sex']) ? dgettext("sex", $row['Sex']) : '';
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new CandidateListRow($row, $cid, $pid);

--- a/modules/candidate_list/php/options.class.inc
+++ b/modules/candidate_list/php/options.class.inc
@@ -85,6 +85,12 @@ class Options extends \LORIS\Http\Endpoint
             $participant_status_options[$name] = $name;
         }
 
+        // Data is translated in the table, while the keys are not,
+        // so we need to convert the array format to
+        // $translated => $translated in order for filtering to
+        // work.
+        $sexes = \Utility::getSexList();
+        $sexes = array_combine($sexes, $sexes);
         return [
             'visitlabel'        => $visit_label_options,
             'site'              => $site_options,
@@ -92,7 +98,7 @@ class Options extends \LORIS\Http\Endpoint
             'cohort'            => $cohort_options,
             'participantstatus' => $participant_status_options,
             'useedc'            => $config->getSetting("useEDC"),
-            'Sex'               => \Utility::getSexList(),
+            'Sex'               => $sexes,
         ];
     }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -141,7 +141,11 @@ class Utility
 
         $result = $DB->pselectCol($query, []);
 
-        return array_combine($result, $result);
+        $translated = [];
+        foreach ($result as $val) {
+            $translated[$val] = dgettext("sex", $val);
+        }
+        return $translated;
     }
 
     /**

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -61,7 +61,7 @@ class Sex implements \JsonSerializable
      */
     public static function validate(string $value, array $validValues): bool
     {
-        return in_array($value, array_values($validValues), true);
+        return in_array($value, array_keys($validValues), true);
     }
 
     /**


### PR DESCRIPTION
This adds the ability to translate to options for "Sex" on the candidate_list page by having a language specific sex.po in project/locale/$lang/LC_MESSAGES/