### PR TITLE
[candidate_list] Translate Entity Type

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -265,10 +265,7 @@ class CandidateListIndex extends Component {
         filter: {
           name: 'entityType',
           type: 'select',
-          options: {
-            'Human': 'Human',
-            'Scanner': 'Scanner',
-          },
+          options: options.entitytype,
         },
       },
       {

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -123,6 +123,9 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
             }
         }
         $row['Sex'] = isset($row['Sex']) ? dgettext("sex", $row['Sex']) : '';
+
+        $row['EntityType'] = dgettext("candidate", $row['EntityType']);
+
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new CandidateListRow($row, $cid, $pid);

--- a/modules/candidate_list/php/options.class.inc
+++ b/modules/candidate_list/php/options.class.inc
@@ -91,6 +91,12 @@ class Options extends \LORIS\Http\Endpoint
         // work.
         $sexes = \Utility::getSexList();
         $sexes = array_combine($sexes, $sexes);
+
+        $entityTypes = [
+            dgettext("candidate", 'Human')   => dgettext("candidate", 'Human'),
+            dgettext("candidate", 'Scanner') => dgettext("candidate", 'Scanner'),
+        ];
+
         return [
             'visitlabel'        => $visit_label_options,
             'site'              => $site_options,
@@ -99,6 +105,7 @@ class Options extends \LORIS\Http\Endpoint
             'participantstatus' => $participant_status_options,
             'useedc'            => $config->getSetting("useEDC"),
             'Sex'               => $sexes,
+            'entitytype'        => $entityTypes,
         ];
     }
 


### PR DESCRIPTION
This translates the Entity Type on the candidate_list page.

Note that even though the values are a known enum, they have to be translated on the PHP side so that projects can override other aspects of the candidate table (ie. Ethnicity) in project/locale.