### PR TITLE
[candidate_list] Add ability to translate visit filters

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -239,6 +239,7 @@ class CandidateListIndex extends Component {
           name: 'visitLabel',
           type: 'multiselect',
           options: options.visitlabel,
+          sortByValue: false,
         },
       },
       {

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -362,7 +362,7 @@ class User extends UserPermissions implements
             if (in_array(\ProjectID::singleton($projectID), $userProjectIDs)) {
                 $visitLabel = $visit->getName();
                 if (!in_array($visitLabel, $visit_labels)) {
-                    $visit_labels[$visitLabel] = $visitLabel;
+                    $visit_labels[$visitLabel] = dgettext('visit', $visitLabel);
                 }
             }
         }


### PR DESCRIPTION
This adds the ability to translate the visits in the visit label filter on the candidate_list page, for languages where it may be desired.

For testing, I used the following Japanese translations:

```
msgid ""
msgstr ""

"Project-Id-Version: LORIS 28\n"
"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
"POT-Creation-Date: 2025-04-08 14:37-0400\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: ja\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"

msgid "V1"
msgstr "一訪問"

msgid "V2"
msgstr "二訪問"

msgid "V3"
msgstr "三訪問"

msgid "V4"
msgstr "四訪問"

msgid "V5"
msgstr "五訪問"

msgid "V6"
msgstr "六訪問"
```

which revealed that the "sortByValue" default in the visit list didn't work very well, so sorting had to be disabled.