### PR TITLE
[raisinbread] Add test translations

### DIFF
--- a/raisinbread/locale/Project.pot
+++ b/raisinbread/locale/Project.pot
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Challah"
+msgstr ""
+
+msgid "DCP"
+msgstr ""
+
+msgid "Pumpernickel"
+msgstr ""
+
+msgid "Rye"
+msgstr ""
+

--- a/raisinbread/locale/candidate.pot
+++ b/raisinbread/locale/candidate.pot
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Human"
+msgstr ""
+
+msgid "Scanner"
+msgstr ""
+
+msgid "White"
+msgstr ""
+
+msgid "Black"
+msgstr ""
+
+msgid "Indigenous"
+msgstr ""
+
+msgid "Asian"
+msgstr ""
+
+msgid "Hispanic"
+msgstr ""
+

--- a/raisinbread/locale/cohort.pot
+++ b/raisinbread/locale/cohort.pot
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Fresh"
+msgstr ""
+
+msgid "High Yeast"
+msgstr ""
+
+msgid "Low Yeast"
+msgstr ""
+
+msgid "Stale"
+msgstr ""
+

--- a/raisinbread/locale/ja/LC_MESSAGES/Project.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/Project.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Challah"
+msgstr "チャラパン"
+
+msgid "DCP"
+msgstr "データ調整プロジェクト"
+
+msgid "Pumpernickel"
+msgstr "プンパーニッケルパン"
+
+msgid "Rye"
+msgstr "ライ麦パン"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/candidate.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/candidate.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Human"
+msgstr "人間"
+
+msgid "Scanner"
+msgstr "スキャナー"
+
+msgid "White"
+msgstr "白人"
+
+msgid "Black"
+msgstr "黒人"
+
+msgid "Indigenous"
+msgstr "先住民"
+
+msgid "Asian"
+msgstr "アジア人"
+
+msgid "Hispanic"
+msgstr "ヒスパニック系の人"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/cohort.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/cohort.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Fresh"
+msgstr "出来立て"
+
+msgid "High Yeast"
+msgstr "高酵母"
+
+msgid "Low Yeast"
+msgstr "イースト菌が少ない"
+
+msgid "Stale"
+msgstr "陳腐"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/participant_status_options.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/participant_status_options.po
@@ -1,0 +1,50 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Active"
+msgstr "能動"
+
+msgid "Refused/Not Enrolled"
+msgstr "拒否／未登録"
+
+msgid "Ineligible"
+msgstr "不適格"
+
+msgid "Excluded"
+msgstr "除外"
+
+msgid "Inactive"
+msgstr "非アクティブ"
+
+msgid "Incomplete"
+msgstr "不完全"
+
+msgid "Complete"
+msgstr "完了"
+
+msgid "Unsure"
+msgstr "不明"
+
+msgid "Requiring Further Investigation"
+msgstr "さらなる調査が必要"
+
+msgid "Not Responding"
+msgstr "応答なし"
+
+msgid "Death"
+msgstr "死んだ"
+
+msgid "Lost to Followup"
+msgstr "追跡不能"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/psc.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/psc.po
@@ -1,0 +1,32 @@
+# Default LORIS strings to be translated (English)
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Coordinating Center"
+msgstr "データ調整センター"
+
+msgid "Montreal"
+msgstr "モントリオール"
+
+msgid "Ottawa"
+msgstr "オタワ"
+
+msgid "Rome"
+msgstr "ローマ"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/sex.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/sex.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Female"
+msgstr "女の人"
+
+msgid "Male"
+msgstr "男の人"
+
+msgid "Other"
+msgstr "不明"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/visit.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/visit.po
@@ -1,0 +1,32 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "V1"
+msgstr "一訪問"
+
+msgid "V2"
+msgstr "二訪問"
+
+msgid "V3"
+msgstr "三訪問"
+
+msgid "V4"
+msgstr "四訪問"
+
+msgid "V5"
+msgstr "五訪問"
+
+msgid "V6"
+msgstr "六訪問"
+

--- a/raisinbread/locale/participant_status_options.pot
+++ b/raisinbread/locale/participant_status_options.pot
@@ -1,0 +1,50 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Active"
+msgstr ""
+
+msgid "Refused/Not Enrolled"
+msgstr ""
+
+msgid "Ineligible"
+msgstr ""
+
+msgid "Excluded"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Incomplete"
+msgstr ""
+
+msgid "Complete"
+msgstr ""
+
+msgid "Unsure"
+msgstr ""
+
+msgid "Requiring Further Investigation"
+msgstr ""
+
+msgid "Not Responding"
+msgstr ""
+
+msgid "Death"
+msgstr ""
+
+msgid "Lost to Followup"
+msgstr ""
+

--- a/raisinbread/locale/psc.pot
+++ b/raisinbread/locale/psc.pot
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Data Coordinating Center"
+msgstr ""
+
+msgid "Montreal"
+msgstr ""
+
+msgid "Ottawa"
+msgstr ""
+
+msgid "Rome"
+msgstr ""
+

--- a/raisinbread/locale/sex.pot
+++ b/raisinbread/locale/sex.pot
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Female"
+msgstr ""
+
+msgid "Male"
+msgstr ""
+
+msgid "Other"
+msgstr ""
+

--- a/raisinbread/locale/visit.pot
+++ b/raisinbread/locale/visit.pot
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Living_Phantom_DCC_SD_3dwi"
+msgstr ""
+
+msgid "Living_Phantom_DCC_SD_3mprage"
+msgstr ""
+
+msgid "Living_Phantom_DCC_SD_3t2"
+msgstr ""
+
+msgid "V1"
+msgstr ""
+
+msgid "V2"
+msgstr ""
+
+msgid "V3"
+msgstr ""
+
+msgid "V4"
+msgstr ""
+
+msgid "V5"
+msgstr ""
+
+msgid "V6"
+msgstr ""
+


### PR DESCRIPTION
This adds the pot files and Japanese po files I used for testing translations on the candidate_list page.

pot files were generated by the script in #10448, while test translation strings mostly come from Google Translate.

To use them, you need to manually copy the raisinbread locale to the project/locale directory and run `msgfmt -o table.mo table.po` for each.

This is not currently done by the raisinbread refresh script which only deals with the database.
