### PR TITLE
[main.tpl] Translate Site List in main template

### DIFF
--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -74,7 +74,7 @@ class Site implements
      */
     function getCenterName(): string
     {
-        return strval($this->_siteInfo['Name']);
+        return dgettext("psc", strval($this->_siteInfo['Name']));
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -453,20 +453,6 @@ class User extends UserPermissions implements
     }
 
     /**
-     * Returns all user's sites in an associative array (CenterID => CenterName)
-     *
-     * @return array
-     */
-    function getSiteNamesList(): array
-    {
-        $sites = [];
-        foreach ($this->getSites() as $site) {
-            $sites[$site->getCenterID()->__toString()] = $site->getCenterName();
-        }
-        return $sites;
-    }
-
-    /**
      * Returns all user's sites that are StudySites
      *
      * @return array

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -204,7 +204,10 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // Retrieve site and project names for tooltips
         $tpl_data['user']['SitesTooltip']    = implode(
             "<br/>",
-            $this->user->getSiteNames()
+            array_map(
+                fn($site) => $site->getCenterName(),
+                $this->user->getSites(),
+            )
         );
         $tpl_data['user']['ProjectsTooltip'] = implode(
             "<br/>",


### PR DESCRIPTION
Translate the site names in the main.tpl template based on the logged in user's locale.

There are multiple functions in the user class that get a list of sites.
1. getSiteNames
2. getSiteNamesList
3. getSites

Option 1 was used to populate the site list in the main template. However, it can not be updated to be translated without breaking the API and making it user specific, as it's also used in the API.
Option 3 returns a site singleton, which can be used to get the site name with an array_map, so is the most powerful option. The middleware is updated to use that.
Option 2 did not have any references in the code, so it is deleted here as it's redundant.