### PR TITLE
[timepoint_list] Translate database values on timepoint_list page

### DIFF
--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -32,10 +32,10 @@
       {$edc_age}
     </td>
     <td>
-      {$candidate.Sex}
+      {dgettext("sex", $candidate.Sex)}
     </td>
       <td>
-        {$candidate.ProjectTitle}
+        {dgettext("Project", $candidate.ProjectTitle)}
       </td>
     {foreach from=$candidate.DisplayParameters item=value key=name}
       <td>
@@ -84,13 +84,13 @@
         <tr>
             <td>
               <a href="{$baseurl|default}/instrument_list/?candID={$candID}&sessionID={$timePoints[timepoint].SessionID}">
-                  {$timePoints[timepoint].Visit_label}
+                  {dgettext("visit", $timePoints[timepoint].Visit_label)}
               </a>
             </td>
-            <td>{$timePoints[timepoint].CohortTitle}</td>
+            <td>{dgettext("cohort", $timePoints[timepoint].CohortTitle)}</td>
 
-            <td>{$timePoints[timepoint].SiteAlias}</td>
-            <td>{$timePoints[timepoint].ProjectName}</td>
+            <td>{dgettext("psc", $timePoints[timepoint].SiteName)}</td>
+            <td>{dgettext("Project", $timePoints[timepoint].ProjectName)}</td>
 
             {if $timePoints[timepoint].staticStage|default != "" || $timePoints[timepoint].Current_stage == "Not Started"}
             <td colspan="3">{dgettext("loris", $timePoints[timepoint].Current_stage)}</td>
@@ -155,9 +155,9 @@
             <td>
                 {$timePoints[timepoint].Real_name}
             </td>
-<td>
+            <td>
                 {$timePoints[timepoint].language->label}
-</td>
+            </td>
         </tr>
     {sectionelse}
         <tr><td colspan="10">{dgettext("timepoint_list", "You do not have access to any timepoints registered for this candidate.")}</td></tr>

--- a/modules/timepoint_list/test/TimepointListIntegrationTest.php
+++ b/modules/timepoint_list/test/TimepointListIntegrationTest.php
@@ -32,7 +32,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
     private static $_TST0001_SESSION = [
         'Test',
         '',
-        'DCC',
+        'Data Coordinating Center',
         'Pumpernickel',
         'Not Started',
         '-',

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -146,6 +146,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
                          s.registeredBy, s.UserID, u.Real_name, s.Hardcopy_request,
                          s.BVLQCStatus, s.BVLQCType, s.BVLQCExclusion, s.Scan_done,
                          pr.Name as ProjectName, p.Alias as SiteAlias,
+                         p.Name as SiteName,
 			 s.ProjectID as ProjectID,
                          l.language_code as LanguageCode,
                          l.language_label as LanguageLabel


### PR DESCRIPTION
This translates all of the database values that appear on the timepoint_list page, using the translations from #10466 for testing.
