### PR TITLE
[issue tracker] batch edit enhancements 

### DIFF
--- a/modules/issue_tracker/css/issue_card.css
+++ b/modules/issue_tracker/css/issue_card.css
@@ -33,6 +33,7 @@
   display: flex;
   gap: 8px;
   margin-bottom: 16px;
+  flex-wrap: wrap;
 }
 
 .issue-content {

--- a/modules/issue_tracker/css/issue_tracker_batchmode.css
+++ b/modules/issue_tracker/css/issue_tracker_batchmode.css
@@ -42,7 +42,7 @@
   padding-right: 10px;
 }
 
-.filter label input {
+.filter-list label input {
   margin: 0;
   margin-right: 4px;
   margin-bottom: 4px;

--- a/modules/issue_tracker/css/issue_tracker_batchmode.css
+++ b/modules/issue_tracker/css/issue_tracker_batchmode.css
@@ -30,20 +30,28 @@
 }
 
 .filter-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: auto auto auto;
+  padding: 10px;
+  overflow-y: scroll;
+  max-height: 300px;
 }
 
 .filter-list label {
   display: flex;
-  align-items: center;
-  margin-bottom: 0;
-  font-weight: normal;
+  padding-right: 10px;
+}
+
+.filter label input {
+  margin: 0;
+  margin-right: 4px;
+  margin-bottom: 4px;
 }
 
 .filter-list label span {
-  margin-left: 3px;
+  margin-left: 5px;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .issues-list {

--- a/modules/issue_tracker/jsx/IssueCard.js
+++ b/modules/issue_tracker/jsx/IssueCard.js
@@ -4,6 +4,7 @@ import swal from 'sweetalert2';
 import Modal from 'jsx/Modal';
 import {withTranslation, Trans} from 'react-i18next';
 import '../css/issue_card.css';
+import Markdown from 'jsx/Markdown';
 
 const IssueCard = React.memo(function IssueCard(props) {
   const {t} = props;
@@ -457,7 +458,8 @@ const IssueCard = React.memo(function IssueCard(props) {
             ) : (
               <div className="description-container">
                 <p className="description-text">
-                  {description}</p>
+                  <Markdown content={description} />
+                </p>
               </div>
             )}
           </div>
@@ -469,7 +471,8 @@ const IssueCard = React.memo(function IssueCard(props) {
                 issue.topComments.map((comment, index) => (
                   <div key={index} className="comment">
                     <p className="comment-text">
-                      {comment.issueComment}</p>
+                      <Markdown content={comment.issueComment} />
+                    </p>
                     <span className="comment-meta">
                       <Trans
                         ns="issue_tracker"

--- a/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
+++ b/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
@@ -21,6 +21,7 @@ function IssueTrackerBatchMode({options = {}, t}) {
   const [selectedPriorities, setSelectedPriorities] = useState([]);
   const [selectedStatuses, setSelectedStatuses] = useState([]);
   const [selectedSites, setSelectedSites] = useState([]);
+  const [selectedAssignees, setSelectedAssignees] = useState([]);
   const [filteredIssues, setFilteredIssues] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -37,6 +38,7 @@ function IssueTrackerBatchMode({options = {}, t}) {
   const statuses = options.statuses || {};
   const categories = options.categories || {};
   const sites = options.sites || {};
+  const assigneesPossible = options.assigneesList || {};
 
   useEffect(() => {
     fetchIssues();
@@ -49,6 +51,7 @@ function IssueTrackerBatchMode({options = {}, t}) {
     selectedPriorities,
     selectedStatuses,
     selectedSites,
+    selectedAssignees,
     issues,
   ]);
 
@@ -102,7 +105,9 @@ function IssueTrackerBatchMode({options = {}, t}) {
       (selectedStatuses.length === 0 ||
         selectedStatuses.includes(issue.status)) &&
       (selectedSites.length === 0 ||
-        selectedSites.includes(String(issue.centerID)))
+        selectedSites.includes(String(issue.centerID))) &&
+      (selectedAssignees.length === 0 ||
+        selectedAssignees.includes(String(issue.assignee)))
     ));
   }
 
@@ -129,6 +134,7 @@ function IssueTrackerBatchMode({options = {}, t}) {
     setSelectedPriorities([]);
     setSelectedStatuses([]);
     setSelectedSites([]);
+    setSelectedAssignees([]);
   }
 
   /**
@@ -203,6 +209,15 @@ function IssueTrackerBatchMode({options = {}, t}) {
         <span>
           {t('Site', {ns: 'loris', count: 1})}{' '}
           <span className="badge bg-primary">{selectedSites.length}</span>
+        </span>
+      ),
+    },
+    {
+      id: 'assignee', // Added assignee tab
+      label: (
+        <span>
+          Assignee{' '}
+          <span className="badge bg-primary">{selectedAssignees.length}</span>
         </span>
       ),
     },
@@ -316,6 +331,23 @@ function IssueTrackerBatchMode({options = {}, t}) {
               ))}
             </div>
           </TabPane>
+          <TabPane TabId="assignee">
+            <div className="filter-list">
+              {Object.entries(assigneesPossible).map(([value, label]) => (
+                <label key={label.match(/\(([^)]+)\)/)?.[1]} className="d-block">
+                  <input
+                    type="checkbox"
+                    checked={selectedAssignees.includes(label.match(/\(([^)]+)\)/)?.[1])}
+                    onChange={() =>
+                      toggleFilter(selectedAssignees, setSelectedAssignees, label.match(/\(([^)]+)\)/)?.[1])
+                    }
+                    className="checkbox me-2"
+                  />
+                  <span>{value}</span>
+                </label>
+              ))}
+            </div>
+          </TabPane>
         </Tabs>
       </Panel>
       <br/>
@@ -415,6 +447,7 @@ IssueTrackerBatchMode.propTypes = {
     statuses: PropTypes.object,
     categories: PropTypes.object,
     sites: PropTypes.object,
+    assigneesList: PropTypes.object,
   }).isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
+++ b/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
@@ -338,7 +338,11 @@ function IssueTrackerBatchMode({options = {}, t}) {
                     type="checkbox"
                     checked={selectedAssignees.includes(value)}
                     onChange={() =>
-                      toggleFilter(selectedAssignees, setSelectedAssignees, value)
+                      toggleFilter(
+                        selectedAssignees,
+                        setSelectedAssignees,
+                        value
+                      )
                     }
                     className="checkbox me-2"
                   />

--- a/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
+++ b/modules/issue_tracker/jsx/IssueTrackerBatchMode.js
@@ -38,7 +38,6 @@ function IssueTrackerBatchMode({options = {}, t}) {
   const statuses = options.statuses || {};
   const categories = options.categories || {};
   const sites = options.sites || {};
-  const assigneesPossible = options.assigneesList || {};
 
   useEffect(() => {
     fetchIssues();
@@ -333,17 +332,17 @@ function IssueTrackerBatchMode({options = {}, t}) {
           </TabPane>
           <TabPane TabId="assignee">
             <div className="filter-list">
-              {Object.entries(assigneesPossible).map(([value, label]) => (
-                <label key={label.match(/\(([^)]+)\)/)?.[1]} className="d-block">
+              {Object.entries(assignees).map(([value, label]) => (
+                <label key={value} className="d-block">
                   <input
                     type="checkbox"
-                    checked={selectedAssignees.includes(label.match(/\(([^)]+)\)/)?.[1])}
+                    checked={selectedAssignees.includes(value)}
                     onChange={() =>
-                      toggleFilter(selectedAssignees, setSelectedAssignees, label.match(/\(([^)]+)\)/)?.[1])
+                      toggleFilter(selectedAssignees, setSelectedAssignees, value)
                     }
                     className="checkbox me-2"
                   />
-                  <span>{value}</span>
+                  <span>{label}</span>
                 </label>
               ))}
             </div>
@@ -447,7 +446,7 @@ IssueTrackerBatchMode.propTypes = {
     statuses: PropTypes.object,
     categories: PropTypes.object,
     sites: PropTypes.object,
-    assigneesList: PropTypes.object,
+    assignees: PropTypes.object,
   }).isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -379,6 +379,7 @@ class IssueTrackerIndex extends Component {
               statuses: this.state.data.fieldOptions.statuses,
               categories: this.state.data.fieldOptions.categories,
               sites: this.state.data.fieldOptions.sites,
+              assigneesList: this.state.data.fieldOptions.assignees,
             }}
           />
         </TabPane>

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -379,7 +379,7 @@ class IssueTrackerIndex extends Component {
               statuses: this.state.data.fieldOptions.statuses,
               categories: this.state.data.fieldOptions.categories,
               sites: this.state.data.fieldOptions.sites,
-              assigneesList: this.state.data.fieldOptions.assignees,
+              assignees: this.state.data.fieldOptions.assignees,
             }}
           />
         </TabPane>

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -1269,8 +1269,8 @@ class Edit extends \NDB_Page implements ETagCalculator
             return "AnonymousUser";
         }
 
-        //
-        $db = $this->loris->getdatabaseConnection();
+        // get real name
+        $db       = $this->loris->getdatabaseConnection();
         $realName = $db->pselectOne(
             "SELECT Real_name
             FROM users
@@ -1278,10 +1278,14 @@ class Edit extends \NDB_Page implements ETagCalculator
             ",
             ["uid" => $userid]
         );
+
+        // not found => Anonymous
         if ($realName === null) {
             // same as the real name for AnonymousUser object
             return "AnonymousUser";
         }
+
+        // else full name + username
         return "{$realName} ({$userid})";
     }
 

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -1264,14 +1264,21 @@ class Edit extends \NDB_Page implements ETagCalculator
      */
     function formatUserInformation(string $userid)
     {
-        $user = \User::factory($userid);
-        $un   = $user->getUsername();
-        if (empty($un)) {
-            // e.g. in case of anonymous user
-            return $user->getFullname();
-        } else {
-            return $user->getFullname() . " (" . $un . ")";
+        if ($userid === null) {
+            // same as the real name for AnonymousUser object
+            return "AnonymousUser";
         }
+
+        //
+        $db = $this->loris->getdatabaseConnection();
+        $realName = $db->pselectOne(
+            "SELECT Real_name
+            FROM users
+            WHERE userid = :uid
+            ",
+            ["uid" => $userid]
+        );
+        return "{$realName} ({$userid})";
     }
 
     /**

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -1258,11 +1258,11 @@ class Edit extends \NDB_Page implements ETagCalculator
     /**
      * Get a formatted string from user information.
      *
-     * @param string $userid a username/userid
+     * @param string|null $userid a username/userid, or null
      *
      * @return string a formatted string "fullname (userid)"
      */
-    function formatUserInformation(string $userid)
+    function formatUserInformation(?string $userid)
     {
         if ($userid === null) {
             // same as the real name for AnonymousUser object
@@ -1278,6 +1278,10 @@ class Edit extends \NDB_Page implements ETagCalculator
             ",
             ["uid" => $userid]
         );
+        if ($realName === null) {
+            // same as the real name for AnonymousUser object
+            return "AnonymousUser";
+        }
         return "{$realName} ({$userid})";
     }
 


### PR DESCRIPTION
## Brief summary of changes

This PR adds batch edit enhancements, already included to HBCD:
- enables markdown in batch edit description and comments.
- adds some CSS adjustments such as checkboxes aligned with label, filters items in grid layout, and wraps possibly long dropdown items when editing an issue.
- adds a 4th filter tab on possible assignees. 

### Tests

compile the module with `target=issue_tracker npm run compile`.

- Go to `Menu > Tools > Issue tracker` module
- Go to `batch edit` tab.
- Add/modify a comment/description with markdown e.g. formatting, link. and see the formatted result.
- Check assignees in assignee filter tab. and see the filtered issues.