### PR TITLE
modify _status field position check

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -397,7 +397,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
                 $type      = $pieces[0];
                 $fieldname = isset($pieces[1]) ? $pieces[1] : null;
-                if (strpos($fieldname, "_status") !== false) {
+                if (substr($fieldname, -7) === "_status") {
                     continue;
                 }
                 if ($fieldname == 'Date_taken'


### PR DESCRIPTION
Modifies the field check to ensure that the substr "_status" is at the end of the fieldname. 
The previous check looks for any position within the field name, which would cause the code to skip over some required fields.
