### PR TITLE
[electrophysiology_browser] On-demand file download tarring

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -170,12 +170,9 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return new \LORIS\Http\Response\JSON\NotFound($e->getMessage());
         }
 
-        $mimetype = substr($recording->getMetadata('header'), 0, 4) === 'hdf5' ?
-            'application/x.minc2' : 'application/octet-stream';
-
         $info = $recording->getFileInfo();
 
-        if (!$info->isFile()) {
+        if (!$info->isFile() && !$info->isDir()) {
             error_log('file in database but not in file system');
             return new \LORIS\Http\Response\JSON\NotFound();
         }
@@ -185,13 +182,45 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return new \LORIS\Http\Response\JSON\NotFound();
         }
 
-        $body = new \LORIS\Http\FileStream($info->getRealPath(), 'r');
+        // Tar the acquisition file if it is actually a directory (such as for MEG
+        // CTF acquisitions).
+        if ($info->isDir()) {
+            $filename = $this->_filename . '.tar';
+            $mimetype = 'application/x-tar';
+
+            $tarfile = sys_get_temp_dir() . '/recording_' . uniqid() . '.tar';
+
+            try {
+                $phar = new \PharData($tarfile);
+                $phar->buildFromDirectory($info->getRealPath());
+            } catch (\Exception $e) {
+                $this->logger->error(
+                    'Failed to create tar archive: ' . $e->getMessage()
+                );
+
+                if (file_exists($tarfile)) {
+                    unlink($tarfile);
+                }
+
+                return new \LORIS\Http\Response\JSON\InternalServerError();
+            }
+
+            $filepath = $tarfile;
+        } else {
+            $filename = $this->_filename;
+            $filepath = $info->getRealPath();
+            $mimetype = substr($recording->getMetadata('header'), 0, 4) === 'hdf5'
+                ? 'application/x.minc2'
+                : 'application/octet-stream';
+        }
+
+        $body = new \LORIS\Http\FileStream($filepath, 'r', true);
 
         return (new \LORIS\Http\Response())
             ->withHeader('Content-Type', $mimetype)
             ->withHeader(
                 'Content-Disposition',
-                'attachment; filename=' . $this->_filename
+                'attachment; filename=' . $filename
             )
             ->withBody($body);
     }

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -170,7 +170,8 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return new \LORIS\Http\Response\JSON\NotFound($e->getMessage());
         }
 
-        $info = $recording->getFileInfo();
+        $info     = $recording->getFileInfo();
+        $filepath = $info->getRealPath();
 
         if (!$info->isFile() && !$info->isDir()) {
             error_log('file in database but not in file system');
@@ -187,34 +188,14 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
         if ($info->isDir()) {
             $filename = $this->_filename . '.tar';
             $mimetype = 'application/x-tar';
-
-            $tarfile = sys_get_temp_dir() . '/recording_' . uniqid() . '.tar';
-
-            try {
-                $phar = new \PharData($tarfile);
-                $phar->buildFromDirectory($info->getRealPath());
-            } catch (\Exception $e) {
-                $this->logger->error(
-                    'Failed to create tar archive: ' . $e->getMessage()
-                );
-
-                if (file_exists($tarfile)) {
-                    unlink($tarfile);
-                }
-
-                return new \LORIS\Http\Response\JSON\InternalServerError();
-            }
-
-            $filepath = $tarfile;
+            $body     = new \LORIS\Http\ArchiveStream($filepath);
         } else {
             $filename = $this->_filename;
-            $filepath = $info->getRealPath();
             $mimetype = substr($recording->getMetadata('header'), 0, 4) === 'hdf5'
                 ? 'application/x.minc2'
                 : 'application/octet-stream';
+            $body     = new \LORIS\Http\FileStream($filepath, 'r');
         }
-
-        $body = new \LORIS\Http\FileStream($filepath, 'r', true);
 
         return (new \LORIS\Http\Response())
             ->withHeader('Content-Type', $mimetype)

--- a/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
+++ b/modules/electrophysiology_browser/jsx/components/DownloadPanel.js
@@ -33,7 +33,7 @@ class DownloadPanel extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
-    const {t} = this.props;
+    const {t, dccid, visit, physioFileName} = this.props;
     return (
       <Panel
         id={this.props.id}
@@ -58,6 +58,24 @@ class DownloadPanel extends Component {
                 }>
                 {Object.entries(panel.links).map(([type, download], j) => {
                   const disabled = (download.file === '');
+
+                  let recordingFileUrl = `/api/v0.0.3/candidates/${dccid}/`
+                    + `${visit}/recordings/${physioFileName}`;
+
+                  switch (type) {
+                  case 'physiological_event_files':
+                    recordingFileUrl += '/bidsfiles/events';
+                    break;
+                  case 'all_files':
+                    recordingFileUrl += '/bidsfiles/archive';
+                    break;
+                  case 'physiological_channel_file':
+                    recordingFileUrl += '/bidsfiles/channels';
+                    break;
+                  case 'physiological_electrode_file':
+                    recordingFileUrl += '/bidsfiles/electrodes';
+                    break;
+                  }
 
                   // Ignore physiological_coord_system_file
                   return type !== 'physiological_coord_system_file'
@@ -93,13 +111,13 @@ class DownloadPanel extends Component {
                           : <a
                             className='btn btn-primary download col-xs-6'
                             href={
-                              (type ==
-                                'physiological_event_files' ||
-                                type == 'all_files') ?
-                                this.state.annotationsAction
-                                + '?physioFileID=' + this.state.physioFileID
-                                + '&filePath=' + download.file
-                                : '/mri/jiv/get_file.php?file=' + download.file
+                              (type == 'physiological_event_files')
+                                ? (
+                                  this.state.annotationsAction
+                                  + '?physioFileID=' + this.state.physioFileID
+                                  + '&filePath=' + download.file
+                                )
+                                : recordingFileUrl
                             }
                             target='_blank'
                             style={{
@@ -141,7 +159,10 @@ class DownloadPanel extends Component {
 
 DownloadPanel.propTypes = {
   downloads: PropTypes.array,
+  dccid: PropTypes.string,
+  visit: PropTypes.string,
   physioFileID: PropTypes.number,
+  physioFileName: PropTypes.string,
   outputType: PropTypes.string,
   id: PropTypes.string,
   t: PropTypes.func,

--- a/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologySessionView.js
@@ -509,7 +509,10 @@ class ElectrophysiologySessionView extends Component {
                       <DownloadPanel
                         id={'file_download_' + i}
                         downloads={this.state.database[i].file.downloads}
+                        dccid={this.state.patient.info.dccid}
+                        visit={this.state.patient.info.visit_label}
                         physioFileID={this.state.database[i].file.id}
+                        physioFileName={this.state.database[i].file.name}
                         outputType={this.state.database[i].file.output_type}
                         t={t}
                       />

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -62,10 +62,39 @@ class Recording
                        FileType                 as filetype,
                        s.CenterID               as centerid,
                        c.Entity_type            as entitytype,
-                       pc.FilePath              as channel_file_path,
-                       pe.FilePath              as electrode_file_path,
-                       pte.FilePath             as event_file_path,
-                       pa.FilePath              as archive_file_path
+                       (
+                         SELECT pc.FilePath
+                         FROM physiological_channel pc
+                         WHERE pc.PhysiologicalFileID = f.PhysiologicalFileID
+                         ORDER BY pc.PhysiologicalChannelID
+                         LIMIT 1
+                       ) as channel_file_path,
+                       (
+                         SELECT pe.FilePath
+                         FROM physiological_electrode pe
+                         INNER JOIN physiological_coord_system_electrode_rel pcser
+                           USING (PhysiologicalElectrodeID)
+                         WHERE pcser.PhysiologicalFileID
+                           = f.PhysiologicalFileID
+                         ORDER BY pe.PhysiologicalElectrodeID
+                         LIMIT 1
+                       ) as electrode_file_path,
+                       (
+                         SELECT pef.FilePath
+                         FROM physiological_task_event pte
+                         INNER JOIN physiological_event_file pef
+                           USING (EventFileID)
+                         WHERE pte.PhysiologicalFileID = f.PhysiologicalFileID
+                         ORDER BY pte.PhysiologicalTaskEventID
+                         LIMIT 1
+                       ) as event_file_path,
+                       (
+                         SELECT pa.FilePath
+                         FROM physiological_archive pa
+                         WHERE pa.PhysiologicalFileID = f.PhysiologicalFileID
+                         ORDER BY pa.PhysiologicalArchiveID
+                         LIMIT 1
+                       ) as archive_file_path
                      FROM
                        physiological_file f
                      LEFT JOIN session s
@@ -80,30 +109,6 @@ class Recording
                        ON (
                         pm.PhysiologicalModalityID = f.PhysiologicalModalityID
                        )
-                     LEFT JOIN (
-                       SELECT PhysiologicalFileID, FilePath
-                       FROM physiological_channel
-                       LIMIT 1
-                     ) pc
-                       ON (pc.PhysiologicalFileID = f.PhysiologicalFileID)
-                     LEFT JOIN (
-                       SELECT pcser.PhysiologicalFileID, pe2.FilePath
-                       FROM physiological_electrode pe2
-                        INNER JOIN physiological_coord_system_electrode_rel pcser
-                        USING (PhysiologicalElectrodeID)
-                       LIMIT 1
-                     ) pe
-                       ON (pe.PhysiologicalFileID = f.PhysiologicalFileID)
-                     LEFT JOIN (
-                       SELECT pte.PhysiologicalFileID, pef.FilePath
-                       FROM physiological_task_event pte
-                        INNER JOIN physiological_event_file pef
-                        USING (EventFileID)
-                       LIMIT 1
-                     ) pte
-                       ON (pte.PhysiologicalFileID = f.PhysiologicalFileID)
-                     LEFT JOIN physiological_archive pa
-                       ON (pa.PhysiologicalFileID = f.PhysiologicalFileID)
                      WHERE f.PhysiologicalFileID = :v_fileid
                     ',
                     ['v_fileid' => $fileid]

--- a/src/Http/ArchiveStream.php
+++ b/src/Http/ArchiveStream.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file implements an ArchiveStream, which creates a temporary tar archive
+ * from a directory and provides it as a PSR7 StreamInterface.
+ *
+ * @category PSR7
+ * @package  Http
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ */
+namespace LORIS\Http;
+
+/**
+ * An ArchiveStream creates a temporary tar archive from a directory
+ * and provides it as a PSR7 StreamInterface. The temporary archive file
+ * is deleted when the stream is closed.
+ *
+ * @category PSR7
+ * @package  Http
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class ArchiveStream extends \Laminas\Diactoros\Stream implements \Psr\Http\Message\StreamInterface
+{
+    /**
+     * The path to the temporary archive file
+     *
+     * @var string
+     */
+    private string $archivePath;
+
+    /**
+     * Constructor
+     *
+     * Creates a tar archive from the given directory and opens it as a stream.
+     * The archive file is deleted when the stream is closed.
+     *
+     * @param string $directoryPath The path to the directory to archive
+     *
+     * @throws \Exception if archive creation fails
+     */
+    public function __construct(string $directoryPath)
+    {
+        $this->archivePath = sys_get_temp_dir() . '/' . uniqid() . '.tar';
+
+        $phar = new \PharData($this->archivePath);
+        $phar->buildFromDirectory($directoryPath);
+
+        parent::__construct($this->archivePath, 'r');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close(): void
+    {
+        parent::close();
+
+        if (file_exists($this->archivePath)) {
+            unlink($this->archivePath);
+        }
+    }
+}

--- a/src/Http/FileStream.php
+++ b/src/Http/FileStream.php
@@ -27,38 +27,4 @@ namespace LORIS\Http;
  */
 class FileStream extends \Laminas\Diactoros\Stream implements \Psr\Http\Message\StreamInterface
 {
-    /**
-     * @var bool Whether the file be deleted when the stream is closed, used for
-     *           temporary files.
-     */
-    private bool $deleteOnClose;
-
-    /**
-     * Constructor
-     *
-     * @param string $stream        The path to the file or a stream resource
-     * @param string $mode          The mode to open the stream with
-     * @param bool   $deleteOnClose If true, delete the file when the stream is closed
-     */
-    public function __construct(
-        string $stream,
-        string $mode = 'r',
-        bool $deleteOnClose = false,
-    ) {
-        parent::__construct($stream, $mode);
-        $this->deleteOnClose = $deleteOnClose;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function close(): void
-    {
-        if ($this->deleteOnClose
-            && is_string($this->resource)
-            && file_exists($this->resource)
-        ) {
-            unlink($this->resource);
-        }
-    }
 }

--- a/src/Http/FileStream.php
+++ b/src/Http/FileStream.php
@@ -27,4 +27,38 @@ namespace LORIS\Http;
  */
 class FileStream extends \Laminas\Diactoros\Stream implements \Psr\Http\Message\StreamInterface
 {
+    /**
+     * @var bool Whether the file be deleted when the stream is closed, used for
+     *           temporary files.
+     */
+    private bool $deleteOnClose;
+
+    /**
+     * Constructor
+     *
+     * @param string $stream        The path to the file or a stream resource
+     * @param string $mode          The mode to open the stream with
+     * @param bool   $deleteOnClose If true, delete the file when the stream is closed
+     */
+    public function __construct(
+        string $stream,
+        string $mode = 'r',
+        bool $deleteOnClose = false,
+    ) {
+        parent::__construct($stream, $mode);
+        $this->deleteOnClose = $deleteOnClose;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close(): void
+    {
+        if ($this->deleteOnClose
+            && is_string($this->resource)
+            && file_exists($this->resource)
+        ) {
+            unlink($this->resource);
+        }
+    }
 }


### PR DESCRIPTION
Alternative to https://github.com/aces/Loris/pull/10411 

## Description

This PR makes two changes;
- Replace the download links in the electrophysiology browser to use the LORIS API instead of `get_file.php`.
- Add a new `ArchiveStream` class to LORIS core to tar on-demand a file or directory and make it available to download. This new class is adopted in the electrophysiology browser to make it possible to download CTF directories for MEG.