### PR TITLE
Fix macOS PHP built-in server command

### DIFF
--- a/docs/wiki/99_Developers/Alternative_Install/LORIS_on_Macintosh/README.md
+++ b/docs/wiki/99_Developers/Alternative_Install/LORIS_on_Macintosh/README.md
@@ -83,9 +83,9 @@ sudo apachectl -k restart
 ```
 
 
-#### An alternative to Apache is using php -S in the htdocs directory.
+#### An alternative to Apache is using php -S from the LORIS root directory.
 ```
-php -S localhost:8000 -t . router.php
+php -S localhost:8000 -t htdocs/ htdocs/router.php
 ```
 Logs will be sent to stderr.
 


### PR DESCRIPTION
Updated the macOS developer install guide to run PHP’s built-in server from the LORIS root directory.

#10399