### PR TITLE
Fix candidate parameters breadcrumbs

### DIFF
--- a/modules/candidate_parameters/jsx/CandidateParameters.js
+++ b/modules/candidate_parameters/jsx/CandidateParameters.js
@@ -119,13 +119,6 @@ class CandidateParameters extends Component {
 
     return (
       <div>
-        <a className='btn btn-sm btn-primary'
-          href={loris.BaseURL + '/' + this.props.candID}
-          style={{marginBottom: '20px'}}
-        >
-          {t('Return to timepoint list', {ns: 'candidate_parameters'})}
-        </a>
-        <br />
         <Tabs tabs={tabList} defaultTab='candidateInfo' updateURL={true}>
           {this.getTabPanes(tabList)}
         </Tabs>

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -92,10 +92,20 @@ class Candidate_Parameters extends \NDB_Form
     {
         $candidate =& \Candidate::singleton(new CandID($this->identifier));
         $candID    = $candidate->getCandID();
+        $pscid     = $candidate->getPSCID();
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
-                dgettext("candidate_parameters", 'Candidate Parameters'),
+                dgettext("candidate_list", 'Access Profile'),
+                '/candidate_list'
+            ),
+            new \LORIS\Breadcrumb(
+                dgettext("candidate_profile", "Candidate Profile")
+                . " $candID / $pscid",
+                "/$candID"
+            ),
+            new \LORIS\Breadcrumb(
+                dgettext("candidate_parameters", "Candidate Parameters"),
                 "/candidate_parameters/?candID=$candID&identifier=$candID"
             )
         );


### PR DESCRIPTION
## Brief summary of changes

- Update Candidate Parameters breadcrumbs to include Access Profile and the candidate profile link.
- Remove the redundant “Return to timepoint list” button now that the breadcrumb trail links back to the candidate profile.

#### Testing instructions (if applicable)

- Ran `php -l modules/candidate_parameters/php/candidate_parameters.class.inc`
- Verified in browser at `http://localhost:8080/candidate_parameters/?candID=300001&identifier=300001`
- Confirmed the page shows `Access Profile > Candidate Profile 300001 / MTL001 > Candidate Parameters`
- Confirmed `Return to timepoint list` no longer appears

#### Link(s) to related issue(s)

* Resolves #10482
