### PR TITLE
[redcap] repeated field ordering and configuration

### DIFF
--- a/modules/redcap/CONFIGURATION.md
+++ b/modules/redcap/CONFIGURATION.md
@@ -15,6 +15,7 @@ The configuration is of the following form:
       <redcap-api-token>ABCDEFGGHIJKLMNOPQRSTUVWXYZ</redcap-api-token>
       <prefix-instrument-variable>false</prefix-instrument-variable>
       <redcap-participant-id>record_id</redcap-participant-id>
+      <redcap-repeat-id>repeat_instance</redcap-repeat-id>
       <candidate-id>pscid</candidate-id>
       <visit>
         <visit-label>visit_1</visit-label>
@@ -50,6 +51,7 @@ In a `project` entry, the configuration parameters are the following:
 - `redcap-api-token` (required): The REDCap API token used by LORIS to retrieve REDCap data for this project.
 - `prefix-instrument-variable` (optional): Whether or not the instrument field variable names are prefixed by their instrument name in REDCap. The two options are `true` or `false`. If not present, `false` is used.
 - `redcap-participant-id` (optional): The type of REDCap participant identifier used to map the REDCap participants with the LORIS candidates. The two options are `record_id` and `survey_participant_id`. If not present, `record_id` is used.
+- `redcap-repeat-id` (optional): only active when repeated instruments are in use. The type of REDCap repeat identifier (i.e. a REDCap instrument field) used to order repeated instrument records. The two options are `repeat_instance` and `timestamp`. If not present, `repeat_instance` is used.
 - `candidate-id` (optional): The type of LORIS candidate identifier used to map the REDCap participants with the LORIS candidates. The three options are `pscid`, `candid`, and `external_id`. If not present, `pscid` is used.
 - `visit` (optional, multiple allowed): A list of visit mappings that describe how REDCap arms and events are mapped to LORIS visits. If not present, the REDCap arms are ignored and the REDCap event names are matched to LORIS visit labels with the same name.
 

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -733,10 +733,11 @@ class RedcapHttpClient
             )
         ) {
             // If the record_id is null then all records have been imported.
-            // We need to group them by record_id to make sense and not have thousands of
-            // overlapping repeated records.
+            // We need to group them by record_id to make sense and not have
+            // thousands of overlapping repeated records.
             if ($record_id === null) {
-                // need to be grouped by record id = possibly multiple repeated records.
+                // need to be grouped by record id = possibly multiple
+                // repeated records.
                 $record_groups = [];
                 foreach ($record_dicts as $record_dict) {
                     $record_group_id = $record_dict["record_id"];
@@ -838,7 +839,6 @@ class RedcapHttpClient
                     return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
                 }
             );
-
 
             // build records
             foreach ($raw_records as $index => $record) {

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -721,19 +721,12 @@ class RedcapHttpClient
                 $unique_event_name
             )
         ) {
-            // TODO: ${instrument_name}_dtt seems to be HBCD-specific. The code
-            // could probably be cleaner with a single timestamp abstraction. The
-            // problem is that the repeating index depends on the order in which the
-            // records were filled. However, this index might also be obtainable
-            // from a field in the record. Investigation needed.
-            // Order the records by ${instrument_name}_dtt field value
+            // sort based on the instance index number
             usort(
                 $record_dicts,
-                function ($a, $b) use ($instrument_name) {
-                    $dttField = "{$instrument_name}_dtt";
-                    $a_date   = new \DateTimeImmutable($a[$dttField]);
-                    $b_date   = new \DateTimeImmutable($b[$dttField]);
-                    return $a_date <=> $b_date;
+                function ($a, $b) {
+                    $redcapRepeatIndex = "redcap_repeat_instance";
+                    return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
                 }
             );
 

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -732,34 +732,41 @@ class RedcapHttpClient
                 $unique_event_name
             )
         ) {
-            // sort based on the instance index number
-            if ($this->_repeat_index_field === RedcapConfigRepeatId::RepeatInstance) {
-                usort(
-                    $record_dicts,
-                    function ($a, $b) {
-                        $redcapRepeatIndex = "redcap_repeat_instance";
-                        return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
-                    }
-                );
-            } else if ($this->_repeat_index_field === RedcapConfigRepeatId::Timestamp) {
-                // sort based on the record timestamp
-                usort(
-                    $record_dicts,
-                    function ($a, $b) use ($instrument_name) {
-                        $tsField = "{$instrument_name}_timestamp";
-                        $ts_a    = new \DateTimeImmutable($a[$tsField]);
-                        $ts_b    = new \DateTimeImmutable($b[$tsField]);
-                        return $ts_a <=> $ts_b;
-                    }
-                );
-            }
+            // If the record_id is null then all records have been imported.
+            // We need to group them by record_id to make sense and not have thousands of
+            // overlapping repeated records.
+            if ($record_id === null) {
+                // need to be grouped by record id = possibly multiple repeated records.
+                $record_groups = [];
+                foreach ($record_dicts as $record_dict) {
+                    $record_group_id = $record_dict["record_id"];
 
-            foreach ($record_dicts as $index => $record) {
-                $records[] = new RedcapRepeatingRecord(
+                    // group them by "record_id"
+                    if (array_key_exists($record_group_id, $record_groups)) {
+                        $record_groups[$record_group_id][] = $record_dict;
+                    } else {
+                        $record_groups[$record_group_id] = [$record_dict];
+                    }
+                }
+
+                // foreach group or record_id, parse them into RepeatedRecords
+                foreach ($record_groups as $record_group_id => $record_group) {
+                    $records = array_merge(
+                        $records,
+                        $this->_buildRepeatedRecords(
+                            strval($record_group_id),
+                            $instrument_name,
+                            $record_group
+                        )
+                    );
+                }
+            } else {
+                // does not neeed to group by record_id = only one RepeatedRecord
+                $records[] = $this->_buildRepeatedRecords(
+                    $record_id,
                     $instrument_name,
-                    $record,
-                    $index + 1
-                );
+                    $record_dicts
+                )[0];
             }
         } else {
             // Transform the record dictionaries into record objects.
@@ -797,6 +804,83 @@ class RedcapHttpClient
         }
 
         return $records;
+    }
+
+    /**
+     * Build a list of RepeatedRecord out of a array of record dictionaries.
+     * The build process takes the configuration::RedcapConfigRepeatId in account
+     * to either build with the redcap_repeat_instance or the timestamp field.
+     *
+     * @param string $record_id       A REDCap record_id.
+     * @param string $instrument_name A REDCap instrument name.
+     * @param array  $raw_records     An array of record dictionaries.
+     *
+     * @return RedcapRepeatingRecord[] an array of repeated records
+     */
+    private function _buildRepeatedRecords(
+        string $record_id,
+        string $instrument_name,
+        array $raw_records
+    ): array {
+        // log record_id
+        $tag = "[instrument:{$instrument_name}][record_id:{$record_id}]";
+        error_log("[redcap] {$tag} building repeated records");
+
+        $repeated_records = [];
+
+        // instrument repeat instance as the ordering point
+        if ($this->_repeat_index_field === RedcapConfigRepeatId::RepeatInstance) {
+            // sort based on the instance index number
+            usort(
+                $raw_records,
+                function ($a, $b) {
+                    $redcapRepeatIndex = "redcap_repeat_instance";
+                    return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
+                }
+            );
+
+
+            // build records
+            foreach ($raw_records as $index => $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $record["redcap_repeat_instance"]
+                );
+            }
+        } else if ($this->_repeat_index_field === RedcapConfigRepeatId::Timestamp) {
+            // sort based on the record timestamp
+            usort(
+                $raw_records,
+                function ($a, $b) use ($instrument_name) {
+                    $tsField = "{$instrument_name}_timestamp";
+                    $ts_a    = new \DateTimeImmutable($a[$tsField]);
+                    $ts_b    = new \DateTimeImmutable($b[$tsField]);
+                    return $ts_a <=> $ts_b;
+                }
+            );
+
+            // build records
+            foreach ($raw_records as $index => $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $index + 1
+                );
+            }
+        } else {
+            // default process = iterate and increment record id.
+            foreach ($raw_records as $index => $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $index + 1
+                );
+            }
+        }
+
+        // built repeated records
+        return $repeated_records;
     }
 
     /**

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -26,6 +26,7 @@ use LORIS\redcap\client\models\mappings\RedcapRepeatingInstrumentEvent;
 use LORIS\redcap\client\models\mappings\RedcapInstrumentEventMap;
 use LORIS\redcap\client\models\records\RedcapRecord;
 use LORIS\redcap\client\models\records\RedcapRepeatingRecord;
+use LORIS\redcap\config\RedcapConfigRepeatId;
 
 /**
  * A REDCap Client.
@@ -61,6 +62,11 @@ class RedcapHttpClient
     private Client $_client;
 
     /**
+     * REDCap repeated instrument field.
+     */
+    private RedcapConfigRepeatId $_repeat_index_field;
+
+    /**
      * A cache of all already done calls.
      *
      * @var array
@@ -70,13 +76,15 @@ class RedcapHttpClient
     /**
      * Create a new REDCap Client for a specific REDCap instance and project.
      *
-     * @param string $instance_url      A REDCap instance URL.
-     * @param string $project_api_token A REDCap project API token.
-     * @param bool   $verbose           Verbose mode.
+     * @param string               $instance_url      A REDCap instance URL.
+     * @param string               $project_api_token A REDCap project API token.
+     * @param RedcapConfigRepeatId $repeat_index      The REDCap repeated field.
+     * @param bool                 $verbose           Verbose mode.
      */
     public function __construct(
         string $instance_url,
         string $project_api_token,
+        RedcapConfigRepeatId $repeat_index,
         bool $verbose = false
     ) {
         $trimmed_url    = rtrim($instance_url, '/');
@@ -85,6 +93,9 @@ class RedcapHttpClient
         $this->_token   = $project_api_token;
         $this->_client  = new Client($api_url);
         $this->_verbose = $verbose;
+
+        // only useful when repeated instruments exist.
+        $this->_repeat_index_field = $repeat_index;
     }
 
     /**
@@ -722,13 +733,26 @@ class RedcapHttpClient
             )
         ) {
             // sort based on the instance index number
-            usort(
-                $record_dicts,
-                function ($a, $b) {
-                    $redcapRepeatIndex = "redcap_repeat_instance";
-                    return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
-                }
-            );
+            if ($this->_repeat_index_field === RedcapConfigRepeatId::RepeatInstance) {
+                usort(
+                    $record_dicts,
+                    function ($a, $b) {
+                        $redcapRepeatIndex = "redcap_repeat_instance";
+                        return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
+                    }
+                );
+            } else if ($this->_repeat_index_field === RedcapConfigRepeatId::Timestamp) {
+                // sort based on the record timestamp
+                usort(
+                    $record_dicts,
+                    function ($a, $b) use ($instrument_name) {
+                        $tsField = "{$instrument_name}_timestamp";
+                        $ts_a    = new \DateTimeImmutable($a[$tsField]);
+                        $ts_b    = new \DateTimeImmutable($b[$tsField]);
+                        return $ts_a <=> $ts_b;
+                    }
+                );
+            }
 
             foreach ($record_dicts as $index => $record) {
                 $records[] = new RedcapRepeatingRecord(

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -841,7 +841,7 @@ class RedcapHttpClient
             );
 
             // build records
-            foreach ($raw_records as $index => $record) {
+            foreach ($raw_records as $record) {
                 $repeated_records[] = new RedcapRepeatingRecord(
                     $instrument_name,
                     $record,

--- a/modules/redcap/php/config/redcapconfig.class.inc
+++ b/modules/redcap/php/config/redcapconfig.class.inc
@@ -64,6 +64,13 @@ class RedcapConfig
     public readonly RedcapConfigLorisId $candidate_id;
 
     /**
+     * The type of REDCap repeated identifier to match against the LORIS repeated instrument index.
+     *
+     * @var RedcapConfigRepeatId
+     */
+    public readonly RedcapConfigRepeatId $redcap_repeat_id;
+
+    /**
      * The configuration parameters to map the REDCap arms and events to the LORIS
      * visits.
      *
@@ -89,6 +96,9 @@ class RedcapConfig
      * @param RedcapConfigLorisId  $candidate_id               The REDCap LORIS
      *                                                         candidate identifier
      *                                                         configuration.
+     * @param RedcapConfigRepeatId $redcap_repeat_id           The REDCap LORIS
+     *                                                         repeat index
+     *                                                         identifier.
      * @param ?array               $visits                     The REDCap visit
      *                                                         mappings.
      */
@@ -98,6 +108,7 @@ class RedcapConfig
         string $redcap_api_token,
         bool $prefix_instrument_variable,
         RedcapConfigRedcapId $redcap_participant_id,
+        RedcapConfigRepeatId $redcap_repeat_id,
         RedcapConfigLorisId $candidate_id,
         ?array $visits,
     ) {
@@ -106,7 +117,8 @@ class RedcapConfig
         $this->redcap_api_token           = $redcap_api_token;
         $this->prefix_instrument_variable = $prefix_instrument_variable;
         $this->redcap_participant_id      = $redcap_participant_id;
-        $this->candidate_id = $candidate_id;
-        $this->visits       = $visits;
+        $this->redcap_repeat_id           = $redcap_repeat_id;
+        $this->candidate_id               = $candidate_id;
+        $this->visits                     = $visits;
     }
 }

--- a/modules/redcap/php/config/redcapconfig.class.inc
+++ b/modules/redcap/php/config/redcapconfig.class.inc
@@ -64,7 +64,8 @@ class RedcapConfig
     public readonly RedcapConfigLorisId $candidate_id;
 
     /**
-     * The type of REDCap repeated identifier to match against the LORIS repeated instrument index.
+     * The type of REDCap repeated identifier to match against the LORIS repeated
+     * instrument index.
      *
      * @var RedcapConfigRepeatId
      */
@@ -93,12 +94,12 @@ class RedcapConfig
      *                                                         participant
      *                                                         identifier
      *                                                         configuration.
-     * @param RedcapConfigLorisId  $candidate_id               The REDCap LORIS
-     *                                                         candidate identifier
-     *                                                         configuration.
      * @param RedcapConfigRepeatId $redcap_repeat_id           The REDCap LORIS
      *                                                         repeat index
      *                                                         identifier.
+     * @param RedcapConfigLorisId  $candidate_id               The REDCap LORIS
+     *                                                         candidate identifier
+     *                                                         configuration.
      * @param ?array               $visits                     The REDCap visit
      *                                                         mappings.
      */
@@ -118,7 +119,7 @@ class RedcapConfig
         $this->prefix_instrument_variable = $prefix_instrument_variable;
         $this->redcap_participant_id      = $redcap_participant_id;
         $this->redcap_repeat_id           = $redcap_repeat_id;
-        $this->candidate_id               = $candidate_id;
-        $this->visits                     = $visits;
+        $this->candidate_id = $candidate_id;
+        $this->visits       = $visits;
     }
 }

--- a/modules/redcap/php/config/redcapconfigparser.class.inc
+++ b/modules/redcap/php/config/redcapconfigparser.class.inc
@@ -130,8 +130,8 @@ class RedcapConfigParser
             $redcap_api_token,
             $prefix_instrument_variable,
             $redcap_participant_id,
-            $candidate_id,
             $redcap_repeat_id,
+            $candidate_id,
             $visits,
         );
     }

--- a/modules/redcap/php/config/redcapconfigparser.class.inc
+++ b/modules/redcap/php/config/redcapconfigparser.class.inc
@@ -16,6 +16,7 @@ use LORIS\redcap\config\RedcapConfig;
 use LORIS\redcap\config\RedcapConfigLorisId;
 use LORIS\redcap\config\RedcapConfigRedcapId;
 use LORIS\redcap\config\RedcapConfigVisit;
+use LORIS\redcap\config\RedcapConfigRepeatId;
 
 /**
  * This represents a REDCap configuration parser.
@@ -117,6 +118,9 @@ class RedcapConfigParser
         $redcap_participant_id      = $this->_parseRedcapParticipantId(
             $project_node
         );
+        $redcap_repeat_id           = $this->_parseRedcapRepeatId(
+            $project_node
+        );
         $candidate_id = $this->_parseCandidateId($project_node);
         $visits       = $this->_parseVisits($project_node);
 
@@ -127,6 +131,7 @@ class RedcapConfigParser
             $prefix_instrument_variable,
             $redcap_participant_id,
             $candidate_id,
+            $redcap_repeat_id,
             $visits,
         );
     }
@@ -286,6 +291,35 @@ class RedcapConfigParser
                 . " found '$redcap_participant_id'."
             );
         }
+    }
+
+    /**
+     * Parse the REDCap repeat identifier configuration from a REDCap
+     * configuration project XML node.
+     *
+     * @param array $project_node The REDCap configuration project XML node.
+     *
+     * @return RedcapConfigRepeatId The REDCap repeat identifier.
+     */
+    private function _parseRedcapRepeatId(
+        array $project_node,
+    ): RedcapConfigRepeatId {
+        $redcap_repeat_id = $project_node['redcap-repeat-id'] ?? null;
+
+        // Default value.
+        if ($redcap_repeat_id === null) {
+            return RedcapConfigRepeatId::RepeatInstance;
+        }
+
+        return match ($redcap_repeat_id) {
+            "repeat_instance" => RedcapConfigRepeatId::RepeatInstance,
+            "timestamp"       => RedcapConfigRepeatId::Timestamp,
+            default           => throw $this->_exception(
+                "invalid REDCap repeat identifier type for the selected"
+                . " project, expected 'timestamp' or 'repeat_instance' but"
+                . " found '{$redcap_repeat_id}'."
+            )
+        };
     }
 
     /**

--- a/modules/redcap/php/config/redcapconfigrepeatid.class.inc
+++ b/modules/redcap/php/config/redcapconfigrepeatid.class.inc
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * PHP Version 8
+ *
+ * @category REDCap
+ * @package  Main
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\redcap\config;
+
+/**
+ * Enumeration that describes which kind of index is used to order repeating instrument records.
+ *
+ * @category REDCap
+ * @package  Main
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+enum RedcapConfigRepeatId
+{
+    /**
+     * REDCap repeated records are ordered by the "redcap_repeat_instance" field.
+     */
+    case RepeatInstance;
+
+    /**
+     * REDCap repeated records are ordered by the "timestamp" field.
+     */
+    case Timestamp;
+}

--- a/modules/redcap/php/config/redcapconfigrepeatid.class.inc
+++ b/modules/redcap/php/config/redcapconfigrepeatid.class.inc
@@ -12,7 +12,8 @@
 namespace LORIS\redcap\config;
 
 /**
- * Enumeration that describes which kind of index is used to order repeating instrument records.
+ * Enumeration that describes which kind of index is used to order repeating
+ * instrument records.
  *
  * @category REDCap
  * @package  Main

--- a/modules/redcap/php/endpoints/notifications.class.inc
+++ b/modules/redcap/php/endpoints/notifications.class.inc
@@ -170,6 +170,7 @@ class Notifications extends Endpoint
             $redcap_client = new RedcapHttpClient(
                 $config->redcap_instance_url,
                 $config->redcap_api_token,
+                $config->redcap_repeat_id
             );
 
             $notification_handler = new RedcapNotificationHandler(

--- a/modules/redcap/php/redcaprecordimporter.class.inc
+++ b/modules/redcap/php/redcaprecordimporter.class.inc
@@ -218,6 +218,8 @@ class RedcapRecordImporter
                 return !in_array(
                     $name,
                     [
+                        "redcap_repeat_instrument",
+                        "redcap_repeat_instance",
                         "record_id",
                         "redcap_data_access_group",
                         "redcap_event_name",

--- a/tools/import_redcap_records.php
+++ b/tools/import_redcap_records.php
@@ -76,6 +76,7 @@ if ($redcap_config === null) {
 $redcap_client = new RedcapHttpClient(
     $redcap_config->redcap_instance_url,
     $redcap_config->redcap_api_token,
+    $redcap_config->redcap_repeat_id,
 );
 
 $redcap_mapper = new RedcapMapper($lorisInstance, $redcap_client, $redcap_config);


### PR DESCRIPTION
## Brief summary of changes

This PR:
- adds a new configuration for the repeated instrument index field choice at project level.
  - Imported repeated records will be ordered automatically based on the chosen field (defaults to `repeat_instance`, and `timestamp` still available). 
  - `<redcap-repeat-id>repeat_instance</redcap-repeat-id>`
- bugfixes the repeated record case. Cause/chain of events:
  - All repeated records were downloaded [at once when using the import script](https://github.com/aces/Loris/blob/9a7f31c38a0ec8af5f33b70c6d984e1faea93dbd/tools/import_redcap_records.php#L111).
  - [the change introduced in the REDCap importer and associated script](https://github.com/aces/Loris/pull/9905/changes#diff-079ed2bdd68553f882ac915c47ffa9ec9fbf5598600aaa968b1924aad9e89f85L662) was missing the repeated instrument logic.
  - The original ["timestamp"-based ordering + index increment](https://github.com/aces/Loris/blob/9a7f31c38a0ec8af5f33b70c6d984e1faea93dbd/modules/redcap/php/client/redcaphttpclient.class.inc#L730-L746) was scrambling the records order and we ended up with thousand of unrelated index numbers (e.g. Q1K case).
  - The fix isolates the "bulk" i.e. script import process (`client::getInstrumentRecords(record_id = null)`) from the single record import when receiving REDCap notification (`client::getInstrumentRecords(record_id != null)`).

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. have a REDCap set up that includes repeated instruments.
2. import of single REDCap repeated instrument: trigger one repeated instrument import (notification class path).
3. import multiple REDCap repeated instruments (single event): trigger the REDcap importer tool (bulk import path).

