### PR TITLE
Add numeric range filtering for dashboard and Biobank filters

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -374,8 +374,18 @@ class DataTable extends Component {
       result = (filterData === data);
     }
 
+    // Handle numeric range inputs
+    if (typeof filterData === 'object' && !Array.isArray(filterData)) {
+      const numericData = Number.parseFloat(data);
+      const min = Number.parseFloat(filterData.min);
+      const max = Number.parseFloat(filterData.max);
+      result = !Number.isNaN(numericData) &&
+        (Number.isNaN(min) || numericData >= min) &&
+        (Number.isNaN(max) || numericData <= max);
+    }
+
     // Handle array inputs for multiselects
-    if (typeof filterData === 'object') {
+    if (Array.isArray(filterData)) {
       let match = false;
       for (let i = 0; i < filterData.length; i += 1) {
         searchKey = filterData[i].toLowerCase();

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -7,6 +7,7 @@ import {
   TimeElement,
   FormElement,
   NumericElement,
+  NumericRangeElement,
   SelectElement,
   TextboxElement,
 } from 'jsx/Form';
@@ -32,6 +33,21 @@ function Filter(props) {
    */
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
+    props.fields.forEach((field) => {
+      const filter = field.filter;
+      if (!filter || filter.hide === true) {
+        return;
+      }
+
+      if (filter.type === 'number-range' || filter.type === 'numeric-range') {
+        const min = searchParams.get(`${filter.name}Min`) || '';
+        const max = searchParams.get(`${filter.name}Max`) || '';
+        if (min !== '' || max !== '') {
+          onFieldUpdate(filter.name, {min, max});
+        }
+      }
+    });
+
     searchParams.forEach((value, name) => {
       // This checks to make sure the filter actually exists
       if (props.fields.find((field) => (field.filter||{}).name == name)) {
@@ -51,8 +67,11 @@ function Filter(props) {
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'
-      || type === 'datetime' || type === 'multiselect'));
+      || type === 'datetime' || type === 'multiselect'
+      || type === 'number-range' || type === 'numeric-range'));
     if (value === null || value === '' ||
+      (typeof value === 'object' && !Array.isArray(value) &&
+        (value.min || '') === '' && (value.max || '') === '') ||
       (value.constructor === Array && value.length === 0) ||
       (type === 'checkbox' && value === false)) {
       props.removeFilter(name);
@@ -102,6 +121,17 @@ function Filter(props) {
             labelPlacementTop
           />;
           break;
+        case 'number-range':
+        case 'numeric-range':
+          element = <NumericRangeElement
+            min={filter.min}
+            max={filter.max}
+            step={filter.step}
+            minLabel={filter.minLabel}
+            maxLabel={filter.maxLabel}
+            labelPlacementTop
+          />;
+          break;
         case 'date':
           element = <DateElement labelPlacementTop />;
           break;
@@ -127,7 +157,10 @@ function Filter(props) {
             key: filter.name,
             name: filter.name,
             label: field.label,
-            value: (props.filters[filter.name] || {}).value || null,
+            value: (props.filters[filter.name] || {}).value || (
+              filter.type === 'number-range' ||
+              filter.type === 'numeric-range' ? {} : null
+            ),
             onUserInput: onFieldUpdate,
           }
         ));

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -39,7 +39,7 @@ function Filter(props) {
         return;
       }
 
-      if (filter.type === 'number-range' || filter.type === 'numeric-range') {
+      if (filter.type === 'number-range') {
         const min = searchParams.get(`${filter.name}Min`) || '';
         const max = searchParams.get(`${filter.name}Max`) || '';
         if (min !== '' || max !== '') {
@@ -68,7 +68,7 @@ function Filter(props) {
       .find((field) => (field.filter||{}).name == name).filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'
       || type === 'datetime' || type === 'multiselect'
-      || type === 'number-range' || type === 'numeric-range'));
+      || type === 'number-range'));
     if (value === null || value === '' ||
       (typeof value === 'object' && !Array.isArray(value) &&
         (value.min || '') === '' && (value.max || '') === '') ||
@@ -122,7 +122,6 @@ function Filter(props) {
           />;
           break;
         case 'number-range':
-        case 'numeric-range':
           element = <NumericRangeElement
             min={filter.min}
             max={filter.max}
@@ -158,8 +157,7 @@ function Filter(props) {
             name: filter.name,
             label: field.label,
             value: (props.filters[filter.name] || {}).value || (
-              filter.type === 'number-range' ||
-              filter.type === 'numeric-range' ? {} : null
+              filter.type === 'number-range' ? {} : null
             ),
             onUserInput: onFieldUpdate,
           }

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -59,6 +59,13 @@ class FilterableDataTable extends Component {
     Object.entries(filters).forEach(([name, filter]) => {
       if (filter.value.constructor === Array) {
         filter.value.forEach((v) => searchParams.append(name, v));
+      } else if (typeof filter.value === 'object') {
+        if ((filter.value.min || '') !== '') {
+          searchParams.set(`${name}Min`, filter.value.min);
+        }
+        if ((filter.value.max || '') !== '') {
+          searchParams.set(`${name}Max`, filter.value.max);
+        }
       } else {
         searchParams.set(name, filter.value);
       }

--- a/jsx/Form.d.ts
+++ b/jsx/Form.d.ts
@@ -395,6 +395,63 @@ export class NumericElement {
     forceUpdate(): void
 }
 
+type numericRangeValue = {
+    min?: string
+    max?: string
+};
+
+type numericRangeElementProps = {
+    name: string
+    min?: number
+    max?: number
+    step?: string
+    label?: string
+    value?: numericRangeValue
+    id?: string
+    disabled?: boolean
+    required?: boolean
+    onUserInput: (name: string, value: numericRangeValue) => void
+    labelPlacementTop?: boolean
+    minLabel?: string
+    maxLabel?: string
+};
+
+/**
+ * NumericRangeElement class. See Form.js
+ */
+export class NumericRangeElement {
+    props: numericRangeElementProps
+    state: any
+    context: object
+    refs: {[key: string]: ReactInstance}
+
+    /**
+     * Construct a NumericRangeElement
+     *
+     * @param {numericRangeElementProps} props - React props
+     */
+    constructor(props: numericRangeElementProps)
+
+    /**
+     * React lifecycle method
+     *
+     * @returns {ReactNode} - the element
+     */
+    render(): ReactNode
+
+    /**
+     * React lifecycle method
+     *
+     * @param {object} newstate - the state to override
+     */
+    setState(newstate: object): void
+
+    /**
+     * React lifecycle method.
+     */
+    forceUpdate(): void
+}
+
 type dateElementProps = {
     name: string
     label?: string
@@ -647,6 +704,7 @@ export default {
   TimeElement,
   DateTimeElement,
   NumericElement,
+  NumericRangeElement,
   FileElement,
   StaticElement,
   HeaderElement,

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1881,6 +1881,143 @@ NumericElement.defaultProps = {
 };
 
 /**
+ * Numeric range component.
+ * React wrapper for filtering a numeric value between two bounds.
+ */
+export class NumericRangeElement extends Component {
+  /**
+   * @constructor
+   * @param {object} props - React Component properties
+   */
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  /**
+   * Handle change
+   *
+   * @param {object} e - Event
+   */
+  handleChange(e) {
+    this.props.onUserInput(
+      this.props.name,
+      {
+        ...this.props.value,
+        [e.target.name]: e.target.value,
+      }
+    );
+  }
+
+  /**
+   * Renders the React component.
+   *
+   * @return {JSX} - React markup for the component
+   */
+  render() {
+    const value = this.props.value || {};
+    const minID = `${this.props.id || this.props.name}_min`;
+    const maxID = `${this.props.id || this.props.name}_max`;
+    const wrapperClass =
+      this.props.label && !this.props.labelPlacementTop ?
+        'col-sm-9' : 'col-sm-12';
+
+    return (
+      <div
+        className="row form-group"
+        style={this.props.labelPlacementTop ?
+          {display: 'flex', flexDirection: 'column'} : {}}
+      >
+        {this.props.label && (
+          <InputLabel
+            label={this.props.label}
+            required={this.props.required}
+            fullWidth={this.props.labelPlacementTop}
+          />
+        )}
+        <div className={wrapperClass}>
+          <div style={{display: 'flex', gap: '8px'}}>
+            <div style={{flex: 1}}>
+              <label className="sr-only" htmlFor={minID}>
+                {this.props.minLabel}
+              </label>
+              <input
+                type="number"
+                className="form-control"
+                name="min"
+                id={minID}
+                min={this.props.min}
+                max={this.props.max}
+                step={this.props.step}
+                value={value.min || ''}
+                placeholder={this.props.minLabel}
+                disabled={this.props.disabled}
+                onChange={this.handleChange}
+              />
+            </div>
+            <div style={{flex: 1}}>
+              <label className="sr-only" htmlFor={maxID}>
+                {this.props.maxLabel}
+              </label>
+              <input
+                type="number"
+                className="form-control"
+                name="max"
+                id={maxID}
+                min={this.props.min}
+                max={this.props.max}
+                step={this.props.step}
+                value={value.max || ''}
+                placeholder={this.props.maxLabel}
+                disabled={this.props.disabled}
+                onChange={this.handleChange}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+NumericRangeElement.propTypes = {
+  name: PropTypes.string.isRequired,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.string,
+  label: PropTypes.string,
+  value: PropTypes.shape({
+    min: PropTypes.string,
+    max: PropTypes.string,
+  }),
+  id: PropTypes.string,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  onUserInput: PropTypes.func,
+  labelPlacementTop: PropTypes.bool,
+  minLabel: PropTypes.string,
+  maxLabel: PropTypes.string,
+};
+
+NumericRangeElement.defaultProps = {
+  name: '',
+  min: null,
+  max: null,
+  step: '1',
+  label: '',
+  value: {},
+  id: null,
+  required: false,
+  disabled: false,
+  onUserInput: function() {
+    console.warn('onUserInput() callback is not set');
+  },
+  labelPlacementTop: false,
+  minLabel: 'Minimum',
+  maxLabel: 'Maximum',
+};
+
+/**
  * File Component
  * React wrapper for a simple or 'multiple' <input type="file"> element.
  */
@@ -2469,6 +2606,10 @@ export class LorisElement extends Component {
     case 'numeric':
       elementHtml = (<NumericElement {...elementProps} />);
       break;
+    case 'numeric-range':
+    case 'number-range':
+      elementHtml = (<NumericRangeElement {...elementProps} />);
+      break;
     case 'textarea':
       elementHtml = (<TextareaElement {...elementProps} />);
       break;
@@ -2825,6 +2966,7 @@ export default {
   TimeElement,
   DateTimeElement,
   NumericElement,
+  NumericRangeElement,
   FileElement: FileElementWithTranslation,
   StaticElement,
   HeaderElement,

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2606,7 +2606,6 @@ export class LorisElement extends Component {
     case 'numeric':
       elementHtml = (<NumericElement {...elementProps} />);
       break;
-    case 'numeric-range':
     case 'number-range':
       elementHtml = (<NumericRangeElement {...elementProps} />);
       break;

--- a/modules/biobank/jsx/specimenTab.js
+++ b/modules/biobank/jsx/specimenTab.js
@@ -274,7 +274,7 @@ class SpecimenTab extends Component {
       }},
       {label: t('Age at Collection', {ns: 'biobank'}), show: true, filter: {
         name: 'age',
-        type: 'number',
+        type: 'number-range',
       }},
       {label: this.props.t('Diagnosis', {ns: 'biobank'}), show: true, filter: {
         name: 'diagnosis',

--- a/modules/statistics/jsx/WidgetIndex.js
+++ b/modules/statistics/jsx/WidgetIndex.js
@@ -210,7 +210,19 @@ const WidgetIndex = (props) => {
 
     let formObject = new FormData();
     for (const key in formDataObj) {
-      if (formDataObj[key] != '' && formDataObj[key] != ['']) {
+      if (formDataObj[key] &&
+        typeof formDataObj[key] === 'object' &&
+        !Array.isArray(formDataObj[key])
+      ) {
+        Object.entries(formDataObj[key]).forEach(([rangeKey, value]) => {
+          if (value !== '') {
+            const parameterName = `${key}${
+              rangeKey.charAt(0).toUpperCase()
+            }${rangeKey.slice(1)}`;
+            formObject.append(parameterName, value);
+          }
+        });
+      } else if (formDataObj[key] != '' && formDataObj[key] != ['']) {
         formObject.append(key, formDataObj[key]);
       }
     }

--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -1,6 +1,12 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
-import {SelectElement, FormElement, ButtonElement, DateElement} from 'jsx/Form';
+import {
+  SelectElement,
+  FormElement,
+  ButtonElement,
+  DateElement,
+  NumericRangeElement,
+} from 'jsx/Form';
 import {useTranslation} from 'react-i18next';
 
 /**
@@ -46,7 +52,13 @@ const QueryChartForm = (props) => {
 
   const setFormData = (formElement, value) => {
     let normalizedValue = value;
-    if (!formElement.includes('date')) {
+    if (formElement === 'candidateAge') {
+      normalizedValue = value;
+      if ((normalizedValue.min || '') === '' &&
+        (normalizedValue.max || '') === '') {
+        normalizedValue = undefined;
+      }
+    } else if (!formElement.includes('date')) {
       normalizedValue = Array.isArray(value) ? value : [value];
       // Handle clear selection
       if (normalizedValue.includes('__clear__')) {
@@ -199,6 +211,23 @@ const QueryChartForm = (props) => {
           </div>
         )}
 
+        {/* Candidate Age Section */}
+        {props.showCandidateAge && (
+          <div>
+            <NumericRangeElement
+              name='candidateAge'
+              id={`${props.id}_candidateAge`}
+              value={formDataObj['candidateAge'] || {}}
+              onUserInput={(name, value) => {
+                setFormData(name, value);
+              }}
+              label={t('Candidate Age at Registration', {ns: 'statistics'})}
+              minLabel={t('Range Start', {ns: 'statistics'})}
+              maxLabel={t('Range End', {ns: 'statistics'})}
+            />
+          </div>
+        )}
+
         {/* DateRegistered Section */}
         <div>
           <label style ={{fontWeight: 'bold',
@@ -249,9 +278,11 @@ QueryChartForm.propTypes = {
   Module: PropTypes.string,
   name: PropTypes.string,
   id: PropTypes.string,
+  showCandidateAge: PropTypes.bool,
 };
 QueryChartForm.defaultProps = {
   data: {},
+  showCandidateAge: false,
 };
 
 export {

--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -53,7 +53,6 @@ const QueryChartForm = (props) => {
   const setFormData = (formElement, value) => {
     let normalizedValue = value;
     if (formElement === 'candidateAge') {
-      normalizedValue = value;
       if ((normalizedValue.min || '') === '' &&
         (normalizedValue.max || '') === '') {
         normalizedValue = undefined;

--- a/modules/statistics/jsx/widgets/recruitment.js
+++ b/modules/statistics/jsx/widgets/recruitment.js
@@ -135,6 +135,7 @@ const Recruitment = (props) => {
             name={'recruitment'}
             id={'recruitmentForm' + section}
             data={json}
+            showCandidateAge={true}
             callback={async (formDataObj) => {
               await updateFilters(formDataObj, section);
             }}

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -772,6 +772,26 @@ class Charts extends \NDB_Page
             $projectQuery      .= " AND c.Date_registered <= :$paramName";
             $params[$paramName] = $queryParams['dateRegisteredEnd'];
         }
+        if (is_numeric($queryParams['candidateAgeMin'] ?? null)) {
+            $candJoin           = "JOIN candidate c ON c.ID=s.CandidateID";
+            $paramName          = 'candidateAgeMin' . (++$paramCounter);
+            $projectQuery      .= " AND TIMESTAMPDIFF(
+                YEAR,
+                c.DoB,
+                c.Date_registered
+            ) >= :$paramName";
+            $params[$paramName] = $queryParams['candidateAgeMin'];
+        }
+        if (is_numeric($queryParams['candidateAgeMax'] ?? null)) {
+            $candJoin           = "JOIN candidate c ON c.ID=s.CandidateID";
+            $paramName          = 'candidateAgeMax' . (++$paramCounter);
+            $projectQuery      .= " AND TIMESTAMPDIFF(
+                YEAR,
+                c.DoB,
+                c.Date_registered
+            ) <= :$paramName";
+            $params[$paramName] = $queryParams['candidateAgeMax'];
+        }
 
         return [
             'projectQuery'           => $projectQuery,


### PR DESCRIPTION
## Brief summary of changes

- Adds a reusable `NumericRangeElement` form component for min/max numeric filtering.
- Extends shared table filtering and filter query-string handling to support `<field>Min` / `<field>Max` range values.
- Uses the numeric range filter for Biobank `Age at Collection`.
- Adds a Candidate Age at Registration range filter to Statistics recruitment dashboard charts and applies it in the chart API with parameterized age bounds.

#### Testing instructions (if applicable)

- On the Statistics dashboard, open Recruitment filters, enter a Candidate Age range such as `20` to `40`, and confirm chart requests include `candidateAgeMin=20&candidateAgeMax=40`.
- Open `http://localhost:8080/biobank/?ageMin=10&ageMax=30` and confirm `Age at Collection` shows Minimum/Maximum numeric range inputs populated from the URL.
- Run `php -l modules/statistics/php/charts.class.inc` and targeted ESLint on the changed JS/JSX files.

#### Link(s) to related issue(s)

* Resolves #8939