### PR TITLE
Support reusable date range filters

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -323,9 +323,10 @@ class DataTable extends Component {
       exactMatch = this.props.filters[name].exactMatch;
       opposite = this.props.filters[name].opposite;
     }
-    const filter = (this.props.fields.find(
+    const field = this.props.fields.find(
       (field) => (field.filter || {}).name === name
-    ) || {}).filter || {};
+    );
+    const filter = field && field.filter ? field.filter : {};
 
     // Handle null inputs
     if (filterData === null || data === null) {

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -323,6 +323,9 @@ class DataTable extends Component {
       exactMatch = this.props.filters[name].exactMatch;
       opposite = this.props.filters[name].opposite;
     }
+    const filter = (this.props.fields.find(
+      (field) => (field.filter || {}).name === name
+    ) || {}).filter || {};
 
     // Handle null inputs
     if (filterData === null || data === null) {
@@ -330,7 +333,9 @@ class DataTable extends Component {
     }
 
     // Handle date range inputs.
-    if (typeof filterData === 'object' && !Array.isArray(filterData)) {
+    if (filter.type === 'date-range' &&
+      typeof filterData === 'object' &&
+      !Array.isArray(filterData)) {
       const dateData = (data !== null && data !== undefined) ?
         data.toString() : '';
       const min = filterData.min || '';
@@ -387,7 +392,9 @@ class DataTable extends Component {
     }
 
     // Handle numeric range inputs
-    if (typeof filterData === 'object' && !Array.isArray(filterData)) {
+    if (filter.type === 'number-range' &&
+      typeof filterData === 'object' &&
+      !Array.isArray(filterData)) {
       const numericData = Number.parseFloat(data);
       const min = Number.parseFloat(filterData.min);
       const max = Number.parseFloat(filterData.max);

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -329,6 +329,18 @@ class DataTable extends Component {
       return false;
     }
 
+    // Handle date range inputs.
+    if (typeof filterData === 'object' && !Array.isArray(filterData)) {
+      const dateData = (data !== null && data !== undefined) ?
+        data.toString() : '';
+      const min = filterData.min || '';
+      const max = filterData.max || '';
+
+      return dateData !== '' &&
+        (min === '' || dateData >= min) &&
+        (max === '' || dateData <= max);
+    }
+
     // Handle numeric inputs
     if (typeof filterData === 'number') {
       let intData = Number.parseInt(data, 10);

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -324,7 +324,7 @@ class DataTable extends Component {
       opposite = this.props.filters[name].opposite;
     }
     const field = this.props.fields.find(
-      (field) => (field.filter || {}).name === name
+      (field) => field.filter?.name === name
     );
     const filter = field && field.filter ? field.filter : {};
 

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   CheckboxElement,
   DateElement,
+  DateRangeElement,
   FieldsetElement,
   TimeElement,
   FormElement,
@@ -34,25 +35,29 @@ function Filter(props) {
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     props.fields.forEach((field) => {
-      const filter = field.filter;
+      const filter = field.filter || {};
       if (!filter || filter.hide === true) {
         return;
       }
 
-      if (filter.type === 'number-range') {
+      if (filter.type === 'number-range' || filter.type === 'date-range') {
         const min = searchParams.get(`${filter.name}Min`) || '';
         const max = searchParams.get(`${filter.name}Max`) || '';
         if (min !== '' || max !== '') {
           onFieldUpdate(filter.name, {min, max});
         }
+        return;
       }
-    });
 
-    searchParams.forEach((value, name) => {
-      // This checks to make sure the filter actually exists
-      if (props.fields.find((field) => (field.filter||{}).name == name)) {
-        onFieldUpdate(name, searchParams.getAll(name));
+      const values = searchParams.getAll(filter.name);
+      if (values.length === 0) {
+        return;
       }
+
+      onFieldUpdate(
+        filter.name,
+        filter.type === 'multiselect' ? values : values[0]
+      );
     });
   }, []);
 
@@ -67,12 +72,16 @@ function Filter(props) {
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'
-      || type === 'datetime' || type === 'multiselect'
-      || type === 'number-range'));
+      || type === 'datetime' || type === 'date-range'
+      || type === 'multiselect' || type === 'number-range'));
+    const emptyRange = value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      (value.min || '') === '' &&
+      (value.max || '') === '';
     if (value === null || value === '' ||
-      (typeof value === 'object' && !Array.isArray(value) &&
-        (value.min || '') === '' && (value.max || '') === '') ||
       (value.constructor === Array && value.length === 0) ||
+      emptyRange ||
       (type === 'checkbox' && value === false)) {
       props.removeFilter(name);
     } else {
@@ -134,6 +143,18 @@ function Filter(props) {
         case 'date':
           element = <DateElement labelPlacementTop />;
           break;
+        case 'date-range':
+          element = (
+            <DateRangeElement
+              dateFormat={filter.dateFormat}
+              minYear={filter.minYear}
+              maxYear={filter.maxYear}
+              minLabel={filter.minLabel}
+              maxLabel={filter.maxLabel}
+              labelPlacementTop
+            />
+          );
+          break;
         case 'datetime':
           element = <DateTimePartialElement labelPlacementTop />;
           break;
@@ -156,9 +177,10 @@ function Filter(props) {
             key: filter.name,
             name: filter.name,
             label: field.label,
-            value: (props.filters[filter.name] || {}).value || (
-              filter.type === 'number-range' ? {} : null
-            ),
+            value: (filter.type === 'number-range' ||
+              filter.type === 'date-range') ?
+              (props.filters[filter.name] || {}).value || {} :
+              (props.filters[filter.name] || {}).value || null,
             onUserInput: onFieldUpdate,
           }
         ));

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -35,8 +35,8 @@ function Filter(props) {
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     props.fields.forEach((field) => {
-      const filter = field.filter || {};
-      if (!filter || filter.hide === true) {
+      const filter = field.filter;
+      if (!filter) {
         return;
       }
 
@@ -168,6 +168,9 @@ function Filter(props) {
           element = <TextboxElement labelPlacementTop />;
         }
 
+        const filterValue = props.filters[filter.name] ?
+          props.filters[filter.name].value : null;
+
         // The value prop has to default to false if the first two options
         // are undefined so that the checkbox component is a controlled input
         // element with a starting default value
@@ -179,8 +182,8 @@ function Filter(props) {
             label: field.label,
             value: (filter.type === 'number-range' ||
               filter.type === 'date-range') ?
-              (props.filters[filter.name] || {}).value || {} :
-              (props.filters[filter.name] || {}).value || null,
+              filterValue || {} :
+              filterValue || null,
             onUserInput: onFieldUpdate,
           }
         ));

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -69,8 +69,9 @@ function Filter(props) {
    */
   const onFieldUpdate = (name, value) => {
     const {fields} = JSON.parse(JSON.stringify(props));
-    const type = fields
-      .find((field) => (field.filter||{}).name == name).filter.type;
+    const field = fields.find((field) => (field.filter || {}).name === name);
+    const filter = field && field.filter ? field.filter : {};
+    const type = filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'
       || type === 'datetime' || type === 'date-range'
       || type === 'multiselect' || type === 'number-range'));

--- a/jsx/Form.d.ts
+++ b/jsx/Form.d.ts
@@ -501,6 +501,59 @@ export class DateElement {
     forceUpdate(): void
 }
 
+type dateRangeElementProps = {
+    name: string
+    label?: string
+    value?: {
+        min?: string
+        max?: string
+    }
+    id?: string
+    maxYear?: string|number
+    minYear?: string|number
+    dateFormat?: string
+    disabled?: boolean
+    required?: boolean
+    minLabel?: string
+    maxLabel?: string
+    onUserInput: (name: string, value: any) => void
+};
+/**
+ * DateRangeElement class. See Form.js
+ */
+export class DateRangeElement {
+    props: dateRangeElementProps
+    state: any
+    context: object
+    refs: {[key: string]: ReactInstance}
+
+    /**
+     * Construct a DateRangeElement
+     *
+     * @param {dateRangeElementProps} props - React props
+     */
+    constructor(props: dateRangeElementProps)
+
+    /**
+     * React lifecycle method
+     *
+     * @returns {ReactNode} - the element
+     */
+    render(): ReactNode
+
+    /**
+     * React lifecycle method
+     *
+     * @param {object} newstate - the state to override
+     */
+    setState(newstate: object): void
+
+    /**
+     * React lifecycle method.
+     */
+    forceUpdate(): void
+}
+
 type timeElementProps = {
     name: string
     label?: string
@@ -701,6 +754,7 @@ export default {
   TextareaElement,
   PasswordElement,
   DateElement,
+  DateRangeElement,
   TimeElement,
   DateTimeElement,
   NumericElement,

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1603,6 +1603,171 @@ DateElement.defaultProps = {
 };
 
 /**
+ * Date range component.
+ * React wrapper for filtering date values between two bounds.
+ */
+export class DateRangeElement extends Component {
+  /**
+   * @constructor
+   * @param {object} props - React Component properties
+   */
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  /**
+   * Handle change
+   *
+   * @param {object} e - Event
+   */
+  handleChange(e) {
+    this.props.onUserInput(
+      this.props.name,
+      {
+        ...this.props.value,
+        [e.target.name]: e.target.value,
+      }
+    );
+  }
+
+  /**
+   * Renders the React component.
+   *
+   * @return {JSX} - React markup for the component
+   */
+  render() {
+    const value = this.props.value || {};
+    const minID = `${this.props.id || this.props.name}_min`;
+    const maxID = `${this.props.id || this.props.name}_max`;
+    const minLabel = this.props.labelPlacementTop && this.props.label ?
+      `${this.props.label} ${this.props.minLabel}` : this.props.minLabel;
+    const maxLabel = this.props.labelPlacementTop && this.props.label ?
+      `${this.props.label} ${this.props.maxLabel}` : this.props.maxLabel;
+    const wrapperClass =
+      this.props.label && !this.props.labelPlacementTop ?
+        'col-sm-9' : 'col-sm-12';
+
+    let minYear = this.props.minYear;
+    let maxYear = this.props.maxYear;
+    if (this.props.minYear === '' || this.props.minYear === null) {
+      minYear = '1000';
+    }
+    if (this.props.maxYear === '' || this.props.maxYear === null) {
+      maxYear = '9999';
+    }
+
+    const currentDate = new Date();
+    const currentDay = `${currentDate.getDate()}`.padStart(2, '0');
+    const currentMonth = `${currentDate.getMonth() + 1}`.padStart(2, '0');
+
+    let inputType = 'date';
+    let minFullDate = minYear + '-01-01';
+    let maxFullDate = maxYear + '-' + currentMonth + '-' + currentDay;
+    if (!this.props.dateFormat.match(/d/i)) {
+      inputType = 'month';
+      minFullDate = minYear + '-01';
+      maxFullDate = maxYear + '-' + currentMonth;
+    }
+
+    return (
+      <div
+        className="row form-group"
+        style={this.props.labelPlacementTop ? {
+          display: 'flex',
+          flexDirection: 'column',
+        } : {}}
+      >
+        {this.props.label && !this.props.labelPlacementTop && (
+          <InputLabel
+            label={this.props.label}
+            required={this.props.required}
+            fullWidth={this.props.labelPlacementTop}
+          />
+        )}
+        <div className={wrapperClass}>
+          <div style={{display: 'flex', gap: '8px'}}>
+            <div style={{flex: 1}}>
+              <label htmlFor={minID}>
+                {minLabel}
+              </label>
+              <input
+                type={inputType}
+                className="form-control"
+                name="min"
+                id={minID}
+                min={minFullDate}
+                max={maxFullDate}
+                value={value.min || ''}
+                placeholder={minLabel}
+                required={this.props.required}
+                disabled={this.props.disabled}
+                onChange={this.handleChange}
+              />
+            </div>
+            <div style={{flex: 1}}>
+              <label htmlFor={maxID}>
+                {maxLabel}
+              </label>
+              <input
+                type={inputType}
+                className="form-control"
+                name="max"
+                id={maxID}
+                min={minFullDate}
+                max={maxFullDate}
+                value={value.max || ''}
+                placeholder={maxLabel}
+                required={this.props.required}
+                disabled={this.props.disabled}
+                onChange={this.handleChange}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+DateRangeElement.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  value: PropTypes.shape({
+    min: PropTypes.string,
+    max: PropTypes.string,
+  }),
+  id: PropTypes.string,
+  maxYear: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  minYear: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  dateFormat: PropTypes.string,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  onUserInput: PropTypes.func,
+  labelPlacementTop: PropTypes.bool,
+  minLabel: PropTypes.string,
+  maxLabel: PropTypes.string,
+};
+
+DateRangeElement.defaultProps = {
+  name: '',
+  label: '',
+  value: {},
+  id: null,
+  maxYear: '9999',
+  minYear: '1000',
+  dateFormat: 'YMd',
+  disabled: false,
+  required: false,
+  onUserInput: function() {
+    console.warn('onUserInput() callback is not set');
+  },
+  labelPlacementTop: false,
+  minLabel: 'Minimum',
+  maxLabel: 'Maximum',
+};
+
+/**
  * Time Component
  * React wrapper for a <input type="time"> element.
  */
@@ -2600,6 +2765,9 @@ export class LorisElement extends Component {
     case 'date':
       elementHtml = (<DateElement {...elementProps} />);
       break;
+    case 'date-range':
+      elementHtml = (<DateRangeElement {...elementProps} />);
+      break;
     case 'time':
       elementHtml = (<TimeElement {...elementProps} />);
       break;
@@ -2962,6 +3130,7 @@ export default {
   TextboxElement,
   PasswordElement,
   DateElement,
+  DateRangeElement,
   TimeElement,
   DateTimeElement,
   NumericElement,

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1640,8 +1640,12 @@ class DateRangeElementBase extends Component {
     const value = this.props.value || {};
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
-    const minRangeLabel = this.props.t(this.props.minLabel, {ns: 'loris'});
-    const maxRangeLabel = this.props.t(this.props.maxLabel, {ns: 'loris'});
+    const minRangeLabel = this.props.minLabel ?
+      this.props.t(this.props.minLabel, {ns: 'loris'}) :
+      this.props.t('Minimum', {ns: 'loris'});
+    const maxRangeLabel = this.props.maxLabel ?
+      this.props.t(this.props.maxLabel, {ns: 'loris'}) :
+      this.props.t('Maximum', {ns: 'loris'});
     const minLabel = this.props.labelPlacementTop && this.props.label ?
       this.props.t('{{label}} Minimum', {
         ns: 'loris',
@@ -1777,8 +1781,8 @@ DateRangeElementBase.defaultProps = {
     return text;
   },
   labelPlacementTop: false,
-  minLabel: 'Minimum',
-  maxLabel: 'Maximum',
+  minLabel: '',
+  maxLabel: '',
 };
 
 export const DateRangeElement = withTranslation('loris')(DateRangeElementBase);
@@ -2099,8 +2103,12 @@ class NumericRangeElementBase extends Component {
     const value = this.props.value || {};
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
-    const minLabel = this.props.t(this.props.minLabel, {ns: 'loris'});
-    const maxLabel = this.props.t(this.props.maxLabel, {ns: 'loris'});
+    const minLabel = this.props.minLabel ?
+      this.props.t(this.props.minLabel, {ns: 'loris'}) :
+      this.props.t('Minimum', {ns: 'loris'});
+    const maxLabel = this.props.maxLabel ?
+      this.props.t(this.props.maxLabel, {ns: 'loris'}) :
+      this.props.t('Maximum', {ns: 'loris'});
     const wrapperClass =
       this.props.label && !this.props.labelPlacementTop ?
         'col-sm-9' : 'col-sm-12';
@@ -2202,8 +2210,8 @@ NumericRangeElementBase.defaultProps = {
     return text;
   },
   labelPlacementTop: false,
-  minLabel: 'Minimum',
-  maxLabel: 'Maximum',
+  minLabel: '',
+  maxLabel: '',
 };
 
 export const NumericRangeElement = withTranslation('loris')(

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1606,7 +1606,7 @@ DateElement.defaultProps = {
  * Date range component.
  * React wrapper for filtering date values between two bounds.
  */
-export class DateRangeElement extends Component {
+class DateRangeElementBase extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -1626,7 +1626,7 @@ export class DateRangeElement extends Component {
       this.props.name,
       {
         ...this.props.value,
-        [e.target.name]: e.target.value,
+        [e.target.dataset.rangeBound]: e.target.value,
       }
     );
   }
@@ -1640,10 +1640,18 @@ export class DateRangeElement extends Component {
     const value = this.props.value || {};
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
+    const minRangeLabel = this.props.t(this.props.minLabel, {ns: 'loris'});
+    const maxRangeLabel = this.props.t(this.props.maxLabel, {ns: 'loris'});
     const minLabel = this.props.labelPlacementTop && this.props.label ?
-      `${this.props.label} ${this.props.minLabel}` : this.props.minLabel;
+      this.props.t('{{label}} Minimum', {
+        ns: 'loris',
+        label: this.props.label,
+      }) : minRangeLabel;
     const maxLabel = this.props.labelPlacementTop && this.props.label ?
-      `${this.props.label} ${this.props.maxLabel}` : this.props.maxLabel;
+      this.props.t('{{label}} Maximum', {
+        ns: 'loris',
+        label: this.props.label,
+      }) : maxRangeLabel;
     const wrapperClass =
       this.props.label && !this.props.labelPlacementTop ?
         'col-sm-9' : 'col-sm-12';
@@ -1694,7 +1702,8 @@ export class DateRangeElement extends Component {
               <input
                 type={inputType}
                 className="form-control"
-                name="min"
+                name={`${this.props.name}Min`}
+                data-range-bound="min"
                 id={minID}
                 min={minFullDate}
                 max={maxFullDate}
@@ -1712,7 +1721,8 @@ export class DateRangeElement extends Component {
               <input
                 type={inputType}
                 className="form-control"
-                name="max"
+                name={`${this.props.name}Max`}
+                data-range-bound="max"
                 id={maxID}
                 min={minFullDate}
                 max={maxFullDate}
@@ -1730,7 +1740,7 @@ export class DateRangeElement extends Component {
   }
 }
 
-DateRangeElement.propTypes = {
+DateRangeElementBase.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   value: PropTypes.shape({
@@ -1747,9 +1757,10 @@ DateRangeElement.propTypes = {
   labelPlacementTop: PropTypes.bool,
   minLabel: PropTypes.string,
   maxLabel: PropTypes.string,
+  t: PropTypes.func,
 };
 
-DateRangeElement.defaultProps = {
+DateRangeElementBase.defaultProps = {
   name: '',
   label: '',
   value: {},
@@ -1762,10 +1773,15 @@ DateRangeElement.defaultProps = {
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },
+  t: function(text) {
+    return text;
+  },
   labelPlacementTop: false,
   minLabel: 'Minimum',
   maxLabel: 'Maximum',
 };
+
+export const DateRangeElement = withTranslation('loris')(DateRangeElementBase);
 
 /**
  * Time Component
@@ -2049,7 +2065,7 @@ NumericElement.defaultProps = {
  * Numeric range component.
  * React wrapper for filtering a numeric value between two bounds.
  */
-export class NumericRangeElement extends Component {
+class NumericRangeElementBase extends Component {
   /**
    * @constructor
    * @param {object} props - React Component properties
@@ -2069,7 +2085,7 @@ export class NumericRangeElement extends Component {
       this.props.name,
       {
         ...this.props.value,
-        [e.target.name]: e.target.value,
+        [e.target.dataset.rangeBound]: e.target.value,
       }
     );
   }
@@ -2083,6 +2099,8 @@ export class NumericRangeElement extends Component {
     const value = this.props.value || {};
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
+    const minLabel = this.props.t(this.props.minLabel, {ns: 'loris'});
+    const maxLabel = this.props.t(this.props.maxLabel, {ns: 'loris'});
     const wrapperClass =
       this.props.label && !this.props.labelPlacementTop ?
         'col-sm-9' : 'col-sm-12';
@@ -2104,36 +2122,38 @@ export class NumericRangeElement extends Component {
           <div style={{display: 'flex', gap: '8px'}}>
             <div style={{flex: 1}}>
               <label className="sr-only" htmlFor={minID}>
-                {this.props.minLabel}
+                {minLabel}
               </label>
               <input
                 type="number"
                 className="form-control"
-                name="min"
+                name={`${this.props.name}Min`}
+                data-range-bound="min"
                 id={minID}
                 min={this.props.min}
                 max={this.props.max}
                 step={this.props.step}
                 value={value.min || ''}
-                placeholder={this.props.minLabel}
+                placeholder={minLabel}
                 disabled={this.props.disabled}
                 onChange={this.handleChange}
               />
             </div>
             <div style={{flex: 1}}>
               <label className="sr-only" htmlFor={maxID}>
-                {this.props.maxLabel}
+                {maxLabel}
               </label>
               <input
                 type="number"
                 className="form-control"
-                name="max"
+                name={`${this.props.name}Max`}
+                data-range-bound="max"
                 id={maxID}
                 min={this.props.min}
                 max={this.props.max}
                 step={this.props.step}
                 value={value.max || ''}
-                placeholder={this.props.maxLabel}
+                placeholder={maxLabel}
                 disabled={this.props.disabled}
                 onChange={this.handleChange}
               />
@@ -2145,7 +2165,7 @@ export class NumericRangeElement extends Component {
   }
 }
 
-NumericRangeElement.propTypes = {
+NumericRangeElementBase.propTypes = {
   name: PropTypes.string.isRequired,
   min: PropTypes.number,
   max: PropTypes.number,
@@ -2162,9 +2182,10 @@ NumericRangeElement.propTypes = {
   labelPlacementTop: PropTypes.bool,
   minLabel: PropTypes.string,
   maxLabel: PropTypes.string,
+  t: PropTypes.func,
 };
 
-NumericRangeElement.defaultProps = {
+NumericRangeElementBase.defaultProps = {
   name: '',
   min: null,
   max: null,
@@ -2177,10 +2198,17 @@ NumericRangeElement.defaultProps = {
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },
+  t: function(text) {
+    return text;
+  },
   labelPlacementTop: false,
   minLabel: 'Minimum',
   maxLabel: 'Maximum',
 };
+
+export const NumericRangeElement = withTranslation('loris')(
+  NumericRangeElementBase
+);
 
 /**
  * File Component

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1641,10 +1641,10 @@ class DateRangeElementBase extends Component {
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
     const minRangeLabel = this.props.minLabel ?
-      this.props.t(this.props.minLabel, {ns: 'loris'}) :
+      this.props.minLabel :
       this.props.t('Minimum', {ns: 'loris'});
     const maxRangeLabel = this.props.maxLabel ?
-      this.props.t(this.props.maxLabel, {ns: 'loris'}) :
+      this.props.maxLabel :
       this.props.t('Maximum', {ns: 'loris'});
     const minLabel = this.props.labelPlacementTop && this.props.label ?
       this.props.t('{{label}} Minimum', {
@@ -2104,10 +2104,10 @@ class NumericRangeElementBase extends Component {
     const minID = `${this.props.id || this.props.name}_min`;
     const maxID = `${this.props.id || this.props.name}_max`;
     const minLabel = this.props.minLabel ?
-      this.props.t(this.props.minLabel, {ns: 'loris'}) :
+      this.props.minLabel :
       this.props.t('Minimum', {ns: 'loris'});
     const maxLabel = this.props.maxLabel ?
-      this.props.t(this.props.maxLabel, {ns: 'loris'}) :
+      this.props.maxLabel :
       this.props.t('Maximum', {ns: 'loris'});
     const wrapperClass =
       this.props.label && !this.props.labelPlacementTop ?

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -366,6 +366,18 @@ msgstr "Sauvegarde en cours"
 msgid "Reset"
 msgstr "Réinitialiser"
 
+msgid "Minimum"
+msgstr "Minimum"
+
+msgid "Maximum"
+msgstr "Maximum"
+
+msgid "{{label}} Minimum"
+msgstr "{{label}} minimum"
+
+msgid "{{label}} Maximum"
+msgstr "{{label}} maximum"
+
 msgid "Note"
 msgstr "Note"
 

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -146,6 +146,18 @@ msgstr "सहेजें"
 msgid "Reset"
 msgstr "रीसेट करें"
 
+msgid "Minimum"
+msgstr "न्यूनतम"
+
+msgid "Maximum"
+msgstr "अधिकतम"
+
+msgid "{{label}} Minimum"
+msgstr "{{label}} न्यूनतम"
+
+msgid "{{label}} Maximum"
+msgstr "{{label}} अधिकतम"
+
 msgid "Note"
 msgstr "नोट"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -373,6 +373,18 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+msgid "Minimum"
+msgstr ""
+
+msgid "Maximum"
+msgstr ""
+
+msgid "{{label}} Minimum"
+msgstr ""
+
+msgid "{{label}} Maximum"
+msgstr ""
+
 msgid "Note"
 msgstr ""
 

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -297,7 +297,7 @@ class CandidateListIndex extends Component {
         'show': true,
         'filter': {
           name: 'DoB',
-          type: 'date',
+          type: 'date-range',
           hide: this.state.hideFilter,
         },
       },

--- a/modules/candidate_list/test/CandidateListTestIntegrationTest.php
+++ b/modules/candidate_list/test/CandidateListTestIntegrationTest.php
@@ -38,7 +38,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
     // advanced filter
     static $scanDone    = 'select[name="scanDone"]';
     static $Participant = 'select[name="participantStatus"]';
-    static $dob         = 'input[name="min"]';
+    static $dob         = 'input[name="DoBMin"]';
     static $visitCount  = 'input[name="visitCount"]';
     static $feedback    = 'select[name="feedback"]';
     static $edc         = 'input[name="edc"]';
@@ -144,7 +144,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
             WebDriverBy::Name("participantStatus")
         );
            $this->assertEquals("select", $participantsStatusOptions->getTagName());
-           $dobOptions = $this->safeFindElement(WebDriverBy::Name("min"));
+           $dobOptions = $this->safeFindElement(WebDriverBy::Name("DoBMin"));
            $this->assertEquals("input", $dobOptions->getTagName());
            // Not currently done
            //$this->assertEquals("date",$dobOptions->getAttribute("type"));

--- a/modules/candidate_list/test/CandidateListTestIntegrationTest.php
+++ b/modules/candidate_list/test/CandidateListTestIntegrationTest.php
@@ -38,7 +38,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
     // advanced filter
     static $scanDone    = 'select[name="scanDone"]';
     static $Participant = 'select[name="participantStatus"]';
-    static $dob         = 'input[name="DoB"]';
+    static $dob         = 'input[name="min"]';
     static $visitCount  = 'input[name="visitCount"]';
     static $feedback    = 'select[name="feedback"]';
     static $edc         = 'input[name="edc"]';
@@ -144,7 +144,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
             WebDriverBy::Name("participantStatus")
         );
            $this->assertEquals("select", $participantsStatusOptions->getTagName());
-           $dobOptions = $this->safeFindElement(WebDriverBy::Name("DoB"));
+           $dobOptions = $this->safeFindElement(WebDriverBy::Name("min"));
            $this->assertEquals("input", $dobOptions->getTagName());
            // Not currently done
            //$this->assertEquals("date",$dobOptions->getAttribute("type"));
@@ -264,13 +264,6 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
             self::$clearFilter,
             "Active",
             '436'
-        );
-        $this->_filterTest(
-            self::$dob,
-            self::$display,
-            self::$clearFilter,
-            "2003-06-30",
-            '1 row'
         );
         $this->_filterTest(
             self::$visitCount,

--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -4,8 +4,8 @@ import {
   SelectElement,
   FormElement,
   ButtonElement,
-  DateElement,
   NumericRangeElement,
+  DateRangeElement,
 } from 'jsx/Form';
 import {useTranslation} from 'react-i18next';
 
@@ -43,6 +43,26 @@ const QueryChartForm = (props) => {
     [props.data]
   );
 
+  const getCallbackData = (formData) => {
+    const callbackData = {...formData};
+    const dateRegistered = callbackData.dateRegistered || {};
+
+    delete callbackData.dateRegistered;
+    if ((dateRegistered.min || '') !== '') {
+      callbackData.dateRegisteredStart = dateRegistered.min;
+    } else {
+      delete callbackData.dateRegisteredStart;
+    }
+
+    if ((dateRegistered.max || '') !== '') {
+      callbackData.dateRegisteredEnd = dateRegistered.max;
+    } else {
+      delete callbackData.dateRegisteredEnd;
+    }
+
+    return callbackData;
+  };
+
   /**
    * setFormData - Stores the value of the element in formDataObj state.
    *
@@ -51,6 +71,23 @@ const QueryChartForm = (props) => {
    */
 
   const setFormData = (formElement, value) => {
+    if (formElement === 'dateRegistered') {
+      const min = value.min || '';
+      const max = value.max || '';
+      if ((min !== '' && min < '1900-01-01') ||
+        (max !== '' && max < '1900-01-01')) {
+        return;
+      }
+
+      const newFormData = {
+        ...formDataObj,
+        dateRegistered: value,
+      };
+      props.callback(getCallbackData(newFormData));
+      setFormDataObj(newFormData);
+      return;
+    }
+
     let normalizedValue = value;
     if (formElement === 'candidateAge') {
       if ((normalizedValue.min || '') === '' &&
@@ -89,7 +126,7 @@ const QueryChartForm = (props) => {
       Module ={props.Module}
       name ={props.name}
       id ={props.id}
-      onSubmit ={() => props.callback(formDataObj)}
+      onSubmit ={() => props.callback(getCallbackData(formDataObj))}
       method ='GET'
     >
       <div className ="filter-grid">
@@ -229,31 +266,16 @@ const QueryChartForm = (props) => {
 
         {/* DateRegistered Section */}
         <div>
-          <label style ={{fontWeight: 'bold',
-            marginBottom: '5px',
-            display: 'block'}}>
-            {t('Date Registered', {ns: 'statistics'})}</label>
-          <DateElement
-            name='dateRegisteredStart'
-            value={formDataObj['dateRegisteredStart'] || ''}
-            onUserInput ={(name, value) => {
-              setFormData(name, value);
-            }}
-            style={{width: '100%', padding: '8px',
-              borderRadius: '5px',
-              border: '1px solid #ccc'}}
-            label={t('Range Start', {ns: 'statistics'})}
-          />
-          <DateElement
-            name='dateRegisteredEnd'
-            value={formDataObj['dateRegisteredEnd'] || ''}
+          <DateRangeElement
+            name='dateRegistered'
+            value={formDataObj['dateRegistered'] || {}}
             onUserInput={(name, value) => {
               setFormData(name, value);
             }}
-            style={{width: '100%', padding: '8px',
-              borderRadius: '5px',
-              border: '1px solid #ccc'}}
-            label={t('Range End', {ns: 'statistics'})}
+            label={t('Date Registered', {ns: 'statistics'})}
+            minLabel={t('Range Start', {ns: 'statistics'})}
+            maxLabel={t('Range End', {ns: 'statistics'})}
+            labelPlacementTop
           />
         </div>
       </div>


### PR DESCRIPTION
## Brief summary of changes

- Adds a reusable `DateRangeElement` form component for min/max date filtering.
- Extends shared table filtering and filter query-string handling to support `<field>Min` / `<field>Max` date range values.

#### Testing instructions (if applicable)

- Open `http://localhost:8000/candidate_list/?DoBMin=2000-01-01&DoBMax=2005-12-31` and confirm the `DoB Minimum` / `DoB Maximum` inputs are populated from the URL.
- On Candidate List, change the DoB range and confirm the table filters to dates within the selected bounds and the URL updates with `DoBMin` / `DoBMax`.
- On the Statistics dashboard, open chart filters and confirm Date Registered appears as a range control with `Range Start` / `Range End`.

#### Link(s) to related issue(s)

* Resolves #10472