### PR TITLE
[DQT] Simplify Welcome Page, Improve UI (#9863)

### DIFF
--- a/jsx/Form.d.ts
+++ b/jsx/Form.d.ts
@@ -634,6 +634,48 @@ export class RadioElement {
 }
 
 
+type ctaProps = {
+    label?: string;
+    buttonClass?: string;
+    onUserInput?: (e: any) => void;
+}
+
+/**
+ * CTA class. See Form.js
+ */
+export class CTA {
+    props: ctaProps
+    state: any
+    context: object
+    refs: {[key: string]: ReactInstance}
+
+    /**
+     * Construct a CTA
+     *
+     * @param {ctaProps} props - React props
+     */
+    constructor(props: ctaProps)
+
+    /**
+     * React lifecycle method
+     *
+     * @returns {ReactNode} - the element
+     */
+    render(): ReactNode
+
+    /**
+     * React lifecycle method
+     *
+     * @param {object} newstate - the state to override
+     */
+    setState(newstate: object): void
+
+    /**
+     * React lifecycle method.
+     */
+    forceUpdate(): void
+}
+
 export default {
   FormElement,
   FieldsetElement,

--- a/modules/dataquery/css/dataquery.css
+++ b/modules/dataquery/css/dataquery.css
@@ -1,0 +1,30 @@
+/**
+ * Data Query Tool (Beta) - Module Specific Styles
+ *
+ * Customizes the help panel to be wider and center-aligned
+ * for better readability of the query instructions.
+ */
+
+/* Override help panel width - make it 2x wider for dataquery module */
+.help-content {
+    width: 640px;
+    /* Center the panel below the ? button by shifting right edge alignment to center */
+    left: auto;
+    right: 0;
+    transform: translateX(0);
+}
+
+/* On smaller screens, make it responsive */
+@media (max-width: 768px) {
+    .help-content {
+        width: 100%;
+        max-width: calc(100vw - 20px);
+    }
+}
+
+/* Custom size for the Welcome page CTA button */
+.dqt-welcome-cta {
+    padding: 15px 40px !important;
+    font-size: 16px !important;
+    border-radius: 4px !important;
+}

--- a/modules/dataquery/css/dataquery.css
+++ b/modules/dataquery/css/dataquery.css
@@ -7,8 +7,7 @@
 
 /* Override help panel width - make it 2x wider for dataquery module */
 .help-content {
-    width: 640px;
-    /* Center the panel below the ? button by shifting right edge alignment to center */
+    width: 380px;
     left: auto;
     right: 0;
     transform: translateX(0);

--- a/modules/dataquery/help/dataquery.md
+++ b/modules/dataquery/help/dataquery.md
@@ -1,14 +1,14 @@
-# Data Query
+# Data Query Tool (Beta)
 
 This module allows you to query data within LORIS.
 There are three steps to defining a query:
 
-- First, you must select the fields that you're
-  interested in on the **Define Fields** page.
-- Next, you can optionally define filters on the
-  **Define Filters** page to restrict the population
-  that is returned.
-- Finally, you view your query results on the **View Data** page
+1. First, you must select the fields that you're
+   interested in on the **Define Fields** page.
+2. Next, you can optionally define filters on the
+   **Define Filters** page to restrict the population
+   that is returned.
+3. Finally, you view your query results on the **View Data** page.
 
 The **Next Steps** on the bottom right of your screen always the
 context-sensitive next steps that you can do to build your query.

--- a/modules/dataquery/help/dataquery.md
+++ b/modules/dataquery/help/dataquery.md
@@ -1,31 +1,13 @@
 # Data Query Tool (Beta)
 
-This module allows you to query data within LORIS.
-There are three steps to defining a query:
+Select **Define Fields** to get started.
 
-1. First, you must select the fields that you're
-   interested in on the **Define Fields** page.
-2. Next, you can optionally define filters on the
-   **Define Filters** page to restrict the population
-   that is returned.
-3. Finally, you view your query results on the **View Data** page.
+**Recent Queries** shows your queries.
 
-The **Next Steps** on the bottom right of your screen always the
-context-sensitive next steps that you can do to build your query.
+Select ↻ to load a query.
 
-Your recently run queries will be displayed in the **Recent Queries** panel
-on the first screen of the module (you can return to it at any time by using
-the LORIS breadcrumbs.) Instead of building a new query, you can reload a
-query that you've recently run by clicking on the load icon next to the query.
+Select ✎ to name a query.
 
-Queries can be shared with others by clicking the share icon.
-This will cause the query to be shared with all users who
-have access to the fields used by the query. It will display
-in a **Shared Queries** panel below the **Recent Queries**.
+Select ★ to star a query.
 
-You may also give a query a name at any time by clicking the
-pencil icon. This makes it easier to find queries you care
-about by giving them an easier to remember name that can be used
-for filtering. When you share a query, the name will be shared
-along with it.
-
+Select 🌐 to share a query.

--- a/modules/dataquery/jsx/nextsteps.tsx
+++ b/modules/dataquery/jsx/nextsteps.tsx
@@ -27,7 +27,7 @@ function NextSteps(props: {
 
   const canRun = (props.fields && props.fields.length > 0);
   const fieldLabel = (props.fields && props.fields.length > 0)
-    ? t('Modify Fields', {ns: 'dataquery'})
+    ? t('Define Fields', {ns: 'dataquery'})
     : t('Choose Fields', {ns: 'dataquery'});
   const filterLabel = (props.filters && props.filters.group.length > 0)
     ? t('Modify Filters', {ns: 'dataquery'})

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -8,7 +8,7 @@ import NameQueryModal from './welcome.namequerymodal';
 import AdminQueryModal from './welcome.adminquerymodal';
 import getDictionaryDescription from './getdictionarydescription';
 import PaginationLinks from 'jsx/PaginationLinks';
-import {ButtonElement, CheckboxElement, TextboxElement} from 'jsx/Form';
+import {CheckboxElement, TextboxElement, CTA} from 'jsx/Form';
 import {APIQueryField} from './types';
 import {FullDictionary} from './types';
 import {FlattenedField, FlattenedQuery, VisitOption} from './types';
@@ -92,16 +92,6 @@ function Welcome(props: {
     });
   }
   panels.push({
-    title: t('Instructions', {ns: 'dataquery'}),
-    content: <IntroductionMessage
-      hasStudyQueries={props.topQueries.length > 0}
-      onContinue={props.onContinue}
-    />,
-    alwaysOpen: false,
-    defaultOpen: true,
-    id: 'p2',
-  });
-  panels.push({
     title: t('Recent Queries', {ns: 'dataquery'}),
     content: (
       <div>
@@ -160,6 +150,17 @@ function Welcome(props: {
       }}>
         {t('Welcome to the Data Query Tool', {ns: 'dataquery'})}
       </h1>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'center',
+        margin: '30px 0',
+      }}>
+        <CTA
+          label={t('Continue to Define Fields', {ns: 'dataquery'})}
+          onUserInput={props.onContinue}
+          buttonClass="btn btn-primary dqt-welcome-cta"
+        />
+      </div>
       <ExpansionPanels panels={panels} />
     </div>
   );
@@ -1081,71 +1082,6 @@ function NameIcon(props: {
   >
     <i className="fas fa-pencil-alt fa-stack-1x"> </i>
   </span>);
-}
-
-/**
- * Displays the message for the introduction panel
- *
- * @param {object} props - React props
- * @param {function} props.onContinue - Action to take when "Continue" button is pressed
- * @param {boolean} props.hasStudyQueries - Whether or not study queries exist
- * @returns {React.ReactElement} - The React element
- */
-function IntroductionMessage(props: {
-    onContinue: () => void,
-    hasStudyQueries: boolean,
-}): React.ReactElement {
-  const {t} = useTranslation('dataquery');
-  const studyQueriesParagraph = props.hasStudyQueries ? (
-    <p>
-      {t('Above, there is also a Study Queries panel. This are a'
-        +' special type of shared queries that have been pinned by a study'
-        +' administer to always display at the top of this page.',
-      {ns: 'dataquery'})}
-    </p>
-  ) : '';
-  return (
-    <div>
-      <p>{t('The data query tool allows you to query data within LORIS. '
-        +'There are three steps to defining a query:', {ns: 'dataquery'})}</p>
-      <ol>
-        <li>{t('First, you must select the fields that you\'re interested in'
-          +' on the Define Fields page.', {ns: 'dataquery'})}</li>
-        <li>{t('Next, you can optionally define filters on the Define '
-          +'Filters page to restrict the population that is returned.',
-        {ns: 'dataquery'})}</li>
-        <li>{t('Finally, you view your query results on the View Data page',
-          {ns: 'dataquery'})}</li>
-      </ol>
-      <p>{t('The Next Steps on the bottom right of your screen always the '
-        +'context-sensitive next steps that you can do to build your query.',
-      {ns: 'dataquery'})}</p>
-      <p>{t('Your recently run queries will be displayed in the Recent '
-        +'Queries panel below. Instead of building a new query, you can '
-        +'reload a query that you\'ve recently run by clicking on the icon'
-        +' next to the query.', {ns: 'dataquery'})}</p>
-      <p>{t('Queries can be shared with others by clicking the icon. This will'
-        +' cause the query to be shared with all users who have access to the '
-        +'fields used by the query. It will display in a Shared Queries panel '
-        +'below the Recent Queries.', {ns: 'dataquery'})}</p>
-      <p>{t('You may also give a query a name at any time by clicking the icon.'
-      +' This makes it easier to find queries you care about by giving them an'
-        +' easier to remember name that can be used for filtering. When you '
-        +'share a query, the name will be shared along with it.',
-      {ns: 'dataquery'})}</p>
-      {studyQueriesParagraph}
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}>
-        <ButtonElement
-          columnSize="col-sm-12"
-          onUserInput={props.onContinue}
-          label={t('Continue to Define Fields', {ns: 'dataquery'})} />
-      </div>
-    </div>
-  );
 }
 
 export default Welcome;

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -61,4 +61,22 @@ class Dataquery extends \NDB_Page
             ]
         );
     }
+
+    /**
+     * Include module-specific CSS for customizing the help panel
+     *
+     * @return array of CSS to be inserted
+     */
+    function getCSSDependencies()
+    {
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getCSSDependencies();
+        return array_merge(
+            $deps,
+            [
+                $baseURL . "/dataquery/css/dataquery.css",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Rebased replacement for [#10300](https://github.com/aces/Loris/pull/10300) onto 28.0-release.

Previous PR description : 
## Brief summary of changes

- **Simplified Welcome Page**: Removed the redundant "Instructions" panel and added a prominent "Continue to Define Fields" call-to-action (CTA) button.
- **Improved Help Documentation**: Widened the help panel (380px) to make descriptions easier to read.
- **Underlying Fixes**:
  - Added TypeScript definitions for the `CTA` component in `Form.d.ts`.
  - Added a module-specific CSS file to handle DQT-specific layout adjustments.
  - Removed unused `IntroductionMessage` component code to reduce technical debt.

Final Results:
![Screen Recording 2026-01-23 at 17 24 46](https://github.com/user-attachments/assets/48bef02d-f9ee-4a8b-94d0-ffe564b1ae15)

Original UI:
<img width="2190" height="1513" alt="image" src="https://github.com/user-attachments/assets/680eba09-cf7d-4e56-a513-a1b40e65e04a" />

## Testing Instructions
1. Run `made dev`
2. Go to 'dqt' module
3. Verify that instructions were moved to only be under '?' (help). See [issue](https://github.com/aces/Loris/issues/9863) for more context
4. Ensure the module still works as intended (see testplan if needed)

#### Link(s) to related issue(s)

* Resolves #9863