### PR TITLE
[candidate_parameters] Family tab rely on options from SQL instead of redefining them in JS

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1366,6 +1366,7 @@ CREATE TABLE `family` (
   `FamilyID` int(6) NOT NULL,
   `CandidateID` int(10) unsigned NOT NULL,
   `Relationship_type` enum('half_sibling','full_sibling','1st_cousin') DEFAULT NULL,
+  `RelationshipLabel` VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (`ID`),
   CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1372,10 +1372,10 @@ CREATE TABLE `family` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `FamilyID` int(6) NOT NULL,
   `CandidateID` int(10) unsigned NOT NULL,
-  `Relationship_type` int(10) unsigned DEFAULT NULL,
+  `Relationship_type_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`ID`),
   CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`),
-  CONSTRAINT `FK_family_relationship_type_1` FOREIGN KEY (`Relationship_type`) REFERENCES `family_relationship_type`(`ID`)
+  CONSTRAINT `FK_family_relationship_type_1` FOREIGN KEY (`Relationship_type_id`) REFERENCES `family_relationship_type`(`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1366,9 +1366,15 @@ CREATE TABLE `family` (
   `FamilyID` int(6) NOT NULL,
   `CandidateID` int(10) unsigned NOT NULL,
   `Relationship_type` enum('half_sibling','full_sibling','1st_cousin') DEFAULT NULL,
-  `RelationshipLabel` VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (`ID`),
   CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `family_relationship_type` (
+  `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `Name` varchar(255) DEFAULT NULL,
+  `Label` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1361,20 +1361,21 @@ CREATE TABLE `participant_status_history` (
   CONSTRAINT `FK_participant_status_history_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `family` (
-  `ID` int(10) NOT NULL AUTO_INCREMENT,
-  `FamilyID` int(6) NOT NULL,
-  `CandidateID` int(10) unsigned NOT NULL,
-  `Relationship_type` enum('half_sibling','full_sibling','1st_cousin') DEFAULT NULL,
-  PRIMARY KEY (`ID`),
-  CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 CREATE TABLE `family_relationship_type` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Name` varchar(255) DEFAULT NULL,
   `Label` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `family` (
+  `ID` int(10) NOT NULL AUTO_INCREMENT,
+  `FamilyID` int(6) NOT NULL,
+  `CandidateID` int(10) unsigned NOT NULL,
+  `Relationship_type` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`ID`),
+  CONSTRAINT `FK_family_candidate_1` FOREIGN KEY (`CandidateID`) REFERENCES `candidate`(`ID`),
+  CONSTRAINT `FK_family_relationship_type_1` FOREIGN KEY (`Relationship_type`) REFERENCES `family_relationship_type`(`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -194,6 +194,7 @@ DROP TABLE IF EXISTS `examiners`;
 
 DROP TABLE IF EXISTS `participant_status_history`;
 DROP TABLE IF EXISTS `family`;
+DROP TABLE IF EXISTS `family_relationship_type`;
 DROP TABLE IF EXISTS `participant_emails`;
 DROP TABLE IF EXISTS `participant_accounts`;
 DROP TABLE IF EXISTS `participant_status`;

--- a/SQL/New_patches/2026-05-25_add_family_label.sql
+++ b/SQL/New_patches/2026-05-25_add_family_label.sql
@@ -1,0 +1,6 @@
+ALTER TABLE family ADD COLUMN RelationshipLabel VARCHAR(255);
+
+-- LORIS specific labels (can be modified for projects)
+UPDATE family SET RelationshipLabel = 'Full Sibling' WHERE Relationship_type = 'full_sibling';
+UPDATE family SET RelationshipLabel = 'Half Sibling' WHERE Relationship_type = 'half_sibling';
+UPDATE family SET RelationshipLabel = '1st Cousin' WHERE Relationship_type = '1st_cousin';

--- a/SQL/New_patches/2026-05-25_add_family_label.sql
+++ b/SQL/New_patches/2026-05-25_add_family_label.sql
@@ -1,6 +1,0 @@
-ALTER TABLE family ADD COLUMN RelationshipLabel VARCHAR(255);
-
--- LORIS specific labels (can be modified for projects)
-UPDATE family SET RelationshipLabel = 'Full Sibling' WHERE Relationship_type = 'full_sibling';
-UPDATE family SET RelationshipLabel = 'Half Sibling' WHERE Relationship_type = 'half_sibling';
-UPDATE family SET RelationshipLabel = '1st Cousin' WHERE Relationship_type = '1st_cousin';

--- a/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
+++ b/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `family_relationship_type` (
+  `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `Name` varchar(255) DEFAULT NULL,
+  `Label` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`ID`)
+)

--- a/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
+++ b/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
@@ -6,9 +6,9 @@ CREATE TABLE `family_relationship_type` (
 )
 
 ALTER TABLE family
-MODIFY COLUMN Relationship_type int(10) unsigned DEFAULT NULL;
+MODIFY COLUMN Relationship_type_id int(10) unsigned DEFAULT NULL;
 
 ALTER TABLE family
 ADD CONSTRAINT `FK_family_relationship_type_1`
-FOREIGN KEY (`Relationship_type`)
+FOREIGN KEY (`Relationship_type_id`)
 REFERENCES `family_relationship_type`(`ID`);

--- a/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
+++ b/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
@@ -4,3 +4,11 @@ CREATE TABLE `family_relationship_type` (
   `Label` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ID`)
 )
+
+ALTER TABLE family
+MODIFY COLUMN Relationship_type int(10) unsigned DEFAULT NULL;
+
+ALTER TABLE family
+ADD CONSTRAINT `FK_family_relationship_type_1`
+FOREIGN KEY (`Relationship_type`)
+REFERENCES `family_relationship_type`(`ID`);

--- a/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
+++ b/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
@@ -3,12 +3,51 @@ CREATE TABLE `family_relationship_type` (
   `Name` varchar(255) DEFAULT NULL,
   `Label` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ID`)
-)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-ALTER TABLE family
-MODIFY COLUMN Relationship_type_id int(10) unsigned DEFAULT NULL;
+-- Extract the values from the existing enum for each project (limitation: every relationship_type present in code, hardcoded in js is assumed to present in the enum).
+SET @enum_list = (
+    SELECT SUBSTRING(
+        COLUMN_TYPE,
+        6,
+        CHAR_LENGTH(COLUMN_TYPE) - 6
+    )
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'family'
+      AND COLUMN_NAME = 'Relationship_type'
+);
 
-ALTER TABLE family
+SET @s = CONCAT(
+    'INSERT INTO family_relationship_type (`Name`) VALUES (',
+    REPLACE(@enum_list, ',', '),('),
+    ');'
+);
+
+PREPARE stmt FROM @s;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Populate labels
+UPDATE family_relationship_type
+SET Label = CONCAT(
+    UPPER(LEFT(REPLACE(Name, '_', ' '), 1)),
+    SUBSTRING(REPLACE(Name, '_', ' '), 2)
+);
+
+ALTER TABLE `family`
+ADD COLUMN `Relationship_type_id` int(10) unsigned DEFAULT NULL;
+
+-- Convert existing enum values to the new corresponding integer values (ID of the family_relationship_type table).
+UPDATE `family` f
+INNER JOIN `family_relationship_type` frt
+    ON frt.`Name` = f.`Relationship_type`
+SET f.`Relationship_type_id` = frt.`ID`;
+
+ALTER TABLE `family`
+DROP COLUMN `Relationship_type`;
+
+ALTER TABLE `family`
 ADD CONSTRAINT `FK_family_relationship_type_1`
 FOREIGN KEY (`Relationship_type_id`)
 REFERENCES `family_relationship_type`(`ID`);

--- a/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
+++ b/SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE `family_relationship_type` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Extract the values from the existing enum for each project (limitation: every relationship_type present in code, hardcoded in js is assumed to present in the enum).
+-- Extract the values from the existing enum for each project (limitation: every relationship_type hardcoded in javascript is assumed to be present in the enum)
 SET @enum_list = (
     SELECT SUBSTRING(
         COLUMN_TYPE,
@@ -38,7 +38,7 @@ SET Label = CONCAT(
 ALTER TABLE `family`
 ADD COLUMN `Relationship_type_id` int(10) unsigned DEFAULT NULL;
 
--- Convert existing enum values to the new corresponding integer values (ID of the family_relationship_type table).
+-- Convert existing enum values to the new corresponding IDs in the family_relationship_type table
 UPDATE `family` f
 INNER JOIN `family_relationship_type` frt
     ON frt.`Name` = f.`Relationship_type`

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -306,11 +306,27 @@ function getFamilyInfoFields()
         ]
     );
 
+    $relationshipList = iterator_to_array(
+        $db->pselect(
+            "SELECT DISTINCT Relationship_type, RelationshipLabel
+                FROM family
+                WHERE Relationship_type IS NOT NULL
+                ORDER BY RelationshipLabel",
+            []
+        )
+    );
+
+    $relationshipOptions = [];
+    foreach ($relationshipList as $row) {
+        $relationshipOptions[$row['Relationship_type']] = $row['RelationshipLabel'];
+    }
+
     $result = [
         'pscid'                 => $pscid,
         'candID'                => $candID->__toString(),
         'candidates'            => $candidates,
         'existingFamilyMembers' => $familyMembers,
+        'relationshipOptions' => $relationshipOptions,
     ];
 
     return $result;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -320,7 +320,7 @@ function getFamilyInfoFields()
         'candID'                => $candID->__toString(),
         'candidates'            => $candidates,
         'existingFamilyMembers' => $familyMembers,
-        'relationshipOptions' => $relationshipOptions,
+        'relationshipOptions'   => $relationshipOptions,
     ];
 
     return $result;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -306,20 +306,14 @@ function getFamilyInfoFields()
         ]
     );
 
-    $relationshipList = iterator_to_array(
-        $db->pselect(
-            "SELECT DISTINCT Relationship_type, RelationshipLabel
-                FROM family
-                WHERE Relationship_type IS NOT NULL
-                ORDER BY RelationshipLabel",
-            []
-        )
+    $relationshipOptions = $db->pselectWithIndexKey(
+        "SELECT DISTINCT Relationship_type, RelationshipLabel
+        FROM family
+        WHERE Relationship_type IS NOT NULL
+        ORDER BY RelationshipLabel",
+        [],
+        'Relationship_type'
     );
-
-    $relationshipOptions = [];
-    foreach ($relationshipList as $row) {
-        $relationshipOptions[$row['Relationship_type']] = $row['RelationshipLabel'];
-    }
 
     $result = [
         'pscid'                 => $pscid,

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -307,10 +307,9 @@ function getFamilyInfoFields()
     );
 
     $relationshipOptions = $db->pselectWithIndexKey(
-        "SELECT DISTINCT Relationship_type, RelationshipLabel
-        FROM family
-        WHERE Relationship_type IS NOT NULL
-        ORDER BY RelationshipLabel",
+        "SELECT NAME AS Relationship_type, Label
+        FROM family_relationship_type
+        ORDER BY Label",
         [],
         'Relationship_type'
     );

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -293,7 +293,7 @@ function getFamilyInfoFields()
     }
 
     $familyMembers = $db->pselect(
-        "SELECT c1.CandID as FamilyCandidate, f1.Relationship_type
+        "SELECT c1.CandID as FamilyCandidate, f1.Relationship_type_id
         FROM family f1
         JOIN family f2 ON f1.FamilyID=f2.FamilyID
         JOIN candidate c1 ON f1.CandidateID=c1.ID
@@ -307,11 +307,11 @@ function getFamilyInfoFields()
     );
 
     $relationshipOptions = $db->pselectWithIndexKey(
-        "SELECT NAME AS Relationship_type, Label
+        "SELECT ID, Name, Label
         FROM family_relationship_type
         ORDER BY Label",
         [],
-        'Relationship_type'
+        'ID'
     );
 
     $result = [

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -132,11 +132,14 @@ class FamilyInfo extends Component {
         </button>
       );
     }
-    let relationshipOptions = {
-      'full_sibling': t('Full Sibling', {ns: 'candidate_parameters'}),
-      'half_sibling': t('Half Sibling', {ns: 'candidate_parameters'}),
-      '1st_cousin': t('First Cousin', {ns: 'candidate_parameters'}),
-    };
+    let relationshipOptions = {};
+
+    Object.keys(this.state.Data.relationshipOptions).forEach((type) => {
+      relationshipOptions[type] = t(
+        this.state.Data.relationshipOptions[type],
+        {ns: 'candidate_parameters'}
+      );
+    });
 
     let disabled = true;
     let addButton = null;

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -136,7 +136,7 @@ class FamilyInfo extends Component {
 
     Object.keys(this.state.Data.relationshipOptions).forEach((type) => {
       relationshipOptions[type] = t(
-        this.state.Data.relationshipOptions[type],
+        this.state.Data.relationshipOptions[type].RelationshipLabel,
         {ns: 'candidate_parameters'}
       );
     });

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -135,10 +135,8 @@ class FamilyInfo extends Component {
     let relationshipOptions = {};
 
     Object.keys(this.state.Data.relationshipOptions).forEach((type) => {
-      relationshipOptions[type] = t(
-        this.state.Data.relationshipOptions[type].RelationshipLabel,
-        {ns: 'candidate_parameters'}
-      );
+      relationshipOptions[type] = this.state.Data.relationshipOptions[type].Label;
+      console.log(this.state.Data.relationshipOptions[type].Label);
     });
 
     let disabled = true;

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -132,11 +132,10 @@ class FamilyInfo extends Component {
         </button>
       );
     }
-    let relationshipOptions = {};
+    const relationshipOptions = {};
 
-    Object.keys(this.state.Data.relationshipOptions).forEach((type) => {
-      relationshipOptions[type] = this.state.Data.relationshipOptions[type].Label;
-      console.log(this.state.Data.relationshipOptions[type].Label);
+    Object.keys(this.state.Data.relationshipOptions).forEach((id) => {
+      relationshipOptions[id] = this.state.Data.relationshipOptions[id].Label;
     });
 
     let disabled = true;
@@ -155,7 +154,7 @@ class FamilyInfo extends Component {
     for (let key in familyMembers) {
       if (familyMembers.hasOwnProperty(key)) {
         let candID = familyMembers[key].FamilyCandID;
-        let relationship = familyMembers[key].Relationship_type;
+        let relationshipId = familyMembers[key].Relationship_type_id;
         let link = '?candID=' + candID + '&identifier=' + candID;
 
         familyMembersHTML.push(
@@ -168,7 +167,7 @@ class FamilyInfo extends Component {
             />
             <StaticElement
               label={t('Relation Type', {ns: 'candidate_parameters'})}
-              text={relationshipOptions[relationship]}
+              text={relationshipOptions[relationshipId]}
             />
 
             <ButtonElement
@@ -236,13 +235,13 @@ class FamilyInfo extends Component {
           />
           <SelectElement
             label={t('Relation Type', {ns: 'candidate_parameters'})}
-            name="Relationship_type"
+            name="Relationship_type_id"
             options={relationshipOptions}
             onUserInput={this.setFormData}
-            ref="Relationship_type"
+            ref="Relationship_type_id"
             disabled={disabled}
             required={true}
-            value={this.state.formData.Relationship_type}
+            value={this.state.formData.Relationship_type_id}
           />
           {addButton}
         </FormElement>

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -155,15 +155,6 @@ msgstr ""
 msgid "Relation Type"
 msgstr ""
 
-msgid "Full Sibling"
-msgstr ""
-
-msgid "Half Sibling"
-msgstr ""
-
-msgid "First Cousin"
-msgstr ""
-
 msgid "Delete"
 msgstr ""
 

--- a/modules/candidate_parameters/locale/es/LC_MESSAGES/candidate_parameters.po
+++ b/modules/candidate_parameters/locale/es/LC_MESSAGES/candidate_parameters.po
@@ -155,15 +155,6 @@ msgstr "Identificador del miembro Familiar (CCDID)"
 msgid "Relation Type"
 msgstr "Tipo de relación"
 
-msgid "Full Sibling"
-msgstr "Hermano"
-
-msgid "Half Sibling"
-msgstr "Medio hermano"
-
-msgid "First Cousin"
-msgstr "Primo hermano"
-
 msgid "Delete"
 msgstr "Borrar"
 

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,8 +1,9 @@
+/*M!999999\- enable the sandbox mode */ 
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,'half_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (21,1,1004,'full_sibling','Full Sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (24,1,1005,'full_sibling','Full Sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (26,2,166,'half_sibling','Half Sibling');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,4 +1,3 @@
-/*M!999999\- enable the sandbox mode */ 
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,8 +1,8 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,1);
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,1);
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,2);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (21,1,1004,1);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (24,1,1005,1);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (26,2,166,2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,8 +1,8 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,'half_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (21,1,1004,2);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (24,1,1005,2);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (26,2,166,1);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,9 +1,8 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,'full_sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,'half_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,1);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,1);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;
-w

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,8 +1,8 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (21,1,1004,1);
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (24,1,1005,1);
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type_id`) VALUES (26,2,166,2);
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,'full_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,'full_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,'half_sibling');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family.sql
+++ b/raisinbread/RB_files/RB_family.sql
@@ -1,8 +1,9 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `family`;
 LOCK TABLES `family` WRITE;
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (21,1,1004,'full_sibling','Full Sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (24,1,1005,'full_sibling','Full Sibling');
-INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`, `RelationshipLabel`) VALUES (26,2,166,'half_sibling','Half Sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (21,1,1004,'full_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (24,1,1005,'full_sibling');
+INSERT INTO `family` (`ID`, `FamilyID`, `CandidateID`, `Relationship_type`) VALUES (26,2,166,'half_sibling');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;
+w

--- a/raisinbread/RB_files/RB_family_relationship_type.sql
+++ b/raisinbread/RB_files/RB_family_relationship_type.sql
@@ -1,8 +1,0 @@
-SET FOREIGN_KEY_CHECKS=0;
-TRUNCATE TABLE `family_relationship_type`;
-LOCK TABLES `family_relationship_type` WRITE;
-INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (1,'full_sibling','Full Sibling');
-INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (2,'half_sibling','Half Sibling');
-INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (3,'1st_cousin','First Cousin');
-UNLOCK TABLES;
-SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family_relationship_type.sql
+++ b/raisinbread/RB_files/RB_family_relationship_type.sql
@@ -1,0 +1,8 @@
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `family_relationship_type`;
+LOCK TABLES `family_relationship_type` WRITE;
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (1,'full_sibling','Full Sibling');
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (2,'half_sibling','Half Sibling');
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (3,'1st_cousin','First Cousin');
+UNLOCK TABLES;
+SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_family_relationship_type.sql
+++ b/raisinbread/RB_files/RB_family_relationship_type.sql
@@ -1,0 +1,8 @@
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `family_relationship_type`;
+LOCK TABLES `family_relationship_type` WRITE;
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (1,'half_sibling','Half sibling');
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (2,'full_sibling','Full sibling');
+INSERT INTO `family_relationship_type` (`ID`, `Name`, `Label`) VALUES (3,'1st_cousin','1st cousin');
+UNLOCK TABLES;
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

The primary goal of this PR is to load family relationship options dynamically from the database instead of relying on hardcoded values in the frontend. To achieve this, it introduces a new family_relationship_type table that stores Name/Label pairs (e.g. ('full_sibling', 'Full sibling')). It also replaces the Relationship_type enum from the family table with a Relationship_type_id integer foreign key referencing the new table.

#### Testing instructions (if applicable)

1. git fetch aces
2. Source the test database on aces/main (base of this branch)
3. git checkout HachemJ/FixFamilyTabLabelsFromSQL
4. Apply the SQL patch: 
```bash
mysql <raisinbread_db>  < SQL/New_patches/2026-07-15_add_family_relationship_type_table.sql 
```

Note: This is the command I typically use to apply the SQL patch. Feel free to use whichever method you prefer.

5. Assert that this patch runs without any errors
6. Access your db and verify that the new family_relationship_type_table was created and populated
```sql
SELECT *
FROM family_relationship_type
ORDER BY ID;
```

7. Assert that Relationship_type_id exists, it is an unsigned integer with a foreign key referencing family_relationship_type.ID
```sql 
SHOW CREATE TABLE family;
```

8. Assert that the existing family records were migrated to the correct IDs
```sql
SELECT
    f.ID,
    f.CandidateID,
    f.Relationship_type_id,
    frt.Name,
    frt.Label
FROM family f
LEFT JOIN family_relationship_type frt
    ON frt.ID = f.Relationship_type_id
ORDER BY f.ID;
```

9. Add a row to the family_relationship_type table 
```sql
INSERT INTO family_relationship_type (Name, Label)
VALUES ('second_cousin', 'Second Cousin');
```

10. (Optional) In some cases the Family tab is unaccessible if the study configuration does not have it enabled (check config module). You can also enable it from going to Admin --> Configuration --> select useFamily --> Submit

11. Go to the Family Information tab. (The Candidate parameters module is reachable by going to 'Candidate' -> 'Access Profile --> click on any candidate's PSCID --> click on Candidate Info)

12. Open the Relation Type dropdown

13. Reload the page and assert that Second Cousin appears without any hardcoded frontend changes 

14. Delete the unused test option
```sql
DELETE FROM family_relationship_type
WHERE Name = 'second_cousin';
```

15. Reload the page and assert that Second Cousin no longer appears in the dropdown

16. Try deleting a relationship type that is associated with an existing family record
```sql
DELETE FROM family_relationship_type
WHERE Name = 'second_cousin';
```

17. Assert that you get the following error
```sql
ERROR 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`raisinbread_db`.`family`, CONSTRAINT `FK_family_relationship_type_1` FOREIGN KEY (`Relationship_type_id`) REFERENCES `family_relationship_type` (`ID`))
```

Do not expect a successful submission if you try adding a full sibling/half sibling or first cousin between candidates. The functionality currently seems broken on main. #10511 

<img width="1710" height="949" alt="image" src="https://github.com/user-attachments/assets/039b5e77-e76c-4903-ba8d-7e0f0667a81e" />


#### Link(s) to related issue(s)

* Resolves #10499 