### PR TITLE
[candidate_parameters] Fixed broken Family Information tab (add, render and delete)

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -293,7 +293,14 @@ function editFamilyInfoFields(\Database $db)
             $updateValues['FamilyID'] = $newFamilyID;
             $db->insert('family', $updateValues);
 
-            $updateValues['Candidate'] = $candID;
+            // Add a corresponding row for the candidate whose profile is
+            // being edited
+            $candidateID = $db->pselectOne(
+            "SELECT ID FROM candidate WHERE CandID=:candID",
+            ['candID' => $candID]
+            );
+
+            $updateValues['CandidateID'] = $candidateID;
             $db->insert('family', $updateValues);
         }
     }
@@ -354,9 +361,16 @@ function deleteFamilyMember(\Database $db)
         ['cid' => $candID]
     );
 
+    $familyMemberCandidateID = $db->pselectOne(
+        'SELECT ID
+        FROM candidate
+        WHERE CandID=:cid',
+        ['cid' => $familyMemberID]
+    );
+
     $where = [
-        'FamilyID'  => $familyID,
-        'Candidate' => $familyMemberID,
+        'FamilyID'    => $familyID,
+        'CandidateID' => $familyMemberCandidateID,
     ];
 
     $db->delete('family', $where);

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -293,8 +293,6 @@ function editFamilyInfoFields(\Database $db)
             $updateValues['FamilyID'] = $newFamilyID;
             $db->insert('family', $updateValues);
 
-            // Add a corresponding row for the candidate whose profile is
-            // being edited
             $candidateID = $db->pselectOne(
             "SELECT ID FROM candidate WHERE CandID=:candID",
             ['candID' => $candID]

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -292,18 +292,20 @@ function getFamilyInfoFields()
         }
     }
 
-    $familyMembers = $db->pselect(
-        "SELECT c1.CandID as FamilyCandidate, f1.Relationship_type
-        FROM family f1
-        JOIN family f2 ON f1.FamilyID=f2.FamilyID
-        JOIN candidate c1 ON f1.CandidateID=c1.ID
-        JOIN candidate c2 ON f2.CandidateID=c2.ID
-        WHERE c2.CandID=:candid AND c1.CandID <> :candid2
-        ORDER BY c1.CandID",
-        [
-            'candid'  => $candID,
-            'candid2' => $candID,
-        ]
+    $familyMembers = iterator_to_array(
+        $db->pselect(
+            "SELECT c1.CandID as FamilyCandID, f1.Relationship_type
+            FROM family f1
+            JOIN family f2 ON f1.FamilyID=f2.FamilyID
+            JOIN candidate c1 ON f1.CandidateID=c1.ID
+            JOIN candidate c2 ON f2.CandidateID=c2.ID
+            WHERE c2.CandID=:candid AND c1.CandID <> :candid2
+            ORDER BY c1.CandID",
+            [
+                'candid'  => $candID,
+                'candid2' => $candID,
+            ]
+        )
     );
 
     $result = [


### PR DESCRIPTION
## Brief summary of changes

This PR updates family creation and deletion to use the internal CandidateID instead of CandID, and returns family members as an array to prevent errors in FamilyInfo.js, which expects an array when calling .push().

#### Testing instructions

1. Go to the Family Information tab: 'Candidate' -> 'Access profile'  -> Click on any candidate’s PSCID -> Click on 'Candidate Info' -> 'Family Information' tab

2. 

Note: In some cases the Family tab is unaccessible if the study configuration does not have it enabled (check config module). You can also enable it from going to Admin --> Configuration --> select useFamily --> Submit.

#### Link(s) to related issue(s)

* Resolves #10511
* Resolves #10982  (pretty much a duplicate of the above) 