### PR TITLE
[27.0-release] issue tracker PATCH fix

### DIFF
--- a/SQL/Archive/27.0/2024-02-06-issuetracker-Adds-Description-To-Issues-Table.sql
+++ b/SQL/Archive/27.0/2024-02-06-issuetracker-Adds-Description-To-Issues-Table.sql
@@ -3,4 +3,4 @@ ALTER TABLE `issues`
     AFTER `category`;
 
 ALTER TABLE `issues_history`
-    MODIFY `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description') NOT NULL DEFAULT 'comment';
+    MODIFY `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'watching', 'description') NOT NULL DEFAULT 'comment';

--- a/SQL/Release_patches/26.0_To_27.0_upgrade.sql
+++ b/SQL/Release_patches/26.0_To_27.0_upgrade.sql
@@ -61,7 +61,8 @@ ALTER TABLE `issues`
     AFTER `category`;
 
 ALTER TABLE `issues_history`
-    MODIFY `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'description') NOT NULL DEFAULT 'comment';
+    MODIFY `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID', 'watching', 'description') NOT NULL DEFAULT 'comment';
+    
 CREATE TABLE `instrument_data` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Data` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(`Data`)),


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a flaw in logic with the UPGRADE SQL patch for the 27 version. This specifically deals with the  `fieldChanged` column of the `issues_history`. This field is an enum that on [version 26 contains the option "watching"](https://github.com/aces/Loris/blob/26.0-release/SQL/0000-00-00-schema.sql#L1545) but it mysteriously gets deleted by this commit https://github.com/aces/Loris/pull/8864/ with no explanations on the removal and no handling of the data for existing projects.

My assessments is the changes in https://github.com/aces/Loris/pull/8864/ removing the watching option is a mistake and was done accidentally while adding the description option to the enum. This corrects that mistake.

This issue being fixed here causes a failure of the upgrade patch for any project using the issue_tracker on loris version 26 and below

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
