### PR TITLE
mri scan type PATCH fix

### DIFF
--- a/SQL/Archive/27.0/2024-06-25-Clean-Mri-Scan-Type.sql
+++ b/SQL/Archive/27.0/2024-06-25-Clean-Mri-Scan-Type.sql
@@ -1,5 +1,5 @@
 ALTER TABLE `mri_protocol_checks`
-  DROP FOREIGN KEY 'FK_mriProtocolChecks_ScanType';
+  DROP FOREIGN KEY `FK_mriProtocolChecks_ScanType`;
 
 -- Rename foreign key fields for consistency
 

--- a/SQL/Archive/27.0/2024-06-25-Clean-Mri-Scan-Type.sql
+++ b/SQL/Archive/27.0/2024-06-25-Clean-Mri-Scan-Type.sql
@@ -1,3 +1,6 @@
+ALTER TABLE `mri_protocol_checks`
+  DROP FOREIGN KEY 'FK_mriProtocolChecks_ScanType';
+
 -- Rename foreign key fields for consistency
 
 ALTER TABLE `mri_scan_type`
@@ -46,6 +49,5 @@ ALTER TABLE `mri_violations_log`
 -- Rename the existing constraints for consistency
 
 ALTER TABLE `mri_protocol_checks`
-  DROP FOREIGN KEY `FK_mriProtocolChecks_ScanType`,
   ADD CONSTRAINT `FK_mri_protocol_checks_scan_type`
     FOREIGN KEY (`MriScanTypeID`) REFERENCES `mri_scan_type` (`MriScanTypeID`);

--- a/SQL/Release_patches/26.0_To_27.0_upgrade.sql
+++ b/SQL/Release_patches/26.0_To_27.0_upgrade.sql
@@ -95,7 +95,7 @@ DELETE FROM Config WHERE ConfigID IN (SELECT ID FROM ConfigSettings WHERE Name =
 DELETE FROM ConfigSettings WHERE Name = 'DoubleDataEntryInstruments';
 
 ALTER TABLE `mri_protocol_checks`
-  DROP FOREIGN KEY 'FK_mriProtocolChecks_ScanType';
+  DROP FOREIGN KEY `FK_mriProtocolChecks_ScanType`;
 
 -- Rename foreign key fields for consistency
 

--- a/SQL/Release_patches/26.0_To_27.0_upgrade.sql
+++ b/SQL/Release_patches/26.0_To_27.0_upgrade.sql
@@ -93,6 +93,10 @@ UPDATE test_battery SET DoubleDataEntryEnabled = 'Y' WHERE Test_name IN (
 DELETE FROM Config WHERE ConfigID IN (SELECT ID FROM ConfigSettings WHERE Name = 'DoubleDataEntryInstruments');
 
 DELETE FROM ConfigSettings WHERE Name = 'DoubleDataEntryInstruments';
+
+ALTER TABLE `mri_protocol_checks`
+  DROP FOREIGN KEY 'FK_mriProtocolChecks_ScanType';
+
 -- Rename foreign key fields for consistency
 
 ALTER TABLE `mri_scan_type`
@@ -141,7 +145,6 @@ ALTER TABLE `mri_violations_log`
 -- Rename the existing constraints for consistency
 
 ALTER TABLE `mri_protocol_checks`
-  DROP FOREIGN KEY `FK_mriProtocolChecks_ScanType`,
   ADD CONSTRAINT `FK_mri_protocol_checks_scan_type`
     FOREIGN KEY (`MriScanTypeID`) REFERENCES `mri_scan_type` (`MriScanTypeID`);
 -- Drop nonsensical defaults and put use right type for others.


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a flaw in logic with the UPGRADE SQL patch for the 27 version. 
This is the error I was getting when running the following CHANGE command:

```sql
ALTER TABLE `mri_scan_type`
  CHANGE `ID` `MriScanTypeID` int(11) unsigned NOT NULL auto_increment;
```

```sql
ERROR 1846 (0A000): ALGORITHM=COPY is not supported. Reason: Columns participating in a foreign key are renamed. Try ALGORITHM=INPLACE
```

I tried bypassing this error by dropping the foreign keys of the table and re-adding them with the renamed table columns. 

This resulted in an additional error further along the release patch because one of the three foreign keys that were needed to be dropped in order to bypass the first error is dropped later on in the patch:

```sql
ALTER TABLE `mri_protocol_checks`
  DROP FOREIGN KEY `FK_mriProtocolChecks_ScanType`,
  ADD CONSTRAINT `FK_mri_protocol_checks_scan_type`
    FOREIGN KEY (`MriScanTypeID`) REFERENCES `mri_scan_type` (`MriScanTypeID`);
 ```