### PR TITLE
Translate create_timepoint success button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ POFILES=locale/fr/LC_MESSAGES/loris.po \
 	modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po \
 	modules/create_timepoint/locale/fr/LC_MESSAGES/create_timepoint.po \
 	modules/create_timepoint/locale/ja/LC_MESSAGES/create_timepoint.po \
+	modules/create_timepoint/locale/hi/LC_MESSAGES/create_timepoint.po \
 	modules/create_timepoint/locale/es/LC_MESSAGES/create_timepoint.po \
 	modules/brainbrowser/locale/fr/LC_MESSAGES/brainbrowser.po \
 	modules/brainbrowser/locale/ja/LC_MESSAGES/brainbrowser.po \

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -193,7 +193,7 @@ msgstr "sélectionné"
 
 # Common swal labels
 msgid "OK"
-msgstr "D'accord"
+msgstr "OK"
 
 msgid "Cancel"
 msgstr "Annuler"

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -193,7 +193,7 @@ msgstr "sélectionné"
 
 # Common swal labels
 msgid "OK"
-msgstr "OK"
+msgstr "D'accord"
 
 msgid "Cancel"
 msgstr "Annuler"

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -44,6 +44,9 @@ msgstr "प्रोजेक्ट अफिलिएशन्स"
 msgid "Log Out"
 msgstr "लॉग आउट"
 
+msgid "OK"
+msgstr "ठीक है"
+
 msgid "My Preferences"
 msgstr "मेरी पसंद"
 

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -17,6 +17,7 @@ import {
 
 import esStrings from '../locale/es/LC_MESSAGES/create_timepoint.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/create_timepoint.json';
+import hiStrings from '../locale/hi/LC_MESSAGES/create_timepoint.json';
 import frStrings from '../locale/fr/LC_MESSAGES/create_timepoint.json';
 import zhStrings from '../locale/zh/LC_MESSAGES/create_timepoint.json';
 /**
@@ -206,7 +207,11 @@ class CreateTimepoint extends React.Component {
         });
       state.messages = [errorMessage];
       state.messages = [errorMessage];
-      swal.fire(errorMessage, '', 'error');
+      swal.fire({
+        title: errorMessage,
+        icon: 'error',
+        confirmButtonText: t('OK', {ns: 'loris'}),
+      });
       state.form.options.cohort = {};
       state.form.options.visit = {};
     } else {
@@ -252,7 +257,11 @@ class CreateTimepoint extends React.Component {
             ],
           });
         state.messages = [errorMessage];
-        swal.fire(errorMessage, '', 'error');
+        swal.fire({
+          title: errorMessage,
+          icon: 'error',
+          confirmButtonText: t('OK', {ns: 'loris'}),
+        });
         state.form.options.visit = {};
       } else {
         state.form.options.visit = state.storage.visit[
@@ -283,6 +292,25 @@ class CreateTimepoint extends React.Component {
     } else if (formElement === 'cohort') {
       this.handleVisitLabel();
     }
+  }
+
+  translateServerMessage(message) {
+    const {t} = this.props;
+    const timepointExists = message.match(new RegExp(
+      '^A timepoint with these conditions '
+      + '\\(([^,]+), ([^,]+), ([^,]+), ([^)]+)\\) already exists\\.$'
+    ));
+    if (!timepointExists) {
+      return message;
+    }
+
+    return timepointExists.slice(1).reduce(
+      (translated, value) => translated.replace('%s', value),
+      t(
+        'A timepoint with these conditions (%s, %s, %s, %s) already exists.',
+        {ns: 'create_timepoint'}
+      )
+    );
   }
 
   /**
@@ -330,7 +358,11 @@ class CreateTimepoint extends React.Component {
         response.json().then((data) => {
           if (data.error) {
             // display conflicts on form.
-            this.setState({messages: JSON.parse(data.error)});
+            const messages = JSON.parse(data.error);
+            Object.keys(messages).forEach((key) => {
+              messages[key] = this.translateServerMessage(messages[key]);
+            });
+            this.setState({messages});
           }
         });
       }
@@ -492,6 +524,7 @@ CreateTimepoint.propTypes = {
 window.addEventListener('load', () => {
   i18n.addResourceBundle('es', 'create_timepoint', esStrings);
   i18n.addResourceBundle('ja', 'create_timepoint', jaStrings);
+  i18n.addResourceBundle('hi', 'create_timepoint', hiStrings);
   i18n.addResourceBundle('fr', 'create_timepoint', frStrings);
   i18n.addResourceBundle('zh', 'create_timepoint', zhStrings);
 

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -294,25 +294,6 @@ class CreateTimepoint extends React.Component {
     }
   }
 
-  translateServerMessage(message) {
-    const {t} = this.props;
-    const timepointExists = message.match(new RegExp(
-      '^A timepoint with these conditions '
-      + '\\(([^,]+), ([^,]+), ([^,]+), ([^)]+)\\) already exists\\.$'
-    ));
-    if (!timepointExists) {
-      return message;
-    }
-
-    return timepointExists.slice(1).reduce(
-      (translated, value) => translated.replace('%s', value),
-      t(
-        'A timepoint with these conditions (%s, %s, %s, %s) already exists.',
-        {ns: 'create_timepoint'}
-      )
-    );
-  }
-
   /**
    * Handle form submission
    *
@@ -358,11 +339,7 @@ class CreateTimepoint extends React.Component {
         response.json().then((data) => {
           if (data.error) {
             // display conflicts on form.
-            const messages = JSON.parse(data.error);
-            Object.keys(messages).forEach((key) => {
-              messages[key] = this.translateServerMessage(messages[key]);
-            });
-            this.setState({messages});
+            this.setState({messages: JSON.parse(data.error)});
           }
         });
       }

--- a/modules/create_timepoint/jsx/createTimepointIndex.js
+++ b/modules/create_timepoint/jsx/createTimepointIndex.js
@@ -315,9 +315,12 @@ class CreateTimepoint extends React.Component {
       }
     ).then((response) => {
       if (response.ok) {
-        swal.fire(
-          t('Success!', {ns: 'loris'}),
-          t('Timepoint created.', {ns: 'create_timepoint'}), 'success')
+        swal.fire({
+          title: t('Success!', {ns: 'loris'}),
+          text: t('Timepoint created.', {ns: 'create_timepoint'}),
+          icon: 'success',
+          confirmButtonText: t('OK', {ns: 'loris'}),
+        })
           .then(() => {
             window.location.replace(
               `${this.props.baseURL}/${this.state.url.params.candID}`

--- a/modules/create_timepoint/locale/hi/LC_MESSAGES/create_timepoint.po
+++ b/modules/create_timepoint/locale/hi/LC_MESSAGES/create_timepoint.po
@@ -1,0 +1,49 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Create Timepoint"
+msgstr "टाइमपॉइंट बनाएं"
+
+msgid "No cohorts defined for project: {{project}}"
+msgstr "प्रोजेक्ट {{project}} के लिए कोई समूह परिभाषित नहीं है"
+
+msgid "No visit labels defined for the combination project: {{project}} and cohort: {{cohort}}"
+msgstr "प्रोजेक्ट {{project}} और समूह {{cohort}} के संयोजन के लिए कोई विजिट लेबल परिभाषित नहीं है"
+
+msgid "Timepoint created."
+msgstr "टाइमपॉइंट बनाया गया."
+
+msgid "A timepoint with these conditions (%s, %s, %s, %s) already exists."
+msgstr "इन शर्तों (%s, %s, %s, %s) वाला टाइमपॉइंट पहले से मौजूद है."
+
+msgid "You must be affiliated with a site to create a timepoint."
+msgstr "टाइमपॉइंट बनाने के लिए आपका किसी साइट से संबद्ध होना आवश्यक है."
+
+msgid "Site must be selected from the available dropdown."
+msgstr "साइट उपलब्ध ड्रॉपडाउन से चुनी जानी चाहिए."
+
+msgid "You must be affiliated with a project to create a timepoint."
+msgstr "टाइमपॉइंट बनाने के लिए आपका किसी प्रोजेक्ट से संबद्ध होना आवश्यक है."
+
+msgid "A project must be selected from the available dropdown."
+msgstr "प्रोजेक्ट उपलब्ध ड्रॉपडाउन से चुना जाना चाहिए."
+
+msgid "A language must be selected."
+msgstr "एक भाषा चुनी जानी चाहिए."


### PR DESCRIPTION
## Brief summary of changes

- Translates the Create Timepoint SweetAlert confirmation button through the shared `loris` namespace.
- Adds missing Create Timepoint Hindi locale coverage.
- Translates the no-cohort alert and duplicate-timepoint validation message in French, Hindi, and Japanese.
- Keeps the existing Create Timepoint submission flow unchanged.
<img width="2370" height="1620" alt="CleanShot 2026-06-02 at 13 09 53@2x" src="https://github.com/user-attachments/assets/f6e6a650-13c0-42a1-a220-db6e1c0af0ab" />


#### Testing instructions (if applicable)

- Open Create Timepoint and switch between French, Hindi, and Japanese.
- Submit an existing timepoint combination and confirm the duplicate-timepoint message is translated.

#### Link(s) to related issue(s)

* Resolves #10261
* Resolves #10276