### PR TITLE
Fix publication variable help translation

### DIFF
--- a/modules/publication/locale/fr/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/fr/LC_MESSAGES/publication.po
@@ -187,6 +187,5 @@ msgstr "Type de publication"
 msgid "Publication Version"
 msgstr "Version publiée"
 
-#, fuzzy
 msgid "helpFindingVariables"
-msgstr "aideRechercheDeVariables"
+msgstr "Pour vous aider à trouver des variables d'intérêt, consultez le <ddLink>Dictionnaire de données</ddLink>"


### PR DESCRIPTION
## Brief summary of changes

- Updates the French publication `helpFindingVariables` translation.
- Removes the fuzzy placeholder text so the variable help line renders as readable French.

<img width="2202" height="826" alt="CleanShot 2026-06-02 at 13 57 55@2x" src="https://github.com/user-attachments/assets/bc9d8cce-727a-4565-b38e-3530d3593159" />

#### Testing instructions (if applicable)

- Run `make publication`.
- Open the Publication upload form in French.
- Confirm the variable help text appears as readable French text with the Data Dictionary link.

#### Link(s) to related issue(s)

* Resolves #10274