### PR TITLE
[mri_violations] [jsx] Fix Clear filter bug for the 'Time Run' input field.

### DIFF
--- a/jsx/form/DateTimePartialElement.tsx
+++ b/jsx/form/DateTimePartialElement.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, ReactNode, useState} from 'react';
+import React, {ChangeEvent, ReactNode, useEffect, useState} from 'react';
 import InputLabel from 'jsx/form/InputLabel';
 
 const format = 'YYYY-MM-DD hh:mm:ss';
@@ -156,6 +156,10 @@ const DateTimePartialElement: React.FC<DateTimePartialElementProps> = (
     : () => console.warn('onUserInput() callback is not set');
 
   const [value, setValue] = useState(props.value ?? '');
+
+  useEffect(() => {
+    setValue(props.value ?? '');
+  }, [props.value]);
 
   /**
    * Handle a change in the input.


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bug where the 'Time Run' input field wouldn't clear after using the clear filter button on the MRI violated scans page found under Imaging --> MRI Violated Scans.

#### Testing instructions (if applicable)

1. Go to the MRI violated scans page. (The Mri Violations module is reachable by going to Imaging --> MRI Violated Scans)
2. Enter a timestamp in the 'Time Run' input field (please try both valid and invalid ones).
3. Click on the 'Clear Filter' button.
4. The 'Time Run' input should now be cleared.

The two videos below show the Before / After the changes with a 'valid' timestamp.

https://github.com/user-attachments/assets/9c883bf4-5db8-4470-9d6e-983e62d0d018

https://github.com/user-attachments/assets/3323f4a7-0b54-4297-a516-469f14534556

#### Link(s) to related issue(s)

* Resolves #9928 
