### PR TITLE
[I18n] Fix error when switching languages not logged in

### DIFF
--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -95,4 +95,15 @@ class AnonymousUser extends \User
     {
         return false;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array $set The array formatted for use in a Database call
+     *
+     * @return void
+     */
+    public function update(array $set): void
+    {
+    }
 }


### PR DESCRIPTION
Make the update() function in AnonymousUser a no-op. Currently, when the language is switched from the frontend if a user is not logged in, the update triggers a warning because there is no UserID. There is no situation where we should be updating the database for an anonymous user, so just make the whole function a no-op.
