### PR TITLE
[dataquery] Improve labels on pin query modal

### DIFF
--- a/modules/dataquery/jsx/welcome.adminquerymodal.tsx
+++ b/modules/dataquery/jsx/welcome.adminquerymodal.tsx
@@ -86,11 +86,11 @@ function AdminQueryModal(props: {
         onUserInput={
           (name: string, value: boolean) => setTopQuery(value)
         }
-        label={t('Pin Study Query', {ns: 'dataquery'})}
+        label={t('Pin study query', {ns: 'dataquery'})}
       />
       <CheckboxElement name='dashboardquery'
         value={dashboardQuery}
-        label={t('Pin Dashboard Summary', {ns: 'dataquery'})}
+        label={t('Show on dashboard', {ns: 'dataquery'})}
         onUserInput={
           (name: string, value: boolean) =>
             setDashboardQuery(value)
@@ -98,7 +98,7 @@ function AdminQueryModal(props: {
       />
       <CheckboxElement name='loginpage'
         value={loginQuery}
-        label={t('Pin To Login Page', {ns: 'dataquery'})}
+        label={t('Show summary on login page', {ns: 'dataquery'})}
         onUserInput={
           (name: string, value: boolean) =>
             setLoginQuery(value)

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -817,7 +817,7 @@ function SingleQueryDisplay(props: {
   const loadIcon = <LoadIcon onClick={loadQuery} />;
 
   const pinIcon = props.queryAdmin
-    ? <span title={t('Pin Study Query', {ns: 'dataquery'})}
+    ? <span title={t('Pin study query', {ns: 'dataquery'})}
       style={{cursor: 'pointer'}}
       className="fa-stack"
       onClick={() => {

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -440,13 +440,13 @@ msgstr ""
 msgid "Pin Top Query"
 msgstr ""
 
-msgid "Pin Study Query"
+msgid "Pin study query"
 msgstr ""
 
-msgid "Pin Dashboard Summary"
+msgid "Show on dashboard"
 msgstr ""
 
-msgid "Pin To Login Page"
+msgid "Show summary on login page"
 msgstr ""
 
 msgid "Must pin as study query, to dashboard, or to the login page."

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -602,16 +602,16 @@ msgstr "Vous devez fournir un nom de requête."
 msgid "Pin Top Query"
 msgstr "Requête épinglée au sommet"
 
-msgid "Pin Study Query"
+msgid "Pin study query"
 msgstr "Épingler la requête d'étude"
 
 #, fuzzy
-msgid "Pin Dashboard Summary"
-msgstr "Résumé du tableau de bord des épingles"
+msgid "Show on dashboard"
+msgstr "Afficher sur le tableau de bord"
 
 #, fuzzy
-msgid "Pin To Login Page"
-msgstr "Épingler à la page de connexion"
+msgid "Show summary on login page"
+msgstr "Afficher le résumé sur la page de connexion"
 
 #, fuzzy
 msgid "Must pin as study query, to dashboard, or to the login page."

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -448,14 +448,14 @@ msgstr "क्वेरी का नाम देना होगा।"
 msgid "Pin Top Query"
 msgstr "पिन टॉप क्वेरी"
 
-msgid "Pin Study Query"
+msgid "Pin study query"
 msgstr "पिन अध्ययन क्वेरी"
 
-msgid "Pin Dashboard Summary"
-msgstr "पिन डैशबोर्ड सारांश"
+msgid "Show on dashboard"
+msgstr "डैशबोर्ड पर दिखाएँ"
 
-msgid "Pin To Login Page"
-msgstr "लॉगिन पेज पर पिन करें"
+msgid "Show summary on login page"
+msgstr "लॉगिन पृष्ठ पर सारांश दिखाएँ"
 
 msgid "Must pin as study query, to dashboard, or to the login page."
 msgstr "स्टडी क्वेरी के तौर पर, डैशबोर्ड पर, या लॉगिन पेज पर पिन करना होगा।"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -435,14 +435,14 @@ msgstr "クエリ名を指定する必要があります。"
 msgid "Pin Top Query"
 msgstr "ピントップクエリ"
 
-msgid "Pin Study Query"
+msgid "Pin study query"
 msgstr "ピンスタディクエリ"
 
-msgid "Pin Dashboard Summary"
-msgstr "ピンダッシュボードの概要"
+msgid "Show on dashboard"
+msgstr "ダッシュボードに表示"
 
-msgid "Pin To Login Page"
-msgstr "ログインページにピン留めする"
+msgid "Show summary on login page"
+msgstr "ログインページに概要を表示"
 
 msgid "Must pin as study query, to dashboard, or to the login page."
 msgstr "調査クエリとしてダッシュボードまたはログイン ページにピン留めする必要があります。"

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -435,14 +435,14 @@ msgstr "必须提供查询名称。"
 msgid "Pin Top Query"
 msgstr "置顶查询"
 
-msgid "Pin Study Query"
+msgid "Pin study query"
 msgstr "固定研究查询"
 
-msgid "Pin Dashboard Summary"
-msgstr "固定仪表盘摘要"
+msgid "Show on dashboard"
+msgstr "在仪表板上显示"
 
-msgid "Pin To Login Page"
-msgstr "固定到登录页面"
+msgid "Show summary on login page"
+msgstr "在登录页面显示摘要"
 
 msgid "Must pin as study query, to dashboard, or to the login page."
 msgstr "必须固定为研究查询、固定到仪表盘或登录页面。"

--- a/modules/dataquery/test/TestPlan.md
+++ b/modules/dataquery/test/TestPlan.md
@@ -21,21 +21,21 @@
    13. Click the `Pin` icon to pin some queries.
       1. With and empty text in the `query name` text field, click the `Submit` button.
       2. Assert that: the error message `Must provide a query name to pin query as.` is triggered.
-      3. Unchecking all checkboxes (i.e. `Pin Study Query` and `Pin Dashboard Summary` and `Pin to Login Page`).
+      3. Unchecking all checkboxes (i.e. `Pin study query` and `Show on dashboard` and `Show summary on login page`).
       4. Assert that: clicking `Submit` triggers the error message `Must pin as study query, to dashboard, or to the login page.`.
-      5. Check the `Pin Study Query` checkbox and click the submit button.
+      5. Check the `Pin study query` checkbox and click the submit button.
       6. Assert that: the query is now pinned at the top of the page in the `Study Queries` panel.
       7. Go to LORIS main page by clicking the `LORIS` name in the top-left corner.
       8. Assert that: the query is **NOT** displayed inside the right-side `Study Queries` panel.
       9. Go back to the module.
-      10. Create a new named pinned query, only checking the `Pin Dashboard Summary` this time.
+      10. Create a new named pinned query, only checking the `Show on dashboard` this time.
       11. Assert that: the query is **NOT** pinned at the top of the page in the `Study Queries` panel.
       12. Go to LORIS main page by clicking the `LORIS` name in the top-left corner.
       13. Assert that: the query is displayed inside the right-side `Study Queries` panel.
       14. Click the pinned query.
       15. Assert that: the confirmation message `Query loaded` is displayed and query can immediately be executed.
-      16. Try pinning a query with `Pin Study Query`, `Pin Dashboard Summary` and `Pin to Login Page` options.
-      17. For testing the `Pin to Login Page` option, check the Login module test plan: `modules/login/test/Login_Statistics_Test_Plan.md`.
+      16. Try pinning a query with `Pin study query`, `Show on dashboard` and `Show summary on login page` options.
+      17. For testing the `Show summary on login page` option, check the Login module test plan: `modules/login/test/Login_Statistics_Test_Plan.md`.
       18. Assert that: `Study Queries` in the dataquery module **AND** `Study Queries` in LORIS welcome page **AND** `Data in LORIS` on the LORIS Login Page are displayed.
    14. Assert that: the query is now pinned at the top of the page, in `Study Queries` panel.
    15. Go back to `LORIS main page`.

--- a/modules/login/test/Login_Statistics_Test_Plan.md
+++ b/modules/login/test/Login_Statistics_Test_Plan.md
@@ -2,7 +2,7 @@
 
 1. Create a query in the dataquery module, including the Project column.
 2. Pin the query to the login page by pressing the Pin icon, then entering a name, 
-and checking "Pin to Login Page". If a query returns more than one row, the name will be appended with an 's'. Note that the query will not be pinned if it returns 0 rows, and will not be pinned if it does not include the Project column.
+and checking "Show summary on login page". If a query returns more than one row, the name will be appended with an 's'. Note that the query will not be pinned if it returns 0 rows, and will not be pinned if it does not include the Project column.
 3. Run `tools/update_login_summary_statistics.php` and confirm the output matches the count of the rows
 from the dqt.
 4. Log out of LORIS and confirm you can see the Login Statistics widget along with the pinned DQT query.


### PR DESCRIPTION
## Brief summary of changes

This PR is a replacement for #9622 and has been rebased onto main.

This updates the labels and translations required on the dataquery "pin query" modal to be more user friendly.
It also replaces every instance of the old labels in files such as the Test plan etc.

Note: I used AI for the translations. 
I can only confirm that the french translation is correct.

