### PR TITLE
[Statistics/Dashboard] Order Recruitment Pie By DoB

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -242,7 +242,8 @@ class Charts extends \NDB_Page
             {$conditions['cohortQuery']}
             {$conditions['visitQuery']}
             {$conditions['siteQuery']}
-            {$conditions['participantStatusQuery']}",
+            {$conditions['participantStatusQuery']}
+            ORDER BY c.DoB DESC",
             $conditions['params']
         );
 

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -278,13 +278,6 @@ class Charts extends \NDB_Page
             $label      = $startOfSplit . '-' . $endOfSplit;
             $recruitmentByAgeData[] = ["label" => $label, "total" => $count];
         }
-        // sort the labels
-        usort(
-            $recruitmentByAgeData,
-            function ($a, $b) {
-                return $a['label'] <=> $b['label'];
-            }
-        );
 
         return (new \LORIS\Http\Response\JsonResponse($recruitmentByAgeData));
     }


### PR DESCRIPTION
## Brief summary of changes
- Update the dashboard recruitment age chart to show Age ranges in order

#### Testing instructions (if applicable)

1. Ensure that the recruitment age pie chart has its age ranges ordered by lowest range to highest range rather than just the first DoB it finds when fetching participants
<img width="471" height="401" alt="image" src="https://github.com/user-attachments/assets/1f12c890-d7fc-45df-b4cd-0032d675a046" />

