### PR TITLE
[Policies] Fix missing on mobile

### DIFF
--- a/jsx/PolicyButton.js
+++ b/jsx/PolicyButton.js
@@ -35,7 +35,7 @@ const PolicyButton = ({
   }
   if (onClickPolicy) {
     return <a
-      className="hidden-xs hidden-sm"
+      // className="hidden-xs hidden-sm"
       id="on-click-policy-button"
       style={{...buttonStyle}}
       href="#"

--- a/jsx/PolicyButton.js
+++ b/jsx/PolicyButton.js
@@ -35,7 +35,6 @@ const PolicyButton = ({
   }
   if (onClickPolicy) {
     return <a
-      // className="hidden-xs hidden-sm"
       id="on-click-policy-button"
       style={{...buttonStyle}}
       href="#"

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -157,7 +157,7 @@
                             </li>
                             {/if}
                             {if $header_policy}
-                                <li class="hidden-xs hidden-sm" id="header-policy-button"></li>
+                                <li id="header-policy-button"></li>
                             {/if}
 
                             <li class="hidden-xs hidden-sm help-container"></li>


### PR DESCRIPTION
## Brief summary of changes
- Makes the Header policy button and the Policy button in request account / login show on Mobile devices
<img width="530" height="537" alt="image" src="https://github.com/user-attachments/assets/884197d3-4569-475f-99ed-2ba82dd6430b" />

#### Testing instructions (if applicable)

1. Using your browser dev tools, change your interface to a mobile device
2. See that the Terms of Use button on login is still present and that you can finish the request account workflow

#### Link(s) to related issue(s)

* Closes #10150