### PR TITLE
[DQT] Changes to "Query loaded" dialog message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ other improvements such as
 - Add infrastructure to track user decisions to policies 
 - Add Support for TOTP / 2FA
 
+#### Updates and Improvements
+- [docs] Update login page Setup Guide link to readthedocs (PR #7071)
 ### Notes For Existing Projects
 
 Upgrading LORIS requires following the upgrade process each major and minor release (bug fix releases can be script) to ensure the schema is up to date.
@@ -567,3 +569,4 @@ be used by projects having custom modules not in LORIS. (PR #5913)
 
 #### Schedule Module
 - New module created to schedule appointment within LORIS. (PR #6150)
+

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -808,7 +808,9 @@ function SingleQueryDisplay(props: {
     swal.fire({
       type: 'success',
       title: t('Query Loaded', {ns: 'dataquery'}),
-      text: t('Successfully loaded query.', {ns: 'dataquery'}),
+      text: t('Return to the previous page to run or modify your query.',
+        {ns: 'dataquery'}),
+      confirmButtonText: t('Return', {ns: 'dataquery'}),
     });
   };
 

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -407,7 +407,10 @@ msgstr ""
 msgid "Query Loaded"
 msgstr ""
 
-msgid "Successfully loaded query."
+msgid "Return to the previous page to run or modify your query."
+msgstr ""
+
+msgid "Return"
 msgstr ""
 
 msgid "(Run on {{runTime}})"

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -560,9 +560,11 @@ msgstr "Partager"
 msgid "Query Loaded"
 msgstr "Requête chargée"
 
-#, fuzzy
-msgid "Successfully loaded query."
-msgstr "Requête chargée avec succès."
+msgid "Return to the previous page to run or modify your query."
+msgstr "Retournez à la page précédente pour exécuter ou modifier votre requête."
+
+msgid "Return"
+msgstr "Retour"
 
 #, fuzzy
 msgid "(Run on {{runTime}})"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -415,8 +415,11 @@ msgstr "साझा करें"
 msgid "Query Loaded"
 msgstr "क्वेरी लोड हो गई"
 
-msgid "Successfully loaded query."
-msgstr "क्वेरी सफलतापूर्वक लोड हो गई।"
+msgid "Return to the previous page to run or modify your query."
+msgstr "अपनी क्वेरी को चलाने या संशोधित करने के लिए पिछले पृष्ठ पर वापस लौटें।"
+
+msgid "Return"
+msgstr "वापस लौटें"
 
 msgid "(Run on {{runTime}})"
 msgstr "(चलाया गया {{runTime}} पर)"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -402,8 +402,11 @@ msgstr "共有"
 msgid "Query Loaded"
 msgstr "クエリが読み込まれました"
 
-msgid "Successfully loaded query."
-msgstr "クエリが正常に読み込まれました。"
+msgid "Return to the previous page to run or modify your query."
+msgstr "前のページに戻ってクエリを実行または変更してください。"
+
+msgid "Return"
+msgstr "戻る"
 
 msgid "(Run on {{runTime}})"
 msgstr "({{runTime}} に実行)"


### PR DESCRIPTION
## Brief summary of changes
Updated the "Query loaded" success dialog. The message is now changed from "Successfully loaded query." to "Return to the previous page to run or modify your query." and the button is changed from "OK" to "Return".
(issue from PR: https://github.com/aces/Loris/pull/10304)

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to DQT (beta) and refresh one of the fields 
2. the success message was changed and Ok changes to return works as in the previous PR

#### Link(s) to related issue(s)

* Resolves #10128   (Reference the issue this fixes, if any.)
