### PR TITLE
[DQT] Fixes to "Add Condition" Modal Warning Logic and UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ other improvements such as
 - Add infrastructure to track user decisions to policies 
 - Add Support for TOTP / 2FA
 
+#### Updates and Improvements
+- [docs] Update login page Setup Guide link to readthedocs (PR #7071)
+
 ### Notes For Existing Projects
 
 Upgrading LORIS requires following the upgrade process each major and minor release (bug fix releases can be script) to ensure the schema is up to date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ other improvements such as
 - Add infrastructure to track user decisions to policies 
 - Add Support for TOTP / 2FA
 
-#### Updates and Improvements
-- [docs] Update login page Setup Guide link to readthedocs (PR #7071)
-
 ### Notes For Existing Projects
 
 Upgrading LORIS requires following the upgrade process each major and minor release (bug fix releases can be script) to ensure the schema is up to date.

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -55,6 +55,12 @@ const Modal = ({
         showCancelButton: true,
         confirmButtonText: t('Proceed', {ns: 'loris'}),
         cancelButtonText: t('Cancel', {ns: 'loris'}),
+        focusCancel: true,
+        reverseButtons: true,
+        customClass: {
+          confirmButton: 'btn-secondary',
+          cancelButton: 'btn-primary'
+        }
       }).then((result) => result.value && onClose());
     } else {
       onClose(); // Close immediately if no warning

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -59,8 +59,8 @@ const Modal = ({
         reverseButtons: true,
         customClass: {
           confirmButton: 'btn-secondary',
-          cancelButton: 'btn-primary'
-        }
+          cancelButton: 'btn-primary',
+        },
       }).then((result) => result.value && onClose());
     } else {
       onClose(); // Close immediately if no warning

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -111,6 +111,7 @@ function AddFilterModal(props: {
   const [op, setOp] = useState<Operators|null>(null);
   const [value, setValue] = useState<string|string[]>('');
   const [selectedVisits, setSelectedVisits] = useState<string[]|null>(null);
+   const [hasUserMadeSelection, setHasUserMadeSelection] = useState(false);
 
   const dropdownTitle = t('Field', {ns: 'dataquery', count: 99});
   if (props.displayedFields) {
@@ -129,6 +130,7 @@ function AddFilterModal(props: {
         setFieldname(fieldname);
         setOp(null);
         setValue('');
+        setHasUserMadeSelection(true);
         if (dict.visits) {
           setSelectedVisits(dict.visits);
         } else {
@@ -284,7 +286,7 @@ function AddFilterModal(props: {
   return (
     <Modal title={t('Add criteria', {ns: 'dataquery'})}
       show={true}
-      throwWarning={true}
+      throwWarning={hasUserMadeSelection}
       onClose={props.closeModal}
       onSubmit={submitPromise}>
       <div style={{width: '100%', padding: '1em'}}>
@@ -300,6 +302,7 @@ function AddFilterModal(props: {
                 setOp(null);
                 setValue('');
                 setSelectedVisits(null);
+                setHasUserMadeSelection(true);
                 props.onCategoryChange(module, category);
               }}
             />

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -111,7 +111,7 @@ function AddFilterModal(props: {
   const [op, setOp] = useState<Operators|null>(null);
   const [value, setValue] = useState<string|string[]>('');
   const [selectedVisits, setSelectedVisits] = useState<string[]|null>(null);
-   const [hasUserMadeSelection, setHasUserMadeSelection] = useState(false);
+  const [hasUserMadeSelection, setHasUserMadeSelection] = useState(false);
 
   const dropdownTitle = t('Field', {ns: 'dataquery', count: 99});
   if (props.displayedFields) {


### PR DESCRIPTION
## Brief summary of changes
**Fix Warning Logic**: The "Add Condition" modal now tracks active user selection state (hasUserMadeSelection), ensuring the exit warning only appears if data was actually entered in the current session.
**Fail-Safe UX**: Updated the modal to use safe defaults by making Cancel the primary and default action, positioning it first to reduce accidental confirmation.

(From PR: https://github.com/aces/Loris/pull/10307)

- [ ] Have you updated related documentation?

#### Link(s) to related issue(s)

* Resolves #10306   (Reference the issue this fixes, if any.)
