### PR TITLE
[dashboard/dataquery] Fix "Study Queries" translation

### DIFF
--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -111,7 +111,7 @@ class Module extends \Module
             if (count($studyqueries) > 0) {
                 $widgets[] = new \LORIS\dashboard\Widget(
                     new \LORIS\dashboard\WidgetContent(
-                        dgettext("dataquery", "Study Queries"),
+                        dngettext("dataquery", "Study Query", "Study Queries", count($studyqueries)),
                         $this->renderTemplate(
                             "studyquerieswidget.tpl",
                             [

--- a/modules/dataquery/php/module.class.inc
+++ b/modules/dataquery/php/module.class.inc
@@ -111,7 +111,12 @@ class Module extends \Module
             if (count($studyqueries) > 0) {
                 $widgets[] = new \LORIS\dashboard\Widget(
                     new \LORIS\dashboard\WidgetContent(
-                        dngettext("dataquery", "Study Query", "Study Queries", count($studyqueries)),
+                        dngettext(
+                            "dataquery",
+                            "Study Query",
+                            "Study Queries",
+                            count($studyqueries)
+                        ),
                         $this->renderTemplate(
                             "studyquerieswidget.tpl",
                             [


### PR DESCRIPTION
Fix translation of "Study Queries" widget header on dashboard.

Resolves #10266
