### PR TITLE
[imaging_qc] Translates imaging qc module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,9 @@ POFILES=locale/fr/LC_MESSAGES/loris.po \
 	modules/survey_accounts/locale/zh/LC_MESSAGES/survey_accounts.po \
 	modules/timepoint_list/locale/zh/LC_MESSAGES/timepoint_list.po \
 	modules/biobank/locale/zh/LC_MESSAGES/biobank.po \
-	modules/user_accounts/locale/zh/LC_MESSAGES/user_accounts.po
+	modules/user_accounts/locale/zh/LC_MESSAGES/user_accounts.po \
+	modules/imaging_qc/locale/fr/LC_MESSAGES/imaging_qc.po \
+	modules/imaging_qc/locale/hi/LC_MESSAGES/imaging_qc.po
 
 MOFILES=$(patsubst %.po,%.mo,$(POFILES))
 I18NJSONFILES=$(patsubst %.po,%.json,$(POFILES))

--- a/locale/en/LC_MESSAGES/loris.po
+++ b/locale/en/LC_MESSAGES/loris.po
@@ -160,6 +160,9 @@ msgstr[1] "Cohorts"
 msgid "Session"
 msgstr "Session"
 
+msgid "SessionID"
+msgstr "SessionID"
+
 msgid "Date of registration"
 msgstr "Date of registration"
 

--- a/locale/en/LC_MESSAGES/loris.po
+++ b/locale/en/LC_MESSAGES/loris.po
@@ -229,6 +229,9 @@ msgstr "Updated"
 msgid "Uploaded"
 msgstr "Uploaded"
 
+msgid "Uploaded By"
+msgstr "Uploaded By"
+
 msgid "Total"
 msgstr "Total"
 

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -287,6 +287,9 @@ msgstr "Actualizado"
 msgid "Uploaded"
 msgstr "Subido"
 
+msgid "Uploaded By"
+msgstr "Subido por"
+
 msgid "Total"
 msgstr "Total"
 

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -197,6 +197,9 @@ msgstr[1] "Cohortes"
 msgid "Session"
 msgstr ""
 
+msgid "SessionID"
+msgstr "Identificador de sesión"
+
 msgid "Date of registration"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -248,6 +248,9 @@ msgstr[1] "Cohortes"
 msgid "Session"
 msgstr "Session"
 
+msgid "SessionID"
+msgstr "ID de Session"
+
 msgid "Date of registration"
 msgstr "Date d'inscription"
 

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -418,6 +418,9 @@ msgstr "Mis à jour"
 msgid "Uploaded"
 msgstr "Téléversé"
 
+msgid "Uploaded By"
+msgstr "Téléverser par"
+
 # User Account related
 msgid "Password Rules"
 msgstr "Règles de mot de passe"

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -274,6 +274,9 @@ msgid_plural "Sessions"
 msgstr[0] "सत्र"
 msgstr[1] "सत्र"
 
+msgid "SessionID"
+msgstr "सत्र आईडी"
+
 msgid "Date of registration"
 msgstr "पंजीकरण की तिथि"
 

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -401,6 +401,9 @@ msgstr "अद्यतन किया गया"
 msgid "Uploaded"
 msgstr "अपलोड किया गया"
 
+msgid "Uploaded By"
+msgstr "द्वारा अपलोड किया गया"
+
 # User Account related
 msgid "Password Rules"
 msgstr "पासवर्ड नियम"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -391,6 +391,9 @@ msgstr "更新"
 msgid "Uploaded"
 msgstr "アップロード済み"
 
+msgid "Uploaded By"
+msgstr "アップロード者"
+
 # User Account related
 msgid "Password Rules"
 msgstr "パスワードルール"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -234,6 +234,9 @@ msgid "Session"
 msgid_plural "Sessions"
 msgstr[0] "セッション"
 
+msgid "SessionID"
+msgstr "SessionID"
+
 msgid "Date of registration"
 msgstr "入学日"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -239,7 +239,7 @@ msgid_plural "Sessions"
 msgstr[0] ""
 
 msgid "SessionID"
-msgstr "Identifiant de session"
+msgstr ""
 
 msgid "Date of registration"
 msgstr ""

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -425,6 +425,9 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
+msgid "Uploaded By"
+msgstr ""
+
 # User Account related
 msgid "Password Rules"
 msgstr ""

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -238,6 +238,9 @@ msgid "Session"
 msgid_plural "Sessions"
 msgstr[0] ""
 
+msgid "SessionID"
+msgstr "Identifiant de session"
+
 msgid "Date of registration"
 msgstr ""
 

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -234,6 +234,9 @@ msgid "Session"
 msgid_plural "Sessions"
 msgstr[0] "会话"
 
+msgid "SessionID"
+msgstr "会话ID"
+
 msgid "Date of registration"
 msgstr "注册日期"
 

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -391,6 +391,9 @@ msgstr "已更新"
 msgid "Uploaded"
 msgstr "已上传"
 
+msgid "Uploaded By"
+msgstr "上传者"
+
 # User Account related
 msgid "Password Rules"
 msgstr "密码规则"

--- a/modules/dicom_archive/jsx/dicom_archive.js
+++ b/modules/dicom_archive/jsx/dicom_archive.js
@@ -98,7 +98,7 @@ class DicomArchive extends Component {
       break;
     }
     case t('MRI Browser', {ns: 'dicom_archive'}): {
-      const sessionID = row[t('SessionID', {ns: 'dicom_archive'})];
+      const sessionID = row[t('SessionID', {ns: 'loris'})];
       if (sessionID === null || sessionID === '') {
         result = <td>&nbsp;</td>;
       } else {
@@ -181,7 +181,7 @@ class DicomArchive extends Component {
         options: options.sites,
       }},
       {label: t('TarchiveID', {ns: 'dicom_archive'}), show: false},
-      {label: t('SessionID', {ns: 'dicom_archive'}), show: false},
+      {label: t('SessionID', {ns: 'loris'}), show: false},
       {label: t('CenterID', {ns: 'dicom_archive'}), show: false},
       {label: t('IsPhantom', {ns: 'dicom_archive'}), show: false},
     ];

--- a/modules/dicom_archive/locale/dicom_archive.pot
+++ b/modules/dicom_archive/locale/dicom_archive.pot
@@ -45,9 +45,6 @@ msgstr ""
 msgid "TarchiveID"
 msgstr ""
 
-msgid "SessionID"
-msgstr ""
-
 msgid "CenterID"
 msgstr ""
 

--- a/modules/dicom_archive/locale/fr/LC_MESSAGES/dicom_archive.po
+++ b/modules/dicom_archive/locale/fr/LC_MESSAGES/dicom_archive.po
@@ -53,10 +53,6 @@ msgid "TarchiveID"
 msgstr "ID de tarchive"
 
 #, fuzzy
-msgid "SessionID"
-msgstr "ID de session"
-
-#, fuzzy
 msgid "CenterID"
 msgstr "Site ID"
 

--- a/modules/dicom_archive/locale/hi/LC_MESSAGES/dicom_archive.po
+++ b/modules/dicom_archive/locale/hi/LC_MESSAGES/dicom_archive.po
@@ -45,9 +45,6 @@ msgstr "सीरीज़ यूआईडी"
 msgid "TarchiveID"
 msgstr "टीआर्काइवआईडी"
 
-msgid "SessionID"
-msgstr "सत्र आईडी"
-
 msgid "CenterID"
 msgstr "केंद्र आईडी"
 

--- a/modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.po
+++ b/modules/dicom_archive/locale/ja/LC_MESSAGES/dicom_archive.po
@@ -45,9 +45,6 @@ msgstr "シリーズ固有識別子"
 msgid "TarchiveID"
 msgstr "TarchiveID"
 
-msgid "SessionID"
-msgstr "SessionID"
-
 msgid "CenterID"
 msgstr "CenterID"
 

--- a/modules/dicom_archive/locale/zh/LC_MESSAGES/dicom_archive.po
+++ b/modules/dicom_archive/locale/zh/LC_MESSAGES/dicom_archive.po
@@ -46,9 +46,6 @@ msgstr "系列唯一标识"
 msgid "TarchiveID"
 msgstr "档案ID"
 
-msgid "SessionID"
-msgstr "会话ID"
-
 msgid "CenterID"
 msgstr "中心ID"
 

--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -185,10 +185,10 @@ class DocIndex extends React.Component {
       let downloadURL = loris.BaseURL
                           + '/document_repository/Files/'
                           + encodeURIComponent(row[t('Uploaded By',
-                            {ns: 'document_repository'})])
+                            {ns: 'loris'})])
                           + '/'
                           + encodeURIComponent(row[t('File Name',
-                            {ns: 'document_repository'})]);
+                            {ns: 'loris'})]);
       result = <td>
         <a
           href={downloadURL}
@@ -293,7 +293,7 @@ class DocIndex extends React.Component {
       {label: t('Instrument',
         {ns: 'loris', count: 1}), show: false},
       {label: t('Uploaded By',
-        {ns: 'document_repository'}), show: true, filter: {
+        {ns: 'loris'}), show: true, filter: {
         name: 'uploadedBy',
         type: 'text',
       }},

--- a/modules/document_repository/locale/document_repository.pot
+++ b/modules/document_repository/locale/document_repository.pot
@@ -141,13 +141,7 @@ msgstr ""
 msgid "Delete Successful!"
 msgstr ""
 
-msgid "Upload"
-msgstr ""
-
 msgid "File Name"
-msgstr ""
-
-msgid "Uploaded By"
 msgstr ""
 
 msgid "For Site"

--- a/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
@@ -158,14 +158,8 @@ msgstr "Supprimer l'erreur !"
 msgid "Delete Successful!"
 msgstr "Suppression réussie !"
 
-msgid "Upload"
-msgstr "Téléverser"
-
 msgid "File Name"
 msgstr "Nom du fichier"
-
-msgid "Uploaded By"
-msgstr "Téléverser par"
 
 #, fuzzy
 msgid "For Site"

--- a/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
@@ -146,9 +146,6 @@ msgstr "हटाना सफल रहा!"
 msgid "File Name"
 msgstr "फ़ाइल का नाम"
 
-msgid "Uploaded By"
-msgstr "द्वारा अपलोड किया गया"
-
 msgid "For Site"
 msgstr "साइट के लिए"
 

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -147,9 +147,6 @@ msgstr "アップロード"
 msgid "File Name"
 msgstr "ファイル名"
 
-msgid "Uploaded By"
-msgstr "アップロード者"
-
 msgid "For Site"
 msgstr "サイト向け"
 

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -141,9 +141,6 @@ msgstr "削除エラー!"
 msgid "Delete Successful!"
 msgstr "削除に成功しました!"
 
-msgid "Upload"
-msgstr "アップロード"
-
 msgid "File Name"
 msgstr "ファイル名"
 

--- a/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
@@ -142,9 +142,6 @@ msgstr "删除错误！"
 msgid "Delete Successful!"
 msgstr "删除成功！"
 
-msgid "Upload"
-msgstr "上传"
-
 msgid "File Name"
 msgstr "文件名"
 

--- a/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
@@ -148,9 +148,6 @@ msgstr "上传"
 msgid "File Name"
 msgstr "文件名"
 
-msgid "Uploaded By"
-msgstr "上传者"
-
 msgid "For Site"
 msgstr "对于网站"
 

--- a/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
@@ -78,7 +78,7 @@ class ElectrophysiologyBrowserIndex extends Component {
     const style = '';
     let result = <td className={style}>{cell}</td>;
     const {t} = this.props;
-    const sessionIDKey = t('SessionID', {ns: 'electrophysiology_browser'});
+    const sessionIDKey = t('SessionID', {ns: 'loris'});
     const sessionID = row[sessionIDKey] || row.SessionID;
     switch (column) {
     case t('Links', {ns: 'electrophysiology_browser'}):
@@ -181,7 +181,7 @@ class ElectrophysiologyBrowserIndex extends Component {
           type: 'multiselect',
           options: options.types,
         }},
-      {label: t('SessionID', {ns: 'electrophysiology_browser'}), show: false},
+      {label: t('SessionID', {ns: 'loris'}), show: false},
     ];
 
     return (

--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -43,9 +43,6 @@ msgstr ""
 msgid "Signal Viewer"
 msgstr ""
 
-msgid "SessionID"
-msgstr ""
-
 msgid "split {{splitNum}}"
 msgstr ""
 

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -50,10 +50,6 @@ msgid "Signal Viewer"
 msgstr "Visualiseur de signaux"
 
 #, fuzzy
-msgid "SessionID"
-msgstr "ID de session"
-
-#, fuzzy
 msgid "split {{splitNum}}"
 msgstr "diviser {{splitNum}}"
 

--- a/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
@@ -43,9 +43,6 @@ msgstr "タイプ"
 msgid "Signal Viewer"
 msgstr "シグナルビューアー"
 
-msgid "SessionID"
-msgstr "SessionID"
-
 msgid "split {{splitNum}}"
 msgstr "{{splitNum}} を分割"
 

--- a/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
@@ -43,9 +43,6 @@ msgstr "类型"
 msgid "Signal Viewer"
 msgstr "信号查看器"
 
-msgid "SessionID"
-msgstr "会话ID"
-
 msgid "split {{splitNum}}"
 msgstr "分割{{splitNum}}"
 

--- a/modules/electrophysiology_uploader/jsx/UploadViewer.js
+++ b/modules/electrophysiology_uploader/jsx/UploadViewer.js
@@ -83,7 +83,7 @@ export default function UploadViewer(props) {
       show: true,
     },
     {
-      label: t('Uploaded By', {ns: 'electrophysiology_uploader'}),
+      label: t('Uploaded By', {ns: 'loris'}),
       show: true,
     },
   ];

--- a/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
+++ b/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
@@ -84,9 +84,6 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-msgid "Uploaded By"
-msgstr ""
-
 # upload.class.inc
 msgid "File not found."
 msgstr ""

--- a/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
@@ -104,9 +104,6 @@ msgstr "Temps de téléversement"
 msgid "Status"
 msgstr "Statut"
 
-msgid "Uploaded By"
-msgstr "Téléverser par"
-
 # upload.class.inc
 msgid "File not found."
 msgstr "Fichier introuvable."

--- a/modules/electrophysiology_uploader/locale/hi/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/hi/LC_MESSAGES/electrophysiology_uploader.po
@@ -83,6 +83,3 @@ msgstr "अपलोड समय"
 
 msgid "Status"
 msgstr "स्थिति"
-
-msgid "Uploaded By"
-msgstr "द्वारा अपलोड किया गया"

--- a/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
@@ -83,6 +83,3 @@ msgstr "アップロード時間"
 
 msgid "Status"
 msgstr "状態"
-
-msgid "Uploaded By"
-msgstr "アップロード者"

--- a/modules/electrophysiology_uploader/locale/zh/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/zh/LC_MESSAGES/electrophysiology_uploader.po
@@ -84,6 +84,3 @@ msgstr "上传时间"
 
 msgid "Status"
 msgstr "状态"
-
-msgid "Uploaded By"
-msgstr "上传者"

--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -70,7 +70,7 @@ class ImagingBrowserIndex extends Component {
     const style = '';
     let result = <td className={style}>{cell}</td>;
     const {t} = this.props;
-    const sessionIDKey = t('SessionID', {ns: 'imaging_browser'});
+    const sessionIDKey = t('SessionID', {ns: 'loris'});
     const sessionID = row[sessionIDKey];
     switch (column) {
     case t('New Data', {ns: 'imaging_browser'}):
@@ -172,7 +172,7 @@ class ImagingBrowserIndex extends Component {
       {label: t('Last QC', {ns: 'imaging_browser'}), show: true},
       {label: t('New Data', {ns: 'imaging_browser'}), show: true},
       {label: t('Links', {ns: 'imaging_browser'}), show: true},
-      {label: t('SessionID', {ns: 'imaging_browser'}), show: false},
+      {label: t('SessionID', {ns: 'loris'}), show: false},
       {label: t('Sequence Type', {ns: 'imaging_browser'}),
         show: false, filter: {
           name: 'sequenceType',

--- a/modules/imaging_browser/locale/fr/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/fr/LC_MESSAGES/imaging_browser.po
@@ -63,10 +63,6 @@ msgid "Links"
 msgstr "Liens"
 
 #, fuzzy
-msgid "SessionID"
-msgstr "ID de session"
-
-#, fuzzy
 msgid "Sequence Type"
 msgstr "Type de séquence"
 

--- a/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
@@ -48,9 +48,6 @@ msgstr "नया डेटा"
 msgid "Links"
 msgstr "लिंक"
 
-msgid "SessionID"
-msgstr "सेशन आईडी"
-
 msgid "Sequence Type"
 msgstr "सीक्वेंस प्रकार"
 

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -50,9 +50,6 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
-msgid "SessionID"
-msgstr ""
-
 msgid "Sequence Type"
 msgstr ""
 

--- a/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
@@ -77,9 +77,6 @@ msgstr "新しいデータ"
 msgid "Links"
 msgstr "リンク"
 
-msgid "SessionID"
-msgstr "SessionID"
-
 msgid "Sequence Type"
 msgstr "シーケンスタイプ"
 

--- a/modules/imaging_browser/locale/zh/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/zh/LC_MESSAGES/imaging_browser.po
@@ -77,9 +77,6 @@ msgstr "新数据"
 msgid "Links"
 msgstr "链接"
 
-msgid "SessionID"
-msgstr "会话ID"
-
 msgid "Sequence Type"
 msgstr "序列类型"
 

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -7,7 +7,9 @@ import PropTypes from 'prop-types';
 // eslint-disable-next-line no-unused-vars
 import i18n from 'I18nSetup';
 
+import hiStrings from '../locale/hi/LC_MESSAGES/imaging_qc.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/imaging_qc.json';
+import frStrings from '../locale/fr/LC_MESSAGES/imaging_qc.json';
 import zhStrings from '../locale/zh/LC_MESSAGES/imaging_qc.json';
 /**
  * Imaging Quality Control React Component
@@ -122,7 +124,7 @@ class ImagingQCIndex extends Component {
             type: 'text',
           },
         },
-        {label: t('Session ID', {ns: 'loris'}), show: true},
+        {label: t('SessionID', {ns: 'loris'}), show: true},
         {
           label: t('DCCID', {ns: 'loris'}), show: true, filter: {
             name: 'candId',
@@ -238,7 +240,7 @@ class ImagingQCIndex extends Component {
             <>
               <h3>{t(
                   'The MRI parameter form instrument must be installed in-order '
-                  + ' to use this module.', {ns: 'imaging_qc'})}
+                  + 'to use this module.', {ns: 'imaging_qc'})}
               </h3>
               <p>{t(
                   'Please contact your administrator '
@@ -261,8 +263,10 @@ ImagingQCIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
-  i18n.addResourceBundle('ja', 'document_repository', jaStrings);
-  i18n.addResourceBundle('zh', 'document_repository', zhStrings);
+  i18n.addResourceBundle('hi', 'imaging_qc', hiStrings);
+  i18n.addResourceBundle('ja', 'imaging_qc', jaStrings);
+  i18n.addResourceBundle('zh', 'imaging_qc', zhStrings);
+  i18n.addResourceBundle('fr', 'imaging_qc', frStrings);
 
   const TranslatedImagingQCIndex = withTranslation(
     ['imaging_qc', 'loris']

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -93,7 +93,8 @@ class ImagingQCIndex extends Component {
         return resp.text();
       })
       .then((data) => {
-        if (data === t('MRI Parameter Form table does not exist', {ns: 'imaging_qc'})) {
+        if (data === t('MRI Parameter Form table does not exist',
+           {ns: 'imaging_qc'})) {
           this.setState({error: data});
         } else {
           this.setState({[state]: JSON.parse(data)});
@@ -167,14 +168,16 @@ class ImagingQCIndex extends Component {
           },
         },
         {
-          label: t('MRI Parameter Form', {ns: 'imaging_qc'}), show: true, filter: {
+          label: t('MRI Parameter Form',
+             {ns: 'imaging_qc'}), show: true, filter: {
             name: 'mRIParameterForm',
             type: 'select',
             options: ImgOptions.mRIParameterForm,
           },
         },
         {
-          label: t('Scan Done in MRI PF', {ns: 'imaging_qc'}), show: true, filter: {
+          label: t('Scan Done in MRI PF',
+             {ns: 'imaging_qc'}), show: true, filter: {
             name: 'scanDoneInMRIPF',
             type: 'select',
             options: ImgOptions.scanDoneInMRIPF,
@@ -235,20 +238,20 @@ class ImagingQCIndex extends Component {
     } else {
       return (
         <div>
-          {this.state.error === 
-          t('MRI Parameter Form table does not exist', {ns: 'imaging_qc'}) ?
+          {this.state.error ===
+           t('MRI Parameter Form table does not exist', {ns: 'imaging_qc'}) ?
             <>
               <h3>{t(
-                  'The MRI parameter form instrument must be installed in-order '
-                  + 'to use this module.', {ns: 'imaging_qc'})}
+                'The MRI parameter form instrument must be installed '
+                  + 'in-order to use this module.', {ns: 'imaging_qc'})}
               </h3>
               <p>{t(
-                  'Please contact your administrator '
+                'Please contact your administrator '
                   + 'if you require this functionality.', {ns: 'imaging_qc'})}
               </p>
             </> :
             <h3>
-                {t('An error occurred while loading the page.', {ns: 'loris'})}
+              {t('An error occurred while loading the page.', {ns: 'loris'})}
             </h3>
           }
         </div>
@@ -260,6 +263,7 @@ class ImagingQCIndex extends Component {
 ImagingQCIndex.propTypes = {
   ImgDataURL: PropTypes.string.isRequired,
   hasPermission: PropTypes.func.isRequired,
+  t: PropTypes.string.isRequired,
 };
 
 window.addEventListener('load', () => {

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -94,7 +94,7 @@ class ImagingQCIndex extends Component {
       })
       .then((data) => {
         if (data === t('MRI Parameter Form table does not exist',
-           {ns: 'imaging_qc'})) {
+          {ns: 'imaging_qc'})) {
           this.setState({error: data});
         } else {
           this.setState({[state]: JSON.parse(data)});
@@ -169,7 +169,7 @@ class ImagingQCIndex extends Component {
         },
         {
           label: t('MRI Parameter Form',
-             {ns: 'imaging_qc'}), show: true, filter: {
+            {ns: 'imaging_qc'}), show: true, filter: {
             name: 'mRIParameterForm',
             type: 'select',
             options: ImgOptions.mRIParameterForm,
@@ -177,7 +177,7 @@ class ImagingQCIndex extends Component {
         },
         {
           label: t('Scan Done in MRI PF',
-             {ns: 'imaging_qc'}), show: true, filter: {
+            {ns: 'imaging_qc'}), show: true, filter: {
             name: 'scanDoneInMRIPF',
             type: 'select',
             options: ImgOptions.scanDoneInMRIPF,

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -1,10 +1,14 @@
 import {createRoot} from 'react-dom/client';
 import React, {Component} from 'react';
+import {withTranslation} from 'react-i18next';
 import Loader from 'Loader';
 import FilterableDataTable from 'FilterableDataTable';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-unused-vars
 import i18n from 'I18nSetup';
+
+import jaStrings from '../locale/ja/LC_MESSAGES/imaging_qc.json';
+import zhStrings from '../locale/zh/LC_MESSAGES/imaging_qc.json';
 /**
  * Imaging Quality Control React Component
  */
@@ -81,12 +85,13 @@ class ImagingQCIndex extends Component {
    * @return {object}
    */
   fetchData(url, state) {
+    const {t} = this.props;
     return fetch(url, {credentials: 'same-origin'})
       .then((resp) => {
         return resp.text();
       })
       .then((data) => {
-        if (data === 'MRI Parameter Form table does not exist') {
+        if (data === t('MRI Parameter Form table does not exist', {ns: 'imaging_qc'})) {
           this.setState({error: data});
         } else {
           this.setState({[state]: JSON.parse(data)});
@@ -103,6 +108,7 @@ class ImagingQCIndex extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
+    const {t} = this.props;
     if (!this.state.isLoadedImg) {
       return <Loader/>;
     }
@@ -111,104 +117,104 @@ class ImagingQCIndex extends Component {
 
       const ImgFields = [
         {
-          label: 'PSCID', show: true, filter: {
+          label: t('PSCID', {ns: 'loris'}), show: true, filter: {
             name: 'pSCID',
             type: 'text',
           },
         },
-        {label: 'Session ID', show: true},
+        {label: t('Session ID', {ns: 'loris'}), show: true},
         {
-          label: 'DCCID', show: true, filter: {
+          label: t('DCCID', {ns: 'loris'}), show: true, filter: {
             name: 'candId',
             type: 'text',
           },
         },
         {
-          label: 'Site', show: true, filter: {
+          label: t('Site', {ns: 'loris'}), show: true, filter: {
             name: 'site',
             type: 'select',
             options: ImgOptions.site,
           },
         },
         {
-          label: 'Project', show: true, filter: {
+          label: t('Project', {ns: 'loris'}), show: true, filter: {
             name: 'project',
             type: 'select',
             options: ImgOptions.project,
           },
         },
         {
-          label: 'Cohort', show: true, filter: {
+          label: t('Cohort', {ns: 'loris'}), show: true, filter: {
             name: 'cohort',
             type: 'select',
             options: ImgOptions.cohort,
           },
         },
         {
-          label: 'Visit Label', show: true, filter: {
+          label: t('Visit Label', {ns: 'loris'}), show: true, filter: {
             name: 'visitLabel',
             type: 'select',
             options: ImgOptions.visitLabel,
           },
         },
         {
-          label: 'Scan Type', show: true, filter: {
+          label: t('Scan Type', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'scanType',
             type: 'select',
             options: ImgOptions.scanType,
           },
         },
         {
-          label: 'MRI Parameter Form', show: true, filter: {
+          label: t('MRI Parameter Form', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'mRIParameterForm',
             type: 'select',
             options: ImgOptions.mRIParameterForm,
           },
         },
         {
-          label: 'Scan Done in MRI PF', show: true, filter: {
+          label: t('Scan Done in MRI PF', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'scanDoneInMRIPF',
             type: 'select',
             options: ImgOptions.scanDoneInMRIPF,
           },
         },
         {
-          label: 'Tarchive', show: true, filter: {
+          label: t('Tarchive', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'tarchive',
             type: 'select',
             options: ImgOptions.tarchive,
           },
         },
         {
-          label: 'Scan Location', show: true, filter: {
+          label: t('Scan Location', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'scanLocation',
             type: 'select',
             options: ImgOptions.scanLocation,
           },
         },
         {
-          label: 'QC Status', show: true, filter: {
+          label: t('QC Status', {ns: 'imaging_qc'}), show: true, filter: {
             name: 'qCStatus',
             type: 'select',
             options: ImgOptions.qCStatus,
           },
         },
         {
-          label: 'Uploaded By', show: true, filter: {
+          label: t('Uploaded By', {ns: 'loris'}), show: true, filter: {
             name: 'uploadedBy',
             type: 'select',
             options: ImgOptions.uploadedBy,
           },
         },
         {
-          label: 'Selected', show: true, filter: {
+          label: t('Selected', {ns: 'loris'}), show: true, filter: {
             name: 'selected',
             type: 'select',
             options: ImgOptions.selected,
           },
         },
-        {label: 'CommentID', show: false},
-        {label: 'TarchiveID', show: false},
+        {label: t('CommentID', {ns: 'imaging_qc'}), show: false},
+        {label: t('TarchiveID', {ns: 'imaging_qc'}), show: false},
       ];
 
       const datatable = (
@@ -227,19 +233,20 @@ class ImagingQCIndex extends Component {
     } else {
       return (
         <div>
-          {this.state.error === 'MRI Parameter Form table does not exist' ?
+          {this.state.error === 
+          t('MRI Parameter Form table does not exist', {ns: 'imaging_qc'}) ?
             <>
-              <h3>
-                  The MRI parameter form instrument must be
-                  installed in-order to use this module.
+              <h3>{t(
+                  'The MRI parameter form instrument must be installed in-order '
+                  + ' to use this module.', {ns: 'imaging_qc'})}
               </h3>
-              <p>
-                  Please contact your administrator
-                  if you require this functionality.
+              <p>{t(
+                  'Please contact your administrator '
+                  + 'if you require this functionality.', {ns: 'imaging_qc'})}
               </p>
             </> :
             <h3>
-                An error occurred while loading the page.
+                {t('An error occurred while loading the page.', {ns: 'loris'})}
             </h3>
           }
         </div>
@@ -254,10 +261,16 @@ ImagingQCIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'document_repository', jaStrings);
+  i18n.addResourceBundle('zh', 'document_repository', zhStrings);
+
+  const TranslatedImagingQCIndex = withTranslation(
+    ['imaging_qc', 'loris']
+  )(ImagingQCIndex);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <ImagingQCIndex
+    <TranslatedImagingQCIndex
       ImgDataURL={`${loris.BaseURL}/imaging_qc/?format=json`}
       hasPermission={loris.userHasPermission}
     />

--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -263,7 +263,7 @@ class ImagingQCIndex extends Component {
 ImagingQCIndex.propTypes = {
   ImgDataURL: PropTypes.string.isRequired,
   hasPermission: PropTypes.func.isRequired,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 window.addEventListener('load', () => {

--- a/modules/imaging_qc/locale/fr/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/fr/LC_MESSAGES/imaging_qc.po
@@ -13,40 +13,41 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Imaging Quality Control"
-msgstr ""
+msgstr "Contrôle de la qualité de l'imagerie"
 
 msgid "MRI Parameter Form table does not exist"
-msgstr ""
+msgstr "Le tableau « Formulaire des paramètres IRM » n'existe pas"
 
 msgid "Scan Type"
-msgstr ""
+msgstr "Type de scan"
 
 msgid "MRI Parameter Form"
-msgstr ""
+msgstr "Formulaire des paramètres IRM"
 
 msgid "Scan Done in MRI PF"
-msgstr ""
+msgstr "Examen IRM réalisé"
 
 msgid "TarchiveID"
-msgstr ""
+msgstr "ID de tarchive"
 
 msgid "Scan Location"
-msgstr ""
+msgstr "Emplacement de scan"
 
 msgid "QC Status"
-msgstr ""
+msgstr "État du contrôle qualité"
 
 msgid "CommentID"
-msgstr ""
+msgstr "ID de commentaire"
 
-msgid "The MRI parameter form instrument must be installed in-order to use this module. "
-msgstr ""
+msgid "The MRI parameter form instrument must be installed in-order to use this module."
+msgstr "Pour pouvoir utiliser ce module, il est nécessaire d'installer l'outil de configuration des paramètres IRM."
 
 msgid "Please contact your administrator if you require this functionality."
-msgstr ""
+msgstr "Veuillez contacter votre administrateur si vous avez besoin de cette fonctionnalité."

--- a/modules/imaging_qc/locale/hi/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/hi/LC_MESSAGES/imaging_qc.po
@@ -13,40 +13,41 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Imaging Quality Control"
-msgstr ""
+msgstr "इमेजिंग गुणवत्ता नियंत्रण"
 
 msgid "MRI Parameter Form table does not exist"
-msgstr ""
+msgstr "एमआरआई पैरामीटर फॉर्म तालिका मौजूद नहीं है।"
 
 msgid "Scan Type"
-msgstr ""
+msgstr "स्कैन प्रकार"
 
 msgid "MRI Parameter Form"
-msgstr ""
+msgstr "एमआरआई पैरामीटर फॉर्म"
 
 msgid "Scan Done in MRI PF"
-msgstr ""
+msgstr "एमआरआई पीएफ में स्कैन पूरा"
 
 msgid "TarchiveID"
-msgstr ""
+msgstr "टार्चिवआईडी"
 
 msgid "Scan Location"
-msgstr ""
+msgstr "स्कैन स्थान"
 
 msgid "QC Status"
-msgstr ""
+msgstr "QC स्थिति"
 
 msgid "CommentID"
-msgstr ""
+msgstr "टिप्पणी आईडी"
 
 msgid "The MRI parameter form instrument must be installed in-order to use this module. "
-msgstr ""
+msgstr "इस मॉड्यूल का उपयोग करने के लिए एमआरआई पैरामीटर फॉर्म इंस्ट्रूमेंट स्थापित किया जाना चाहिए।"
 
 msgid "Please contact your administrator if you require this functionality."
-msgstr ""
+msgstr "यदि आपको इस सुविधा की आवश्यकता है, तो कृपया अपने प्रशासक से संपर्क करें।"

--- a/modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/ja/LC_MESSAGES/imaging_qc.po
@@ -17,6 +17,38 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 
 msgid "Imaging Quality Control"
 msgstr "画像品質管理"
+
+msgid "MRI Parameter Form table does not exist"
+msgstr "「MRIパラメータフォーム」テーブルが存在しません"
+
+msgid "Scan Type"
+msgstr "スキャン方式"
+
+msgid "MRI Parameter Form"
+msgstr "MRIパラメータ設定書"
+
+msgid "Scan Done in MRI PF"
+msgstr "MRI PFでのスキャン完了"
+
+msgid "TarchiveID"
+msgstr "TarchiveID"
+
+msgid "Scan Location"
+msgstr "スキャン場所"
+
+msgid "QC Status"
+msgstr "品質管理状況"
+
+msgid "CommentID"
+msgstr "コメントID"
+
+msgid "The MRI parameter form instrument must be installed in-order to use this module."
+msgstr "このモジュールを使用するには、MRIパラメータフォームツールがインストールされている必要があります。"
+
+msgid "Please contact your administrator if you require this functionality."
+msgstr "この機能が必要な場合は、管理者にお問い合わせください。"
+

--- a/modules/imaging_qc/locale/zh/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/zh/LC_MESSAGES/imaging_qc.po
@@ -21,3 +21,33 @@ msgstr ""
 
 msgid "Imaging Quality Control"
 msgstr "成像质量控制"
+
+msgid "MRI Parameter Form table does not exist"
+msgstr "不存在 MRI 參數表"
+
+msgid "Scan Type"
+msgstr "掃描類型"
+
+msgid "MRI Parameter Form"
+msgstr "磁振造影參數表"
+
+msgid "Scan Done in MRI PF"
+msgstr "已在 MRI PF 完成掃描"
+
+msgid "TarchiveID"
+msgstr "TarchiveID"
+
+msgid "Scan Location"
+msgstr "掃描位置"
+
+msgid "QC Status"
+msgstr "品質控制狀態"
+
+msgid "CommentID"
+msgstr "評論編號"
+
+msgid "The MRI parameter form instrument must be installed in-order to use this module."
+msgstr "必須安裝 MRI 參數表工具，才能使用此模組。"
+
+msgid "Please contact your administrator if you require this functionality."
+msgstr "若您需要此功能，請聯絡您的系統管理員。"

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -234,7 +234,7 @@ class MediaIndex extends Component {
         type: 'select',
         options: options.projects,
       }},
-      {label: t('Uploaded By', {ns: 'media'}), show: true, filter: {
+      {label: t('Uploaded By', {ns: 'loris'}), show: true, filter: {
         name: 'uploadedBy',
         type: 'text',
       }},

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -261,7 +261,7 @@ class MediaIndex extends Component {
     const tabs = [{id: 'browse', label: t('Browse', {ns: 'media'})}];
     const uploadTab = () => {
       if (this.props.hasPermission('media_write')) {
-        tabs.push({id: 'upload', label: t('Upload', {ns: 'media'})});
+        tabs.push({id: 'upload', label: t('Upload', {ns: 'loris'})});
         return (
           <TabPane TabId={tabs[1].id}>
             <MediaUploadForm

--- a/modules/media/locale/es/LC_MESSAGES/media.po
+++ b/modules/media/locale/es/LC_MESSAGES/media.po
@@ -27,9 +27,6 @@ msgstr "Nombre del archivo"
 msgid "Instrument"
 msgstr "Instrumento"
 
-msgid "Uploaded By"
-msgstr "Subido por"
-
 msgid "Date Taken"
 msgstr "Fecha de toma"
 

--- a/modules/media/locale/es/LC_MESSAGES/media.po
+++ b/modules/media/locale/es/LC_MESSAGES/media.po
@@ -60,9 +60,6 @@ msgstr "Editar"
 msgid "Browse"
 msgstr "Navegar"
 
-msgid "Upload"
-msgstr "Subir"
-
 msgid "An error occured while loading the page."
 msgstr "Se ha producido un error al cargar la página."
 

--- a/modules/media/locale/fr/LC_MESSAGES/media.po
+++ b/modules/media/locale/fr/LC_MESSAGES/media.po
@@ -65,9 +65,6 @@ msgstr "Modifier"
 msgid "Browse"
 msgstr "Parcourir"
 
-msgid "Upload"
-msgstr "Téléverser"
-
 msgid "An error occured while loading the page."
 msgstr "Une erreur s'est produite lors du chargement de la page."
 

--- a/modules/media/locale/fr/LC_MESSAGES/media.po
+++ b/modules/media/locale/fr/LC_MESSAGES/media.po
@@ -28,9 +28,6 @@ msgstr "Nom du fichier"
 msgid "Instrument"
 msgstr "Instrument"
 
-msgid "Uploaded By"
-msgstr "Téléverser par"
-
 msgid "Date Taken"
 msgstr "Date de passage"
 

--- a/modules/media/locale/hi/LC_MESSAGES/media.po
+++ b/modules/media/locale/hi/LC_MESSAGES/media.po
@@ -27,9 +27,6 @@ msgstr "फ़ाइल नाम"
 msgid "Instrument"
 msgstr "इंस्ट्रूमेंट"
 
-msgid "Uploaded By"
-msgstr "अपलोड किया गया"
-
 msgid "Date Taken"
 msgstr "तारीख ली गई"
 

--- a/modules/media/locale/hi/LC_MESSAGES/media.po
+++ b/modules/media/locale/hi/LC_MESSAGES/media.po
@@ -60,9 +60,6 @@ msgstr "संपादित करें"
 msgid "Browse"
 msgstr "ब्राउज़ करें"
 
-msgid "Upload"
-msgstr "अपलोड करें"
-
 msgid "An error occured while loading the page."
 msgstr "पृष्ठ लोड करते समय एक त्रुटि हुई।"
 

--- a/modules/media/locale/ja/LC_MESSAGES/media.po
+++ b/modules/media/locale/ja/LC_MESSAGES/media.po
@@ -30,9 +30,6 @@ msgstr "ファイル名"
 msgid "Instrument"
 msgstr "楽器"
 
-msgid "Uploaded By"
-msgstr "アップロード者"
-
 msgid "Date Taken"
 msgstr "撮影日"
 

--- a/modules/media/locale/ja/LC_MESSAGES/media.po
+++ b/modules/media/locale/ja/LC_MESSAGES/media.po
@@ -63,9 +63,6 @@ msgstr "編集"
 msgid "Browse"
 msgstr "ブラウズ"
 
-msgid "Upload"
-msgstr "アップロード"
-
 msgid "An error occured while loading the page."
 msgstr "ページの読み込み中にエラーが発生しました。"
 

--- a/modules/media/locale/media.pot
+++ b/modules/media/locale/media.pot
@@ -27,9 +27,6 @@ msgstr ""
 msgid "Instrument"
 msgstr ""
 
-msgid "Uploaded By"
-msgstr ""
-
 msgid "Date Taken"
 msgstr ""
 

--- a/modules/media/locale/zh/LC_MESSAGES/media.po
+++ b/modules/media/locale/zh/LC_MESSAGES/media.po
@@ -64,9 +64,6 @@ msgstr "编辑"
 msgid "Browse"
 msgstr "浏览"
 
-msgid "Upload"
-msgstr "上传"
-
 msgid "An error occured while loading the page."
 msgstr "加载页面时发生错误。"
 

--- a/modules/media/locale/zh/LC_MESSAGES/media.po
+++ b/modules/media/locale/zh/LC_MESSAGES/media.po
@@ -31,9 +31,6 @@ msgstr "文件名"
 msgid "Instrument"
 msgstr "量表/评估工具"
 
-msgid "Uploaded By"
-msgstr "上传者"
-
 msgid "Date Taken"
 msgstr "拍摄日期"
 


### PR DESCRIPTION
## Brief summary of changes

This PR translates the imaging qc module (+ adds missing french and hindi locale directories for that module)
It also refactors existing translations to use the loris namespace rather than duplicating identical translations across modules (e.g., 'SessionID', 'Upload', 'Uploaded By').

Note: All translations were done using DeepL.

#### Link(s) to related issue(s)

* Resolves #10538 (Reference the issue this fixes, if any.)
