### PR TITLE
[configuration] Fix deprecation error

### DIFF
--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -179,7 +179,7 @@ class Configuration extends \NDB_Form
             $tree[intval($node['ID'])] = &$node;
         }
         foreach ($configs as &$node) {
-            $tree[$node['Parent']]['Children'][] = &$node;
+            $tree[$node['Parent'] ?? '']['Children'][] = &$node;
         }
 
         return $configs;


### PR DESCRIPTION
Fix warning:

<b>Deprecated</b>:  Using null as an array offset is deprecated, use an empty string instead in <b>modules/configuration/php/configuration.class.inc</b> on line <b>182</b><br />

when accessing the configuration module with PHP 8.5.
