### PR TITLE
[Dashboard] Add some more study progression widgets

### DIFF
--- a/modules/conflict_resolver/locale/conflict_resolver.pot
+++ b/modules/conflict_resolver/locale/conflict_resolver.pot
@@ -28,6 +28,10 @@ msgstr[0] ""
 msgid "Unresolved Conflicts"
 msgstr ""
 
+msgid "% conflict resolved"
+msgid_plural "% conflicts resolved"
+msgstr[0] ""
+
 msgid "Number of Conflicts"
 msgstr ""
 

--- a/modules/conflict_resolver/locale/fr/LC_MESSAGES/conflict_resolver.po
+++ b/modules/conflict_resolver/locale/fr/LC_MESSAGES/conflict_resolver.po
@@ -33,6 +33,11 @@ msgstr[1] "Conflits de saisie des données"
 msgid "Unresolved Conflicts"
 msgstr "Conflits non résolus"
 
+msgid "% conflict resolved"
+msgid_plural "% conflicts resolved"
+msgstr[0] "% conflit résolu"
+msgstr[1] "% conflits résolus"
+
 #, fuzzy
 msgid "Number of Conflicts"
 msgstr "Nombre de conflits"

--- a/modules/conflict_resolver/locale/hi/LC_MESSAGES/conflict_resolver.po
+++ b/modules/conflict_resolver/locale/hi/LC_MESSAGES/conflict_resolver.po
@@ -27,6 +27,11 @@ msgstr "डेटा प्रविष्टि टकराव"
 msgid "Unresolved Conflicts"
 msgstr "असुलझे टकराव"
 
+msgid "% conflict resolved"
+msgid_plural "% conflicts resolved"
+msgstr[0] "% टकराव सुलझा"
+msgstr[1] "% टकराव सुलझे"
+
 msgid "Unresolved"
 msgstr "असुलझा"
 

--- a/modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.po
+++ b/modules/conflict_resolver/locale/ja/LC_MESSAGES/conflict_resolver.po
@@ -27,6 +27,10 @@ msgstr "データ入力の競合"
 msgid "Unresolved Conflicts"
 msgstr "未解決の紛争"
 
+msgid "% conflict resolved"
+msgid_plural "% conflicts resolved"
+msgstr[0] "解決済みの競合 %"
+
 msgid "Number of Conflicts"
 msgstr "競合の数"
 

--- a/modules/conflict_resolver/locale/zh/LC_MESSAGES/conflict_resolver.po
+++ b/modules/conflict_resolver/locale/zh/LC_MESSAGES/conflict_resolver.po
@@ -28,6 +28,10 @@ msgstr "数据输入冲突"
 msgid "Unresolved Conflicts"
 msgstr "未解决的冲突"
 
+msgid "% conflict resolved"
+msgid_plural "% conflicts resolved"
+msgstr[0] "已解决冲突 %"
+
 msgid "Number of Conflicts"
 msgstr "冲突数量"
 

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -214,7 +214,7 @@ class Module extends \Module
             $params = [];
 
             if (!$user->hasPermission('access_all_profiles')) {
-                $siteIDs = array_map(
+                $siteIDs    = array_map(
                     fn($centerID) => (string)$centerID,
                     $user->getCenterIDs()
                 );
@@ -229,16 +229,16 @@ class Module extends \Module
 
                 $sitePlaceholders = [];
                 foreach ($siteIDs as $index => $siteID) {
-                    $placeholder                = "site$index";
-                    $sitePlaceholders[]         = ':' . $placeholder;
+                    $placeholder          = "site$index";
+                    $sitePlaceholders[]   = ':' . $placeholder;
                     $params[$placeholder] = $siteID;
                 }
 
                 $projectPlaceholders = [];
                 foreach ($projectIDs as $index => $projectID) {
-                    $placeholder                   = "project$index";
-                    $projectPlaceholders[]         = ':' . $placeholder;
-                    $params[$placeholder] = $projectID;
+                    $placeholder           = "project$index";
+                    $projectPlaceholders[] = ':' . $placeholder;
+                    $params[$placeholder]  = $projectID;
                 }
 
                 $query .= "

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -179,6 +179,96 @@ class Module extends \Module
                     1,
                 )
             ];
+        case 'study-progression':
+            $factory = \NDB_Factory::singleton();
+            $baseURL = $factory->settings()->getBaseURL();
+            $DB      = $factory->database();
+
+            $query  = "SELECT
+                    p.ProjectID,
+                    CAST(ROUND(
+                        100 * SUM(
+                            CASE WHEN conflict_status.status = 'resolved'
+                                THEN 1
+                                ELSE 0
+                            END
+                        ) / COUNT(*)
+                    ) AS SIGNED) AS count,
+                    CONCAT('$baseURL/conflict_resolver/?Project=', p.Name)
+                    AS url,
+                    p.Name AS ProjectName
+                FROM (
+                    SELECT CommentId1, 'unresolved' AS status
+                    FROM conflicts_unresolved
+                    UNION ALL
+                    SELECT CommentId1, 'resolved' AS status
+                    FROM conflicts_resolved
+                ) conflict_status
+                    LEFT JOIN flag f ON (conflict_status.CommentId1=f.CommentID)
+                    LEFT JOIN session s ON (f.SessionID=s.ID)
+                    LEFT JOIN candidate c ON (s.CandidateID=c.ID)
+                    LEFT JOIN Project p ON (s.ProjectID=p.ProjectID)
+                WHERE s.Active='Y'
+                    AND c.Active='Y'
+                    AND s.CenterID <> 1";
+            $params = [];
+
+            if (!$user->hasPermission('access_all_profiles')) {
+                $siteIDs = array_map(
+                    fn($centerID) => (string)$centerID,
+                    $user->getCenterIDs()
+                );
+                $projectIDs = array_map(
+                    fn($projectID) => (string)$projectID,
+                    $user->getProjectIDs()
+                );
+
+                if (count($siteIDs) === 0 || count($projectIDs) === 0) {
+                    return [];
+                }
+
+                $sitePlaceholders = [];
+                foreach ($siteIDs as $index => $siteID) {
+                    $placeholder                = "site$index";
+                    $sitePlaceholders[]         = ':' . $placeholder;
+                    $params[$placeholder] = $siteID;
+                }
+
+                $projectPlaceholders = [];
+                foreach ($projectIDs as $index => $projectID) {
+                    $placeholder                   = "project$index";
+                    $projectPlaceholders[]         = ':' . $placeholder;
+                    $params[$placeholder] = $projectID;
+                }
+
+                $query .= "
+                    AND s.CenterID IN (" . implode(', ', $sitePlaceholders) . ")
+                    AND s.ProjectID IN ("
+                    . implode(', ', $projectPlaceholders)
+                    . ")";
+            }
+
+            $query .= "
+                GROUP BY p.ProjectID, p.Name";
+
+            $data = $DB->pselectWithIndexKey(
+                $query,
+                $params,
+                'ProjectID'
+            );
+
+            return [
+                new \LORIS\dashboard\DataWidget(
+                    new \LORIS\GUI\LocalizableString(
+                        "conflict_resolver",
+                        "% conflict resolved",
+                        "% conflicts resolved"
+                    ),
+                    $data,
+                    "",
+                    'rgb(255, 235, 235)',
+                )
+            ];
         }
 
         return [];

--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -22,6 +22,10 @@ msgstr ""
 msgid "Electrophysiology Browser"
 msgstr ""
 
+msgid "EEG Recording"
+msgid_plural "EEG Recordings"
+msgstr[0] ""
+
 msgid "Links"
 msgstr ""
 

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -24,6 +24,11 @@ msgstr ""
 msgid "Electrophysiology Browser"
 msgstr "Navigateur d'électrophysiologie"
 
+msgid "EEG Recording"
+msgid_plural "EEG Recordings"
+msgstr[0] "Enregistrement EEG"
+msgstr[1] "Enregistrements EEG"
+
 msgid "Links"
 msgstr "Liens"
 

--- a/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
@@ -22,6 +22,10 @@ msgstr ""
 msgid "Electrophysiology Browser"
 msgstr "電気生理学ブラウザ"
 
+msgid "EEG Recording"
+msgid_plural "EEG Recordings"
+msgstr[0] "EEG記録"
+
 msgid "Links"
 msgstr "リンク"
 

--- a/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
@@ -22,6 +22,10 @@ msgstr ""
 msgid "Electrophysiology Browser"
 msgstr "电生理学浏览器"
 
+msgid "EEG Recording"
+msgid_plural "EEG Recordings"
+msgstr[0] "EEG 记录"
+
 msgid "Links"
 msgstr "链接"
 

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -83,7 +83,7 @@ class Module extends \Module
             $baseURL = $factory->settings()->getBaseURL();
             $DB      = $factory->database();
 
-            $query = "SELECT
+            $query   = "SELECT
                     Project.ProjectID,
                     COUNT(ppf.PhysiologicalFileID) AS count,
                     CONCAT(
@@ -109,7 +109,7 @@ class Module extends \Module
             $params = [];
 
             if (!$user->hasPermission('electrophysiology_browser_view_allsites')) {
-                $siteIDs = array_map(
+                $siteIDs    = array_map(
                     fn($centerID) => (string)$centerID,
                     $user->getCenterIDs()
                 );
@@ -124,16 +124,16 @@ class Module extends \Module
 
                 $sitePlaceholders = [];
                 foreach ($siteIDs as $index => $siteID) {
-                    $placeholder = "site$index";
-                    $sitePlaceholders[] = ':' . $placeholder;
+                    $placeholder          = "site$index";
+                    $sitePlaceholders[]   = ':' . $placeholder;
                     $params[$placeholder] = $siteID;
                 }
 
                 $projectPlaceholders = [];
                 foreach ($projectIDs as $index => $projectID) {
-                    $placeholder = "project$index";
+                    $placeholder           = "project$index";
                     $projectPlaceholders[] = ':' . $placeholder;
-                    $params[$placeholder] = $projectID;
+                    $params[$placeholder]  = $projectID;
                 }
 
                 $query .= "

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -64,4 +64,108 @@ class Module extends \Module
     {
         return dgettext("electrophysiology_browser", "Electrophysiology Browser");
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
+     *
+     * @return \LORIS\GUI\Widget[]
+     */
+    public function getWidgets(string $type, \User $user, array $options) : array
+    {
+        switch ($type) {
+        case 'study-progression':
+            $factory = \NDB_Factory::singleton();
+            $baseURL = $factory->settings()->getBaseURL();
+            $DB      = $factory->database();
+
+            $query = "SELECT
+                    Project.ProjectID,
+                    COUNT(ppf.PhysiologicalFileID) AS count,
+                    CONCAT(
+                        '$baseURL/electrophysiology_browser/?project=',
+                        Project.Name
+                    ) AS url,
+                    Project.Name AS ProjectName
+                FROM physiological_parameter_file ppf
+                LEFT JOIN physiological_file pf
+                    USING (PhysiologicalFileID)
+                LEFT JOIN physiological_output_type pot
+                    USING (PhysiologicalOutputTypeID)
+                LEFT JOIN Project
+                    ON ppf.ProjectID = Project.ProjectID
+                LEFT JOIN session s
+                    ON pf.SessionID = s.ID
+                WHERE ParameterTypeID = (
+                    SELECT ParameterTypeID
+                    FROM parameter_type
+                    WHERE Name = 'RecordingDuration'
+                )
+                AND Project.showSummaryOnLogin = 1";
+            $params = [];
+
+            if (!$user->hasPermission('electrophysiology_browser_view_allsites')) {
+                $siteIDs = array_map(
+                    fn($centerID) => (string)$centerID,
+                    $user->getCenterIDs()
+                );
+                $projectIDs = array_map(
+                    fn($projectID) => (string)$projectID,
+                    $user->getProjectIDs()
+                );
+
+                if (count($siteIDs) === 0 || count($projectIDs) === 0) {
+                    return [];
+                }
+
+                $sitePlaceholders = [];
+                foreach ($siteIDs as $index => $siteID) {
+                    $placeholder = "site$index";
+                    $sitePlaceholders[] = ':' . $placeholder;
+                    $params[$placeholder] = $siteID;
+                }
+
+                $projectPlaceholders = [];
+                foreach ($projectIDs as $index => $projectID) {
+                    $placeholder = "project$index";
+                    $projectPlaceholders[] = ':' . $placeholder;
+                    $params[$placeholder] = $projectID;
+                }
+
+                $query .= "
+                AND s.CenterID IN (" . implode(', ', $sitePlaceholders) . ")
+                AND Project.ProjectID IN ("
+                    . implode(', ', $projectPlaceholders)
+                    . ")";
+            }
+
+            $query .= "
+                GROUP BY Project.ProjectID, Project.Name";
+
+            $data = $DB->pselectWithIndexKey(
+                $query,
+                $params,
+                'ProjectID'
+            );
+
+            return [
+                new \LORIS\dashboard\DataWidget(
+                    new \LORIS\GUI\LocalizableString(
+                        "electrophysiology_browser",
+                        "EEG Recording",
+                        "EEG Recordings"
+                    ),
+                    $data,
+                    "",
+                    'rgb(255, 224, 171)',
+                )
+            ];
+        }
+
+        return [];
+    }
 }

--- a/modules/electrophysiology_browser/php/module.class.inc
+++ b/modules/electrophysiology_browser/php/module.class.inc
@@ -83,7 +83,7 @@ class Module extends \Module
             $baseURL = $factory->settings()->getBaseURL();
             $DB      = $factory->database();
 
-            $query   = "SELECT
+            $query  = "SELECT
                     Project.ProjectID,
                     COUNT(ppf.PhysiologicalFileID) AS count,
                     CONCAT(

--- a/modules/publication/locale/en/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/en/LC_MESSAGES/publication.po
@@ -18,6 +18,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "Publication"
+msgstr "Publication"
+
 msgid "helpFindingVariables"
 msgstr "For help finding variables of interest, consult the <ddLink>Data Dictionary</ddLink>"
 

--- a/modules/publication/locale/fr/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/fr/LC_MESSAGES/publication.po
@@ -22,6 +22,9 @@ msgstr ""
 msgid "Publications"
 msgstr "Publications"
 
+msgid "Publication"
+msgstr "Publication"
+
 msgid "File to upload"
 msgstr "Sélectionner un fichier à téléverser"
 

--- a/modules/publication/locale/hi/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/hi/LC_MESSAGES/publication.po
@@ -21,6 +21,9 @@ msgstr ""
 msgid "Publications"
 msgstr "प्रकाशन"
 
+msgid "Publication"
+msgstr "प्रकाशन"
+
 msgid "Submit"
 msgstr "जमा करें"
 

--- a/modules/publication/locale/ja/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/ja/LC_MESSAGES/publication.po
@@ -21,6 +21,9 @@ msgstr ""
 msgid "Publications"
 msgstr "出版物"
 
+msgid "Publication"
+msgstr "出版物"
+
 msgid "Submit"
 msgstr "提出する"
 

--- a/modules/publication/locale/publication.pot
+++ b/modules/publication/locale/publication.pot
@@ -21,6 +21,9 @@ msgstr ""
 msgid "Publications"
 msgstr ""
 
+msgid "Publication"
+msgstr ""
+
 msgid "Submit"
 msgstr ""
 

--- a/modules/publication/locale/zh/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/zh/LC_MESSAGES/publication.po
@@ -22,6 +22,9 @@ msgstr ""
 msgid "Publications"
 msgstr "刊物"
 
+msgid "Publication"
+msgstr "刊物"
+
 msgid "Submit"
 msgstr "提交"
 

--- a/modules/publication/php/module.class.inc
+++ b/modules/publication/php/module.class.inc
@@ -83,7 +83,7 @@ class Module extends \Module
             $baseURL = $factory->settings()->getBaseURL();
             $DB      = $factory->database();
 
-            $query = "SELECT
+            $query   = "SELECT
                     pr.ProjectID,
                     COUNT(*) AS count,
                     CONCAT('$baseURL/publication/?project=', pr.Name) AS url,
@@ -96,7 +96,7 @@ class Module extends \Module
                 || $user->hasPermission('publication_propose')
                 || $user->hasPermission('publication_approve'))
             ) {
-                $query .= "
+                $query           .= "
                 JOIN publication_users_edit_perm_rel puepr
                     ON (puepr.PublicationID=p.PublicationID)
                 WHERE puepr.UserID=:userID";

--- a/modules/publication/php/module.class.inc
+++ b/modules/publication/php/module.class.inc
@@ -64,4 +64,68 @@ class Module extends \Module
     {
         return dgettext("publication", "Publications");
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
+     *
+     * @return \LORIS\GUI\Widget[]
+     */
+    public function getWidgets(string $type, \User $user, array $options) : array
+    {
+        switch ($type) {
+        case 'study-progression':
+            $factory = \NDB_Factory::singleton();
+            $baseURL = $factory->settings()->getBaseURL();
+            $DB      = $factory->database();
+
+            $query = "SELECT
+                    pr.ProjectID,
+                    COUNT(*) AS count,
+                    CONCAT('$baseURL/publication/?project=', pr.Name) AS url,
+                    pr.Name AS ProjectName
+                FROM publication p
+                JOIN Project pr ON (p.project=pr.ProjectID)";
+            $params = [];
+
+            if (!($user->hasPermission('publication_view')
+                || $user->hasPermission('publication_propose')
+                || $user->hasPermission('publication_approve'))
+            ) {
+                $query .= "
+                JOIN publication_users_edit_perm_rel puepr
+                    ON (puepr.PublicationID=p.PublicationID)
+                WHERE puepr.UserID=:userID";
+                $params['userID'] = $user->getId();
+            }
+
+            $query .= "
+                GROUP BY pr.ProjectID, pr.Name";
+
+            $data = $DB->pselectWithIndexKey(
+                $query,
+                $params,
+                'ProjectID'
+            );
+
+            return [
+                new \LORIS\dashboard\DataWidget(
+                    new \LORIS\GUI\LocalizableString(
+                        "publication",
+                        "Publication",
+                        "Publications"
+                    ),
+                    $data,
+                    "",
+                    'rgb(209, 195, 255)',
+                )
+            ];
+        }
+
+        return [];
+    }
 }

--- a/modules/publication/php/module.class.inc
+++ b/modules/publication/php/module.class.inc
@@ -83,7 +83,7 @@ class Module extends \Module
             $baseURL = $factory->settings()->getBaseURL();
             $DB      = $factory->database();
 
-            $query   = "SELECT
+            $query  = "SELECT
                     pr.ProjectID,
                     COUNT(*) AS count,
                     CONCAT('$baseURL/publication/?project=', pr.Name) AS url,


### PR DESCRIPTION
## Brief summary of changes

- Added three new widgets to the study progression tab for EEG Recordings, Publications and % of conflicts resolved
- These only appear if you have access to the module AND if the project has > 0
<img width="1002" height="530" alt="image" src="https://github.com/user-attachments/assets/574b0418-03fc-46c6-8008-cc99bc869c32" />

#### Testing instructions (if applicable)

1. Confirm the data is correct
2. Press on the buttons and confirm they take you to the module with working filter
3. Confirm it is translated to the languages that the module supports
4. Confirm if you do not have access to the conflict resolver, you do not see it
5. Confirm if you do not have access to the EEG Browser, you do not see it
6. Confirm if you do not have access to publications, you do not see it