### PR TITLE
[configuration] Add diagnosis trajectory help text

### DIFF
--- a/modules/configuration/help/configuration.md
+++ b/modules/configuration/help/configuration.md
@@ -8,4 +8,4 @@ Some configuration settings can accept multiple values. For these settings, you 
 
 **Note:** Take caution while editing these fields. Once you click **Submit**, there is no way to undo changes, unless you re-edit and re-submit a new form.
 
-**Note:** at the top of the page, you can click the links to configure study projects and cohorts.
+**Note:** at the top of the page, you can click the links to configure study projects, cohorts, and diagnosis evolution trajectories.

--- a/modules/configuration/help/diagnosis_evolution.md
+++ b/modules/configuration/help/diagnosis_evolution.md
@@ -1,6 +1,6 @@
 # Diagnosis Evolution Trajectory
 
-Use this page to manage the diagnosis evolution trajectory of your study, or to add a new one. Your diagnosis trajectories are listed on the left side of the scren. Click on any trajectory name to edit its settings, and click **Save.**
+Use this page to manage the diagnosis evolution trajectory of your study, or to add a new one. Your diagnosis trajectories are listed on the left side of the screen. Click on any trajectory name to edit its settings, and click **Save.**
 
 Click **New Diagnosis Trajectory** to create a new trajectory. Populate the fields and click **Save**. Your new trajectory should now appear in the list after you refresh the page.
 

--- a/modules/configuration/help/diagnosis_evolution.md
+++ b/modules/configuration/help/diagnosis_evolution.md
@@ -1,0 +1,7 @@
+# Diagnosis Evolution Trajectory
+
+Use this page to manage the diagnosis evolution trajectory of your study, or to add a new one. Your diagnosis trajectories are listed on the left side of the scren. Click on any trajectory name to edit its settings, and click **Save.**
+
+Click **New Diagnosis Trajectory** to create a new trajectory. Populate the fields and click **Save**. Your new trajectory should now appear in the list after you refresh the page.
+
+For each project, the current diagnosis will come from the registered trajectory that has the highest "order" setting.


### PR DESCRIPTION
## Brief summary of changes
This PR adds that "diagnosis evolution trajectory" can be edited in the configuration help text, and also adds a help text file for the diagnosis evolution config settings page.

#### Testing instructions (if applicable)

1. Go to the configuration module
2. Click the question mark icon at the top right to see the help text
3. Make sure that the help text includes that you can edit diagnosis evolution trajectory
4. Go to edit diagnosis evolution trajectory
5. Click on the question mark icon at the top right to see the help text
6. Check that the help text properly gives information on the diagnosis evolution trajectory page

#### Link(s) to related issue(s)

* Resolves #10642
