### PR TITLE
[Biobank] Include Visit Label in Specimen Entity

### DIFF
--- a/modules/biobank/jsx/globals.js
+++ b/modules/biobank/jsx/globals.js
@@ -360,11 +360,13 @@ function Globals(props) {
       />
       <InlineField
         label={this.props.t('Visit Label', {ns: 'loris'})}
-        value={options.sessions[specimen.sessionId].label}
+        value={specimen.sessionLabel}
         link={
-          loris.BaseURL+'/instrument_list/?candID='+
-            specimen.candidateId+'&sessionID='+
-            specimen.sessionId
+          options.sessions[specimen.sessionId]
+            ? loris.BaseURL+'/instrument_list/?candID='+
+                specimen.candidateId+'&sessionID='+
+                specimen.sessionId
+            : null
         }
       />
     </div>
@@ -682,7 +684,7 @@ InlineField.propTypes = {
   pencil: PropTypes.node.isRequired,
   editValue: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
-  link: PropTypes.string.isRequired,
+  link: PropTypes.string,
   value: PropTypes.string.isRequired,
 };
 

--- a/modules/biobank/jsx/globals.js
+++ b/modules/biobank/jsx/globals.js
@@ -414,6 +414,7 @@ Globals.propTypes = {
       fTCycle: PropTypes.string,
       projectId: PropTypes.number,
       sessionId: PropTypes.number,
+      sessionLabel: PropTypes.string,
       candidateId: PropTypes.number,
       quantity: PropTypes.number,
       unitId: PropTypes.number,

--- a/modules/biobank/jsx/globals.js
+++ b/modules/biobank/jsx/globals.js
@@ -503,6 +503,7 @@ Globals.propTypes = {
     fTCycle: PropTypes.string,
     projectId: PropTypes.number,
     sessionId: PropTypes.number,
+    sessionLabel: PropTypes.string,
     candidateId: PropTypes.number,
     quantity: PropTypes.number,
     unitId: PropTypes.number,

--- a/modules/biobank/jsx/specimenForm.js
+++ b/modules/biobank/jsx/specimenForm.js
@@ -390,6 +390,7 @@ SpecimenForm.propTypes = {
       specimen: PropTypes.shape({
         candidateId: PropTypes.number,
         sessionId: PropTypes.number,
+        sessionLabel: PropTypes.string,
         typeId: PropTypes.number.isRequired,
       }).isRequired,
       container: PropTypes.shape({

--- a/modules/biobank/jsx/specimenForm.js
+++ b/modules/biobank/jsx/specimenForm.js
@@ -59,6 +59,7 @@ class SpecimenForm extends React.Component {
         .map((item) => item.specimen.id);
       current.candidateId = specimen.candidateId;
       current.sessionId = specimen.sessionId;
+      current.sessionLabel = specimen.sessionLabel;
       current.typeId = specimen.typeId;
       current.originId = container.originId;
       current.centerId = container.centerId;
@@ -225,7 +226,7 @@ class SpecimenForm extends React.Component {
             />
             <StaticElement
               label={this.props.t('Visit Label', {ns: 'loris'})}
-              text={options.sessions[sessionId].label}
+              text={current.sessionLabel}
             />
           </>
         );

--- a/modules/biobank/php/specimen.class.inc
+++ b/modules/biobank/php/specimen.class.inc
@@ -56,6 +56,7 @@ class Specimen implements
      * @var string      $candidatePSCID
      * @var int         $candidateAge
      * @var int         $sessionId
+     * @var string      $sessionLabel
      * @var \CenterID   $sessionCenterId
      * @var int         $poolId
      * @var Collection  $collection
@@ -78,6 +79,7 @@ class Specimen implements
     private $candidatePSCID;
     private $candidateAge;
     private $sessionId;
+    private $sessionLabel;
     private $sessionCenterId;
     private $poolId;
     private $collection;
@@ -411,6 +413,31 @@ class Specimen implements
     }
 
     /**
+     * Sets the visit label of the candidate's session/timepoint in which the
+     * specimen was collected.
+     *
+     * @param string $sessionLabel the visit label of the specimen's session
+     *                             of collection
+     *
+     * @return void
+     */
+    public function setSessionLabel(string $sessionLabel) : void
+    {
+        $this->sessionLabel = $sessionLabel;
+    }
+
+    /**
+     * Gets the visit label of the candidate's session/timepoint in which the
+     * specimen was collected.
+     *
+     * @return ?string
+     */
+    public function getSessionLabel() : ?string
+    {
+        return $this->sessionLabel;
+    }
+
+    /**
      * Sets the Centeer of the candidate's session/timepoint in which the specimen
      * was collected.
      *
@@ -691,6 +718,7 @@ class Specimen implements
             'candidatePSCID'         => $this->candidatePSCID,
             'candidateAge'           => $this->candidateAge,
             'sessionId'              => $this->sessionId,
+            'sessionLabel'           => $this->sessionLabel,
             'sessionCenterId'        => $this->sessionCenterId,
             'poolId'                 => $this->poolId,
             'collection'             => $this->collection->jsonSerialize(),

--- a/modules/biobank/php/specimendao.class.inc
+++ b/modules/biobank/php/specimendao.class.inc
@@ -118,6 +118,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
                       s.CandidateID,
                       c.PSCID as CandidatePSCID,
                       bs.SessionID,
+                      s.Visit_Label as SessionLabel,
                       s.CenterID as SessionCenterID,
                       (
                         SELECT FLOOR(DATEDIFF(s.Date_visit, c.DoB)/365.25)
@@ -374,7 +375,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     public function getProtocolAttributes() : array
     {
         $query = "
-            SELECT 
+            SELECT
                 bsp.SpecimenProtocolID as protocolId,
                 bsa.SpecimenAttributeID as attributeId,
                 bsa.Label as label,
@@ -731,6 +732,9 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
         }
         if (isset($data['SessionID'])) {
             $specimen->setSessionId((int) $data['SessionID']);
+        }
+        if (isset($data['SessionLabel'])) {
+            $specimen->setSessionLabel((string) $data['SessionLabel']);
         }
         if (isset($data['SessionID'])) {
             $specimen->setSessionCenterId(


### PR DESCRIPTION
## Summary
Fixes a front-end crash when viewing a specimen whose collection session is
at a site the user doesn't have access to. The specimen is visible (the user
has access to its container site), but its session is correctly never
provisioned to the front end. The front end then tried to look up the session
label in `options.sessions` and read `.label` off `undefined`, throwing.

The fix provisions the session's visit label directly onto the specimen
entity, so the label can be displayed without depending on the
access-filtered session options. The hyperlink to the session is now rendered
only when the session is present in `options.sessions` (i.e. the user can
access it); otherwise the visit label is shown as plain text.

## Changes
- **`specimendao.class.inc`**: Added `s.Visit_label as SessionLabel` to the
  existing session join in the specimen select, and set it on the specimen in
  `_getInstanceFromSQL`.
- **`specimen.class.inc`**: Added a `sessionLabel` property with
  setter/getter, and included it in `jsonSerialize`.
- **`<display view file>`**: Read the visit label from `specimen.sessionLabel`
  instead of `options.sessions[sessionId].label`, and made the session link
  conditional on the session being present in `options.sessions`.
- **`specimenForm.js`**: Carried `sessionLabel` across from the parent
  specimen in `componentDidUpdate`, and read the label from `current` instead
  of `options.sessions` in `renderGlobalFields`.