### PR TITLE
[login] Fix reset password email subject line

### DIFF
--- a/modules/login/php/reset.class.inc
+++ b/modules/login/php/reset.class.inc
@@ -112,7 +112,6 @@ class Reset extends \NDB_Page implements ETagCalculator
                     $tmp      = $config->getSetting('title');
                     $title    = is_array($tmp) ? implode('', $tmp):$tmp;
                     $msg_data['study']    = $title;
-                    $msg_data['study']    = $config->getSetting('title');
                     $msg_data['url']      = $factory->settings()->getBaseURL();
                     $msg_data['realname'] = $user->getFullname();
                     $msg_data['password'] = $password;

--- a/modules/login/php/reset.class.inc
+++ b/modules/login/php/reset.class.inc
@@ -108,12 +108,12 @@ class Reset extends \NDB_Page implements ETagCalculator
                     // send the user an email
                     $factory = \NDB_Factory::singleton();
 
-                    $msg_data          = [];
-                    $tmp = $config->getSetting('title');
-                    $title = is_array($tmp) ? implode('', $tmp):$tmp;
-                    $msg_data['study'] = $title;
-                    $msg_data['study'] = $config->getSetting('title');
-                    $msg_data['url']   = $factory->settings()->getBaseURL();
+                    $msg_data = [];
+                    $tmp      = $config->getSetting('title');
+                    $title    = is_array($tmp) ? implode('', $tmp):$tmp;
+                    $msg_data['study']    = $title;
+                    $msg_data['study']    = $config->getSetting('title');
+                    $msg_data['url']      = $factory->settings()->getBaseURL();
                     $msg_data['realname'] = $user->getFullname();
                     $msg_data['password'] = $password;
                     \Email::send($email, 'lost_password.tpl', $msg_data);

--- a/modules/login/php/reset.class.inc
+++ b/modules/login/php/reset.class.inc
@@ -109,6 +109,9 @@ class Reset extends \NDB_Page implements ETagCalculator
                     $factory = \NDB_Factory::singleton();
 
                     $msg_data          = [];
+                    $tmp = $config->getSetting('title');
+                    $title = is_array($tmp) ? implode('', $tmp):$tmp;
+                    $msg_data['study'] = $title;
                     $msg_data['study'] = $config->getSetting('title');
                     $msg_data['url']   = $factory->settings()->getBaseURL();
                     $msg_data['realname'] = $user->getFullname();


### PR DESCRIPTION
Related to #10563

Fix 'Array' in the subject line. 

To test:
Try resetting the password from the login page and check the notification email subject is `Lost Password - [study name]`.