### PR TITLE
Fix SQL injection in biobank DAO selectInstances and cascade update

### DIFF
--- a/modules/biobank/php/containerdao.class.inc
+++ b/modules/biobank/php/containerdao.class.inc
@@ -99,7 +99,7 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
         ?array $conditions = [],
         string $operator = 'AND'
     ) : array {
-        $query = 'SELECT bc.ContainerID,
+        $query  = 'SELECT bc.ContainerID,
                      bc.Barcode,
                      bc.ContainerTypeID,
                      bs.SpecimenID,
@@ -134,18 +134,20 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
                     ON bcsr.ShipmentID=s.ShipmentID
                   LEFT JOIN biobank_specimen bs
                     ON bc.ContainerID=bs.ContainerID';
+        $params = [];
         if (!empty($conditions)) {
             $whereClause = [];
+            $i           = 0;
             foreach ($conditions as $condition) {
-                $whereClause[] = $condition['column']
-                    . '="'
-                    . $condition['value']
-                    . '"';
+                $key           = 'param'.$i++;
+                $whereClause[] = $condition['column'].'=:'.$key;
+                $params[$key]  = $condition['value'];
             }
             $query .= ' WHERE '.implode(" $operator ", $whereClause);
         }
         $query        .= ' GROUP BY bc.ContainerID';
-        $containerRows = $this->db->pselectWithIndexKey($query, [], 'ContainerID');
+        $containerRows = $this->db
+            ->pselectWithIndexKey($query, $params, 'ContainerID');
 
         $containers = [];
         foreach ($containerRows as $id => $containerRow) {
@@ -213,7 +215,7 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
     {
         $query      = 'SELECT ContainerCapacityID as id,
                           Quantity as quantity,
-                          UnitID as unitId 
+                          UnitID as unitId
                   FROM biobank_container_capacity';
         $capacities = $this->db->pselectWithIndexKey($query, [], 'id');
 
@@ -234,7 +236,7 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
     public function getUnits() : array
     {
         $query = "SELECT UnitID as id,
-                         Label as unit 
+                         Label as unit
                   FROM biobank_unit";
         $units = $this->db->pselectWithIndexKey($query, [], 'id');
 
@@ -482,10 +484,14 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
         if (empty($childContainerIds)) {
             return [];
         }
-        $query = "UPDATE biobank_container                                      
-                  SET $field=$value                                             
-                  WHERE ContainerID IN (".implode(',', $childContainerIds).");";
-        $this->db->run($query);
+        $query = "UPDATE biobank_container
+                  SET $field=:value
+                  WHERE ContainerID IN (".implode(',', $childContainerIds).")";
+        $this->db->execute(
+            $this->db->prepare($query),
+            ['value' => $value],
+            ['nofetch' => 'true']
+        );
         $conditions = [];
         foreach ($childContainerIds as $id) {
             $conditions[] = ['column' => 'bc.ContainerID', 'value' => $id];
@@ -507,12 +513,12 @@ class ContainerDAO extends \LORIS\Data\ProvisionerInstance
      */
     public function getAllChildContainerIds(Container $container) : array
     {
-        $query = 'WITH recursive cte (ContainerID) as 
+        $query = 'WITH recursive cte (ContainerID) as
                   (
                     SELECT ContainerID
                     FROM biobank_container_parent
                     WHERE ParentContainerID=:i
-                    UNION ALL 
+                    UNION ALL
                     SELECT child.ContainerID
                     FROM biobank_container_parent as child
                     INNER JOIN cte on cte.ContainerID=child.ParentContainerID

--- a/modules/biobank/php/pooldao.class.inc
+++ b/modules/biobank/php/pooldao.class.inc
@@ -87,7 +87,7 @@ class PoolDAO extends \LORIS\Data\ProvisionerInstance
         ?array $conditions = [],
         $operator = 'AND'
     ) : array {
-        $query = "SELECT bp.PoolID,
+        $query  = "SELECT bp.PoolID,
                          bp.Label,
                          bp.Quantity,
                          bp.UnitID,
@@ -102,19 +102,19 @@ class PoolDAO extends \LORIS\Data\ProvisionerInstance
                       biobank_specimen bs ON bs.SpecimenID=bspr.SpecimenID
                   LEFT JOIN
                       biobank_container bc ON bc.ContainerID=bs.ContainerID";
+        $params = [];
         if (!empty($conditions)) {
             $whereClause = [];
+            $i           = 0;
             foreach ($conditions as $condition) {
-                $whereClause[] = $condition['column']
-                    . '='
-                    . '"'
-                    . $condition['value']
-                    . '"';
+                $key           = 'param'.$i++;
+                $whereClause[] = $condition['column'].'=:'.$key;
+                $params[$key]  = $condition['value'];
             }
             $query .= ' WHERE '.implode(" $operator ", $whereClause);
         }
         $query   .= ' GROUP BY bp.PoolID';
-        $poolRows = $this->db->pselectWithIndexKey($query, [], 'PoolID');
+        $poolRows = $this->db->pselectWithIndexKey($query, $params, 'PoolID');
 
         $pools       = [];
         $specimenDAO = new SpecimenDAO($this->loris);

--- a/modules/biobank/php/shipmentdao.class.inc
+++ b/modules/biobank/php/shipmentdao.class.inc
@@ -94,7 +94,7 @@ class ShipmentDAO extends \LORIS\Data\ProvisionerInstance
         ?array $conditions = [],
         $operator = 'AND'
     ) : array {
-        $query = "SELECT s.ShipmentID as id,
+        $query  = "SELECT s.ShipmentID as id,
                          s.Barcode as barcode,
                          st.Label as type,
                          s.DestinationCenterID as destinationCenterId,
@@ -109,22 +109,22 @@ class ShipmentDAO extends \LORIS\Data\ProvisionerInstance
                     ON (s.ShipmentID=bcsr.ShipmentID)
                   LEFT JOIN biobank_container bc
                     ON (bcsr.ContainerID=bc.ContainerID)";
+        $params = [];
         if (!empty($conditions)) {
             $whereClause = [];
+            $i           = 0;
             foreach ($conditions as $condition) {
-                $whereClause[] = $condition['column']
-                    . '='
-                    . '"'
-                    . $condition['value']
-                    . '"';
+                $key           = 'param'.$i++;
+                $whereClause[] = $condition['column'].'=:'.$key;
+                $params[$key]  = $condition['value'];
             }
             $query .= ' WHERE '.implode(" $operator ", $whereClause);
         }
-        $query .= " GROUP BY s.ShipmentID";
+        $query       .= " GROUP BY s.ShipmentID";
+        $shipmentRows = $this->db->pselectWithIndexKey($query, $params, 'barcode');
 
-        $shipments    = [];
-        $shipmentRows = $this->db->pselectWithIndexKey($query, [], 'barcode');
-        $logs         = $this->getLogs();
+        $shipments = [];
+        $logs      = $this->getLogs();
         foreach ($shipmentRows as $barcode => $shipmentRow) {
             $shipmentRow['containerIds']      = $shipmentRow['containerIds'] ?
               explode(',', $shipmentRow['containerIds']) : [];

--- a/modules/biobank/php/specimendao.class.inc
+++ b/modules/biobank/php/specimendao.class.inc
@@ -100,7 +100,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
         ?array $conditions = [],
         string $operator = 'AND'
     ) : array {
-        $query = "SELECT
+        $query  = "SELECT
                       bs.SpecimenID,
                       bs.ContainerID,
                       bc.Barcode,
@@ -169,19 +169,20 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
                  ON bspa.ParentSpecimenID=bs2.SpecimenID
                LEFT JOIN biobank_container bc2
                 ON bs2.ContainerID=bc2.ContainerID";
+        $params = [];
         if (!empty($conditions)) {
             $whereClause = [];
+            $i           = 0;
             foreach ($conditions as $condition) {
-                $whereClause[] = $condition['column']
-                    . '='
-                    . '"'
-                    . $condition['value']
-                    . '"';
+                $key           = 'param'.$i++;
+                $whereClause[] = $condition['column'].'=:'.$key;
+                $params[$key]  = $condition['value'];
             }
             $query .= ' WHERE '.implode(" $operator ", $whereClause);
         }
         $query       .= " GROUP BY bs.SpecimenID";
-        $specimenRows = $this->db->pselectWithIndexKey($query, [], 'SpecimenID');
+        $specimenRows = $this->db
+            ->pselectWithIndexKey($query, $params, 'SpecimenID');
         $specimens    = [];
         foreach ($specimenRows as $id => $specimenRow) {
             $specimens[$id] = $this->_getInstanceFromSQL($specimenRow);
@@ -374,7 +375,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     public function getProtocolAttributes() : array
     {
         $query = "
-            SELECT 
+            SELECT
                 bsp.SpecimenProtocolID as protocolId,
                 bsa.SpecimenAttributeID as attributeId,
                 bsa.Label as label,


### PR DESCRIPTION
## Brief summary of changes
Fixes SQL injection in the biobank module's DAO layer. The `selectInstances`
methods in the container, specimen, pool, and shipment DAOs built their WHERE
clauses by concatenating `$condition['value']` directly into the query string
and passed an empty parameter array to `pselectWithIndexKey`. User-supplied
values reaching these methods (e.g. a container `barcode` or `shipmentBarcodes`
via the container endpoint) could break out of the quoted string and inject
arbitrary SQL.

Both reported exploits hit the same DAO code through different fields:
- `barcode` -> `containerdao::selectInstances` (via container validation)
- `shipmentBarcodes` -> `shipmentdao::selectInstances` (via shipment validation)

All four `selectInstances` methods now bind values to named placeholders and
pass them through to `pselectWithIndexKey`. Column names are left interpolated
as before, since every caller supplies them as hardcoded literals, never from
user input.

Additionally, `containerdao::_cascadeToChildren` built an `UPDATE ... SET
$field=$value` query with the value interpolated raw. `$value` originates from
user-submitted container data (temperature, status, center), so this was a
second injection point on the same endpoint. It now binds the value via a
prepared statement.

## Testing instructions
1. Check out this branch on a LORIS instance with the biobank module enabled.
2. Log in and obtain a session cookie.
3. Attempt the reported exploit against the container endpoint, e.g. a POST with
   a `barcode` of `a" AND extractvalue(1,concat(0x7e,(SELECT @@version)))-- -`.
4. Confirm the request no longer returns a database error leaking server
   information, and that the injected value is treated as a literal barcode.
5. Exercise normal biobank flows (create/edit containers, specimens, pools,
   shipments; cascade a temperature/status/center change to child containers)
   and confirm behaviour is unchanged.

## Link to any issues this addresses
Reported via the Programme privé de prime aux bogues du Gouvernement du Québec
(YesWeHack). Internal refs: RITM0025010, RITM0024993.