### PR TITLE
[docs_repo] fix the name of download file is not correct

### DIFF
--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -100,7 +100,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
         return (new \LORIS\Http\Response\JSON\OK())
             ->withHeader(
                 'Content-Disposition',
-                'attachment; filename=' . urlencode($filename)
+                'attachment; filename=' . urlencode(basename($filename))
             )
             ->withHeader(
                 'Content-Type',


### PR DESCRIPTION
https://github.com/aces/Loris/issues/10678
Test download a docs repo when click file name, it will download the file with correct name. 
before and after
<img width="778" height="190" alt="截屏2026-06-22 上午11 17 04" src="https://github.com/user-attachments/assets/0c0d7d66-bfef-4f68-9a84-db815737601d" />
