### PR TITLE
[dataquery] Import Filters CSV Bug

### DIFF
--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -104,6 +104,18 @@ function ImportCSVModal(props: {
           return;
         }
       }
+      if (idType === 'PSCID') {
+        if (!value.data[i][0] || value.data[i][0].trim() === '') {
+          swal.fire({
+            type: 'error',
+            title: t('Invalid PSCID', {ns: 'dataquery'}),
+            text: t('Invalid PSCID ({{id}}) on line {{line}}.',
+              {ns: 'dataquery', id: value.data[i][0], line: i+1}),
+          });
+          setCSVFile(null);
+          return;
+        }
+      }
     }
 
     // Now that it's been validated, build a new query

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -345,6 +345,12 @@ msgstr ""
 msgid "Invalid DCCID ({{id}}) on line {{line}}."
 msgstr ""
 
+msgid "Invalid PSCID"
+msgstr ""
+
+msgid "Invalid PSCID ({{id}}) on line {{line}}."
+msgstr ""
+
 msgid "Welcome to the Data Query Tool"
 msgstr ""
 

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -488,6 +488,14 @@ msgid "Invalid DCCID ({{id}}) on line {{line}}."
 msgstr "DCCID invalide ({{id}}) sur la ligne {{line}}."
 
 #, fuzzy
+msgid "Invalid PSCID"
+msgstr "PSCID invalide"
+
+#, fuzzy
+msgid "Invalid PSCID ({{id}}) on line {{line}}."
+msgstr "PSCID invalide ({{id}}) sur la ligne {{line}}."
+
+#, fuzzy
 msgid "Welcome to the Data Query Tool"
 msgstr "Bienvenue dans l'outil de requête de données"
 

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -350,6 +350,12 @@ msgstr "無効なDCCID"
 msgid "Invalid DCCID ({{id}}) on line {{line}}."
 msgstr "行 {{line}} の DCCID ({{id}}) が無効です。"
 
+msgid "Invalid PSCID"
+msgstr "無効なPSCID"
+
+msgid "Invalid PSCID ({{id}}) on line {{line}}."
+msgstr "行 {{line}} の PSCID ({{id}}) が無効です。"
+
 msgid "Welcome to the Data Query Tool"
 msgstr "データクエリツールへようこそ"
 

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -350,6 +350,12 @@ msgstr "DCCID 无效"
 msgid "Invalid DCCID ({{id}}) on line {{line}}."
 msgstr "第 {{line}} 行的 DCCID ({{id}}) 无效。"
 
+msgid "Invalid PSCID"
+msgstr "PSCID 无效"
+
+msgid "Invalid PSCID ({{id}}) on line {{line}}."
+msgstr "第 {{line}} 行的 PSCID ({{id}}) 无效。"
+
 msgid "Welcome to the Data Query Tool"
 msgstr "欢迎使用数据查询工具"
 


### PR DESCRIPTION
https://github.com/aces/Loris/issues/10630 Describe the bug
When importing filters via CSV, there are errors if the DCCID does not exist but no errors if the PSCID does not exist.
Adding valid check for PSCID.

