### PR TITLE
[survey_accounts] Add Space For The Validation Message

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -195,7 +195,7 @@ class AddSurvey extends \NDB_Form
                 return [
                     'Test_name' => "Instrument ".
                         $instrument_instance->getFullName().
-                        $reminder. $values['VL'],
+                        " ". $reminder. " ". $values['VL'],
                 ];
             }
         }


### PR DESCRIPTION
## Brief summary of changes

- [X] Add space on the validation error message.

### trsting the fix:

1. Go to 'survey_accounts'
2. Click on 'Add Survey'
3. Choose: DCCID: 2361712077, PSCID: DCC0703, Visit Label: V1 and Instument: BMI Calculator
4. See the error message is missing a space between the instrment name and the word "already"
5. Fix: Instrument BMI Calculator already exists for the given candidate for visitV1

Related to: https://github.com/aces/Loris/issues/10562