### PR TITLE
[NDB_Notifier] Fix 'active_to' query

### DIFF
--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -244,7 +244,7 @@ abstract class NDB_Notifier_Abstract
                     AND nm.operation_type=:ot
                     AND u.Pending_approval = 'N'
                     AND u.Active = 'Y'
-                    AND u.active_to < NOW()
+                    AND u.active_to > NOW()
                     ";
         $params = [
             "nm" => $this->module,

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -244,7 +244,7 @@ abstract class NDB_Notifier_Abstract
                     AND nm.operation_type=:ot
                     AND u.Pending_approval = 'N'
                     AND u.Active = 'Y'
-                    AND u.active_to > NOW()
+                    AND (u.active_to > NOW() OR u.active_to IS NULL)
                     ";
         $params = [
             "nm" => $this->module,


### PR DESCRIPTION
## Brief summary of changes
No notifications were being sent out because the "Active_to" condition in the query for users to be notified had the opposite logic than it should (it was checking users who have already had their access expired instead of users who are still active).

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Create a user and grant the user each permission from the my_preferences page. Make sure the user is active and does not have an active_to date set
2. Test each operation that sends notifications to make sure the notifications are properly sent
3. Edit the user to have an active_to date set before now
4. Make sure the notifications are not sent
5. Edit the user to have an active_to date set after now
6. Make sure the notifications are sent
7. Remove all of the notification settings from my_preferences page
8. Make sure that the notifications are not  sent

#### Link(s) to related issue(s)

* Resolves #10588
