### PR TITLE
[dictionary] Added tests for getDataDictionary() modules

### DIFF
--- a/modules/dictionary/test/TestPlan.md
+++ b/modules/dictionary/test/TestPlan.md
@@ -37,3 +37,9 @@ download table as CSV works as well.
 11. Check that the `tools/exporters/data_dictionary_builder.php` works. Try changing 
 field names in an instrument before running the script and make sure that the 
 corresponding entries in Data Dictionary are updated correctly.
+12. Module enable/disable behaviour. Using the Module Manager (Admin > Modules), disable a module that provides a dictionary (e.g. `imaging_browser` or `candidate_parameters`). Reload the Data Dictionary and confirm:
+ - The module's fields no longer appear in the table.
+ - The module is no longer an option in the "Module" filter.
+ - Selecting any remaining module repopulates the "Category" filter with only that module's categories. Re-enable the module and confirm its fields, "Module" filter option, and "Category" filter options reappear.
+13. Per-user module access. Log in as a user who does NOT have access to a specific module that provides a dictionary. Confirm that the dictionary entries (fields), the "Module" filter option, and the related "Category" options for that module are NOT visible to that user, even though the module is active. Now grant access to that module from an admin account and confirm the same entries and filter options are now visible.
+14. Make sure that the "Module" filter lists only active modules that the logged-in user can access and that actually provide a dictionary (e.g. `instruments`, `imaging_browser`, `candidate_parameters`). The "Category" filter is empty until a Module is selected, then shows only the categories of the selected module.

--- a/modules/dictionary/test/TestPlan.md
+++ b/modules/dictionary/test/TestPlan.md
@@ -1,45 +1,56 @@
-# Data Dictionary - Test Plan  
+# Data Dictionary - Test Plan
 
-1. Check that you have access to the Data Dictionary if the user has one or more of 
-these permissions: 
-   - data_dict
-   - data_dict_edit or superuser.
+1. Check that you have access to the Data Dictionary if the user has one or more of
+these permissions:
+   - data_dict_view (_"Data Dictionary: View Field Descriptions"_)
+   - data_dict_edit (_"Data Dictionary: Edit Field Descriptions"_) or superuser
+   (_"Superuser - supersedes all permissions"_).
   [Automation Testing]
-2. Check that the instruments combo box contains all the instrument names.
+2. Check that the 'Module' filter dropdown lists only the active modules that the
+logged-in user can access and that actually provide a dictionary (e.g. `instruments`,
+`imaging_browser`, `candidate_parameters`).
   [Automation Testing]
-3. Perform various searches and validate the results. 
- - Use any combination of the available search criteria. 
- - Make sure that when performing a keyword search the algorithm takes column Name, 
- SourceField and Description into account. 
- - Make sure that when you choose "Empty" in the Description combo box, all the rows 
- returned have an empty description.
+3. Check that the 'Category' filter dropdown is empty until a Module is selected, and
+that once a Module is selected it is populated only with the categories of that module.
+Changing the selected Module updates the Category options accordingly.
   [Automation Testing]
-4. Check that selecting multiple instruments returns all relevant results.
-5. Check that the table can be sorted according to any column (ascending and descending).
+4. Perform various searches and validate the results.
+ - Use any combination of the available filters ('Module', 'Category', 'Field Name',
+ 'Description', 'Description Status', 'Data Scope', 'Data Type', 'Data Cardinality',
+ 'Visits' and 'Cohort').
+ - Make sure that when you choose "Empty" in the 'Description Status' filter dropdown,
+ all the rows returned have an empty description.
   [Automation Testing]
-6. Check that pushing the Clear button sets the Description search field to 'All', 
-the Instruments search field to 'All instruments', clears the search keyword text 
-field and performs a search with these criteria. Validate the results.
+5. Check that the 'Visits' and 'Cohort' multiselect filters return all relevant results
+when more than one value is selected.
+6. Check that the table can be sorted according to any column (ascending and descending).
   [Automation Testing]
-7. Check that if (and only if) you have the 'data_dict_edit' permission you can edit 
-the Description field. Edit a description, access the Candidate Profile page and 
-access the Data Dictionary page again. Make sure the edit was saved.
+7. Check that pushing the "Clear Filter" button resets all filters to empty.
   [Automation Testing]
-8. Make sure that search keywords are not case-sensitive and that when you specify 
-more than one keyword, the search returns entries that match the whole string.
-  [Automation Testing] 
-9. Check that you can navigate through the search result pages (both by clicking on 
+8. Check that if (and only if) you have the 'data_dict_edit' permission, the edit
+(pencil) icon appears on the Description column. Click it, change the text in the
+"Edit Description" popup and click "Modify". Confirm the row's Description Status shows
+"Modified" and displays "(edited)". Navigate away (e.g. the Candidate Profile page) and
+return to the Data Dictionary; make sure the edit was saved.
+  [Automation Testing]
+9. Check that you can navigate through the search result pages (both by clicking on
 the numbers and arrows in the bottom right corner of the table).
   [Automation Testing]
-10. Check that the maximum rows displayed dropdown works, also check that the 
+10. Check that the maximum rows displayed dropdown works, also check that the
 download table as CSV works as well.
   [Automation Testing]
-11. Check that the `tools/exporters/data_dictionary_builder.php` works. Try changing 
-field names in an instrument before running the script and make sure that the 
-corresponding entries in Data Dictionary are updated correctly.
-12. Module enable/disable behaviour. Using the Module Manager (Admin > Modules), disable a module that provides a dictionary (e.g. `imaging_browser` or `candidate_parameters`). Reload the Data Dictionary and confirm:
+11. Module enable/disable behaviour. Using the Module Manager (Admin > Modules),
+disable a module that provides a dictionary (e.g. `imaging_browser` or
+`candidate_parameters`). Reload the Data Dictionary and confirm:
  - The module's fields no longer appear in the table.
- - The module is no longer an option in the "Module" filter.
- - Selecting any remaining module repopulates the "Category" filter with only that module's categories. Re-enable the module and confirm its fields, "Module" filter option, and "Category" filter options reappear.
-13. Per-user module access. Log in as a user who does NOT have access to a specific module that provides a dictionary. Confirm that the dictionary entries (fields), the "Module" filter option, and the related "Category" options for that module are NOT visible to that user, even though the module is active. Now grant access to that module from an admin account and confirm the same entries and filter options are now visible.
-14. Make sure that the "Module" filter lists only active modules that the logged-in user can access and that actually provide a dictionary (e.g. `instruments`, `imaging_browser`, `candidate_parameters`). The "Category" filter is empty until a Module is selected, then shows only the categories of the selected module.
+ - The module is no longer an option in the 'Module' filter.
+ - Selecting any remaining module repopulates the 'Category' filter with only that
+ module's categories.
+Re-enable the module and confirm its fields, 'Module' filter option, and 'Category'
+filter options reappear.
+12. Per-user module access. Log in as a user who does NOT have access to a specific
+module that provides a dictionary. Confirm that, by design, the dictionary entries
+(fields), the 'Module' filter option, and the related 'Category' options for that
+module are NOT visible to that user, even though the module is active. Log in as a user
+WITH access to that module and confirm the same entries and filter options are now
+visible.


### PR DESCRIPTION
## Brief summary of changes
Added 3 testing instructions to TestPlan.md file for getDataDictionary() modules. Tests visibility of dictionary items and selection filters in the datadict depending on the active/inactive status of module and the permissions of users to these specific modules.
- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1.Read through instructions on test plan and make sure they are easy to follow and include all dictionary module functionalities.

#### Link(s) to related issue(s)

* Resolves #10612  (Reference the issue this fixes, if any.)
