### PR TITLE
[modules | candidate_parameters] Fix DoB page loading for EDC-only participants

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -609,9 +609,10 @@ function getDODFields(): array
     $dobFormat = $config->getSetting('dobFormat');
 
     $dobProcessedFormat = implode("-", str_split($dobFormat, 1));
-    $dobDate            = DateTime::createFromFormat('Y-m-d', $candidateData['DoB']);
-    $dob = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
-
+    $dob    = formatCandidateDate(
+        $candidateData['DoB'] ?? null,
+        $dobProcessedFormat
+    );
     $result = [
         'pscid'     => $candidateData['PSCID'],
         'candID'    => $candID->__toString(),

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -563,8 +563,7 @@ function getDOBFields(): array
     $dobFormat = $config->getSetting('dobFormat');
 
     $dobProcessedFormat = implode("-", str_split($dobFormat, 1));
-    $dobDate            = DateTime::createFromFormat('Y-m-d', $dob);
-    $formattedDate      = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
+    $formattedDate = formatCandidateDate($dob, $dobProcessedFormat);
 
     $result = [
         'pscid'     => $pscid,
@@ -702,5 +701,30 @@ function getDiagnosisEvolutionFields(): array
         'projects'                        => $candProjects
     ];
     return $result;
+}
+
+/**
+ * Format a candidate date for display.
+ *
+ * Returns null when the date is null or invalid.
+ *
+ * @param string|null $date   Database date in Y-m-d format
+ * @param string      $format Display format
+ *
+ * @return string|null
+ */
+function formatCandidateDate(?string $date, string $format): ?string
+{
+    if (empty($date)) {
+        return null;
+    }
+
+    $dateTime = DateTime::createFromFormat('Y-m-d', $date);
+
+    if ($dateTime === false) {
+        return null;
+    }
+
+    return $dateTime->format($format);
 }
 

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -563,7 +563,7 @@ function getDOBFields(): array
     $dobFormat = $config->getSetting('dobFormat');
 
     $dobProcessedFormat = implode("-", str_split($dobFormat, 1));
-    $formattedDate = formatCandidateDate($dob, $dobProcessedFormat);
+    $formattedDate      = formatCandidateDate($dob, $dobProcessedFormat);
 
     $result = [
         'pscid'     => $pscid,


### PR DESCRIPTION
This PR fixes #10644 
## Situation
* The DoB tab failed to load for participants created with an EDC but without a recorded DoB.
* A TypeError was thrown when DateTime::createFromFormat() received a null value.

## Task
* Ensure the DoB tab loads correctly for EDC-only participants.
* Prevent failures when candidate DoB values are null.

## Action
* Added a null-safe date formatting helper.
* Updated DoB date formatting logic to handle null values before attempting date conversion.

## Result
* The DoB and DoD(aditional fix) tabs now loads successfully for EDC-only participants.
* The candidateDOB endpoint returns HTTP 200 instead of a server error.
* Existing participants with valid DoB values continue to function correctly.

<img width="1972" height="944" alt="image" src="https://github.com/user-attachments/assets/d3c2f84a-224c-4054-ad51-f86911aa076a" />


## Testing
* Admin -> Configuration -> Study -> Use EDC (make it yes) and click Submit
* Candidate -> New Profile > Create new profile with EDC only (leave DoB blank) > click create and also note down the candidate details
* Candidate -> Access Profile -> Search for the newly created EDC candidate -> Click on PSCID Link -> Candidate Info -> DoB and it loads DoB
