### PR TITLE
[dictionary] filter disabled logic + category filter disabling trigger

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -92,7 +92,12 @@ function Filter(props) {
         let element;
         switch (filter.type) {
         case 'text':
-          element = <TextboxElement labelPlacementTop/>;
+          element = (
+            <TextboxElement
+              disabled={filter.disabled}
+              labelPlacementTop
+            />
+          );
           break;
         case 'select':
           element = (
@@ -100,6 +105,7 @@ function Filter(props) {
               options={filter.options}
               sortByValue={filter.sortByValue}
               autoSelect={false}
+              disabled={filter.disabled}
               labelPlacementTop
             />
           );
@@ -111,6 +117,7 @@ function Filter(props) {
               sortByValue={filter.sortByValue}
               multiple={true}
               emptyOption={false}
+              disabled={filter.disabled}
               labelPlacementTop
             />
           );
@@ -118,6 +125,7 @@ function Filter(props) {
         case 'numeric':
           element = <NumericElement
             options={filter.options}
+            disabled={filter.disabled}
             labelPlacementTop
           />;
           break;
@@ -128,23 +136,48 @@ function Filter(props) {
             step={filter.step}
             minLabel={filter.minLabel}
             maxLabel={filter.maxLabel}
+            disabled={filter.disabled}
             labelPlacementTop
           />;
           break;
         case 'date':
-          element = <DateElement labelPlacementTop />;
+          element = (
+            <DateElement
+              labelPlacementTop
+              disabled={filter.disabled}
+            />
+          );
           break;
         case 'datetime':
-          element = <DateTimePartialElement labelPlacementTop />;
+          element = (
+            <DateTimePartialElement
+              disabled={filter.disabled}
+              labelPlacementTop
+            />
+          );
           break;
         case 'checkbox':
-          element = <CheckboxElement/>;
+          element = (
+            <CheckboxElement
+              disabled={filter.disabled}
+            />
+          );
           break;
         case 'time':
-          element = <TimeElement labelPlacementTop />;
+          element = (
+            <TimeElement
+              disabled={filter.disabled}
+              labelPlacementTop
+            />
+          );
           break;
         default:
-          element = <TextboxElement labelPlacementTop />;
+          element = (
+            <TextboxElement
+              disabled={filter.disabled}
+              labelPlacementTop
+            />
+          );
         }
 
         // The value prop has to default to false if the first two options

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -253,6 +253,7 @@ class DataDictIndex extends Component {
         filter: {
           name: 'Category',
           type: 'select',
+          disabled: this.state.moduleFilter === '',
           options: this.state.moduleFilter === ''
             ? {}
             : options.categories[this.state.moduleFilter],


### PR DESCRIPTION
## Brief summary of changes

- Fix: filter logic missing in jsx `Filter` 
- add: disabled logic on dictionary _category_ filter based on _module_ filter selection.

#### Testing instructions (if applicable)

Run 
```
target=dictionary npm run compile
```

1. go to `dictionary` module: `Menu bar > Tools > Data Dictionary`.
2. look at the filter menu.
3. if module filter is not set/blank, the category filter will be disabled. Else, it will contain module-specific categories, blank by default to select all categories for a single module.

<img width="923" height="269" alt="image" src="https://github.com/user-attachments/assets/f64f5d7f-87b9-4ac7-aeeb-5a0f22fb4907" />


#### Link(s) to related issue(s)

* Resolves #10611