### PR TITLE
Translate Biobank menu labels

### DIFF
--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -100,6 +100,10 @@ msgstr[0] "為り手"
 msgid "Genomics"
 msgstr "ゲノミクス"
 
+#: modules/biobank/php/module.class.inc:140
+msgid "Biobank"
+msgstr "バイオバンク"
+
 #: modules/electrophysiology_browser/php/module.class.inc:54
 msgid "Electrophysiology"
 msgstr "電気生理学"

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -100,6 +100,10 @@ msgstr[0] "受试者"
 msgid "Genomics"
 msgstr "基因组学"
 
+#: modules/biobank/php/module.class.inc:140
+msgid "Biobank"
+msgstr "生物样本库"
+
 #: modules/electrophysiology_browser/php/module.class.inc:54
 msgid "Electrophysiology"
 msgstr "电生理学"

--- a/modules/biobank/locale/ja/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/ja/LC_MESSAGES/biobank.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-12-05 08:40-0500\n"
+"PO-Revision-Date: 2026-06-22 00:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese <ja@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "Biobank"
+msgstr "バイオバンク"
+
+msgid "Biospecimens"
+msgstr "生体試料"


### PR DESCRIPTION
## Brief summary of changes

- Adds missing Biobank menu category translations for Japanese and Chinese.
- Adds a Japanese Biobank module locale file for Biobank-related labels.
- Registers the Japanese Biobank locale file in the locale build list.

#### Testing instructions

- Open `http://localhost:8080/?lang=ja_JP`
- Confirm the top menu shows `バイオバンク` instead of `Biobank`.
- Confirm the page still loads normally with the Japanese locale selected.

#### Link(s) to related issue(s)

* Resolves #10103