### PR TITLE
[data_release] Fixes issue where users able to upload files to projects they do not have access to.

### DIFF
--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -263,7 +263,7 @@ class Data_Release extends \DataFrameworkMenu
     {
         $user     =& \User::singleton();
         $db       = $this->loris->getDatabaseConnection();
-        $projects = \Utility::getProjectList();
+        $projects = $user->getProjectNames();
         return [
             'currentUser'            => $user->getID(),
             'users'                  => $this->getUsersList($db),

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -181,8 +181,8 @@ class Files extends \NDB_Page
                 ['project' => $projectName]
             );
 
-            if (!$user->hasPermission("data_release_upload") ||
-                !$user->hasProject(
+            if (!$user->hasPermission("data_release_upload")
+                || !$user->hasProject(
                     \ProjectID::singleton((int)$ProjectID)
                 )
             ) {

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -122,17 +122,19 @@ class Files extends \NDB_Page
 
         $user = $request->getAttribute("user");
 
+        $posted = $request->getParsedBody();
+        assert(is_array($posted));
+
         $validateError = $this->_validateUserCanUpload(
             $user,
             $fileName,
+            $posted['project'],
             $overwrite
         );
         if ($validateError !== null) {
             return $validateError;
         }
 
-        $posted = $request->getParsedBody();
-        assert(is_array($posted));
         return $this->_moveFile(
             $uploadhandler,
             $user,
@@ -149,16 +151,18 @@ class Files extends \NDB_Page
      * if there are no errors, or an error response if something
      * is wrong.
      *
-     * @param \User  $user      The user attempting to upload
-     * @param string $fileName  The filename being uploaded
-     * @param bool   $overwrite Whether the overwrite flag is set
+     * @param \User  $user        The user attempting to upload
+     * @param string $fileName    The filename being uploaded
+     * @param string $projectName Name of the project
+     * @param bool   $overwrite   Whether the overwrite flag is set
      *
      * @return ?ResponseInterface
      */
     private function _validateUserCanUpload(
-        \User $user,
+        \User  $user,
         string $fileName,
-        bool $overwrite
+        string $projectName,
+        bool   $overwrite
     ) : ?ResponseInterface {
         // Check if file is duplicate
         $DB            = $this->loris->getDatabaseConnection();
@@ -170,11 +174,21 @@ class Files extends \NDB_Page
         if (!isset($duplicateFile)) {
             // File doesn't exist, user can upload as long as they have
             // permission.
-            if (!$user->hasPermission("data_release_upload")) {
+
+            // Get ProjectID
+            $ProjectID = $DB->pselectOne(
+                "SELECT ProjectID FROM Project WHERE Name=:project",
+                ['project' => $projectName]
+            );
+
+            if (!$user->hasPermission("data_release_upload") ||
+                !$user->hasProject(
+                    \ProjectID::singleton((int)$ProjectID)
+                )
+            ) {
                 return new \LORIS\Http\Response\JSON\Forbidden(
                     "Permission denied."
                 );
-
             }
             return null;
         }


### PR DESCRIPTION
## Brief summary of changes
- Modifies `modules/data_release/php/data_release.class.inc` to only show the projects the user have access in the SelectBox.
- Modifies `modules/data_release/php/files.class.inc` to check the user have access to the project before allowing the insertion.

#### Testing instructions (if applicable)

1. Go to 'data_release' with a user affiliated only to certain projects.
2. Click on 'upload file'
3. Click on 'project
4. Note that only the projects the user have access to are listed.
<img width="585" height="332" alt="data_release_projects_ok" src="https://github.com/user-attachments/assets/2ec32781-7dc1-441e-a2e9-20171c01d89a" />

5. Try to upload a file and checks it properly uploads.
6. Try to change to another user and please repeat steps 1 to 5.
7. The rest of the functionalities should remain unchanged. 

#### Link(s) to related issue(s)

* Resolves #10637
