### PR TITLE
[data_release] Fixed issue where version and file name were displayed as encoded values

### DIFF
--- a/modules/data_release/jsx/manageFileForm.js
+++ b/modules/data_release/jsx/manageFileForm.js
@@ -192,10 +192,10 @@ class ManageFileForm extends Component {
                 label={t('Username', {ns: 'loris'})}
                 options={
                   this.state.fieldOptions.usersByFilePermissions[
-                    this.state.specificReleaseI
+                    this.state.specificReleaseId
                   ]
                 }
-                onUserInput={(value) => {
+                onUserInput={(formElement, value) => {
                   this.setState({
                     selectedUserToRemove: value,
                   });

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -118,9 +118,12 @@ class Data_Release extends \DataFrameworkMenu
 
         $versionsList = [];
         foreach ($versions as $version) {
-            $version = $version == null || $version == '' ?
-                'Unversioned' : html_entity_decode($version, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-            $versionsList[$version] = $version;
+            if ($version === null || $version === '') {
+                $versionsList['Unversioned'] = 'Unversioned';
+            } else {
+                $versionsList[$version] =
+                    html_entity_decode($version, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
         }
 
         return $versionsList;

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -90,7 +90,8 @@ class Data_Release extends \DataFrameworkMenu
 
         foreach ($result as $id => $row) {
             $version     = $row['version'] == null || $row['version'] == '' ?
-               'Unversioned' : html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+               'Unversioned' :
+               html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $result[$id] = $row['file_name'].' - '.$version;
         }
 
@@ -121,10 +122,10 @@ class Data_Release extends \DataFrameworkMenu
             if ($version === null || $version === '') {
                 $versionsList['Unversioned'] = 'Unversioned';
             } else {
-                $versionsList[$version] 
-                = html_entity_decode(
-                        $version, 
-                        ENT_QUOTES | ENT_HTML5, 
+                $versionsList[$version]
+                    = html_entity_decode(
+                        $version,
+                        ENT_QUOTES | ENT_HTML5,
                         'UTF-8'
                     );
             }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -121,8 +121,12 @@ class Data_Release extends \DataFrameworkMenu
             if ($version === null || $version === '') {
                 $versionsList['Unversioned'] = 'Unversioned';
             } else {
-                $versionsList[$version] =
-                    html_entity_decode($version, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $versionsList[$version] 
+                = html_entity_decode(
+                        $version, 
+                        ENT_QUOTES | ENT_HTML5, 
+                        'UTF-8'
+                    );
             }
         }
 

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -92,7 +92,11 @@ class Data_Release extends \DataFrameworkMenu
             $version     = $row['version'] == null || $row['version'] == '' ?
                'Unversioned' :
                html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
-            $filename = html_entity_decode($row['file_name'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $filename    = html_entity_decode(
+                $row['file_name'],
+                ENT_QUOTES | ENT_HTML5,
+                'UTF-8'
+            );
             $result[$id] = $filename.' - '.$version;
         }
 

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -92,7 +92,8 @@ class Data_Release extends \DataFrameworkMenu
             $version     = $row['version'] == null || $row['version'] == '' ?
                'Unversioned' :
                html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
-            $result[$id] = $row['file_name'].' - '.$version;
+            $filename = html_entity_decode($row['file_name'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $result[$id] = $filename.' - '.$version;
         }
 
         return $result;
@@ -237,13 +238,12 @@ class Data_Release extends \DataFrameworkMenu
     {
         $result = $db->pselect(
             "
-            SELECT LOWER(upr.userid) as userid, dr.id as data_release_id
+            SELECT dpr.userid as userid, dr.id as data_release_id
             FROM data_release_permissions dpr
             JOIN data_release dr ON dr.id = dpr.data_release_id
-            JOIN user_project_rel upr ON upr.ProjectID = dr.ProjectID
-            WHERE upr.UserID = :userID",
-            [':userID' => \User::singleton()->getID()],
-            'file_name'
+            WHERE dr.ProjectID IS NULL OR dr.ProjectID IN
+                (SELECT ProjectID FROM user_project_rel WHERE UserID = :userID)",
+            [':userID' => \User::singleton()->getID()]
         );
 
         $users     = $this->getUsersList($db);

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -90,7 +90,7 @@ class Data_Release extends \DataFrameworkMenu
 
         foreach ($result as $id => $row) {
             $version     = $row['version'] == null || $row['version'] == '' ?
-               'Unversioned' : $row['version'];
+               'Unversioned' : html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $result[$id] = $row['file_name'].' - '.$version;
         }
 
@@ -119,7 +119,7 @@ class Data_Release extends \DataFrameworkMenu
         $versionsList = [];
         foreach ($versions as $version) {
             $version = $version == null || $version == '' ?
-                'Unversioned' : $version;
+                'Unversioned' : html_entity_decode($version, ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $versionsList[$version] = $version;
         }
 

--- a/modules/data_release/php/datareleaseprovisioner.class.inc
+++ b/modules/data_release/php/datareleaseprovisioner.class.inc
@@ -93,6 +93,14 @@ class DataReleaseProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     'UTF-8'
                 );
         }
+        if (!empty($row['fileName'])) {
+            $row['fileName']
+                = html_entity_decode(
+                    $row['fileName'],
+                    ENT_QUOTES | ENT_HTML5,
+                    'UTF-8'
+                );
+        }
         return new DataReleaseRow($row);
     }
 }

--- a/modules/data_release/php/datareleaseprovisioner.class.inc
+++ b/modules/data_release/php/datareleaseprovisioner.class.inc
@@ -85,6 +85,9 @@ class DataReleaseProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
+        if (!empty($row['version'])) {
+            $row['version'] = html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }
         return new DataReleaseRow($row);
     }
 }

--- a/modules/data_release/php/datareleaseprovisioner.class.inc
+++ b/modules/data_release/php/datareleaseprovisioner.class.inc
@@ -86,7 +86,12 @@ class DataReleaseProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         if (!empty($row['version'])) {
-            $row['version'] = html_entity_decode($row['version'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $row['version']
+                = html_entity_decode(
+                    $row['version'],
+                    ENT_QUOTES | ENT_HTML5,
+                    'UTF-8'
+                );
         }
         return new DataReleaseRow($row);
     }


### PR DESCRIPTION
## Brief summary of changes
Modifying `data_release` to ensure that version and file name text is always shown decoded to the user while keeping it stored as encoded values. 
<img width="1428" height="212" alt="image" src="https://github.com/user-attachments/assets/13cf4339-d1e5-4e40-9311-5b20054fab59" />
<img width="782" height="420" alt="image" src="https://github.com/user-attachments/assets/903d3177-b846-4c38-b393-575fca473d26" />
<img width="715" height="535" alt="image" src="https://github.com/user-attachments/assets/85bbe763-9354-4bf7-9c5d-a01b72c87590" />

#### Testing instructions (if applicable)

1. Try adding a file with a version name containing special characters.
2. Try selecting it in the dropdown, managing permissions, etc...
3. Ensure that the version name is always shown decoded.
4. Also test for file names

#### Link(s) to related issue(s)

* Resolves [10636](https://github.com/aces/loris/issues/10636 ) (Reference the issue this fixes, if any.)
