### PR TITLE
[javascript] Split form and non-form modals and support custom modal footers

### DIFF
--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -11,23 +11,54 @@ export type ModalProps = PropsWithChildren<{
   throwWarning?: boolean;
   show: boolean;
   onClose: () => void;
-  onSubmit?: () => Promise<any>;
-  onSuccess?: (data: any) => void;
   title?: ReactNode;
   width?: string;
+  footer?: ReactNode;
 }>;
+
+export type FormModalProps = Omit<ModalProps, 'footer'> & {
+  onSubmit?: () => Promise<any> | any;
+  onSuccess?: (data: any) => void;
+};
 
 /**
  * Modal Component
  *
- * A React functional component that renders a modal dialog with optional
- * form submission and loading indicators. Supports asynchronous form submission
- * with loading and success feedback.
+ * A React functional component that renders a generic modal dialog.
  *
  * @param {ModalProps} props - Properties for the modal component
- * @returns {JSX.Element} - A modal dialog box w/ optional submit functionality
+ * @returns {JSX.Element} - A modal dialog box
  */
 const Modal = ({
+  throwWarning = false,
+  show = false,
+  onClose,
+  title,
+  children,
+  width,
+  footer,
+}: ModalProps) => {
+  return (
+    <ModalFrame
+      show={show}
+      title={title}
+      onClose={onClose}
+      throwWarning={throwWarning}
+      width={width}
+    >
+      <div style={bodyStyle}>{show && children}</div>
+      {footer && <div style={footerStyle}>{footer}</div>}
+    </ModalFrame>
+  );
+};
+
+/**
+ * FormModal Component
+ *
+ * A form-specific modal that keeps submit controls inside the form DOM while
+ * preserving the async submit, loading, and success behavior used by LORIS.
+ */
+export const FormModal = ({
   throwWarning = false,
   show = false,
   onClose,
@@ -36,30 +67,10 @@ const Modal = ({
   title,
   children,
   width,
-}: ModalProps) => {
-  const [loading, setLoading] = useState(false); // Tracks loading during submit
-  const [success, setSuccess] = useState(false); // Tracks success after submit
-  const {t} = useTranslation('loris'); // Initialize translation
-
-  /**
-   * Handles modal close event. Shows a confirmation if `throwWarning` is true.
-   */
-  const handleClose = () => {
-    if (throwWarning) { // Display warning if enabled
-      Swal.fire({
-        title: t('Are You Sure?', {ns: 'loris'}),
-        text: t('Leaving the form will result in the loss '
-          +'of any information entered.',
-        {ns: 'loris'}),
-        type: 'warning',
-        showCancelButton: true,
-        confirmButtonText: t('Proceed', {ns: 'loris'}),
-        cancelButtonText: t('Cancel', {ns: 'loris'}),
-      }).then((result) => result.value && onClose());
-    } else {
-      onClose(); // Close immediately if no warning
-    }
-  };
+}: FormModalProps) => {
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const {t} = useTranslation('loris');
 
   /**
    * Manages form submission with loading and success states, calling
@@ -85,92 +96,9 @@ const Modal = ({
     }
   };
 
-  /**
-   * Renders submit button if `onSubmit` is provided and no loading or success.
-   *
-   * @returns {JSX.Element | undefined} - The submit button if conditions are met
-   */
-  const submitButton = () => {
-    if (onSubmit && !(loading || success)) { // Show button if conditions met
-      return <div style={submitStyle}><ButtonElement label={t('Save')}/></div>;
-    }
-  };
-
-  const headerStyle: CSSProperties = {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: '40px',
-    borderTopRightRadius: '10',
-    fontSize: 24,
-    padding: 35,
-    borderBottom: '1px solid #DDDDDD',
-  };
-
-  const glyphStyle: CSSProperties = {
-    marginLeft: 'auto',
-    cursor: 'pointer',
-  };
-
-  const bodyStyle: CSSProperties = {
-    padding: success ? 0 : '15px 15px',
-    maxHeight: success ? 0 : '75vh',
-    overflow: 'scroll',
-    opacity: success ? 0 : 1,
-    transition: '1s ease, opacity 0.3s',
-  };
-
-  const modalContainer: CSSProperties = {
-    display: 'block',
-    position: 'fixed',
-    zIndex: 9999,
-    paddingTop: '100px',
-    paddingBottom: '100px',
-    left: 0,
-    top: 0,
-    width: '100%',
-    height: '100%',
-    overflow: 'auto',
-    backgroundColor: 'rgba(0,0,0,0.7)',
-    visibility: show ? 'visible' : 'hidden',
-  };
-
-  const modalContent: CSSProperties = {
-    opacity: show ? 1 : 0,
-    top: show ? 0 : '-300px',
-    position: 'relative',
-    backgroundColor: '#fefefe',
-    borderRadius: '7px',
-    margin: 'auto',
-    padding: 0,
-    border: '1px solid #888',
-    width: width ?? '700px',
-    boxShadow: '0 4px 8px 0 rbga(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19)',
-    transition: '0.4s ease',
-  };
-
-  const footerStyle: CSSProperties = {
-    borderTop: '1px solid #DDDDDD',
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: '40px',
-    padding: '35px',
-    backgroundColor: success ? '#e0ffec' : undefined,
-  };
-
-  const submitStyle: CSSProperties = {
-    marginLeft: 'auto',
-    marginRight: '20px',
-  };
-
-  const processStyle: CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-evenly',
-    margin: '0px auto',
-    width: '90px',
-  };
+  const submitButton = onSubmit && !(loading || success) && (
+    <div style={submitStyle}><ButtonElement label={t('Save')}/></div>
+  );
 
   /**
    * Loader element displayed during form submission.
@@ -195,37 +123,171 @@ const Modal = ({
     </div>
   );
 
-  const content = (
-    <>
-      <div style={bodyStyle}>{show && children}</div>
-      <div style={footerStyle}>
-        {loader}
-        {successDisplay}
-        {submitButton()}
-      </div>
-    </>
+  return (
+    <ModalFrame
+      show={show}
+      title={title}
+      onClose={onClose}
+      throwWarning={throwWarning}
+      width={width}
+    >
+      <FormElement
+        name='modal'
+        onSubmit={handleSubmit}
+      >
+        <div style={{
+          ...bodyStyle,
+          padding: success ? 0 : bodyStyle.padding,
+          maxHeight: success ? 0 : bodyStyle.maxHeight,
+          opacity: success ? 0 : 1,
+        }}>
+          {show && children}
+        </div>
+        <div style={{
+          ...footerStyle,
+          backgroundColor: success ? '#e0ffec' : undefined,
+        }}>
+          {loader}
+          {successDisplay}
+          {submitButton}
+        </div>
+      </FormElement>
+    </ModalFrame>
   );
+};
+
+type ModalFrameProps = Omit<ModalProps, 'footer'>;
+
+/**
+ * Shared modal frame that owns the chrome and close behavior.
+ */
+const ModalFrame = ({
+  throwWarning = false,
+  show = false,
+  onClose,
+  title,
+  children,
+  width,
+}: ModalFrameProps) => {
+  const {t} = useTranslation('loris');
+
+  /**
+   * Handles modal close event. Shows a confirmation if `throwWarning` is true.
+   */
+  const handleClose = () => {
+    if (throwWarning) { // Display warning if enabled
+      Swal.fire({
+        title: t('Are You Sure?', {ns: 'loris'}),
+        text: t('Leaving the form will result in the loss '
+          +'of any information entered.',
+        {ns: 'loris'}),
+        type: 'warning',
+        showCancelButton: true,
+        confirmButtonText: t('Proceed', {ns: 'loris'}),
+        cancelButtonText: t('Cancel', {ns: 'loris'}),
+      }).then((result) => result.value && onClose());
+    } else {
+      onClose(); // Close immediately if no warning
+    }
+  };
 
   return (
-    <div style={modalContainer} onClick={handleClose}>
-      <div style={modalContent} onClick={(e) => e.stopPropagation()}>
+    <div
+      style={{
+        ...modalContainer,
+        visibility: show ? 'visible' : 'hidden',
+      }}
+      onClick={handleClose}
+    >
+      <div
+        style={{
+          ...modalContent,
+          opacity: show ? 1 : 0,
+          top: show ? 0 : '-300px',
+          width: width ?? '700px',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div style={headerStyle}>
           {title}
           <span style={glyphStyle} onClick={handleClose}>×</span>
         </div>
         <div>
-          {onSubmit ? (
-            <FormElement
-              name='modal'
-              onSubmit={handleSubmit}
-            >
-              {content}
-            </FormElement>
-          ) : content}
+          {children}
         </div>
       </div>
     </div>
   );
+};
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  height: '40px',
+  borderTopRightRadius: '10',
+  fontSize: 24,
+  padding: 35,
+  borderBottom: '1px solid #DDDDDD',
+};
+
+const glyphStyle: CSSProperties = {
+  marginLeft: 'auto',
+  cursor: 'pointer',
+};
+
+const bodyStyle: CSSProperties = {
+  padding: '15px 15px',
+  maxHeight: '75vh',
+  overflow: 'scroll',
+  transition: '1s ease, opacity 0.3s',
+};
+
+const modalContainer: CSSProperties = {
+  display: 'block',
+  position: 'fixed',
+  zIndex: 9999,
+  paddingTop: '100px',
+  paddingBottom: '100px',
+  left: 0,
+  top: 0,
+  width: '100%',
+  height: '100%',
+  overflow: 'auto',
+  backgroundColor: 'rgba(0,0,0,0.7)',
+};
+
+const modalContent: CSSProperties = {
+  position: 'relative',
+  backgroundColor: '#fefefe',
+  borderRadius: '7px',
+  margin: 'auto',
+  padding: 0,
+  border: '1px solid #888',
+  boxShadow: '0 4px 8px 0 rbga(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19)',
+  transition: '0.4s ease',
+};
+
+const footerStyle: CSSProperties = {
+  borderTop: '1px solid #DDDDDD',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  height: '40px',
+  padding: '35px',
+};
+
+const submitStyle: CSSProperties = {
+  marginLeft: 'auto',
+  marginRight: '20px',
+};
+
+const processStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-evenly',
+  margin: '0px auto',
+  width: '90px',
 };
 
 export default Modal;

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -1,10 +1,6 @@
 import {useState, PropsWithChildren, CSSProperties, ReactNode} from 'react';
 import Swal from 'sweetalert2';
 import Loader from './Loader';
-import {
-  ButtonElement,
-  FormElement,
-} from 'jsx/Form';
 import {useTranslation} from 'react-i18next';
 
 export type ModalProps = PropsWithChildren<{
@@ -96,30 +92,36 @@ export const FormModal = ({
     }
   };
 
-  const submitButton = onSubmit && !(loading || success) && (
-    <div style={submitStyle}><ButtonElement label={t('Save')}/></div>
+  const submitFooter = onSubmit && !(loading || success) && (
+    <div style={footerSubmitStyle}>
+      <button type='submit' className='btn btn-primary'>
+        {t('Save')}
+      </button>
+    </div>
   );
 
   /**
    * Loader element displayed during form submission.
    */
-  const loader = loading && (
-    <div style={processStyle}>
+  const loadingFooter = loading && (
+    <div style={footerStatusStyle}>
       <Loader size={20}/>
-      <h5 className='animate-flicker'>{t('Saving', {ns: 'loris'})}</h5>
+      <span className='animate-flicker'>
+        {t('Saving', {ns: 'loris'})}
+      </span>
     </div>
   );
 
   /**
    * Success display element shown after successful form submission.
    */
-  const successDisplay = success && (
-    <div style={processStyle}>
+  const successFooter = success && (
+    <div style={footerStatusStyle}>
       <span
         style={{color: 'green', marginBottom: '2px'}}
         className='glyphicon glyphicon-ok-circle'
       />
-      <h5>{t('Success!', {ns: 'loris'})}</h5>
+      <span>{t('Success!', {ns: 'loris'})}</span>
     </div>
   );
 
@@ -131,27 +133,31 @@ export const FormModal = ({
       throwWarning={throwWarning}
       width={width}
     >
-      <FormElement
+      <form
+        className='form-horizontal'
         name='modal'
-        onSubmit={handleSubmit}
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+        style={formStyle}
       >
         <div style={{
           ...bodyStyle,
           padding: success ? 0 : bodyStyle.padding,
-          maxHeight: success ? 0 : bodyStyle.maxHeight,
           opacity: success ? 0 : 1,
         }}>
           {show && children}
         </div>
         <div style={{
-          ...footerStyle,
+          ...formFooterStyle,
           backgroundColor: success ? '#e0ffec' : undefined,
         }}>
-          {loader}
-          {successDisplay}
-          {submitButton}
+          {loadingFooter}
+          {successFooter}
+          {submitFooter}
         </div>
-      </FormElement>
+      </form>
     </ModalFrame>
   );
 };
@@ -210,9 +216,9 @@ const ModalFrame = ({
       >
         <div style={headerStyle}>
           {title}
-          <span style={glyphStyle} onClick={handleClose}>×</span>
+          <span style={closeButtonStyle} onClick={handleClose}>×</span>
         </div>
-        <div>
+        <div style={contentStyle}>
           {children}
         </div>
       </div>
@@ -222,33 +228,52 @@ const ModalFrame = ({
 
 const headerStyle: CSSProperties = {
   display: 'flex',
-  flexDirection: 'row',
   alignItems: 'center',
-  height: '40px',
-  borderTopRightRadius: '10',
-  fontSize: 24,
-  padding: 35,
+  flex: '0 0 auto',
+  minHeight: '64px',
+  fontSize: 22,
+  fontWeight: 400,
+  lineHeight: 1.25,
+  padding: '16px 20px',
   borderBottom: '1px solid #DDDDDD',
 };
 
-const glyphStyle: CSSProperties = {
+const closeButtonStyle: CSSProperties = {
   marginLeft: 'auto',
   cursor: 'pointer',
 };
 
 const bodyStyle: CSSProperties = {
-  padding: '15px 15px',
-  maxHeight: '75vh',
-  overflow: 'scroll',
-  transition: '1s ease, opacity 0.3s',
+  flex: '1 1 auto',
+  minHeight: 0,
+  padding: '16px',
+  overflow: 'auto',
+  transition: 'opacity 0.3s ease',
+};
+
+const contentStyle: CSSProperties = {
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  minHeight: 0,
+  overflow: 'hidden',
+};
+
+const formStyle: CSSProperties = {
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  minHeight: 0,
+  overflow: 'hidden',
 };
 
 const modalContainer: CSSProperties = {
-  display: 'block',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   position: 'fixed',
   zIndex: 9999,
-  paddingTop: '100px',
-  paddingBottom: '100px',
+  padding: '24px 16px',
   left: 0,
   top: 0,
   width: '100%',
@@ -258,36 +283,44 @@ const modalContainer: CSSProperties = {
 };
 
 const modalContent: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
   position: 'relative',
   backgroundColor: '#fefefe',
-  borderRadius: '7px',
-  margin: 'auto',
-  padding: 0,
+  borderRadius: '8px',
   border: '1px solid #888',
-  boxShadow: '0 4px 8px 0 rbga(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19)',
-  transition: '0.4s ease',
+  maxHeight: '100%',
+  maxWidth: '100%',
+  overflow: 'hidden',
+  boxShadow: '0 4px 8px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19)',
+  transition: 'opacity 0.4s ease, top 0.4s ease',
 };
 
 const footerStyle: CSSProperties = {
   borderTop: '1px solid #DDDDDD',
   display: 'flex',
-  flexDirection: 'row',
   alignItems: 'center',
-  height: '40px',
-  padding: '35px',
+  flex: '0 0 auto',
+  minHeight: '64px',
+  padding: '16px 20px',
 };
 
-const submitStyle: CSSProperties = {
-  marginLeft: 'auto',
-  marginRight: '20px',
+const formFooterStyle: CSSProperties = {
+  ...footerStyle,
+  flexDirection: 'column',
+  gap: '12px',
+  justifyContent: 'center',
 };
 
-const processStyle: CSSProperties = {
+const footerSubmitStyle: CSSProperties = {
+  alignSelf: 'flex-end',
+};
+
+const footerStatusStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'space-evenly',
-  margin: '0px auto',
-  width: '90px',
+  alignSelf: 'center',
+  gap: '8px',
 };
 
 export default Modal;

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -12,11 +12,6 @@ export type ModalProps = PropsWithChildren<{
   footer?: ReactNode;
 }>;
 
-export type FormModalProps = Omit<ModalProps, 'footer'> & {
-  onSubmit?: () => Promise<any> | any;
-  onSuccess?: (data: any) => void;
-};
-
 /**
  * Modal Component
  *
@@ -25,7 +20,7 @@ export type FormModalProps = Omit<ModalProps, 'footer'> & {
  * @param {ModalProps} props - Properties for the modal component
  * @returns {JSX.Element} - A modal dialog box
  */
-const Modal = ({
+function Modal({
   throwWarning = false,
   show = false,
   onClose,
@@ -33,7 +28,7 @@ const Modal = ({
   children,
   width,
   footer,
-}: ModalProps) => {
+}: ModalProps) {
   return (
     <ModalFrame
       show={show}
@@ -46,6 +41,11 @@ const Modal = ({
       {footer && <div style={footerStyle}>{footer}</div>}
     </ModalFrame>
   );
+}
+
+export type FormModalProps<T> = Omit<ModalProps, 'footer'> & {
+  onSubmit: () => Promise<T>;
+  onSuccess?: (data: T) => void;
 };
 
 /**
@@ -54,7 +54,7 @@ const Modal = ({
  * A form-specific modal that keeps submit controls inside the form DOM while
  * preserving the async submit, loading, and success behavior used by LORIS.
  */
-export const FormModal = ({
+export function FormModal<T>({
   throwWarning = false,
   show = false,
   onClose,
@@ -63,7 +63,7 @@ export const FormModal = ({
   title,
   children,
   width,
-}: FormModalProps) => {
+}: FormModalProps<T>) {
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
   const {t} = useTranslation('loris');
@@ -73,8 +73,6 @@ export const FormModal = ({
    * `onSubmit` and handling modal state based on success or failure.
    */
   const handleSubmit = async () => {
-    if (!onSubmit) return; // Ensure onSubmit exists
-
     setLoading(true); // Show loader
 
     try {
@@ -92,7 +90,7 @@ export const FormModal = ({
     }
   };
 
-  const submitFooter = onSubmit && !(loading || success) && (
+  const submitFooter = !(loading || success) && (
     <div style={footerSubmitStyle}>
       <button type='submit' className='btn btn-primary'>
         {t('Save')}
@@ -160,21 +158,21 @@ export const FormModal = ({
       </form>
     </ModalFrame>
   );
-};
+}
 
 type ModalFrameProps = Omit<ModalProps, 'footer'>;
 
 /**
  * Shared modal frame that owns the chrome and close behavior.
  */
-const ModalFrame = ({
+function ModalFrame({
   throwWarning = false,
   show = false,
   onClose,
   title,
   children,
   width,
-}: ModalFrameProps) => {
+}: ModalFrameProps) {
   const {t} = useTranslation('loris');
 
   /**
@@ -224,7 +222,7 @@ const ModalFrame = ({
       </div>
     </div>
   );
-};
+}
 
 const headerStyle: CSSProperties = {
   display: 'flex',

--- a/jsx/Modal.tsx
+++ b/jsx/Modal.tsx
@@ -46,6 +46,7 @@ function Modal({
 export type FormModalProps<T> = Omit<ModalProps, 'footer'> & {
   onSubmit: () => Promise<T>;
   onSuccess?: (data: T) => void;
+  submitDisabled?: boolean;
 };
 
 /**
@@ -60,6 +61,7 @@ export function FormModal<T>({
   onClose,
   onSubmit,
   onSuccess,
+  submitDisabled = false,
   title,
   children,
   width,
@@ -73,6 +75,8 @@ export function FormModal<T>({
    * `onSubmit` and handling modal state based on success or failure.
    */
   const handleSubmit = async () => {
+    if (submitDisabled) return;
+
     setLoading(true); // Show loader
 
     try {
@@ -92,7 +96,11 @@ export function FormModal<T>({
 
   const submitFooter = !(loading || success) && (
     <div style={footerSubmitStyle}>
-      <button type='submit' className='btn btn-primary'>
+      <button
+        type='submit'
+        className='btn btn-primary'
+        disabled={submitDisabled}
+      >
         {t('Save')}
       </button>
     </div>

--- a/jsx/TriggerableModal.tsx
+++ b/jsx/TriggerableModal.tsx
@@ -1,10 +1,13 @@
 import React, {useState, ElementType} from 'react';
-import Modal, {ModalProps} from 'Modal';
+import Modal, {FormModal, ModalProps, FormModalProps} from 'Modal';
 import Form from 'jsx/Form';
 
-interface TriggerableModalProps extends Omit<ModalProps, 'show' | 'onClose'> {
+interface TriggerableModalProps
+  extends Omit<ModalProps, 'show' | 'onClose'> {
   label: string; // Label for the default CTA trigger button
   onClose?: ModalProps['onClose'];
+  onSubmit?: FormModalProps['onSubmit'];
+  onSuccess?: FormModalProps['onSuccess'];
   onUserInput?: () => void; // Optional callback when the trigger is activated
   TriggerTag?: ElementType; // Custom component for the modal trigger
 }
@@ -49,7 +52,16 @@ const TriggerableModal = ({
   return (
     <>
       {trigger}
-      <Modal {...modalProps} show={open} onClose={handleClose} />
+      {modalProps.onSubmit ? (
+        <FormModal
+          {...modalProps}
+          onSubmit={modalProps.onSubmit}
+          show={open}
+          onClose={handleClose}
+        />
+      ) : (
+        <Modal {...modalProps} show={open} onClose={handleClose} />
+      )}
     </>
   );
 };

--- a/jsx/TriggerableModal.tsx
+++ b/jsx/TriggerableModal.tsx
@@ -2,12 +2,12 @@ import React, {useState, ElementType} from 'react';
 import Modal, {FormModal, ModalProps, FormModalProps} from 'Modal';
 import Form from 'jsx/Form';
 
-interface TriggerableModalProps
+interface TriggerableModalProps<T>
   extends Omit<ModalProps, 'show' | 'onClose'> {
   label: string; // Label for the default CTA trigger button
-  onClose?: ModalProps['onClose'];
-  onSubmit?: FormModalProps['onSubmit'];
-  onSuccess?: FormModalProps['onSuccess'];
+  onClose?: () => void;
+  onSubmit?: () => Promise<T>;
+  onSuccess?: (data: T) => void;
   onUserInput?: () => void; // Optional callback when the trigger is activated
   TriggerTag?: ElementType; // Custom component for the modal trigger
 }
@@ -18,12 +18,12 @@ interface TriggerableModalProps
  * Renders a modal triggered by a custom or default CTA component, with `show`
  * controlled internally.
  */
-const TriggerableModal = ({
+function TriggerableModal<T>({
   label,
   onUserInput,
   TriggerTag = Form.CTA, // Default trigger component is CTA
   ...modalProps // Spread other modal-related props to pass to Modal
-}: TriggerableModalProps) => {
+}: TriggerableModalProps<T>) {
   const [open, setOpen] = useState(false);
 
   /**
@@ -64,6 +64,6 @@ const TriggerableModal = ({
       )}
     </>
   );
-};
+}
 
 export default TriggerableModal;

--- a/modules/biobank/jsx/batchEditForm.js
+++ b/modules/biobank/jsx/batchEditForm.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import {withTranslation} from 'react-i18next';
 import SpecimenProcessForm from './processForm';
 import {VerticalTabs, TabPane} from 'Tabs';
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import Loader from 'Loader';
 import {mapFormOptions, clone, isEmpty} from './helpers.js';
 import {
@@ -484,11 +484,11 @@ class BatchEditForm extends React.PureComponent {
     ) : null;
 
     return (
-      <Modal
+      <FormModal
         title={t('Edit Specimens', {ns: 'biobank'})}
         show={this.props.show}
         onClose={handleClose}
-        onSubmit={Object.keys(list).length > 1 && handleSubmit}
+        onSubmit={Object.keys(list).length > 1 ? handleSubmit : undefined}
         throwWarning={true}
       >
         <div className='row'>
@@ -533,7 +533,7 @@ class BatchEditForm extends React.PureComponent {
             {editForms}
           </div>
         </div>
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/modules/biobank/jsx/batchEditForm.js
+++ b/modules/biobank/jsx/batchEditForm.js
@@ -488,7 +488,8 @@ class BatchEditForm extends React.PureComponent {
         title={t('Edit Specimens', {ns: 'biobank'})}
         show={this.props.show}
         onClose={handleClose}
-        onSubmit={Object.keys(list).length > 1 ? handleSubmit : undefined}
+        onSubmit={handleSubmit}
+        submitDisabled={Object.keys(list).length <= 1}
         throwWarning={true}
       >
         <div className='row'>

--- a/modules/biobank/jsx/batchProcessForm.js
+++ b/modules/biobank/jsx/batchProcessForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {withTranslation} from 'react-i18next';
 import SpecimenProcessForm from './processForm';
 import {VerticalTabs, TabPane} from 'Tabs';
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import Loader from 'Loader';
 import {mapFormOptions, clone, isEmpty} from './helpers.js';
 import {
@@ -325,7 +325,7 @@ class BatchProcessForm extends React.PureComponent {
       });
     };
     return (
-      <Modal
+      <FormModal
         title={t('Process Specimens', {ns: 'biobank'})}
         show={this.props.show}
         onClose={handleClose}
@@ -333,7 +333,7 @@ class BatchProcessForm extends React.PureComponent {
         throwWarning={true}
       >
         {form}
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/modules/biobank/jsx/containerForm.js
+++ b/modules/biobank/jsx/containerForm.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {withTranslation} from 'react-i18next';
 
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import {ListForm, ListItem} from './listForm.js';
 import {
   SelectElement,
@@ -78,8 +78,8 @@ class ContainerForm extends Component {
     const {options, show} = this.props;
     const handleClose = () => this.setState(initialState, this.props.onClose);
     return (
-      <Modal
-        title={t('Add New Container', {ns: 'biobank'})}
+      <FormModal
+        title={t('Add New Container')}
         show={show}
         onClose={handleClose}
         onSubmit={this.handleSubmit}
@@ -106,7 +106,7 @@ class ContainerForm extends Component {
         >
           <ContainerSubForm options={options} t={t}/>
         </ListForm>
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/modules/biobank/jsx/globals.js
+++ b/modules/biobank/jsx/globals.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 import {mapFormOptions} from './helpers.js';
 
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import Loader from 'Loader';
 import {
   SelectElement,
@@ -308,7 +308,7 @@ function Globals(props) {
                 </span>
               </div>
               <div>
-                <Modal
+                <FormModal
                   title={t('Update Parent Container', {ns: 'biobank'})}
                   onClose={props.clearAll}
                   show={editable.containerParentForm}
@@ -323,7 +323,7 @@ function Globals(props) {
                     setContainer={props.setContainer}
                     setCurrent={props.setCurrent}
                   />
-                </Modal>
+                </FormModal>
               </div>
             </div>
           );

--- a/modules/biobank/jsx/header.js
+++ b/modules/biobank/jsx/header.js
@@ -5,7 +5,7 @@ import {
   TextboxElement,
   DateElement,
 } from 'jsx/Form';
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import LifeCycle from './lifeCycle.js';
 import SpecimenForm from './specimenForm.js';
 import {clone} from './helpers.js';
@@ -109,7 +109,7 @@ class Header extends Component {
     };
 
     const lotForm = (
-      <Modal
+      <FormModal
         title={this.props.t('Edit Lot Number', {ns: 'biobank'})}
         onClose={this.props.clearAll}
         show={editable.lotForm}
@@ -121,11 +121,11 @@ class Header extends Component {
           onUserInput={this.props.setContainer}
           value={current.container.lotNumber}
         />
-      </Modal>
+      </FormModal>
     );
 
     const expirationForm = (
-      <Modal
+      <FormModal
         title={this.props.t('Edit Expiration Date', {ns: 'biobank'})}
         onClose={this.props.clearAll}
         show={editable.expirationForm}
@@ -137,7 +137,7 @@ class Header extends Component {
           onUserInput={this.props.setContainer}
           value={current.container.expirationDate}
         />
-      </Modal>
+      </FormModal>
     );
 
     const parentBarcodes = this.props.getParentContainerBarcodes(container);

--- a/modules/biobank/jsx/poolSpecimenForm.js
+++ b/modules/biobank/jsx/poolSpecimenForm.js
@@ -1,4 +1,4 @@
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import {withTranslation} from 'react-i18next';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
@@ -324,7 +324,7 @@ class PoolSpecimenForm extends React.Component {
       );
     };
     return (
-      <Modal
+      <FormModal
         title={t('Pool Specimens', {ns: 'biobank'})}
         show={this.props.show}
         onClose={handleClose}
@@ -332,7 +332,7 @@ class PoolSpecimenForm extends React.Component {
         throwWarning={true}
       >
         {form}
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/modules/biobank/jsx/shipmentTab.js
+++ b/modules/biobank/jsx/shipmentTab.js
@@ -6,7 +6,7 @@ import {Link} from 'react-router-dom';
 import FilterableDataTable from '../../../jsx/FilterableDataTable'; // Temporary CBIGR Override for 26.0
 import {UseShipment} from './Shipment';
 // import Container from './Container';
-import Modal from '../../../jsx/Modal'; // Temporary CBIGR Override for 26.0
+import {FormModal} from '../../../jsx/Modal'; // Temporary CBIGR Override for 26.0
 import TriggerableModal from '../../../jsx/TriggerableModal'; // Temporary CBIGR Override for 26.0
 
 import {
@@ -433,7 +433,7 @@ function CreateShipment({
   }, [shipment.containerIds]);
 
   return (
-    <Modal
+    <FormModal
       show={show}
       title={t('Create Shipment', {ns: 'biobank'})}
       onSubmit={onSubmit}
@@ -486,7 +486,7 @@ function CreateShipment({
         errors={errors.logs[logIndex]}
         users={users}
       />
-    </Modal>
+    </FormModal>
   );
 }
 

--- a/modules/biobank/jsx/specimenForm.js
+++ b/modules/biobank/jsx/specimenForm.js
@@ -3,7 +3,7 @@ import {withTranslation} from 'react-i18next';
 import SpecimenProcessForm from './processForm';
 import ContainerParentForm from './containerParentForm';
 import {ListForm, ListItem} from './listForm';
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import {mapFormOptions, clone} from './helpers.js';
 import {
   SearchableDropdown,
@@ -326,7 +326,7 @@ class SpecimenForm extends React.Component {
 
     const handleClose = () => this.setState(initialState, this.props.onClose);
     return (
-      <Modal
+      <FormModal
         title={this.props.title}
         show={this.props.show}
         onClose={handleClose}
@@ -376,7 +376,7 @@ class SpecimenForm extends React.Component {
           onUserInput={(name, value) => this.setState({[name]: value})}
           value={this.state.printBarcodes}
         />
-      </Modal>
+      </FormModal>
     );
   }
 }

--- a/modules/data_release/jsx/managePermissionsForm.js
+++ b/modules/data_release/jsx/managePermissionsForm.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'jsx/Loader';
 import swal from 'sweetalert2';
-import Modal from 'Modal';
+import {FormModal} from 'Modal';
 import {withTranslation} from 'react-i18next';
 import {
   CheckboxElement,
@@ -86,7 +86,7 @@ class ManagePermissionsForm extends Component {
     }
 
     return (
-      <Modal
+      <FormModal
         title={t('Manage Permissions', {ns: 'data_release'})}
         label={t('Manage Permissions', {ns: 'data_release'})}
         show={this.props.show}
@@ -161,7 +161,7 @@ class ManagePermissionsForm extends Component {
             )}
           />
         }
-      </Modal>
+      </FormModal>
     );
   }
 

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 import FilterableSelectGroup from './components/filterableselectgroup';
-import Modal from 'jsx/Modal';
+import {FormModal} from 'jsx/Modal';
 import Select from 'react-select';
 import swal from 'sweetalert2';
 import {
@@ -282,7 +282,7 @@ function AddFilterModal(props: {
     }
     );
   return (
-    <Modal title={t('Add Condition', {ns: 'dataquery'})}
+    <FormModal title={t('Add Condition', {ns: 'dataquery'})}
       show={true}
       throwWarning={true}
       onClose={props.closeModal}
@@ -311,7 +311,7 @@ function AddFilterModal(props: {
         {criteriaSelect}
         {visitSelect}
       </div>
-    </Modal>
+    </FormModal>
   );
 }
 

--- a/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
+++ b/modules/dataquery/jsx/definefilters.importcsvmodal.tsx
@@ -1,4 +1,4 @@
-import Modal from 'jsx/Modal';
+import {FormModal} from 'jsx/Modal';
 import {QueryGroup, QueryTerm} from './querydef';
 import {useState} from 'react';
 import Papa from 'papaparse';
@@ -164,7 +164,7 @@ function ImportCSVModal(props: {
     marginTop: '1em',
   };
 
-  return <Modal title={t('Import Population From CSV', {ns: 'dataquery'})}
+  return <FormModal title={t('Import Population From CSV', {ns: 'dataquery'})}
     show={true}
     throwWarning={true}
     onClose={props.closeModal}
@@ -241,7 +241,7 @@ function ImportCSVModal(props: {
         </dl>
       </div>
     </fieldset>
-  </Modal>;
+  </FormModal>;
 }
 
 export default ImportCSVModal;

--- a/modules/dataquery/jsx/welcome.adminquerymodal.tsx
+++ b/modules/dataquery/jsx/welcome.adminquerymodal.tsx
@@ -1,4 +1,4 @@
-import Modal from 'jsx/Modal';
+import {FormModal} from 'jsx/Modal';
 import swal from 'sweetalert2';
 import {useState} from 'react';
 import {CheckboxElement, TextboxElement, FieldsetElement} from 'jsx/Form';
@@ -67,7 +67,7 @@ function AdminQueryModal(props: {
     }
     return sbmt;
   };
-  return <Modal title={t('Pin Top Query', {ns: 'dataquery'})}
+  return <FormModal title={t('Pin Top Query', {ns: 'dataquery'})}
     show={true}
     throwWarning={true}
     onClose={props.closeModal}
@@ -105,7 +105,7 @@ function AdminQueryModal(props: {
         }
       />
     </FieldsetElement>
-  </Modal>;
+  </FormModal>;
 }
 
 export default AdminQueryModal;

--- a/modules/dataquery/jsx/welcome.namequerymodal.tsx
+++ b/modules/dataquery/jsx/welcome.namequerymodal.tsx
@@ -1,4 +1,4 @@
-import Modal from 'jsx/Modal';
+import {FormModal} from 'jsx/Modal';
 import swal from 'sweetalert2';
 import {useState} from 'react';
 import {TextboxElement, FieldsetElement} from 'jsx/Form';
@@ -44,7 +44,7 @@ function NameQueryModal(props: {
     }
     return sbmt;
   };
-  return <Modal title={t('Name Query', {ns: 'dataquery'})}
+  return <FormModal title={t('Name Query', {ns: 'dataquery'})}
     show={true}
     throwWarning={true}
     onClose={props.closeModal}
@@ -59,7 +59,7 @@ function NameQueryModal(props: {
         }
       />
     </FieldsetElement>
-  </Modal>;
+  </FormModal>;
 }
 
 export default NameQueryModal;

--- a/modules/instrument_manager/jsx/instrumentManagerIndex.js
+++ b/modules/instrument_manager/jsx/instrumentManagerIndex.js
@@ -8,7 +8,7 @@ import FilterableDataTable from 'FilterableDataTable';
 
 import InstrumentUploadForm from './uploadForm';
 
-import Modal from 'jsx/Modal';
+import {FormModal} from 'jsx/Modal';
 import InfoPanel from 'jsx/InfoPanel';
 
 import Select from 'react-select';
@@ -231,7 +231,7 @@ class InstrumentManagerIndex extends Component {
           });
       };
 
-      permsModal = (<Modal
+      permsModal = (<FormModal
         title={t('Edit Permissions for {{instrument}}', {
           ns: 'instrument_manager',
           instrument: this.state.modifyPermissions.instrument,
@@ -278,7 +278,7 @@ class InstrumentManagerIndex extends Component {
             this.setState({modifyPermissions});
           }}
         />
-      </Modal>);
+      </FormModal>);
     }
     if (this.props.hasPermission('instrument_manager_write')) {
       tabs.push({id: 'upload', label: t('Upload', {ns: 'loris'})});


### PR DESCRIPTION
## Description

This PR refactors the LORIS modal to make two major changes:
- Separate form and non-form general modals into separate reusable components.
- Make modal footers optional and allow consumers to provide their own footer for the generic modal.

## Architecture

- The `Modal` component from `jsx/Modals.tsx` is split into three components:
  - `Modal`: The general non-form modal, which allows the consumer to provide the body and optionally the footer.
  - `FormModal`: The form modal, which is similar to the current modal and provides form and submit logic/controls.
  - `ModalFrame`: common architecture between the two modals, technically `FormModal` could also be made to depend directly upon `Modal` but this would require some higher-order component machinery because the form body and content should both be wrapper in a `form` element, and this wrapper is undesirable in the general case.
- The styling relies less on bootstrap and more on flexbox for layout.
- The modals can be scrollable, not sure if that was the case before or not.

## Examples

**Showcase of existing modal behavior:** (added artificial delay to showcase animations)

https://github.com/user-attachments/assets/107d1416-613e-4436-94f2-29b47ee3290d

**Showcase of new non-form modals with custom footers**:

https://github.com/user-attachments/assets/6df24f1c-048d-4864-8d71-8ec5667c505c