### PR TITLE
Fix Behavioural QC feedback status and links

### DIFF
--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -5,6 +5,26 @@ import FilterableDataTable from 'jsx/FilterableDataTable';
 import {withTranslation} from 'react-i18next';
 
 /**
+ * Build a URL with query parameters.
+ *
+ * @param {string} baseURL - LORIS base URL.
+ * @param {string} path - The URL path.
+ * @param {object} params - Query parameters to append.
+ * @return {string} the URL with query parameters.
+ */
+const buildURL = (baseURL, path, params) => {
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.append(key, value);
+    }
+  });
+
+  return baseURL + path + (query.toString() ? '?' + query.toString() : '');
+};
+
+/**
  * Behavioural Feedback Component.
  *
  * @description Behavioural Quality Control 'Behavioural Feedback' tab.
@@ -88,6 +108,7 @@ class BehaviouralFeedback extends Component {
     const labelInstrument = t('Instrument', {ns: 'loris', count: 1});
     const labelTestName = t('Test Name', {ns: 'behavioural_qc'});
     const labelVisit = t('Visit', {ns: 'loris'});
+    const candID = rowData[labelDCCID];
 
     // PSCID column (match English or translated)
     if (column === 'PSCID' || column === labelPSCID) {
@@ -117,26 +138,64 @@ class BehaviouralFeedback extends Component {
     if (column === 'Feedback Level' || column === labelBVL) {
       let bvlLink = '';
       let bvlLevel = '';
-      if (rowData[labelInstrument]) {
-        bvlLink = this.props.baseURL +
-                  '/instruments/' +
-                  rowData[labelTestName] +
-                  '/?candID=' + rowData[labelDCCID] +
-                  '&sessionID=' + rowData['sessionID'] +
-                  '&commentID=' + rowData['commentID'] +
-                  '&showFeedback=true';
+      const feedbackLevel = rowData[labelBVL];
+      const sessionID = rowData['sessionID'];
+      const commentID = rowData['commentID'];
+      const testName = rowData[labelTestName];
+      const instrument = rowData[labelInstrument] || testName || commentID;
+      const hasSession = sessionID !== undefined
+        && sessionID !== null
+        && sessionID !== ''
+        && sessionID !== 0
+        && sessionID !== '0';
+
+      if (feedbackLevel === 'instrument') {
+        if (hasSession) {
+          bvlLink = buildURL(
+            this.props.baseURL,
+            '/instrument_list/',
+            {
+              candID,
+              sessionID,
+              commentID,
+              showFeedback: true,
+            }
+          );
+        } else {
+          bvlLink = buildURL(
+            this.props.baseURL,
+            '/' + candID + '/',
+            {showFeedback: true}
+          );
+        }
         bvlLevel = labelInstrument + ' : '
-        + rowData[labelInstrument];
-      } else if (rowData[labelVisit]) {
-        bvlLink = this.props.baseURL +
-                  '/instrument_list/?candID=' + rowData[labelDCCID] +
-                  '&sessionID=' + rowData['sessionID'] +
-                  '&showFeedback=true';
+        + instrument;
+      } else if (feedbackLevel === 'visit') {
+        if (hasSession) {
+          bvlLink = buildURL(
+            this.props.baseURL,
+            '/instrument_list/',
+            {
+              candID,
+              sessionID,
+              showFeedback: true,
+            }
+          );
+        } else {
+          bvlLink = buildURL(
+            this.props.baseURL,
+            '/' + candID + '/',
+            {showFeedback: true}
+          );
+        }
         bvlLevel = labelVisit + ' : '
         + rowData[labelVisit];
       } else {
-        bvlLink = this.props.baseURL + '/' + rowData[labelDCCID]
-        + '/?showFeedback=true';
+        bvlLink = buildURL(
+          this.props.baseURL,
+          '/' + candID + '/',
+          {showFeedback: true}
+        );
         bvlLevel = t('Profile', {ns: 'behavioural_qc'}) + ' : '
         + rowData[labelPSCID];
       }

--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -16,7 +16,7 @@ const buildURL = (baseURL, path, params) => {
   const query = new URLSearchParams();
 
   Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') {
+    if (value) {
       query.append(key, value);
     }
   });

--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -143,11 +143,7 @@ class BehaviouralFeedback extends Component {
       const commentID = rowData['commentID'];
       const testName = rowData[labelTestName];
       const instrument = rowData[labelInstrument] || testName || commentID;
-      const hasSession = sessionID !== undefined
-        && sessionID !== null
-        && sessionID !== ''
-        && sessionID !== 0
-        && sessionID !== '0';
+      const hasSession = !!sessionID && sessionID !== '0';
 
       if (feedbackLevel === 'instrument') {
         if (hasSession) {

--- a/modules/behavioural_qc/php/provisioners/behaviouralprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/behaviouralprovisioner.class.inc
@@ -1,9 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * Behavioural QC data provisioner for behavioural feedback.
+ *
+ * PHP version 7
+ *
+ * @category Behavioural
+ * @package  Loris
+ * @author   Xavier Lecours <xavier.lecours@mcin.ca>
+ *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris-Trunk
+ */
 namespace LORIS\behavioural_qc\Provisioners;
 
 /**
- * TThis class implements a data provisioner to get all feedback level
+ * This class implements a data provisioner to get all feedback level
  * of visits.
  *
  * PHP version 7
@@ -49,7 +61,7 @@ class BehaviouralProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisione
                 LEFT JOIN test_names tn ON (tn.ID = f.TestID)
             WHERE
                 fb.Public = 'Y'
-                AND fb.Status = 'opened'
+                AND fb.Status <> 'closed'
                 AND fb.active = 'Y'
             ",
             [],

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -338,7 +338,11 @@ class Instrument_List extends \NDB_Menu_Filter
      */
     function getFeedbackPanel(CandID $candID, ?\SessionID $sessionID): string
     {
-        $feedbackPanel = new \BVL_Feedback_Panel($candID, $sessionID);
+        $feedbackPanel = new \BVL_Feedback_Panel(
+            $candID,
+            $sessionID,
+            $this->commentID ?: null
+        );
         $html          =  $feedbackPanel->display();
         return $html;
     }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -564,7 +564,7 @@ class NDB_BVL_Feedback
                          ON (c.ID=ft.CandidateID)
                      LEFT JOIN session as s
                          ON (s.ID = ft.SessionID)
-                     JOIN feedback_bvl_type as ftp
+                     LEFT JOIN feedback_bvl_type as ftp
                          ON (ftp.Feedback_type=ft.Feedback_type)";
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query .= ", flag as f LEFT JOIN test_names tn ON (tn.ID=f.TestID)";
@@ -574,7 +574,7 @@ class NDB_BVL_Feedback
         // cause SQL syntax errors on any code paths.
         // This would make more sense to put in an array and then
         // call "join($arrayname, ", ") at the end to construct the string.
-        $query .= " WHERE ftp.Feedback_type = ft.Feedback_type";
+        $query .= " WHERE 1=1";
 
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query           .= " AND ft.SessionID = :SID";

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -564,26 +564,23 @@ class NDB_BVL_Feedback
                          ON (c.ID=ft.CandidateID)
                      LEFT JOIN session as s
                          ON (s.ID = ft.SessionID)
-                     JOIN feedback_bvl_type as ftp
+                     LEFT JOIN feedback_bvl_type as ftp
                          ON (ftp.Feedback_type=ft.Feedback_type)";
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query .= ", flag as f LEFT JOIN test_names tn ON (tn.ID=f.TestID)";
         }
 
-        // FIXME: This clause is kept here so that the ANDs below don't
-        // cause SQL syntax errors on any code paths.
-        // This would make more sense to put in an array and then
-        // call "join($arrayname, ", ") at the end to construct the string.
-        $query .= " WHERE ftp.Feedback_type = ft.Feedback_type";
+        $where = [];
 
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
-            $query           .= " AND ft.SessionID = :SID";
-            $query           .= " AND ft.CommentID = :ComID
-                                  AND ft.CommentID = f.CommentID";
+            $where[]          = "ft.SessionID = :SID";
+            $where[]          = "ft.CommentID = :ComID";
+            $where[]          = "ft.CommentID = f.CommentID";
             $qparams['SID']   = $this->_feedbackCandidateProfileInfo['SessionID'];
             $qparams['ComID'] = $this->_feedbackObjectInfo['CommentID'];
         } elseif (!empty($this->_feedbackObjectInfo['SessionID'])) {
-            $query            .= " AND ft.SessionID = :SID AND ft.CommentID is null";
+            $where[]           = "ft.SessionID = :SID";
+            $where[]           = "ft.CommentID is null";
             $qparams['SID']    = $this->_feedbackObjectInfo['SessionID'];
             $timepoint         = TimePoint::singleton(
                 new SessionID(strval($qparams['SID']))
@@ -593,9 +590,9 @@ class NDB_BVL_Feedback
                 $timepoint->isAccessibleBy($user)
             );
         } elseif (!empty($this->_feedbackObjectInfo['CandID'])) {
-            $query            .= " AND c.CandID = :CaID
-                                 AND ft.SessionID IS NULL
-                                 AND ft.CommentID IS NULL";
+            $where[]           = "c.CandID = :CaID";
+            $where[]           = "ft.SessionID IS NULL";
+            $where[]           = "ft.CommentID IS NULL";
             $qparams['CaID']   = $this->_feedbackObjectInfo['CandID'];
             $candidate         = Candidate::singleton(
                 new CandID(strval($qparams['CaID']))
@@ -614,16 +611,16 @@ class NDB_BVL_Feedback
         // DCC users should be able to see THEIR OWN inactive threads,
         // other users should see only active threads
         if ($hasReadPermission) {
-            $query .= " AND (ft.Active='Y' OR
-                (ft.Active='N' AND ft.UserID=:Username)
-            )";
+            $where[] = "(ft.Active='Y' OR
+                (ft.Active='N' AND ft.UserID=:Username))";
             $qparams['Username'] = $this->_username;
         } else {
-            $query            .= " AND ft.Active ='Y'
-                                   AND FIND_IN_SET(s.CenterID, :CentID)";
+            $where[]           = "ft.Active ='Y'";
+            $where[]           = "FIND_IN_SET(s.CenterID, :CentID)";
             $qparams['CentID'] = implode(',', $user->getCenterIDs());
         }
 
+        $query .= " WHERE " . implode(" AND ", $where);
         $query .= " ORDER BY c.CandID,
                              ft.Feedback_level,
                              ft.Status,
@@ -653,12 +650,10 @@ class NDB_BVL_Feedback
                   fe.Comment,
                   fe.UserID as UserID,
                   DATE_FORMAT(fe.Testdate, '%Y-%m-%d %H:%i:%s') as Date
-             FROM feedback_bvl_thread as ft,
-                  feedback_bvl_entry as fe,
-                  feedback_bvl_type as ftp
+             FROM feedback_bvl_thread as ft
+                  JOIN feedback_bvl_entry as fe
+                      ON (ft.FeedbackID = fe.FeedbackID)
              WHERE ft.FeedbackID = :FID
-                   AND ft.FeedbackID = fe.FeedbackID
-                   AND ft.Feedback_type = ftp.Feedback_type
              ORDER BY ft.FeedbackID, fe.Testdate ASC";
 
         $result = $db->pselect($query, ['FID' => $feedbackID]);

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -564,7 +564,7 @@ class NDB_BVL_Feedback
                          ON (c.ID=ft.CandidateID)
                      LEFT JOIN session as s
                          ON (s.ID = ft.SessionID)
-                     LEFT JOIN feedback_bvl_type as ftp
+                     JOIN feedback_bvl_type as ftp
                          ON (ftp.Feedback_type=ft.Feedback_type)";
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query .= ", flag as f LEFT JOIN test_names tn ON (tn.ID=f.TestID)";
@@ -574,7 +574,7 @@ class NDB_BVL_Feedback
         // cause SQL syntax errors on any code paths.
         // This would make more sense to put in an array and then
         // call "join($arrayname, ", ") at the end to construct the string.
-        $query .= " WHERE 1=1";
+        $query .= " WHERE ftp.Feedback_type = ft.Feedback_type";
 
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query           .= " AND ft.SessionID = :SID";


### PR DESCRIPTION
## Brief summary of changes

- Hides closed behavioural feedback threads from the Behavioural QC feedback table.
- Routes instrument-level feedback links through `instrument_list` with `commentID` and `showFeedback=true`.
- Passes `commentID` into the instrument list feedback panel so BMI instrument feedback opens the correct thread.
- Keeps feedback threads visible even when the feedback type lookup row is missing.

#### Testing instructions

- Open `http://localhost:8080/behavioural_qc/#tabBehaviouralFeedback`.
- Confirm active/non-closed feedback rows appear in the Behavioural Feedback table.
- Open the BMI feedback row for `300017 / MTL017 / BMI Calculator` and confirm it opens `instrument_list`, not `/instruments/bmi/`.
- Confirm the feedback panel opens and shows the BMI thread.
- Close that thread, refresh Behavioural QC, and confirm the closed row no longer appears.

#### Link(s) to related issue(s)

* Resolves #10268