### PR TITLE
Fix DQT not fetching image acquisition data

### DIFF
--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -478,8 +478,10 @@ abstract class SQLQueryEngine implements QueryEngine
                             } else {
                                 // It is many, so use an array
 
-                                // The question marks in the field name need to be
-                                // quoted (see function getCandidateData)
+                                // The question marks in the field names were quoted (i.e doubled, see
+                                // function getCandidateData) in order for PDO *not* to interpret
+                                // them as SQL parameter placeholders so we have to perform the
+                                // quoting here also (see https://www.php.net/manual/en/pdo.prepare.php).
                                 $quotedFieldName = str_replace('?', '??', $field->getName());
                                 $key = $row[$quotedFieldName . ':key'];
                                 $val = $this->displayValue($field, $row[$quotedFieldName]);

--- a/src/Data/Query/SQLQueryEngine.php
+++ b/src/Data/Query/SQLQueryEngine.php
@@ -477,8 +477,13 @@ abstract class SQLQueryEngine implements QueryEngine
                                                          ];
                             } else {
                                 // It is many, so use an array
-                                $key = $row[$field->getName() . ':key'];
-                                $val = $this->displayValue($field, $row[$fname]);
+
+                                // The question marks in the field name need to be
+                                // quoted (see function getCandidateData)
+                                $quotedFieldName = str_replace('?', '??', $field->getName());
+                                $key = $row[$quotedFieldName . ':key'];
+                                $val = $this->displayValue($field, $row[$quotedFieldName]);
+
                                 // A null val in a cardinality many column means the row came from a left join
                                 // and shouldn't be included (as opposed to a cardinality:optional where it
                                 // means that the value was the value null)


### PR DESCRIPTION
This PR fixes a bug that prevents the DQT from fetching the entire set of imaging acquisition data. See issue #10631 for a complete description of the bug and how to test this PR.
