### PR TITLE
[modules | media] Fix media upload error handling for non-JSON server responses

### DIFF
--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -355,6 +355,7 @@ class MediaUploadForm extends Component {
             msg = JSON.parse(xhr.response).message;
           } catch (e) {
             // Ignore non-JSON responses.
+            console.warn('Upload response was not valid JSON', e);
           }
         }
 

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -345,16 +345,17 @@ class MediaUploadForm extends Component {
       } else {
         let msg = this.props.t('Upload error!', {ns: 'media'});
 
-        if (xhr.response) {
-          if (xhr.statusText) {
-            msg = JSON.parse(xhr.response).message;
-          }
-        }
         if (xhr.status === 409) {
           msg = this.props.t('A file with the same name already exists!',
             {ns: 'media'});
         } else if (xhr.status === 413) {
           msg = this.props.t('File too large!', {ns: 'media'});
+        } else if (xhr.response) {
+          try {
+            msg = JSON.parse(xhr.response).message;
+          } catch (e) {
+            // Ignore non-JSON responses.
+          }
         }
 
         this.setState({


### PR DESCRIPTION
closes #10659 

### Situation

Uploading a file larger than the configured limit in the LORIS Media module caused the browser to freeze and show JavaScript stack traces. The initial assumption was that the backend was failing, but the actual failure mode was in the frontend response handling.

### Task

Identify the root cause of the upload failure, verify it against the nginx-based VM behavior, and update the upload flow so it can safely handle non-JSON error responses.

### Action

I reproduced the issue on the test VM, confirmed that oversized uploads were rejected by nginx with an HTML 413 response as shown in the screenshot, and traced the crash to unconditional `JSON.parse()` calls in the upload handler. I updated the logic to parse responses defensively with `try/catch.
<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/b2d22847-176d-404e-84af-d26fa27af725" />


### Result

The frontend should not freeze or crash when the server returns HTML instead of JSON. Oversized uploads now fall back to the default error message.

## Testing Instructions for a VM with nginx

1. Confirm the VM is using nginx and has the expected upload limit configured.
2. Open the Media upload page.
3. Upload a file larger than the configured limit.
4. Upload the file using the expected filename convention so the frontend accepts it.
5. Verify that nginx returns `413 Request Entity Too Large` and that the response body is HTML.
6. Confirm the browser does not throw `Unexpected token '<'` in the console.
7. Confirm the upload flow shows the default error message instead of freezing.