### PR TITLE
[tools] lorisform_parser multilingual domain

### DIFF
--- a/php/libraries/NullModule.class.inc
+++ b/php/libraries/NullModule.class.inc
@@ -37,7 +37,7 @@ class NullModule extends Module
      * @param \LORIS\LorisInstance $loris The LORIS instance for this module.
      * @param string               $name  An optional name to use for this module.
      */
-    public function __construct(\LORIS\LorisInstance $loris, string $name='loris')
+    public function __construct(\LORIS\LorisInstance $loris, string $name='')
     {
         $this->longname = $name;
         parent::__construct($loris, $name, "");

--- a/php/libraries/NullModule.class.inc
+++ b/php/libraries/NullModule.class.inc
@@ -37,7 +37,7 @@ class NullModule extends Module
      * @param \LORIS\LorisInstance $loris The LORIS instance for this module.
      * @param string               $name  An optional name to use for this module.
      */
-    public function __construct(\LORIS\LorisInstance $loris, string $name='')
+    public function __construct(\LORIS\LorisInstance $loris, string $name='loris')
     {
         $this->longname = $name;
         parent::__construct($loris, $name, "");

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -53,7 +53,7 @@ foreach ($files as $file) {
     echo "Instantiating new object...\n";
     $obj =new $className(
         $lorisInstance,
-        new NullModule($lorisInstance),
+        new NullModule($lorisInstance, "loris"),
         "",
         "",
         "",


### PR DESCRIPTION
## Brief summary of changes

Forces lorisform_parser to use the "loris" domain/name.

#### Testing instructions (if applicable)

1. need backend access
2. run tools/lorisform_parser.

#### Link(s) to related issue(s)

* Resolves #10660