### PR TITLE
[redcap] API endpoint routing fix

### DIFF
--- a/modules/redcap/php/module.class.inc
+++ b/modules/redcap/php/module.class.inc
@@ -62,7 +62,7 @@ class Module extends \Module
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         //
-        $path = trim($request->getURI()->getPath(), "/");
+        $path = trim($request->getAttribute("unhandledURI")->getPath(), "/");
         switch ($path) {
         case 'notifications':
             $handler = new Endpoints\Notifications(


### PR DESCRIPTION
## Brief summary of changes

Redcap API endpoint modified `unhandledURI` path. 
Change was introduced for module endpoint in #10031

#### Testing instructions (if applicable)

1. send a request to `redcap/notifications` 

#### Link(s) to related issue(s)

* Resolves #10666
