### PR TITLE
[candidate_parameters] Add Consent Type and Consent Summary to pot file

### DIFF
--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -227,3 +227,10 @@ msgstr ""
 
 msgid "Comments: "
 msgstr ""
+
+# Widgets
+msgid "Consent Summary"
+msgstr ""
+
+msgid "Consent Type"
+msgstr ""


### PR DESCRIPTION
These strings exist in Japanese and Chinese translations and are referenced by the code, but are missing from the template file.
