### PR TITLE
[dataquery] Fix Candidate matches translations

### DIFF
--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -202,7 +202,7 @@ msgstr "वर्तमान क्वेरी"
 msgid "Note that only candidates which you have permission to access in LORIS are included in results. Number of results may vary from other users running the same query."
 msgstr "ध्यान दें कि केवल वे उम्मीदवार शामिल हैं जिन्हें LORIS में एक्सेस करने की आपको अनुमति है। परिणामों की संख्या अन्य उपयोगकर्ताओं से भिन्न हो सकती है।"
 
-msgid "Candidate matches"
+msgid "Candidate matches:"
 msgstr "उम्मीदवार मेल खाते हैं"
 
 msgid "Note: matches count only includes candidates that you have access to. Results may vary from other users due to permissions."

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -203,7 +203,7 @@ msgid "Note that only candidates which you have permission to access in LORIS ar
 msgstr "ध्यान दें कि केवल वे उम्मीदवार शामिल हैं जिन्हें LORIS में एक्सेस करने की आपको अनुमति है। परिणामों की संख्या अन्य उपयोगकर्ताओं से भिन्न हो सकती है।"
 
 msgid "Candidate matches:"
-msgstr "उम्मीदवार मेल खाते हैं"
+msgstr "उम्मीदवार मिलान:"
 
 msgid "Note: matches count only includes candidates that you have access to. Results may vary from other users due to permissions."
 msgstr "नोट: मेल गिनती केवल उन्हीं उम्मीदवारों को शामिल करती है जिन तक आपकी पहुँच है। अनुमतियों के कारण परिणाम अन्य उपयोगकर्ताओं से भिन्न हो सकते हैं।"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -211,9 +211,6 @@ msgstr "現在のクエリ"
 msgid "Note that only candidates which you have permission to access in LORIS are included in results. Number of results may vary from other users running the same query."
 msgstr "ロリスでアクセス権限を持つ候補のみが結果に含まれることにご注意ください。結果の数は、同じクエリを実行する他のユーザーによって異なる場合があります。"
 
-msgid "Candidate matches"
-msgstr "候補者の一致"
-
 msgid "Select Visits"
 msgstr "選択した訪問"
 

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -211,9 +211,6 @@ msgstr "当前查询"
 msgid "Note that only candidates which you have permission to access in LORIS are included in results. Number of results may vary from other users running the same query."
 msgstr "请注意，结果中仅包含您有权在 LORIS 中访问的受试者。结果数量可能会因其他用户运行相同查询的权限差异而有所不同。"
 
-msgid "Candidate matches"
-msgstr "受试者匹配项"
-
 msgid "Select Visits"
 msgstr "选择访视"
 


### PR DESCRIPTION
The code references "Candidate matches:" (with a colon), so remove or update the "Candidate matches" (without a colon) translations from language that have one, (depending on if there is another "Candidate matches:" translation already present.)
