### PR TITLE
[electrophysiology_browser] Add missing string to pot file

### DIFF
--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -616,3 +616,6 @@ msgstr ""
 
 msgid "View Session"
 msgstr ""
+
+msgid "Channel Types"
+msgstr ""


### PR DESCRIPTION
"Channel Types" is referenced in the french and japanese po files (and by the code) but missing from the template file.
