### PR TITLE
[imaging_browser] Fix po files

### DIFF
--- a/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
@@ -25,10 +25,8 @@ msgid "View Session"
 msgstr "सत्र देखें"
 
 msgid "New and pending imaging session"
-msgstr "नई और लंबित इमेजिंग सत्र"
-
-msgid "New and pending imaging sessions"
-msgstr "नई और लंबित इमेजिंग सत्रों"
+msgid_plural "New and pending imaging sessions"
+msgstr[0] "नई और लंबित इमेजिंग सत्रों"
 
 msgid "Visit QC Status"
 msgstr "विजिट QC स्थिति"

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -28,6 +28,9 @@ msgid "New and pending imaging session"
 msgid_plural "New and pending imaging sessions"
 msgstr[0] ""
 
+msgid "Imaging QC Summary"
+msgstr ""
+
 msgid "Imaging Session"
 msgid_plural "Imaging Sessions"
 msgstr[0] ""

--- a/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/ja/LC_MESSAGES/imaging_browser.po
@@ -26,10 +26,8 @@ msgid "View Session"
 msgstr "セッションを見る"
 
 msgid "New and pending imaging session"
-msgstr "新規および保留中のMRI セッション"
-
-msgid "New and pending imaging sessions"
-msgstr "新規および保留中のMRI セッション"
+msgid_plural "New and pending imaging sessions"
+msgstr[0] "新規および保留中のMRI セッション"
 
 msgid "Imaging Session"
 msgid_plural "Imaging Sessions"

--- a/modules/imaging_browser/locale/zh/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/zh/LC_MESSAGES/imaging_browser.po
@@ -26,10 +26,8 @@ msgid "View Session"
 msgstr "查看会话"
 
 msgid "New and pending imaging session"
-msgstr "新的及待处理的成像会话"
-
-msgid "New and pending imaging sessions"
-msgstr "新的及待处理的成像会话"
+msgid_plural "New and pending imaging sessions"
+msgstr[0] "新的及待处理的成像会话"
 
 msgid "Imaging Session"
 msgid_plural "Imaging Sessions"


### PR DESCRIPTION
Imaging QC Summary existed in Japanese and Chinese translations but not in the pot.

"New and pending imaging sessions" was incorrectly a msgid instead of msgid_plural for some languages.
