### PR TITLE
[imaging_uploader] Fix po files for imaging_uploader

### DIFF
--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -48,7 +48,7 @@ msgstr "Le fichier doit être en format .tgz, tar.gz ou .zip."
 msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr ""
 "Pour les fichiers qui ne sont pas des scans fantômes, le nom du fichier doit "
-"commencer par {{prefix}}"
+"commencer par <0>{{prefix}}</0>"
 
 #, fuzzy
 msgid ""

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -45,10 +45,10 @@ msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr "Le fichier doit être en format .tgz, tar.gz ou .zip."
 
 #, fuzzy
-msgid "For files that are not Phantom Scans, file name must begin with"
+msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr ""
 "Pour les fichiers qui ne sont pas des scans fantômes, le nom du fichier doit "
-"commencer par"
+"commencer par {{prefix}}"
 
 #, fuzzy
 msgid ""

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -40,7 +40,7 @@ msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr "फ़ाइल का प्रकार .tgz, .tar.gz या .zip होना चाहिए"
 
 msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
-msgstr "जो फाइलें फैंटम स्कैन नहीं हैं, उनका नाम इससे शुरू होना चाहिए"
+msgstr "जो फ़ाइलें फैंटम स्कैन नहीं हैं, उनके लिए फ़ाइल का नाम <0>{{prefix}}</0> से शुरू होना चाहिए।"
 
 msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"
 msgstr "उदाहरण के लिए, DCCID {{dccid}}, PSCID {{pscid}}, और विजिट लेबल {{visitLabel}} के लिए फ़ाइल नाम की शुरुआत इससे होनी चाहिए: {{prefix}}"

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -39,7 +39,7 @@ msgstr "फ़ाइल इससे अधिक नहीं हो सकत�
 msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr "फ़ाइल का प्रकार .tgz, .tar.gz या .zip होना चाहिए"
 
-msgid "For files that are not Phantom Scans, file name must begin with"
+msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr "जो फाइलें फैंटम स्कैन नहीं हैं, उनका नाम इससे शुरू होना चाहिए"
 
 msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -39,7 +39,7 @@ msgstr ""
 msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr ""
 
-msgid "For files that are not Phantom Scans, file name must begin with"
+msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr ""
 
 msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"


### PR DESCRIPTION
At some point the imaging_uploader translation mentioning the requirement to name the file with the prefix was updated to include an interpolated variable in Japanese and Chinese. The other languages and template were not updated to reflect this change.

Fix french string, hindi string, and pot template.