### PR TITLE
[module_manager] Fix po/pot files for module_manager

### DIFF
--- a/modules/module_manager/locale/fr/LC_MESSAGES/module_manager.po
+++ b/modules/module_manager/locale/fr/LC_MESSAGES/module_manager.po
@@ -46,5 +46,5 @@ msgid "Continue"
 msgstr "Continuer sans actualiser"
 
 #, fuzzy
-msgid "Could not find module {{id}}"
+msgid "Could not find module {{id}}."
 msgstr "Impossible de trouver le module {{id}}"

--- a/modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
+++ b/modules/module_manager/locale/ja/LC_MESSAGES/module_manager.po
@@ -27,7 +27,7 @@ msgstr "モジュール名"
 msgid "Full Name"
 msgstr "フルネーム"
 
-msgid "Could not update {{name}}"
+msgid "Could not update {{name}}."
 msgstr "{{name}} を更新できませんでした。"
 
 msgid "Updated {{name}} status!"

--- a/modules/module_manager/locale/module_manager.pot
+++ b/modules/module_manager/locale/module_manager.pot
@@ -42,6 +42,6 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-msgid "Could not find module {{id}}"
+msgid "Could not find module {{id}}."
 msgstr ""
 

--- a/modules/module_manager/locale/zh/LC_MESSAGES/module_manager.po
+++ b/modules/module_manager/locale/zh/LC_MESSAGES/module_manager.po
@@ -28,7 +28,7 @@ msgstr "姓名"
 msgid "Full Name"
 msgstr "姓名"
 
-msgid "Could not update {{name}}"
+msgid "Could not update {{name}}."
 msgstr "无法更新{{name}}"
 
 msgid "Updated {{name}} status!"


### PR DESCRIPTION
The punctuation was inconsistent between the pot and po files for some languages. Update them both to reflect the string used in the actual code.
