### PR TITLE
[electrophysiology_browser] Rendering fixes when chunksURL is non-existent or NULL

### DIFF
--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EEGMontage.tsx
@@ -16,7 +16,6 @@ type CProps = {
   hidden: number[],
   coordinateSystem: CoordinateSystem,
   setHidden: (_: number[]) => void,
-  chunksURL: string,
   colorMap?: {
     color: string,
     mode: 'fill' | 'outline'
@@ -32,6 +31,7 @@ type CProps = {
   eventChannels?: string[],
   setChannelSelectorVisible?: Dispatch<SetStateAction<boolean>>,
   eegMontageName: string,
+  timeInterval: [number, number],
 };
 
 const EEGMontage = (
@@ -40,7 +40,6 @@ const EEGMontage = (
     hidden,
     coordinateSystem,
     setHidden,
-    chunksURL,
     colorMap,
     withPanel,
     contentHeight,
@@ -52,6 +51,7 @@ const EEGMontage = (
     eventChannels,
     setChannelSelectorVisible,
     eegMontageName,
+    timeInterval,
   }: CProps) => {
   // if (electrodes.length === 0 || coordinateSystem === null) return null;
   const {t} = useTranslation();
@@ -587,7 +587,6 @@ const EEGMontage = (
           mouseDown={dragStart}
           mouseUp={dragEnd}
           mouseLeave={dragEnd}
-          chunksURL={chunksURL}
           cssClass={
             holdingShift
               ? 'cursor-default'
@@ -595,15 +594,16 @@ const EEGMontage = (
                 ? 'cursor-grabbing'
                 : 'cursor-grab'
           }
+          domain={timeInterval}
         >
           <Montage3D />
         </ResponsiveViewer>
         :
         <ResponsiveViewer
           // @ts-ignore
-          chunksURL={chunksURL}
           parentHeight={withPanel ? 300 : 550}
           cssClass={''}
+          domain={timeInterval}
         >
           <Montage2D />
         </ResponsiveViewer>
@@ -858,7 +858,6 @@ EEGMontage.defaultProps = {
   montage: [],
   hidden: [],
   coordinateSystem: null,
-  chunksURL: '',
   withPanel: true,
   contentHeight: '300px',
   modifiable: false,
@@ -870,9 +869,9 @@ export default connect(
     hidden: state.montage.hidden,
     electrodes: state.montage.electrodes,
     coordinateSystem: state.montage.coordinateSystem,
-    chunksURL: state.dataset.chunksURL,
     channelDelimiter: state.dataset.channelDelimiter,
     eegMontageName: state.dataset.eegMontageName,
+    timeInterval:  state.dataset.timeInterval,
   }),
   (dispatch: (_: any) => void) => ({
     setHidden: R.compose(

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/ResponsiveViewer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/ResponsiveViewer.tsx
@@ -12,8 +12,8 @@ type CProps = {
   mouseUp?: (_: any) => void,
   mouseLeave?: (_: any) => void,
   children?: any,
+  domain?: [number, number],
   showOverflow?: boolean,
-  chunksURL: string,
   cssClass: string,
 };
 
@@ -27,8 +27,8 @@ type CProps = {
  * @param root0.mouseUp
  * @param root0.mouseLeave
  * @param root0.children
+ * @param root0.domain
  * @param root0.showOverflow
- * @param root0.chunksURL
  * @param root0.cssClass
  */
 const ResponsiveViewer : FunctionComponent<CProps> = ({
@@ -39,8 +39,8 @@ const ResponsiveViewer : FunctionComponent<CProps> = ({
   mouseUp,
   mouseLeave,
   children,
+  domain,
   showOverflow,
-  chunksURL,
   cssClass,
 }) => {
   /**
@@ -55,7 +55,6 @@ const ResponsiveViewer : FunctionComponent<CProps> = ({
 
   const layers = React.Children.toArray(children).map(provision);
 
-  const domain = window.EEGLabSeriesProviderStore[chunksURL]?.getState().bounds.domain;
   // Data not loaded yet
   if (!domain) return null;
 

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/SeriesRenderer.tsx
@@ -92,7 +92,7 @@ type CProps = {
   viewerWidth: number,
   viewerHeight: number,
   interval: [number, number],
-  domain: number,
+  domain: [number, number],
   amplitudeScale: number,
   rightPanel: RightPanel,
   timeSelection?: [number, number],
@@ -995,6 +995,8 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
     'HED_ENDORSEMENT': 'HED Endorsements',
   }
 
+  const canEditEvents = chunksURL[0]?.includes('Face13');
+
   return (
     <>
 {/*      {channels.length > 0 ? (*/}
@@ -1010,7 +1012,7 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
           <div id="right-panel-controls">
             <button
               className={'btn btn-primary'}
-              disabled={!chunksURL || !chunksURL[0].includes('Face13') || rightPanel === 'annotationForm'}
+              disabled={!chunksURL || !canEditEvents || rightPanel === 'annotationForm'}
               onClick={() => {
                 confirmPanelClose(() => {
                   setRightPanel('annotationForm')
@@ -1390,8 +1392,8 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
                         R.compose(dragStart, R.nth(0))(v);
                       }, [bounds])}
                       showOverflow={showOverflow}
-                      chunksURL={chunksURL}
                       cssClass={''}
+                      domain={domain}
                     >
                       <EpochsLayer/>
                       <ChannelsLayer
@@ -1579,7 +1581,7 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
               </div>
               {
                 rightPanel === 'annotationForm' &&
-                chunksURL[0].includes('Face13') &&
+                canEditEvents &&
                 <AnnotationForm
                   panelIsDirty={panelIsDirty}
                   setPanelIsDirty={setPanelIsDirty}
@@ -1589,12 +1591,12 @@ const SeriesRenderer: FunctionComponent<CProps> = ({
               }
               {
                 rightPanel === 'eventList' &&
-                <EventManager canEdit={chunksURL[0].includes('Face13')} />
+                <EventManager canEdit={canEditEvents} />
               }
               {
                 rightPanel === 'hedEndorsement' &&
                 <HEDEndorsement
-                  canEndorse={chunksURL[0].includes('Face13')}
+                  canEndorse={canEditEvents}
                   pressedKey={pressedKey}
                 />
               }


### PR DESCRIPTION
Closes #10675.

This PR removes the `chunksURL` prop completely from `ResponsiveViewer`, in favour of the prop it actually requires (domain / recording duration).

It also adds a NULL check for references to `chunksURL` in `SeriesRenderer`, which caused the page to crash when opening the Event panel when chunksURL is non-existant or NULL.

Testing Instructions:
1. [See issue](https://github.com/aces/Loris/issues/10675)
2. Verify that the electrodes now render
3. Verify that the event panel can now be opened