### PR TITLE
[user_accounts] Add missing strings to user_accounts pot file

### DIFF
--- a/modules/user_accounts/locale/user_accounts.pot
+++ b/modules/user_accounts/locale/user_accounts.pot
@@ -206,3 +206,12 @@ msgstr ""
 
 msgid "For any other changes, contact an administrator"
 msgstr ""
+
+msgid "Do you really want to reject this user?"
+msgstr ""
+
+msgid "This action cannot be undone."
+msgstr ""
+
+msgid "Yes, reject user!"
+msgstr "


### PR DESCRIPTION
Reject user strings were referenced by languages but missing from the template.