### PR TITLE
[multilingual] Fix forbidden character string in Chinese

### DIFF
--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -425,8 +425,8 @@ msgstr "确认密码"
 msgid "Email address is required"
 msgstr "电子邮件地址为必填项"
 
-msgid "Email address cannot contain any of the following characters: <, >, &, and "
-msgstr "电子邮件地址不能包含以下任何字符：<、>、& 和 "
+msgid "Email address cannot contain any of the following characters: <, >, &, and \""
+msgstr "电子邮件地址不能包含以下任何字符：<、>、&、 \" 和 "
 
 msgid "The password must be at least 8 characters long."
 msgstr "密码长度必须至少为 8 个字符。"


### PR DESCRIPTION
The Chinese string didn't match the other languages or the template because it was missing the final '\"', so wouldn't have been translated.

I took a guess on where to add the character in the Chinese translation.
