### PR TITLE
[multilingual] Fix Incomplete Forms msgid

### DIFF
--- a/modules/instruments/locale/es/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/es/LC_MESSAGES/instruments.po
@@ -17,15 +17,14 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgid "Instruments"
 msgstr "Instrumentos"
 
 msgid "Incomplete form"
-msgstr "Formulario incompleto"
-
-msgid "Incomplete forms"
-msgstr "Formularios incompletos"
+msgid_plural "Incomplete forms"
+msgstr[0] "Formularios incompletos"
 
 msgid "Clear Instrument"
 msgstr "Limpiar Instrumento"

--- a/modules/instruments/locale/es/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/es/LC_MESSAGES/instruments.po
@@ -24,7 +24,8 @@ msgstr "Instrumentos"
 
 msgid "Incomplete form"
 msgid_plural "Incomplete forms"
-msgstr[0] "Formularios incompletos"
+msgstr[0] "Formulario incompleto"
+msgstr[1] "Formularios incompletos"
 
 msgid "Clear Instrument"
 msgstr "Limpiar Instrumento"

--- a/modules/instruments/locale/fr/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/fr/LC_MESSAGES/instruments.po
@@ -17,6 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.8\n"
 
 msgid "Instruments"

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -22,10 +22,8 @@ msgid "Instruments"
 msgstr "機器"
 
 msgid "Incomplete form"
-msgstr "不完全なフォーム"
-
-msgid "Incomplete forms"
-msgstr "不完全なフォーム"
+msgid_plural "Incomplete forms"
+msgstr[0] "不完全なフォーム"
 
 msgid "Clear Instrument"
 msgstr "クリアインストルメント"

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+
 msgid "Instruments"
 msgstr "機器"
 

--- a/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/ja/LC_MESSAGES/instruments.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
+"Plural-Forms: nplurals=1; plural=0\n"
 msgid "Instruments"
 msgstr "機器"
 

--- a/modules/instruments/locale/zh/LC_MESSAGES/instruments.po
+++ b/modules/instruments/locale/zh/LC_MESSAGES/instruments.po
@@ -23,10 +23,8 @@ msgid "Instruments"
 msgstr "量表/评估工具"
 
 msgid "Incomplete form"
-msgstr "表格不完整"
-
-msgid "Incomplete forms"
-msgstr "表格不完整"
+msgid_plural "Incomplete forms"
+msgstr[0] "表格不完整"
 
 msgid "Clear Instrument"
 msgstr "清除仪器"


### PR DESCRIPTION
It was converted from a gettext to an ngettext at some point, so needs to be the msgid_plural form of "Incomplete Form", not a distinct string.
