### PR TITLE
[configuration] Fix existing project updates

### DIFF
--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -30,7 +30,7 @@ $ProjectList  = Utility::getProjectList();
 $projectName  = $_POST['Name'] ?? '';
 $projectAlias = $_POST['Alias'] ?? '';
 $recTarget    = empty($_POST['recruitmentTarget'])
-    ? null : $_POST['recruitmentTarget'];
+    ? null : intval($_POST['recruitmentTarget']);
 $projectID    = $_POST['ProjectID'] ?? null;
 $cohortIDs    = $_POST['CohortIDs'] ?? [];
 
@@ -100,4 +100,3 @@ if (!empty($cohortIDs)) {
 http_response_code(200);
 echo json_encode(['ok' => 'Success']);
 exit(0);
-

--- a/modules/configuration/js/project.js
+++ b/modules/configuration/js/project.js
@@ -48,8 +48,12 @@ $(document).ready(function() {
               $(form.find(".saveStatus")).text("Failed to save, Alias should be at most 4 characters long!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
           } else {
-            return function () {
-              $(form.find(".saveStatus")).text("Failed to save, same name already exist!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+            return function (data) {
+              var error = "Failed to save, same name already exist!";
+              if (data.status !== 409 && data.responseJSON && data.responseJSON.error) {
+                error = data.responseJSON.error;
+              }
+              $(form.find(".saveStatus")).text(error).css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
           }
         }
@@ -65,6 +69,7 @@ $(document).ready(function() {
                         "recruitmentTarget" : recruitmentTarget,
                         "CohortIDs" : CohortIDs
                     },
+                    "dataType": "json",
                     "success" : successClosure(ProjectID, form),
                     "error" : errorClosure(ProjectID, form)
                 }


### PR DESCRIPTION
## Brief summary of changes

- Casts project recruitment target values before updating existing projects.
- Keeps existing project edits from failing with a misleading duplicate-name error.
- Shows backend error messages for non-duplicate project update failures.

#### Testing instructions

- Open `/configuration/project/`.
- Edit an existing project.
- Change Recruitment Target and Affiliated Cohorts.
- Save and confirm the project updates successfully.

#### Link(s) to related issue(s)

* Resolves #10645