### PR TITLE
[Biobank] Normalize biobank validation strings and fix Center/Site mismatch

### DIFF
--- a/modules/biobank/jsx/batchEditForm.js
+++ b/modules/biobank/jsx/batchEditForm.js
@@ -212,7 +212,7 @@ class BatchEditForm extends React.PureComponent {
       (specimen.typeId !== current.typeId)) {
       Swal.fire(
         t('Oops!', {ns: 'biobank'}),
-        t('Specimens must be of the same Type and Center', {ns: 'biobank'}),
+        t('Specimens must be of the same Type and Site', {ns: 'biobank'}),
         'warning'
       );
       return Promise.reject();

--- a/modules/biobank/jsx/biobankIndex.js
+++ b/modules/biobank/jsx/biobankIndex.js
@@ -515,7 +515,7 @@ class BiobankIndex extends Component {
 
     float.map((field) => {
       if (isNaN(parseInt(specimen[field])) || !isFinite(specimen[field])) {
-        errors[field] = t('This field must be a number. ', {ns: 'biobank'});
+        errors[field] = t('This field must be a number.', {ns: 'biobank'});
       }
     });
 
@@ -601,27 +601,27 @@ class BiobankIndex extends Component {
     // validate required fields
     required && required.map((field) => {
       if (!process[field]) {
-        errors[field] = t('This field is required! ', {ns: 'biobank'});
+        errors[field] = t('This field is required.', {ns: 'biobank'});
       }
     });
 
     // validate floats
     number && number.map((field) => {
       if (isNaN(parseInt(process[field])) || !isFinite(process[field])) {
-        errors[field] = t('This field must be a number! ', {ns: 'biobank'});
+        errors[field] = t('This field must be a number.', {ns: 'biobank'});
       }
     });
 
     // validate date
     regex = /^[12]\d{3}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
     if (regex.test(process.date === false)) {
-      errors.date = t('This field must be a valid date! ', {ns: 'biobank'});
+      errors.date = t('This field must be a valid date.', {ns: 'biobank'});
     }
 
     // validate time
     regex = /^([01]\d|2[0-3]):([0-5]\d)$/;
     if (regex.test(process.time === false)) {
-      errors.time = t('This field must be a valid time! ', {ns: 'biobank'});
+      errors.time = t('This field must be a valid time.', {ns: 'biobank'});
     }
 
     // validate custom attributes
@@ -641,7 +641,7 @@ class BiobankIndex extends Component {
             if (attribute.required == 1
               && !process.data[attribute.id]) {
               errors.data[attribute.id] = t(
-                'This field is required!',
+                'This field is required.',
                 {ns: 'biobank'}
               );
             }
@@ -652,7 +652,7 @@ class BiobankIndex extends Component {
               if (isNaN(parseInt(process.data[attribute.id])) ||
                 !isFinite(process.data[attribute.id])) {
                 errors.data[attribute.id] = t(
-                  'This field must be a number!',
+                  'This field must be a number.',
                   {ns: 'biobank'}
                 );
               }
@@ -663,7 +663,7 @@ class BiobankIndex extends Component {
               regex = /^[12]\d{3}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
               if (regex.test(process.data[attribute.id] === false )) {
                 errors.data[attribute.id] = t(
-                  'This field must be a valid date! ',
+                  'This field must be a valid date.',
                   {ns: 'biobank'}
                 );
               }
@@ -674,7 +674,7 @@ class BiobankIndex extends Component {
               regex = /^([01]\d|2[0-3]):([0-5]\d)$/;
               if (regex.test(process.data[attribute.id] === false)) {
                 errors.data[attribute.id] = t(
-                  'This field must be a valid time! ',
+                  'This field must be a valid time.',
                   {ns: 'biobank'}
                 );
               }
@@ -716,13 +716,13 @@ class BiobankIndex extends Component {
 
     required.map((field) => {
       if (!container[field]) {
-        errors[field] = t('This field is required! ', {ns: 'biobank'});
+        errors[field] = t('This field is required.', {ns: 'biobank'});
       }
     });
 
     float.map((field) => {
       if (isNaN(parseInt(container[field])) || !isFinite(container[field])) {
-        errors[field] = t('This field must be a number! ', {ns: 'biobank'});
+        errors[field] = t('This field must be a number.', {ns: 'biobank'});
       }
     });
 
@@ -754,24 +754,24 @@ class BiobankIndex extends Component {
 
     required.forEach((field) => {
       if (!pool[field]) {
-        errors[field] = t('This field is required! ', {ns: 'biobank'});
+        errors[field] = t('This field is required.', {ns: 'biobank'});
       }
     });
 
     if (isNaN(parseInt(pool.quantity)) || !isFinite(pool.quantity)) {
-      errors.quantity = t('This field must be a number! ', {ns: 'biobank'});
+      errors.quantity = t('This field must be a number.', {ns: 'biobank'});
     }
 
     // validate date
     regex = /^[12]\d{3}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
     if (regex.test(pool.date === false )) {
-      errors.date = t('This field must be a valid date! ', {ns: 'biobank'});
+      errors.date = t('This field must be a valid date.', {ns: 'biobank'});
     }
 
     // validate time
     regex = /^([01]\d|2[0-3]):([0-5]\d)$/;
     if (regex.test(pool.time === false)) {
-      errors.time = t('This field must be a valid time! ', {ns: 'biobank'});
+      errors.time = t('This field must be a valid time.', {ns: 'biobank'});
     }
 
     if (pool.specimenIds == null || pool.specimenIds.length < 2) {

--- a/modules/biobank/jsx/poolSpecimenForm.js
+++ b/modules/biobank/jsx/poolSpecimenForm.js
@@ -156,7 +156,7 @@ class PoolSpecimenForm extends React.Component {
         {
           title: this.props.t('Oops!', {ns: 'biobank'}),
           text: this.props.t(`Specimens must be of the same PSCID,
-                    Visit Label, Type and Center`),
+                    Visit Label, Type and Site`),
           type: 'warning',
         }
       );

--- a/modules/biobank/locale/biobank.pot
+++ b/modules/biobank/locale/biobank.pot
@@ -1,12 +1,12 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Default LORIS strings to be translated (English)
+# Copyright (C) 2026
+# This file is distributed under the same license as the LORIS package.
+# Henri Rabalais <henri.j.rabalais@gmail.com>, 2026
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-12-05 08:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Biobank"
@@ -31,7 +31,7 @@ msgstr ""
 #: jsx/poolSpecimenForm.js:158
 msgid ""
 "Specimens must be of the same PSCID,\n"
-"Visit Label, Type and Center"
+"Visit Label, Type and Site"
 msgstr ""
 
 #: jsx/poolSpecimenForm.js:207
@@ -207,6 +207,10 @@ msgstr ""
 msgid "Current Site"
 msgstr ""
 
+#: jsx/specimenTab.js:75 jsx/globals.js:234
+msgid "Draw Site"
+msgstr ""
+
 #: jsx/container.js:54
 msgid "Checkout Child Containers"
 msgstr ""
@@ -228,7 +232,7 @@ msgid "This field is required."
 msgstr ""
 
 #: jsx/biobankIndex.js:512
-msgid "This field must be a number. "
+msgid "This field must be a number."
 msgstr ""
 
 #: jsx/biobankIndex.js:518
@@ -240,27 +244,21 @@ msgid "This field must be an integer."
 msgstr ""
 
 #: jsx/biobankIndex.js:597 jsx/biobankIndex.js:699 jsx/biobankIndex.js:736
-msgid "This field is required! "
+#: jsx/biobankIndex.js:636
+msgid "This field is required."
 msgstr ""
 
 #: jsx/biobankIndex.js:604 jsx/biobankIndex.js:705 jsx/biobankIndex.js:741
-msgid "This field must be a number! "
+#: jsx/biobankIndex.js:644
+msgid "This field must be a number."
 msgstr ""
 
 #: jsx/biobankIndex.js:611 jsx/biobankIndex.js:652 jsx/biobankIndex.js:747
-msgid "This field must be a valid date! "
+msgid "This field must be a valid date."
 msgstr ""
 
 #: jsx/biobankIndex.js:617 jsx/biobankIndex.js:660 jsx/biobankIndex.js:753
-msgid "This field must be a valid time! "
-msgstr ""
-
-#: jsx/biobankIndex.js:636
-msgid "This field is required!"
-msgstr ""
-
-#: jsx/biobankIndex.js:644
-msgid "This field must be a number!"
+msgid "This field must be a valid time."
 msgstr ""
 
 #: jsx/biobankIndex.js:711
@@ -270,6 +268,12 @@ msgstr ""
 #: jsx/biobankIndex.js:757
 msgid "Pooling requires at least 2 specimens"
 msgstr ""
+
+#: jsx/filter.js:73
+msgid "Container"
+msgid_plural "Containers"
+msgstr[0] ""
+msgstr[1] ""
 
 #: jsx/shipmentTab.js:69 jsx/shipmentTab.js:141
 msgid "Origin Site"
@@ -296,7 +300,7 @@ msgid "User"
 msgstr ""
 
 #: jsx/batchEditForm.js:214
-msgid "Specimens must be of the same Type and Center"
+msgid "Specimens must be of the same Type and Site"
 msgstr ""
 
 #: jsx/batchEditForm.js:274 jsx/globals.js:144
@@ -412,7 +416,7 @@ msgid ""
 msgstr ""
 
 #: jsx/specimenForm.js:219
-msgid "Parent Specimen(s, {ns: 'biobank'})"
+msgid "Parent Specimen(s)"
 msgstr ""
 
 #: jsx/specimenForm.js:255

--- a/modules/biobank/locale/biobank.pot
+++ b/modules/biobank/locale/biobank.pot
@@ -227,14 +227,6 @@ msgstr ""
 msgid "Batch Preparation Successful!"
 msgstr ""
 
-#: jsx/biobankIndex.js:506
-msgid "This field is required."
-msgstr ""
-
-#: jsx/biobankIndex.js:512
-msgid "This field must be a number."
-msgstr ""
-
 #: jsx/biobankIndex.js:518
 msgid "This field must not be negative."
 msgstr ""
@@ -244,12 +236,12 @@ msgid "This field must be an integer."
 msgstr ""
 
 #: jsx/biobankIndex.js:597 jsx/biobankIndex.js:699 jsx/biobankIndex.js:736
-#: jsx/biobankIndex.js:636
+#: jsx/biobankIndex.js:636 jsx/biobankIndex.js:506
 msgid "This field is required."
 msgstr ""
 
 #: jsx/biobankIndex.js:604 jsx/biobankIndex.js:705 jsx/biobankIndex.js:741
-#: jsx/biobankIndex.js:644
+#: jsx/biobankIndex.js:644 jsx/biobankIndex.js:512
 msgid "This field must be a number."
 msgstr ""
 

--- a/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
@@ -238,14 +238,6 @@ msgstr "Imprimer les codes-barres ?"
 msgid "Batch Preparation Successful!"
 msgstr "Préparation du lot réussie !"
 
-#: jsx/biobankIndex.js:506
-msgid "This field is required."
-msgstr "Ce champ est obligatoire."
-
-#: jsx/biobankIndex.js:512
-msgid "This field must be a number."
-msgstr "Ce champ doit être un nombre."
-
 #: jsx/biobankIndex.js:518
 msgid "This field must not be negative."
 msgstr "Ce champ ne doit pas être négatif."
@@ -255,20 +247,22 @@ msgid "This field must be an integer."
 msgstr "Ce champ doit être un entier."
 
 #: jsx/biobankIndex.js:597 jsx/biobankIndex.js:699 jsx/biobankIndex.js:736
-msgid "This field is required!"
-msgstr "Ce champ est obligatoire !"
+#: jsx/biobankIndex.js:506
+msgid "This field is required."
+msgstr "Ce champ est obligatoire."
 
 #: jsx/biobankIndex.js:604 jsx/biobankIndex.js:705 jsx/biobankIndex.js:741
-msgid "This field must be a number!"
-msgstr "Ce champ doit être un nombre !"
+#: jsx/biobankIndex.js:512
+msgid "This field must be a number."
+msgstr "Ce champ doit être un nombre."
 
 #: jsx/biobankIndex.js:611 jsx/biobankIndex.js:652 jsx/biobankIndex.js:747
-msgid "This field must be a valid date!"
-msgstr "Ce champ doit être une date valide !"
+msgid "This field must be a valid date."
+msgstr "Ce champ doit être une date valide."
 
 #: jsx/biobankIndex.js:617 jsx/biobankIndex.js:660 jsx/biobankIndex.js:753
-msgid "This field must be a valid time!"
-msgstr "Ce champ doit être une heure valide !"
+msgid "This field must be a valid time."
+msgstr "Ce champ doit être une heure valide."
 
 #: jsx/biobankIndex.js:711
 msgid "Barcode must be unique."

--- a/modules/biobank/locale/zh/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/zh/LC_MESSAGES/biobank.po
@@ -235,14 +235,6 @@ msgstr "是否打印条形码？"
 msgid "Batch Preparation Successful!"
 msgstr "批量准备成功！"
 
-#: jsx/biobankIndex.js:506
-msgid "This field is required."
-msgstr "此项必填。"
-
-#: jsx/biobankIndex.js:512
-msgid "This field must be a number."
-msgstr "此项必须为数字。"
-
 #: jsx/biobankIndex.js:518
 msgid "This field must not be negative."
 msgstr "此项不能为负数。"
@@ -252,19 +244,21 @@ msgid "This field must be an integer."
 msgstr "此项必须为整数。"
 
 #: jsx/biobankIndex.js:597 jsx/biobankIndex.js:699 jsx/biobankIndex.js:736
-msgid "This field is required!"
+#: jsx/biobankIndex.js:506
+msgid "This field is required."
 msgstr "此项必填！"
 
 #: jsx/biobankIndex.js:604 jsx/biobankIndex.js:705 jsx/biobankIndex.js:741
-msgid "This field must be a number!"
+#: jsx/biobankIndex.js:512
+msgid "This field must be a number."
 msgstr "此项必须为数字！"
 
 #: jsx/biobankIndex.js:611 jsx/biobankIndex.js:652 jsx/biobankIndex.js:747
-msgid "This field must be a valid date!"
+msgid "This field must be a valid date."
 msgstr "此项必须为有效日期！"
 
 #: jsx/biobankIndex.js:617 jsx/biobankIndex.js:660 jsx/biobankIndex.js:753
-msgid "This field must be a valid time!"
+msgid "This field must be a valid time."
 msgstr "此项必须为有效时间！"
 
 #: jsx/biobankIndex.js:711


### PR DESCRIPTION
## Summary

Cleans up inconsistent punctuation and whitespace on the biobank
validation messages, and fixes two `Center`/`Site` mismatches where the
code string didn't match the fr/zh `.po` msgids (so those translations
never resolved). Also corrects a malformed `.pot` entry and adds three
strings that were missing from the template.

## Changes

**Validation strings (`jsx/biobankIndex.js`)**
The same messages were written several different ways (`.`, `! `, `!`,
trailing spaces), which created duplicate msgids and broke translation
matching. Collapsed each to a single form:
- `This field must be a number.`
- `This field is required.`
- `This field must be a valid date.`
- `This field must be a valid time.`

**Center → Site**
- `jsx/batchEditForm.js`: `Specimens must be of the same Type and Site`
- `jsx/poolSpecimenForm.js`: `...PSCID, Visit Label, Type and Site`

The fr and zh `.po` msgids already used "Site", but the code emitted
"Center", so neither translation resolved. The code now matches the
existing translations.

**`locale/biobank.pot`**
- Merged the now-redundant `! `/`!` msgid blocks into the single
  period-form entries.
- Fixed malformed entry `Parent Specimen(s, {ns: 'biobank'})` →
  `Parent Specimen(s)`.
- Added `Container`, `Draw Site`, and `Parent Specimen(s)`.