### PR TITLE
[multilingual] Fix French translation file inconsistencies

### DIFF
--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -129,7 +129,8 @@ msgstr ""
 msgid "to {{channelsInView}} of {{totalChannels}}"
 msgstr ""
 
-msgid "Time (s)"  # s stands for seconds
+# s stands for seconds
+msgid "Time (s)"
 msgstr ""
 
 msgid "No Offset"
@@ -256,7 +257,8 @@ msgstr ""
 msgid "{{label}} search..."
 msgstr ""
 
-msgid "Ignore {{bidsNA}}"   # The BIDS value: n/a
+# The BIDS value: n/a
+msgid "Ignore {{bidsNA}}"
 msgstr ""
 
 msgid "Exclude <text>{{searchText}}</text>"

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -155,9 +155,10 @@ msgstr "Afficher :"
 msgid "to {{channelsInView}} of {{totalChannels}}"
 msgstr "à {{channelsInView}} de {{totalChannels}}"
 
+# s stands for second
 #, fuzzy
-msgid "Time (s)\"  # s stands for second"
-msgstr "Temps (s) » # s signifie seconde"
+msgid "Time (s)"
+msgstr "Temps (s)"
 
 msgid "No Offset"
 msgstr "Pas de décalage"
@@ -310,9 +311,10 @@ msgstr "Afficher par :"
 msgid "{{label}} search..."
 msgstr "{{label}} recherche..."
 
+# The BIDS value N/A
 #, fuzzy
-msgid "Ignore {{bidsNA}}\"   # The BIDS value: n/"
-msgstr "Ignorer {{bidsNA}} » # Valeur BIDS : n/"
+msgid "Ignore {{bidsNA}}"
+msgstr "Ignorer {{bidsNA}}"
 
 #, fuzzy
 msgid "Exclude <text>{{searchText}}</text>"

--- a/modules/publication/locale/fr/LC_MESSAGES/publication.po
+++ b/modules/publication/locale/fr/LC_MESSAGES/publication.po
@@ -22,9 +22,6 @@ msgstr ""
 msgid "Publications"
 msgstr "Publications"
 
-msgid "File to upload"
-msgstr "Sélectionner un fichier à téléverser"
-
 msgid "Submit"
 msgstr "Soummettre"
 


### PR DESCRIPTION
The publication module had an extra "File to upload" string in the publication namespace, which is now in the loris namespace.

The electrophysiology_browser tried to use a "#" at the end of the line for a comment in the pot file, which is invalid. # must be the first character in the line to be a comment. This confused either the person or software doing the translation and resulted in the wrong translated string (it included the comment and a stray quotation mark)

This fixes both issues.
