### PR TITLE
[Statistics] Catch-up all languages to fr + Fix hindi plural across modules

### DIFF
--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 # Smarty template main.tpl strings
 msgid "LORIS"

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 # Smarty template main.tpl strings
 msgid "LORIS"

--- a/modules/behavioural_qc/locale/hi/LC_MESSAGES/behavioural_qc.po
+++ b/modules/behavioural_qc/locale/hi/LC_MESSAGES/behavioural_qc.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Behavioural Quality Control"
 msgstr "व्यवहारिक गुणवत्ता नियंत्रण"

--- a/modules/behavioural_qc/locale/hi/LC_MESSAGES/behavioural_qc.po
+++ b/modules/behavioural_qc/locale/hi/LC_MESSAGES/behavioural_qc.po
@@ -17,6 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Behavioural Quality Control"
 msgstr "व्यवहारिक गुणवत्ता नियंत्रण"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -17,6 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Data Query Tool (Beta)"
 msgstr "डेटा क्वेरी टूल (बीटा)"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Data Query Tool (Beta)"
 msgstr "डेटा क्वेरी टूल (बीटा)"

--- a/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
@@ -17,6 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Imaging Browser"
 msgstr "इमेजिंग ब्राउज़र"

--- a/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/hi/LC_MESSAGES/imaging_browser.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Imaging Browser"
 msgstr "इमेजिंग ब्राउज़र"

--- a/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Issue Tracker"
 msgstr "समस्या ट्रैकर"

--- a/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Issue Tracker"
 msgstr "समस्या ट्रैकर"

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -148,9 +148,7 @@ msgid "Dataset size breakdown by project"
 msgstr "Répartition de taille des données par projet"
 
 msgid "Dataset Size"
-msgid_plural "Dataset Size"
-msgstr[0] "Taille des données"
-msgstr[1] "Taille des données"
+msgstr "Taille des données"
 
 msgid "Size (GB)"
 msgstr "Taille (Go)"

--- a/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
@@ -147,9 +147,7 @@ msgid "Dataset size breakdown by project"
 msgstr "परियोजना के अनुसार डेटासेट आकार का विवरण"
 
 msgid "Dataset Size"
-msgid_plural "Dataset Size"
-msgstr[0] "डेटासेट का आकार"
-msgstr[1] "डेटासेट का आकार"
+msgstr "डेटासेट का आकार"
 
 msgid "Size (GB)"
 msgstr "आकार (जीबी)"

--- a/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
-msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Statistics"
 msgstr "सांख्यिकी"

--- a/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
+msgid "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Statistics"
 msgstr "सांख्यिकी"

--- a/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/hi/LC_MESSAGES/statistics.po
@@ -1,0 +1,167 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Saagar Arya <saagar.arya@mcin.ca>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: 2026-06-10 21:23-0500\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.8\n"
+
+msgid "Statistics"
+msgstr "सांख्यिकी"
+
+msgid "Study Progression"
+msgstr "अध्ययन प्रगति"
+
+msgid "Summary"
+msgstr "सारांश"
+
+msgid "Site Scans"
+msgstr "साइट स्कैन"
+
+msgid "Site Recruitment"
+msgstr "साइट भर्ती"
+
+msgid "-- Clear Selection --"
+msgstr "-- चयन साफ़ करें --"
+
+msgid "Scan sessions per site"
+msgstr "प्रति साइट स्कैन सत्र"
+
+msgid "Recruitment per site"
+msgstr "प्रति साइट भर्ती"
+
+msgid "Download as PNG"
+msgstr "PNG के रूप में डाउनलोड करें"
+
+msgid "Labels"
+msgstr "लेबल"
+
+msgid "Date Registered"
+msgstr "पंजीकरण तिथि"
+
+msgid "Range Start"
+msgstr "सीमा प्रारंभ"
+
+msgid "Range End"
+msgstr "सीमा समाप्त"
+
+msgid "Total recruitment by Age"
+msgstr "आयु के अनुसार कुल भर्ती"
+
+msgid "Ethnicity at Screening"
+msgstr "स्क्रीनिंग के समय जातीयता"
+
+msgid "Total Recruitment per Site"
+msgstr "प्रति साइट कुल भर्ती"
+
+msgid "Biological sex breakdown by site"
+msgstr "साइट के अनुसार जैविक लिंग विभाजन"
+
+msgid "Candidate Age at Registration"
+msgstr "पंजीकरण के समय उम्मीदवार की आयु"
+
+msgid "Candidates registered"
+msgstr "पंजीकृत उम्मीदवार"
+
+msgid "Target: {{target}}"
+msgstr "लक्ष्य: {{target}}"
+
+msgid "Recruitment target of {{target}} was reached."
+msgstr "{{target}} का भर्ती लक्ष्य प्राप्त हो गया।"
+
+msgid "Recruitment target of {{target}} was not reached."
+msgstr "{{target}} का भर्ती लक्ष्य प्राप्त नहीं हुआ।"
+
+msgid "No target set"
+msgstr "कोई लक्ष्य निर्धारित नहीं"
+
+msgid "{{total}} total participants."
+msgstr "कुल {{total}} प्रतिभागी।"
+
+msgid "Overall Recruitment"
+msgstr "कुल भर्ती"
+
+msgid "Recruitment"
+msgstr "भर्ती"
+
+msgid "Overall"
+msgstr "समग्र"
+
+msgid "Site Breakdown"
+msgstr "साइट विभाजन"
+
+msgid "Project Breakdown"
+msgstr "परियोजना विभाजन"
+
+msgid "Cohort Breakdown"
+msgstr "कोहोर्ट विभाजन"
+
+msgid "Total Participants: {{count}}"
+msgstr "कुल प्रतिभागी: {{count}}"
+
+msgid "Projects: {{count}}"
+msgstr "परियोजनाएँ: {{count}}"
+
+msgid "Cohorts: {{count}}"
+msgstr "कोहोर्ट: {{count}}"
+
+msgid "Age (Years)"
+msgstr "आयु (वर्ष)"
+
+msgid "Participants"
+msgstr "प्रतिभागी"
+
+msgid "Unknown"
+msgstr "अज्ञात"
+
+msgid "Total Scans: {{count}}"
+msgstr "कुल स्कैन: {{count}}"
+
+msgid "There have been no scans yet."
+msgstr "अभी तक कोई स्कैन नहीं हुए हैं।"
+
+msgid "There have been no candidates registered yet."
+msgstr "अभी तक कोई उम्मीदवार पंजीकृत नहीं हुए हैं।"
+
+msgid "There is no data yet."
+msgstr "अभी तक कोई डेटा नहीं है।."
+
+# Project sizes
+msgid "Project Dataset Sizes"
+msgstr "परियोजना डेटासेट आकार"
+
+msgid "Dataset size breakdown by project"
+msgstr "परियोजना के अनुसार डेटासेट आकार का विवरण"
+
+msgid "Dataset Size"
+msgid_plural "Dataset Size"
+msgstr[0] "डेटासेट का आकार"
+msgstr[1] "डेटासेट का आकार"
+
+msgid "Size (GB)"
+msgstr "आकार (जीबी)"
+
+msgid "%s GB"
+msgstr "%s जीबी"
+
+msgid "Total Size: {{count}} GB"
+msgstr "कुल आकार: {{count}} जीबी"
+
+msgid "Pie"
+msgstr "पाई"
+
+msgid "Bar"
+msgstr "बार"

--- a/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
@@ -126,3 +126,42 @@ msgstr "参加者"
 
 msgid "Unknown"
 msgstr "未知"
+
+msgid "Total Scans: {{count}}"
+msgstr "スキャン総数：{{count}}"
+
+msgid "There have been no scans yet."
+msgstr "まだスキャンは行われていません。"
+
+msgid "There have been no candidates registered yet."
+msgstr "まだ登録された候補者はいません。"
+
+msgid "There is no data yet."
+msgstr "まだデータはありません。"
+
+# Project sizes
+msgid "Project Dataset Sizes"
+msgstr "プロジェクトのデータセットのサイズ"
+
+msgid "Dataset size breakdown by project"
+msgstr "プロジェクト別のデータセット規模の内訳"
+
+msgid "Dataset Size"
+msgid_plural "Dataset Size"
+msgstr[0] "データセットのサイズ"
+msgstr[1] "データセットのサイズ"
+
+msgid "Size (GB)"
+msgstr "容量（GB）"
+
+msgid "%s GB"
+msgstr "%s GB"
+
+msgid "Total Size: {{count}} GB"
+msgstr "合計サイズ：{{count}} GB"
+
+msgid "Pie"
+msgstr "円グラフ"
+
+msgid "Bar"
+msgstr "棒グラフ"

--- a/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
@@ -147,8 +147,7 @@ msgid "Dataset size breakdown by project"
 msgstr "プロジェクト別のデータセット規模の内訳"
 
 msgid "Dataset Size"
-msgid_plural "Dataset Size"
-msgstr[0] "データセットのサイズ"
+msgstr "データセットのサイズ"
 
 msgid "Size (GB)"
 msgstr "容量（GB）"

--- a/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/ja/LC_MESSAGES/statistics.po
@@ -149,7 +149,6 @@ msgstr "プロジェクト別のデータセット規模の内訳"
 msgid "Dataset Size"
 msgid_plural "Dataset Size"
 msgstr[0] "データセットのサイズ"
-msgstr[1] "データセットのサイズ"
 
 msgid "Size (GB)"
 msgstr "容量（GB）"

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -146,9 +146,7 @@ msgid "Dataset size breakdown by project"
 msgstr ""
 
 msgid "Dataset Size"
-msgid_plural "Dataset Size"
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
 
 msgid "Size (GB)"
 msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -148,6 +148,7 @@ msgstr ""
 msgid "Dataset Size"
 msgid_plural "Dataset Size"
 msgstr[0] ""
+msgstr[1] ""
 
 msgid "Size (GB)"
 msgstr ""

--- a/modules/statistics/locale/zh/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/zh/LC_MESSAGES/statistics.po
@@ -147,8 +147,7 @@ msgid "Dataset size breakdown by project"
 msgstr "按项目划分的数据集大小明细"
 
 msgid "Dataset Size"
-msgid_plural "Dataset Size"
-msgstr[0] "数据集大小"
+msgstr "数据集大小"
 
 msgid "Size (GB)"
 msgstr "大小（GB）"

--- a/modules/statistics/locale/zh/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/zh/LC_MESSAGES/statistics.po
@@ -126,3 +126,41 @@ msgstr "参加者"
 
 msgid "Unknown"
 msgstr "未知"
+
+msgid "Total Scans: {{count}}"
+msgstr "扫描总数：{{count}}"
+
+msgid "There have been no scans yet."
+msgstr "目前还没有扫描。"
+
+msgid "There have been no candidates registered yet."
+msgstr "目前还没有已注册的候选人。"
+
+msgid "There is no data yet."
+msgstr "目前还没有数据。"
+
+# Project sizes
+msgid "Project Dataset Sizes"
+msgstr "项目数据集大小"
+
+msgid "Dataset size breakdown by project"
+msgstr "按项目划分的数据集大小明细"
+
+msgid "Dataset Size"
+msgid_plural "Dataset Size"
+msgstr[0] "数据集大小"
+
+msgid "Size (GB)"
+msgstr "大小（GB）"
+
+msgid "%s GB"
+msgstr "%s GB"
+
+msgid "Total Size: {{count}} GB"
+msgstr "总大小：{{count}} GB"
+
+msgid "Pie"
+msgstr "饼图"
+
+msgid "Bar"
+msgstr "柱状图"


### PR DESCRIPTION
## Brief summary of changes
- Catch-up PO files in statistics to match french

#### Testing instructions (if applicable)

1. Open statistics module in chinese, hindi and japanese and ensure all non-db values are translated.
