### PR TITLE
[imaging_browser/multilingual] Add missing pot strings

### DIFF
--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -173,6 +173,39 @@ msgstr ""
 msgid "Comments saved."
 msgstr ""
 
+msgid "Voxel Size"
+msgstr ""
+
+msgid "Protocol"
+msgstr ""
+
+msgid "Acquisition Date"
+msgstr ""
+
+msgid "Inserted Date"
+msgstr ""
+
+msgid "Series Number"
+msgstr ""
+
+msgid "Series Description"
+msgstr ""
+
+msgid "Slice Thick"
+msgstr ""
+
+msgid "Phase Encoding Direction"
+msgstr ""
+
+msgid "Image Type"
+msgstr ""
+
+msgid "Echo Number"
+msgstr ""
+
+msgid "Number of volumes"
+msgstr ""
+
 msgid "Feedback MRI Popup"
 msgstr ""
 


### PR DESCRIPTION
The panel when expanding a scan was translated into hindi, but missing from the pot template file. As a result, other languages are missing the translations.

This updates the template to reflect what's in the code.
