### PR TITLE
[javascript] better translation typing

### DIFF
--- a/jsx/I18nSetup.d.ts
+++ b/jsx/I18nSetup.d.ts
@@ -1,2 +1,0 @@
-import i18n from 'i18next';
-export default i18n;

--- a/jsx/I18nSetup.ts
+++ b/jsx/I18nSetup.ts
@@ -8,6 +8,14 @@ import enResources from '../locale/en/LC_MESSAGES/loris.json';
 import frResources from '../locale/fr/LC_MESSAGES/loris.json';
 import zhResources from '../locale/zh/LC_MESSAGES/loris.json';
 
+declare const loris: any;
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'loris';
+  }
+}
+
 const resources = {
   ja: {
     loris: jaResources,
@@ -27,7 +35,6 @@ const resources = {
   zh: {
     loris: zhResources,
   },
-
 };
 
 /**
@@ -60,4 +67,5 @@ i18n
     defaultNS: 'loris',
     fallbackNS: [],
   });
+
 export default i18n;

--- a/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
+++ b/modules/dataquery/jsx/definefilters.addfiltermodal.tsx
@@ -19,6 +19,7 @@ import {
 } from './types';
 import {CategoriesAPIReturn} from './hooks/usedatadictionary';
 import {Trans} from 'react-i18next';
+import {TFunction} from 'i18next';
 
 /**
  * Renders a selectable list of visits
@@ -32,7 +33,7 @@ import {Trans} from 'react-i18next';
  * @returns {React.ReactElement} - The visit list dropdown
  */
 function VisitList(props: {
-    t: any,
+    t: TFunction,
     selected: string[],
     options: string[],
     onChange: (newvals: string[]) => void,
@@ -88,7 +89,7 @@ function VisitList(props: {
  * @returns {React.ReactElement} - The modal window
  */
 function AddFilterModal(props: {
-    t: any,
+    t: TFunction,
     query: QueryGroup,
     closeModal: () => void,
     addQueryGroupItem: (group: QueryGroup, condition: QueryTerm) => void,
@@ -320,11 +321,11 @@ function AddFilterModal(props: {
  * Get a list of possible query operators based on a field's dictionary
  *
  * @param {object} dict - the field dictionary
- * @param {any} t useTranslation
+ * @param {TFunction} t useTranslation
  *
  * @returns {object} - list of options for this dictionary
  */
-function getOperatorOptions(dict: FieldDictionary, t: any) {
+function getOperatorOptions(dict: FieldDictionary, t: TFunction) {
   let options: {[operator: string]: string};
   if (dict.type == 'integer' || dict.type == 'date' ||
             dict.type == 'interval' || dict.type == 'time' ||
@@ -395,7 +396,7 @@ function valueInput(fielddict: FieldDictionary,
   op: Operators,
   value: string|string[],
   setValue: (val: string) => void,
-  t: any
+  t: TFunction,
 ) {
   const vs: string = value as string;
   switch (op) {

--- a/modules/dataquery/jsx/index.tsx
+++ b/modules/dataquery/jsx/index.tsx
@@ -23,6 +23,7 @@ import hiStrings from '../locale/hi/LC_MESSAGES/dataquery.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/dataquery.json';
 import frStrings from '../locale/fr/LC_MESSAGES/dataquery.json';
 import zhStrings from '../locale/zh/LC_MESSAGES/dataquery.json';
+import {TFunction} from 'i18next';
 
 type ActiveCategoryType = {
     module: string,
@@ -77,7 +78,7 @@ function useActiveCategory(
  * @returns {React.ReactElement} - The main page of the app
  */
 function DataQueryApp(props: {
-    t: any,
+    t: TFunction,
     queryAdmin: boolean,
 }) {
   const [activeTab, setActiveTab] = useState('Info');

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -11,6 +11,7 @@ import {QueryGroup} from './querydef';
 import {FullDictionary, FieldDictionary} from './types';
 import {calcPayload} from './calcpayload';
 import getDictionaryDescription from './getdictionarydescription';
+import {TFunction} from 'i18next';
 
 type TableRow = (string|null)[];
 
@@ -333,7 +334,7 @@ function useDataOrganization(
  * @returns {React.ReactElement} - The ViewData tab
  */
 function ViewData(props: {
-    t: any
+    t: TFunction,
     fields: APIQueryField[],
     filters: QueryGroup,
     onRun: () => void
@@ -830,7 +831,7 @@ function expandLongitudinalCells(
  *                                        no data should be displayed
  * @param {EnumDisplayTypes} enumDisplay -  The format to display
  *                                          enum values
- * @param {any} t - useTranslation
+ * @param {TFunction} t - useTranslation
 
  * @returns {function} - the appropriate column formatter for
                          this data organization
@@ -842,7 +843,7 @@ function organizedFormatter(
   dict: FullDictionary,
   displayEmptyVisits: boolean,
   enumDisplay: EnumDisplayTypes,
-  t: any,
+  t: TFunction,
 ) {
   let callback;
   switch (visitOrganization) {
@@ -1202,7 +1203,7 @@ type HeaderDisplayType = 'fieldname' | 'fielddesc' | 'fieldnamedesc';
  * @param {string} org - the visit organization
  * @param {string} display - the header display format
  * @param {object} fulldict - the data dictionary
- * @param {any} t - useTranslation
+ * @param {TFunction} t - useTranslation
  * @param {function} onProgress - Callback to indicate progress in processing
  * @returns {array} - A promise which resolves to the array of headers to display
  *                    in the frontend table
@@ -1212,7 +1213,7 @@ function organizeHeaders(
   org: VisitOrgType,
   display: HeaderDisplayType,
   fulldict: FullDictionary,
-  t: any,
+  t: TFunction,
   onProgress: (i: number) => void): Promise<string[]> {
   /**
    * Format a header according to the selected display type

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -15,6 +15,7 @@ import {FlattenedField, FlattenedQuery, VisitOption} from './types';
 import ReplayIcon from './ReplayIcon';
 import ShareIconA from './ShareIconA';
 import {useTranslation} from 'react-i18next';
+import {TFunction} from 'i18next';
 import 'I18nSetup';
 
 declare const loris: any;
@@ -1084,7 +1085,7 @@ function ShareIcon(props: {
  * @returns {React.ReactElement} - The React element
  */
 function NameIcon(props: {
-  t: any,
+  t: TFunction,
   onClick?: () => void
 }): React.ReactElement {
   return (<span title={props.t('Name Query', {ns: 'dataquery'})}

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/eeglab/EEGLabSeriesProvider.tsx
@@ -28,6 +28,7 @@ import {
 import TriggerableModal from 'jsx/TriggerableModal';
 import DatasetTagger from '../series/components/DatasetTagger';
 import {InfoIcon} from '../series/components/components';
+import {TFunction} from 'i18next';
 
 declare global {
   interface Window {
@@ -52,7 +53,7 @@ type CProps = {
   eegMontageName: string,
   recordingHasHED: boolean,
   children: React.ReactNode,
-  t: any,
+  t: TFunction,
 };
 
 const MenuOption = {


### PR DESCRIPTION
## Description

This PR makes three change:
- Change current code from typing `t` with `any` to typing it with `TFunction` (its standard type) when typed explicitly.
- Convert the `I18nSetup.js` file to Typescript instead of untyped Javascript + type definition file.
- Use `i18nest`'s `CustomTypeOptions` interface to specify the default namespace at the type level.

Can either be merged in main or 29 branch, no strong opinion.