### PR TITLE
[javascript] remove unmaintained react fragment library

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import PaginationLinks from 'jsx/PaginationLinks';
-import createFragment from 'react-addons-create-fragment';
 import {CTA} from 'jsx/Form';
 import {withTranslation} from 'react-i18next';
 
@@ -539,7 +538,9 @@ class DataTable extends Component {
         if (cell !== null) {
           curRow.push(React.cloneElement(cell, {key: 'td_col_' + j}));
         } else {
-          curRow.push(createFragment({celldata}));
+          curRow.push(
+            <React.Fragment key={'td_col_' + j}>{celldata}</React.Fragment>
+          );
         }
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
                 "papaparse": "^5.3.0",
                 "prop-types": "^15.7.2",
                 "react": "^18.2.0",
-                "react-addons-create-fragment": "^15.6.2",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^15.4.1",
                 "react-markdown": "^5.0.2",
@@ -3280,10 +3279,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "license": "MIT"
-        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "dev": true,
@@ -4112,10 +4107,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
-        },
-        "node_modules/core-js": {
-            "version": "1.2.7",
-            "license": "MIT"
         },
         "node_modules/core-js-compat": {
             "version": "3.25.4",
@@ -5624,19 +5615,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/fbjs": {
-            "version": "0.8.18",
-            "license": "MIT",
-            "dependencies": {
-                "core-js": "^1.0.0",
-                "isomorphic-fetch": "^2.1.1",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^0.7.30"
-            }
-        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "dev": true,
@@ -6917,13 +6895,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-stream": {
-            "version": "1.1.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-string": {
             "version": "1.0.7",
             "dev": true,
@@ -6991,14 +6962,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/isomorphic-fetch": {
-            "version": "2.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
             }
         },
         "node_modules/jest-worker": {
@@ -8666,14 +8629,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "1.7.3",
-            "license": "MIT",
-            "dependencies": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -9327,13 +9282,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/promise": {
-            "version": "7.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "asap": "~2.0.3"
-            }
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "license": "MIT",
@@ -9475,15 +9423,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-addons-create-fragment": {
-            "version": "15.6.2",
-            "license": "MIT",
-            "dependencies": {
-                "fbjs": "^0.8.4",
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.0"
             }
         },
         "node_modules/react-dom": {
@@ -11648,23 +11587,6 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/ua-parser-js": {
-            "version": "0.7.33",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "dev": true,
@@ -12697,10 +12619,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
-        },
-        "node_modules/whatwg-fetch": {
-            "version": "3.6.2",
-            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
         "papaparse": "^5.3.0",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
-        "react-addons-create-fragment": "^15.6.2",
-        "react-router-dom": "^5.3.4",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.4.1",
         "react-markdown": "^5.0.2",


### PR DESCRIPTION
## Description

This PR removes the unmaintained [`react-addon-create-fragment`](https://www.npmjs.com/package/react-addons-create-fragment) Javascript package to use the proper React Fragment component.

## Details

1. Remove `react-addon-create-fragment` from `package.json`
2. Remove duplicate `react-router-dom` entry in `pacakage.json`. 
3. Update the only call site of this library.
4. Run `npm install` to update the `pacakge-lock.json` file.