### PR TITLE
[issue_tracker/hindi] Fix po/pot mismatches for issue_tracker in Hindi

### DIFF
--- a/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
@@ -182,29 +182,8 @@ msgstr "बनाया गया"
 msgid "Last Updated"
 msgstr "अंतिम अपडेट"
 
-msgid "None"
-msgstr "कोई नहीं"
-
-msgid "Uncategorized"
-msgstr "अवर्गीकृत"
-
 msgid "Comments and History"
 msgstr "टिप्पणियाँ और इतिहास"
-
-msgid "on"
-msgstr "पर"
-
-msgid "at"
-msgstr "पर"
-
-msgid "seconds ago"
-msgstr "सेकंड पहले"
-
-msgid "minutes ago"
-msgstr "मिनट पहले"
-
-msgid "hours ago"
-msgstr "घंटे पहले"
 
 msgid "Title cannot be empty"
 msgstr "शीर्षक खाली नहीं हो सकता"
@@ -230,20 +209,11 @@ msgstr "टिप्पणी"
 msgid "Failed to add comment"
 msgstr "टिप्पणी जोड़ने में विफल"
 
-msgid "of"
-msgstr "का"
-
-msgid "Maximum issues per page"
-msgstr "प्रति पृष्ठ अधिकतम समस्याएँ"
-
 msgid "Failed to fetch issues. Please try again later."
 msgstr "समस्याएँ प्राप्त करने में विफल। कृपया बाद में पुनः प्रयास करें।"
 
 msgid "No issues match the selected filters."
 msgstr "कोई समस्या चयनित फ़िल्टर से मेल नहीं खाती।"
-
-msgid "issues displayed"
-msgstr "समस्याएँ प्रदर्शित"
 
 msgid "({{count}} comment)"
 msgid_plural "({{count}} comments)"
@@ -345,9 +315,6 @@ msgstr "फ़ॉर्म लोड करते समय एक त्रु�
 
 msgid "Please add a comment or make changes"
 msgstr "कृपया एक टिप्पणी जोड़ें या परिवर्तन करें"
-
-msgid "Updated by"
-msgstr "द्वारा अपडेट किया गया"
 
 msgid " to "
 msgstr " से "

--- a/modules/issue_tracker/locale/issue_tracker.pot
+++ b/modules/issue_tracker/locale/issue_tracker.pot
@@ -109,6 +109,9 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
+msgid "Failed to add comment"
+msgstr ""
+
 msgid "Create New Issue"
 msgstr ""
 
@@ -148,6 +151,9 @@ msgstr ""
 msgid "Watchers"
 msgstr ""
 
+msgid "Submitting..."
+msgstr ""
+
 msgid "Add others to watching?"
 msgstr ""
 
@@ -175,6 +181,9 @@ msgstr ""
 msgid "Last Updated By"
 msgstr ""
 
+msgid "Unassigned"
+msgstr ""
+
 msgid "Created"
 msgstr ""
 
@@ -197,7 +206,17 @@ msgstr ""
 msgid "No issues match the selected filters."
 msgstr ""
 
+msgid "({{count}} comment)"
+msgid_plural "({{count}} comments)"
+msgstr[0] ""
+
 msgid "Please confirm the request to delete the \"{{fileName}}\" attachment."
+msgstr ""
+
+msgid "Upload Successful!"
+msgstr ""
+
+msgid "Upload error!"
 msgstr ""
 
 msgid "Title cannot be empty"
@@ -207,6 +226,9 @@ msgid "No changes were made"
 msgstr ""
 
 msgid "Issue updated successfully"
+msgstr ""
+
+msgid "Failed to update issue"
 msgstr ""
 
 msgid "Information"
@@ -272,6 +294,36 @@ msgstr ""
 msgid "Last 3 Comments"
 msgstr ""
 
+msgid "Confirmation"
+msgstr ""
+
+msgid "Delete attachment"
+msgstr ""
+
+msgid "Attachment options: "
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Date of attachment: "
+msgstr ""
+
+msgid "File: "
+msgstr ""
+
+msgid "User: "
+msgstr ""
+
+msgid "Description: "
+msgstr ""
+
+msgid "Attachment History"
+msgstr ""
+
 msgid "The server is not configured to receive a file this large."
 msgstr ""
 
@@ -279,6 +331,15 @@ msgid "The server is not configured for attachments."
 msgstr ""
 
 msgid "Submit Attachment"
+msgstr ""
+
+msgid "An error occurred when loading the form!"
+msgstr ""
+
+msgid "Please add a comment or make changes"
+msgstr ""
+
+msgid " to "
 msgstr ""
 
 msgid "Submit Comment"


### PR DESCRIPTION
This fixes cases where there was a mismatch between the pot file and po msgid presence in the issue tracker by either deleting it from the Hindi if unused by the code or adding it to the pot file if it was used.)
