### PR TITLE
[multilingual/Spanish] Fix po/pot mismatches for Spanish.

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -327,8 +327,10 @@ msgstr "En Progreso"
 msgid "Complete"
 msgstr "Completo"
 
-msgid "Instruments"
-msgstr "Instrumentos"
+msgid "Instrument"
+msgid_plural "Instruments"
+msgstr[0] "Instrumento"
+msgstr[1] "Instrumentos"
 
 msgid "None"
 msgstr "Ninguna"

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -118,7 +118,7 @@ msgid "Last Update"
 msgstr ""
 
 # ProbandInfo Evolution tab
-msgid "'An error occurred when loading the form!'"
+msgid "An error occurred when loading the form!"
 msgstr ""
 
 msgid "DOB do not match!"


### PR DESCRIPTION
Instruments is now a msgid_plural, and the pot had an incorrect extra set of quotes for an error message.
