### PR TITLE
[tools] Add language_completion_check script

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -214,6 +214,26 @@ jobs:
       if: always()
       run: cat error_log
 
+  languagecheck:
+    runs-on: ubuntu-latest
+    needs:
+      - buildphp
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.5']
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: zip, php-ast
+
+    - name: Check for extra language strings
+      run: php tools/language_completion_check.php --extra
+
   docker:
     runs-on: ubuntu-latest
     strategy:

--- a/modules/behavioural_qc/locale/behavioural_qc.pot
+++ b/modules/behavioural_qc/locale/behavioural_qc.pot
@@ -55,3 +55,7 @@ msgstr ""
 msgid "Feedback Status"
 msgstr ""
 
+msgid "Profile"
+msgstr ""
+
+

--- a/modules/configuration/locale/configuration.pot
+++ b/modules/configuration/locale/configuration.pot
@@ -57,7 +57,7 @@ msgstr ""
 msgid "After adding a new cohort, Visit labels for this cohort can only be created by editing the configuration file, \"config.xml\". Please contact your administrator if you need more information."
 msgstr ""
 
-msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer\'s guide."
+msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide."
 msgstr ""
 
 msgid "To configure study cohorts"

--- a/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
+++ b/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
@@ -58,7 +58,8 @@ msgstr "Nouvelle cohorte"
 msgid "After adding a new cohort, Visit labels for this cohort can only be created by editing the configuration file, \"config.xml\". Please contact your administrator if you need more information."
 msgstr "Après l'ajout d'une nouvelle cohorte, les libellés de visite de cette cohorte ne peuvent être créés qu'en modifiant le fichier de configuration « config.xml ». Veuillez communiquer avec votre administrateur si vous avez besoin de plus d'informations."
 
-msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide."
+
+msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer\'s guide."
 msgstr "Veuillez saisir les différentes variables de configuration dans les champs ci-dessous. Pour savoir comment configurer LORIS, consultez la section Aide et/ou le guide du développeur."
 
 msgid "To configure study cohorts"

--- a/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
+++ b/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
@@ -58,7 +58,7 @@ msgstr "Nouvelle cohorte"
 msgid "After adding a new cohort, Visit labels for this cohort can only be created by editing the configuration file, \"config.xml\". Please contact your administrator if you need more information."
 msgstr "Après l'ajout d'une nouvelle cohorte, les libellés de visite de cette cohorte ne peuvent être créés qu'en modifiant le fichier de configuration « config.xml ». Veuillez communiquer avec votre administrateur si vous avez besoin de plus d'informations."
 
-msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer\'s guide."
+msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide."
 msgstr "Veuillez saisir les différentes variables de configuration dans les champs ci-dessous. Pour savoir comment configurer LORIS, consultez la section Aide et/ou le guide du développeur."
 
 msgid "To configure study cohorts"

--- a/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
+++ b/modules/configuration/locale/fr/LC_MESSAGES/configuration.po
@@ -58,7 +58,6 @@ msgstr "Nouvelle cohorte"
 msgid "After adding a new cohort, Visit labels for this cohort can only be created by editing the configuration file, \"config.xml\". Please contact your administrator if you need more information."
 msgstr "Après l'ajout d'une nouvelle cohorte, les libellés de visite de cette cohorte ne peuvent être créés qu'en modifiant le fichier de configuration « config.xml ». Veuillez communiquer avec votre administrateur si vous avez besoin de plus d'informations."
 
-
 msgid "Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer\'s guide."
 msgstr "Veuillez saisir les différentes variables de configuration dans les champs ci-dessous. Pour savoir comment configurer LORIS, consultez la section Aide et/ou le guide du développeur."
 

--- a/modules/survey_accounts/locale/hi/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/hi/LC_MESSAGES/survey_accounts.po
@@ -79,9 +79,6 @@ msgstr "कृपया एक उपकरण चुनें."
 msgid "already exists for given candidate for visit"
 msgstr "दिए गए उम्मीदवार के लिए यात्रा हेतु पहले से ही मौजूद है"
 
-msgid "The email address is not valid."
-msgstr "ईमेल पता मान्य नहीं है."
-
 msgid "Please confirm the email address."
 msgstr "कृपया ईमेल पता की पुष्टि करें."
 

--- a/tools/language_completion_check.php
+++ b/tools/language_completion_check.php
@@ -1,0 +1,165 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * This tool verifies that the language po file and language template pot file are
+ * kept in sync for languages that are supported by LORIS.
+ *
+ * It can be used to either look for strings that are in a language's po
+ * file that are missing from the pot by passing the "--extra" flag or
+ * to look for strings in the template that are missing from a language
+ * by passing the "--missing" flag. (You can also pass both to flag
+ * all errors.)
+ *
+ * The --lang=XX parameter can be used to restrict the script to checking
+ * one specific language.
+ *
+ * The script exits with a "1" if errors are found or "0" if there are
+ * no errors present, so that it can be integrated into our testing pipeline.
+ */
+require_once 'generic_includes.php';
+
+$patterns = [
+    __DIR__ . "/../locale/*.pot",
+    __DIR__ . "/../modules/*/locale/*.pot"
+];
+
+$languages = [
+    'en',
+    'fr',
+    'es',
+    'ja',
+    'hi',
+    'zh'
+
+];
+
+$options = getopt("v", ['missing', 'extra', 'lang:']);
+$missing = isset($options['missing']);
+$extra   = isset($options['extra']);
+$verbose = isset($options['v']);
+if (isset($options['lang'])) {
+    $languages = [$options['lang']];
+}
+
+if ($missing === false && $extra === false) {
+    fprintf(STDERR, "usage: %s [-v] [--lang=..] --missing | --extra\n", $argv[0]);
+    exit(1);
+}
+
+$founderrors = false;
+foreach ($languages as $lang) {
+    if ($verbose) {
+        fwrite(STDERR, "Validating $lang:\n");
+    }
+
+    foreach ($patterns as $pattern) {
+        foreach (glob($pattern) as $filename) {
+            $finfo = pathinfo(realpath($filename));
+            if ($verbose) {
+                fprintf(STDERR, "Validating $finfo[filename]\n");
+            }
+            if ($missing) {
+                validatemissing($finfo['dirname'], $finfo['filename'], $lang);
+
+            }
+            if ($extra) {
+                validateextra($finfo['dirname'], $finfo['filename'], $lang);
+            }
+        }
+    }
+}
+
+/**
+ * Validate that there are no po strings missing that are present in the pot
+ * file. Returns true on success, false on error.
+ *
+ * @param string $dir       The base of the locale directory (LORIS's or the
+ *                          module's)
+ * @param string $namespace The namespace being verified
+ * @param string $language  The language being verified
+ *
+ * @return bool
+ */
+function validatemissing(string $dir, string $namespace, string $language) : bool
+{
+    $transfile = $dir . "/" . $language . "/LC_MESSAGES/" . $namespace . ".po";
+    $potfile   = $dir . "/" . $namespace . ".pot";
+
+    if (file_exists($transfile) === false ) {
+        fprintf(STDERR, "$namespace translations do not exist for $language\n");
+        return false;
+    }
+    $results = compare($potfile, $transfile);
+    if (!empty($results['mismatch'])) {
+        foreach ($results['mismatch'] as $result) {
+            print("$language\t$namespace\tMissing\t$result\n");
+        }
+    }
+    return true;
+}
+
+/**
+ * Validate that there are no pot strings missing that are present in the po
+ * file. Returns true on success, false on error.
+ *
+ * @param string $dir       The base of the locale directory (LORIS's or the
+ *                          module's)
+ * @param string $namespace The namespace being verified
+ * @param string $language  The language being verified
+ *
+ * @return bool
+ */
+function validateextra(string $dir, string $namespace, string $language)
+{
+    $transfile = $dir . "/" . $language . "/LC_MESSAGES/" . $namespace . ".po";
+    $potfile   = $dir . "/" . $namespace . ".pot";
+
+    if (file_exists($transfile) === false ) {
+        return false;
+    }
+
+    $results = compare($transfile, $potfile);
+    if (!empty($results['mismatch'])) {
+        foreach ($results['mismatch'] as $result) {
+            print("$language\t$namespace\tExtra\t$result\n");
+        }
+    }
+    return true;
+
+}
+
+/**
+ * Compare file1 to file2. file1 and file2 must be filenames.
+ *
+ * Returns an array containing a 'total' key with all msgids that
+ * were present in file1, and a "mismatch" line containing all
+ * that were not present in file2.
+ *
+ * @param string $file1 The first file to compare
+ * @param string $file2 The file to compare against
+ *
+ * @return array
+ */
+function compare(string $file1, string $file2) : array
+{
+    global $founderrors;
+    $content = file_get_contents($file1);
+    $matches = [];
+    preg_match_all("/msgid \"(.*)\"/", $content, $matches);
+    $strings = $matches[1];
+
+    $mismatch         = [];
+    $language_content = file_get_contents($file2);
+
+    foreach ($strings as $str) {
+        $mstr = 'msgid "' . $str . '"';
+        if (strpos($language_content, $mstr) === false) {
+            $founderrors = true;
+            $mismatch[]  = $str;
+        }
+    }
+    return ['total' => $matches[1], 'mismatch' => $mismatch];
+}
+
+exit($founderrors === false ? 0 : 1);

--- a/tools/language_completion_check.php
+++ b/tools/language_completion_check.php
@@ -17,7 +17,10 @@
  * The script exits with a "1" if errors are found or "0" if there are
  * no errors present, so that it can be integrated into our testing pipeline.
  */
-require_once 'generic_includes.php';
+// This only uses standard php functions and doesn't use any loris infrastructure,
+// don't include generic_includes because then the GitHub Actions needs a database
+// connecction/project directory/etc
+//require_once 'generic_includes.php';
 
 $patterns = [
     __DIR__ . "/../locale/*.pot",


### PR DESCRIPTION
This adds a simple language_completion_check script to compare for mismatches between msgids in the pot and po file.

It can be used to either look for strings that are in a language's po file that are missing from the pot by passing the "--extra" flag or to look for strings in the template that are missing from a language by passing the "--missing" flag. (You can also pass both to flag all errors.)

The --lang=XX parameter can be used to restrict the script to checking one specific language, otherwise it will look at all languages that LORIS currently supports.

The script exits with a "1" if errors are found or "0" if there are no errors present, so that it can be integrated into our testing pipeline.

A string found with the --extra parameter always indicates a bug. It means that a developer either didn't update the pot file when adding a translation string to a language, or didn't maintain existing ones while updating a reference/moving things between namespaces/etc.

A string found with --missing should be fixed, but doesn't necessarily indicate a bug with a PR. As long as the developer maintains the pot file, a translator can update the language translations later. We should audit supported languages (in particular, French) periodically (especially before a release) but not block development based on translator availability.