### PR TITLE
[modules | imaging_uploader] Fix media upload error handling for non-JSON server responses

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -365,14 +365,15 @@ class UploadForm extends Component {
     let messageToPrint = '';
     let resp = null;
     if (xhr.response) {
-      try{
+      try {
         resp = JSON.parse(xhr.response);
-      } catch(e){
+      } 
+      catch (e) {
         console.warn('Failed upload response was not valid JSON', e);
       }
     }
     if (resp && resp.errors) {
-        errorMessage = resp.errors;
+      errorMessage = resp.errors;
       } else if (xhr.status == 0) {
       errorMessage = {
         'mriFile': [t('Upload failed: a network error occured',

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -363,12 +363,17 @@ class UploadForm extends Component {
 
     let errorMessage = Object.assign({}, this.state.errorMessage);
     let messageToPrint = '';
+    let resp = null;
     if (xhr.response) {
-      const resp = JSON.parse(xhr.response);
-      if (resp.errors) {
-        errorMessage = resp.errors;
+      try{
+        resp = JSON.parse(xhr.response);
+      } catch(e){
+        console.warn('Failed upload response was not valid JSON', e);
       }
-    } else if (xhr.status == 0) {
+    }
+    if (resp && resp.errors) {
+        errorMessage = resp.errors;
+      } else if (xhr.status == 0) {
       errorMessage = {
         'mriFile': [t('Upload failed: a network error occured',
           {ns: 'imaging_uploader'})],

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -367,14 +367,13 @@ class UploadForm extends Component {
     if (xhr.response) {
       try {
         resp = JSON.parse(xhr.response);
-      } 
-      catch (e) {
+      } catch (e) {
         console.warn('Failed upload response was not valid JSON', e);
       }
     }
     if (resp && resp.errors) {
       errorMessage = resp.errors;
-      } else if (xhr.status == 0) {
+    } else if (xhr.status == 0) {
       errorMessage = {
         'mriFile': [t('Upload failed: a network error occured',
           {ns: 'imaging_uploader'})],


### PR DESCRIPTION
This PR Fixes #10662 

## Situation

Uploading a file that exceeded the server upload limit could result in a non-JSON error response (for ex. an HTML 413 *Request Entity Too Large* page). The Imaging Uploader frontend always attempted to parse the response as JSON, causing an uncaught `JSON.parse()` exception and preventing the intended upload error message from being displayed to the user.

## Task

Update the Imaging Uploader frontend to gracefully handle non-JSON upload error responses while preserving the existing behaviour for valid JSON responses returned by the backend.

## Action

- Wrapped `JSON.parse(xhr.response)` in a `try/catch` block to safely handle responses that are not valid JSON.
- Initialized the parsed response to `null` and corrected the error handling logic to as following
  - continue using backend-provided validation errors when a valid JSON response is received,
  - gracefully fall back to HTTP status-based error handling when the response cannot be parsed (for ex. HTML 413 responses).
- Preserved the existing upload validation flow and JSON error handling for all other scenarios.
- Verified the fix by testing:
  - successful uploads with a valid ZIP file,
  - invalid ZIP validation,
  - oversized uploads that trigger an HTTP 413 response.

## Result

The Imaging Uploader should now handle non-JSON server responses without throwing a JavaScript exception. Oversized should upload correctly display the SWAL upload size error message, while existing JSON-based error handling and normal upload behavior remain unchanged.

## Testing Instructions:
- Since this issue is similar to 10559, please refer to the PR 10700