### PR TITLE
[Multilingual] Remove unused "Male"/"Female" translations

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -264,21 +264,6 @@ msgstr "DdN"
 msgid "Sex"
 msgstr "Sexe"
 
-msgid "Female"
-msgid_plural "Females"
-msgstr[0] "Femme"
-msgstr[1] "Femmes"
-
-msgid "Male"
-msgid_plural "Males"
-msgstr[0] "Homme"
-msgstr[1] "Hommes"
-
-msgid "Other"
-msgid_plural "Others"
-msgstr[0] "Autre"
-msgstr[1] "Autres"
-
 msgid "Feedback"
 msgstr "Commentaires"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -256,18 +256,6 @@ msgstr ""
 msgid "Sex"
 msgstr ""
 
-msgid "Female"
-msgid_plural "Females"
-msgstr[0] ""
-
-msgid "Male"
-msgid_plural "Males"
-msgstr[0] ""
-
-msgid "Other"
-msgid_plural "Others"
-msgstr[0] ""
-
 msgid "Feedback"
 msgstr ""
 


### PR DESCRIPTION
Remove unused "Male" and "Female" (and "Other") translations from the loris.pot file.

These are now in the "sex" namespace as they come from the "sex" table. The ones in the loris namespace are no longer used.

I am sending this to main and adding "Discussion Required" because this table has values in the default schema. We currently provide translations in the raisinbread test dataset, but these won't be installed on new (real) loris installs. We need to decide how to deal with translations of tables that have values inserted in the 0000-schema files.