### PR TITLE
[loris.po/ja] Add missing translation strings

### DIFF
--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -250,6 +250,9 @@ msgstr "参加者ステータス"
 msgid "DoB"
 msgstr "生年月日"
 
+msgid "DoD"
+msgstr "死亡日"
+
 msgid "Sex"
 msgstr "性別"
 
@@ -469,6 +472,12 @@ msgstr "スクリーニング"
 msgid "Visit"
 msgstr "訪問"
 
+msgid "Created"
+msgstr "作成済み"
+
+msgid "Sent"
+msgstr "送信済み"
+
 msgid "Approval"
 msgstr "承認"
 
@@ -561,6 +570,10 @@ msgstr "クリア"
 
 msgid "Add"
 msgstr "追加"
+
+#, fuzzy
+msgid "Update"
+msgstr "修正"
 
 msgid "Dataset"
 msgstr "データセット"


### PR DESCRIPTION
This adds translation strings that are missing from the Japanese loris.po file identified by the script in PR #10739