### PR TITLE
[multilingual] Only one type of permission denied

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -576,9 +576,6 @@ msgstr "Chargement en cours..."
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-msgid "Permission Denied"
-msgstr "Permission refusée"
-
 msgid "Unauthorized"
 msgstr "Non autorisé"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -565,9 +565,6 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-msgid "Permission Denied"
-msgstr ""
-
 msgid "Unauthorized"
 msgstr ""
 

--- a/modules/candidate_profile/test/CandidateProfileIntegrationTest.php
+++ b/modules/candidate_profile/test/CandidateProfileIntegrationTest.php
@@ -66,7 +66,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("Permission Denied", $bodyText);
+        $this->assertStringContainsString("Permission denied", $bodyText);
         $this->resetPermissions();
 
         $this->resetStudySite();
@@ -87,7 +87,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("Permission Denied", $bodyText);
+        $this->assertStringContainsString("Permission denied", $bodyText);
         $this->resetPermissions();
 
         $this->resetUserProject();

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -66,7 +66,7 @@ function editFile()
         || (!$user->hasPermission('access_all_profiles')
         && !$user->hasCenter(new \CenterID(strval($row['CenterID']))))
     ) {
-        showMediaError("Permission Denied", 403);
+        showMediaError("Permission denied", 403);
         exit(0);
     }
 
@@ -106,7 +106,7 @@ function uploadFile()
     $config = NDB_Config::singleton();
     $user   =& User::singleton();
     if (!$user->hasPermission('media_write')) {
-        showMediaError("Permission Denied", 403);
+        showMediaError("Permission denied", 403);
         exit(0);
     }
 

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -230,7 +230,7 @@ class MediaEditForm extends Component {
         }
         console.error(msg);
         if (xhr.status === 403) {
-          msg = t('Permission Denied', {ns: 'media'});
+          msg = t('Permission denied', {ns: 'loris'});
         }
         swal.fire(msg, '', 'error');
       }

--- a/modules/media/php/files.class.inc
+++ b/modules/media/php/files.class.inc
@@ -38,7 +38,7 @@ class Files extends \LORIS\Http\FilesPassthroughEndpoint
         $user = \User::singleton();
         // @phan-suppress-next-line PhanUndeclaredMethod
         if (!$this->isAccessibleBy($user)) {
-            return new \LORIS\Http\Response\JSON\Forbidden("Permission Denied");
+            return new \LORIS\Http\Response\JSON\Forbidden("Permission denied");
         }
 
         $url    = $request->getUri()->getPath();

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -778,7 +778,7 @@ class NDB_Page extends \LORIS\Http\Endpoint implements
                 ->process(
                     $request,
                     new \LORIS\Http\StringStream(
-                        dgettext("loris", "Permission Denied")
+                        dgettext("loris", "Permission denied")
                     )
                 )->withStatus(403);
         }


### PR DESCRIPTION
LORIS is inconsistent about the usage of "Permission denied" or "Permission Denied". As a result, both are in the loris.pot file and the string needs to be translated twice. This updates the code to consistently use the "Permission denied" casing, and also fixes a namespace that was incorrect in the media module for the error string I found while auditing the usages.