### PR TITLE
[next_stage] Fix date fields translations in french

### DIFF
--- a/modules/next_stage/locale/fr/LC_MESSAGES/next_stage.po
+++ b/modules/next_stage/locale/fr/LC_MESSAGES/next_stage.po
@@ -28,13 +28,13 @@ msgid "Start Next Stage"
 msgstr "Commencer l'étape suivante"
 
 msgid "Date of %s"
-msgstr "Date du %s"
+msgstr "Date de la %s"
 
 msgid "Retype Date of %s"
-msgstr "Saisir à nouveau la date du %s"
+msgstr "Saisir à nouveau la date de la %s"
 
 msgid "Start %s"
-msgstr "Démarrer le %s"
+msgstr "Démarrer la %s"
 
 msgid "CohortID:"
 msgstr "Identifiant de cohorte :"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes date fields translations in french. In the corresponding issue, it was noted that the date picker is only available in English. I'm pretty confident that it would need to be reworked to be translated with how multi lingual LORIS is designed. In that case, I don't think it is worth changing right now since it could introduced bugs right before LORIS 29 release.

Please correct me if I'm wrong

#### Link(s) to related issue(s)

* Resolves #10622 (Reference the issue this fixes, if any.)
