### PR TITLE
[datadict] Fix 'Legacy' translation in french

### DIFF
--- a/modules/datadict/locale/fr/LC_MESSAGES/datadict.po
+++ b/modules/datadict/locale/fr/LC_MESSAGES/datadict.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Data Dictionary (Legacy)"
-msgstr "Dictionnaire de données (ancienne version)"
+msgstr "Dictionnaire de données (Ancienne version)"
 
 msgid "Source From"
 msgstr "Source provenant de"

--- a/modules/datadict/locale/fr/LC_MESSAGES/datadict.po
+++ b/modules/datadict/locale/fr/LC_MESSAGES/datadict.po
@@ -22,7 +22,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Data Dictionary (Legacy)"
-msgstr "Dictionnaire de données (hérité)"
+msgstr "Dictionnaire de données (ancienne version)"
 
 msgid "Source From"
 msgstr "Source provenant de"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes 'Legacy' translation in french.

#### Link(s) to related issue(s)

* Resolves #10576 (Reference the issue this fixes, if any.)
