### PR TITLE
[candidate_parameters] Fix prop type of t from string to func

### DIFF
--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -215,6 +215,6 @@ CandidateDOB.propTypes = {
   dataURL: PropTypes.string,
   tabName: PropTypes.string,
   action: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 export default withTranslation(['candidate_parameters', 'loris'])(CandidateDOB);

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -227,6 +227,6 @@ CandidateDOD.propTypes = {
   dataURL: PropTypes.string,
   tabName: PropTypes.string,
   action: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 export default withTranslation(['candidate_parameters', 'loris'])(CandidateDOD);

--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -393,7 +393,7 @@ CandidateInfo.propTypes = {
   dataURL: PropTypes.string,
   tabName: PropTypes.string,
   action: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 export default withTranslation(
   ['candidate_parameters', 'loris']

--- a/modules/candidate_parameters/jsx/CandidateParameters.js
+++ b/modules/candidate_parameters/jsx/CandidateParameters.js
@@ -129,7 +129,7 @@ class CandidateParameters extends Component {
 
 CandidateParameters.propTypes = {
   candID: PropTypes.string.isRequired,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 /**

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -577,7 +577,7 @@ ConsentStatus.propTypes = {
   dataURL: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
   tabName: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 export default withTranslation(

--- a/modules/candidate_parameters/jsx/DiagnosisEvolution.js
+++ b/modules/candidate_parameters/jsx/DiagnosisEvolution.js
@@ -251,7 +251,7 @@ DiagnosisEvolution.propTypes = {
   submitURL: PropTypes.string,
   dataURL: PropTypes.string,
   tabName: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 export default withTranslation(
   ['candidate_parameters', 'loris']

--- a/modules/candidate_parameters/jsx/FamilyInfo.js
+++ b/modules/candidate_parameters/jsx/FamilyInfo.js
@@ -406,7 +406,7 @@ FamilyInfo.propTypes = {
   tabName: PropTypes.string,
   candID: PropTypes.string,
   action: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 export default withTranslation(['candidate_parameters', 'loris'])(FamilyInfo);

--- a/modules/candidate_parameters/jsx/ParticipantStatus.js
+++ b/modules/candidate_parameters/jsx/ParticipantStatus.js
@@ -359,7 +359,7 @@ ParticipantStatus.propTypes = {
   dataURL: PropTypes.string,
   tabName: PropTypes.string,
   action: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 export default withTranslation(

--- a/modules/candidate_parameters/jsx/ProbandInfo.js
+++ b/modules/candidate_parameters/jsx/ProbandInfo.js
@@ -371,7 +371,7 @@ ProbandInfo.propTypes = {
   dataURL: PropTypes.string.isRequired,
   action: PropTypes.string.isRequired,
   tabName: PropTypes.string,
-  t: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 export default withTranslation(['candidate_parameters', 'loris'])(ProbandInfo);


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the t prop type from `PropTypes.string.isRequired` to `PropTypes.func.isRequired` since t is used as a function in multi lingual LORIS and the former was causing warnings in the console of the candidate_parameters modules.

#### Testing instructions (if applicable)

1. Please follow the steps described in the corresponding issue.
<img width="412" height="163" alt="image" src="https://github.com/user-attachments/assets/b67682f8-b1b9-4259-9ee9-c61b9428309c" />

2. There should be no more red warnings in the web console.
<img width="1709" height="199" alt="image" src="https://github.com/user-attachments/assets/82e07aa7-e391-474b-b02d-a120afd6174e" />


#### Link(s) to related issue(s)

* Resolves #10765 (Reference the issue this fixes, if any.)
