### PR TITLE
[candidate_list] Fix Candidate List page not loading in Spanish + minor multilingual changes

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -198,7 +198,7 @@ msgid "Session"
 msgstr ""
 
 msgid "Date of registration"
-msgstr ""
+msgstr "Fecha de inscripción"
 
 msgid "Participant Status"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -323,7 +323,7 @@ msgstr "Type d’entité"
 
 #, fuzzy
 msgid "Scan Done"
-msgstr "Scan terminé"
+msgstr "Scan d’imagerie complété"
 
 msgid "Language"
 msgstr "Langage"

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -157,17 +157,24 @@ class CandidateListIndex extends Component {
       || column === this.props.t('Date of registration', {ns: 'loris'})) {
       if (cell) {
         const date = new Date(cell);
-        return <td>{this.dateFormatter.format(date)}</td>;
+
+        if (!Number.isNaN(date.getTime())) {
+          return <td>{this.dateFormatter.format(date)}</td>;
+        }
       }
       return <td></td>;
     }
     if (column === this.props.t('Feedback', {ns: 'loris'})) {
       switch (cell) {
-      case '1': return <td style ={{background: '#E4A09E'}}>Opened</td>;
-      case '2': return <td style ={{background: '#EEEEAA'}}>Answered</td>;
-      case '3': return <td style ={{background: '#99CC99'}}>Closed</td>;
-      case '4': return <td style ={{background: '#99CCFF'}}>Comment</td>;
-      default: return <td>None</td>;
+        case '1': return <td style={{background: '#E4A09E'}}>
+          {this.props.t('Opened', {ns: 'candidate_list'})}</td>;
+        case '2': return <td style={{background: '#EEEEAA'}}>
+          {this.props.t('Answered', {ns: 'candidate_list'})}</td>;
+        case '3': return <td style={{background: '#99CC99'}}>
+          {this.props.t('Closed', {ns: 'candidate_list'})}</td>;
+        case '4': return <td style={{background: '#99CCFF'}}>
+          {this.props.t('Comment', {ns: 'candidate_list'})}</td>;
+        default: return <td>{this.props.t('None', {ns: 'loris'})}</td>;
       }
     }
     if (column === this.props.t('Scan Done', {ns: 'loris'})) {
@@ -336,11 +343,11 @@ class CandidateListIndex extends Component {
           type: 'select',
           hide: this.state.hideFilter,
           options: {
-            '0': 'None',
-            '1': 'Opened',
-            '2': 'Answered',
-            '3': 'Closed',
-            '4': 'Comment',
+            '0': this.props.t('None', {ns: 'loris'}),
+            '1': this.props.t('Opened', {ns: 'candidate_list'}),
+            '2': this.props.t('Answered', {ns: 'candidate_list'}),
+            '3': this.props.t('Closed', {ns: 'candidate_list'}),
+            '4': this.props.t('Comment', {ns: 'candidate_list'}),
           },
         },
       },

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -163,15 +163,15 @@ class CandidateListIndex extends Component {
     }
     if (column === this.props.t('Feedback', {ns: 'loris'})) {
       switch (cell) {
-        case '1': return <td style={{background: '#E4A09E'}}>
-          {this.props.t('Opened', {ns: 'candidate_list'})}</td>;
-        case '2': return <td style={{background: '#EEEEAA'}}>
-          {this.props.t('Answered', {ns: 'candidate_list'})}</td>;
-        case '3': return <td style={{background: '#99CC99'}}>
-          {this.props.t('Closed', {ns: 'candidate_list'})}</td>;
-        case '4': return <td style={{background: '#99CCFF'}}>
-          {this.props.t('Comment', {ns: 'candidate_list'})}</td>;
-        default: return <td>{this.props.t('None', {ns: 'loris'})}</td>;
+      case '1': return <td style={{background: '#E4A09E'}}>
+        {this.props.t('Opened', {ns: 'candidate_list'})}</td>;
+      case '2': return <td style={{background: '#EEEEAA'}}>
+        {this.props.t('Answered', {ns: 'candidate_list'})}</td>;
+      case '3': return <td style={{background: '#99CC99'}}>
+        {this.props.t('Closed', {ns: 'candidate_list'})}</td>;
+      case '4': return <td style={{background: '#99CCFF'}}>
+        {this.props.t('Comment', {ns: 'candidate_list'})}</td>;
+      default: return <td>{this.props.t('None', {ns: 'loris'})}</td>;
       }
     }
     if (column === this.props.t('Scan Done', {ns: 'loris'})) {

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -157,10 +157,7 @@ class CandidateListIndex extends Component {
       || column === this.props.t('Date of registration', {ns: 'loris'})) {
       if (cell) {
         const date = new Date(cell);
-
-        if (!Number.isNaN(date.getTime())) {
-          return <td>{this.dateFormatter.format(date)}</td>;
-        }
+        return <td>{this.dateFormatter.format(date)}</td>;
       }
       return <td></td>;
     }

--- a/modules/candidate_list/locale/candidate_list.pot
+++ b/modules/candidate_list/locale/candidate_list.pot
@@ -29,3 +29,21 @@ msgstr ""
 
 msgid "New %s (Beta)"
 msgstr ""
+
+msgid "Scanner"
+msgstr ""
+
+msgid "Human"
+msgstr ""
+
+msgid "Opened"
+msgstr ""
+
+msgid "Answered"
+msgstr ""
+
+msgid "Closed"
+msgstr ""
+
+msgid "Comment"
+msgstr ""

--- a/modules/candidate_list/locale/fr/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/fr/LC_MESSAGES/candidate_list.po
@@ -31,3 +31,21 @@ msgstr "Ouvrir le profil"
 
 msgid "New %s (Beta)"
 msgstr "%s (Nouveau/Bêta)"
+
+msgid "Scanner"
+msgstr "Scanner"
+
+msgid "Human"
+msgstr "Humain"
+
+msgid "Opened"
+msgstr "Ouvert"
+
+msgid "Answered"
+msgstr "Répondu"
+
+msgid "Closed"
+msgstr "Fermé"
+
+msgid "Comment"
+msgstr "Commentaire"

--- a/modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
@@ -34,6 +34,16 @@ msgstr "स्कैनर"
 msgid "Human"
 msgstr "मानव"
 
+msgid "Opened"
+msgstr "खोला गया"
 
+msgid "Answered"
+msgstr "उत्तर दिया गया"
+
+msgid "Closed"
+msgstr "बंद"
+
+msgid "Comment"
+msgstr "टिप्पणी"
 
 

--- a/modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/hi/LC_MESSAGES/candidate_list.po
@@ -22,13 +22,18 @@ msgstr ""
 msgid "Access Profile"
 msgstr "प्रोफ़ाइल तक पहुँचें"
 
-
-
 msgid "Visit Count"
 msgstr "आगंतुक गणना"
 
 msgid "Open Profile"
 msgstr "प्रोफ़ाइल खोलें"
+
+msgid "Scanner"
+msgstr "स्कैनर"
+
+msgid "Human"
+msgstr "मानव"
+
 
 
 

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
@@ -28,3 +28,8 @@ msgstr "訪問回数"
 msgid "Open Profile"
 msgstr "プロフィールを開く"
 
+msgid "Scanner"
+msgstr "スキャナー"
+
+msgid "Human"
+msgstr "人間"

--- a/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/ja/LC_MESSAGES/candidate_list.po
@@ -33,3 +33,15 @@ msgstr "スキャナー"
 
 msgid "Human"
 msgstr "人間"
+
+msgid "Opened"
+msgstr "オープンしました"
+
+msgid "Answered"
+msgstr "回答済み"
+
+msgid "Closed"
+msgstr "閉鎖"
+
+msgid "Comment"
+msgstr "コメント"

--- a/modules/candidate_list/locale/zh/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/zh/LC_MESSAGES/candidate_list.po
@@ -34,3 +34,14 @@ msgstr "扫描仪"
 msgid "Human"
 msgstr "受试者"
 
+msgid "Opened"
+msgstr "已打开"
+
+msgid "Answered"
+msgstr "已回复"
+
+msgid "Closed"
+msgstr "关闭"
+
+msgid "Comment"
+msgstr "评论"

--- a/modules/candidate_list/locale/zh/LC_MESSAGES/candidate_list.po
+++ b/modules/candidate_list/locale/zh/LC_MESSAGES/candidate_list.po
@@ -27,3 +27,10 @@ msgstr "访问次数"
 
 msgid "Open Profile"
 msgstr "打开资料"
+
+msgid "Scanner"
+msgstr "扫描仪"
+
+msgid "Human"
+msgstr "受试者"
+


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a crash that occurred when the Spanish locale was selected on the Candidate List page.

The root cause was that the general LORIS Spanish locale was missing a translation for “Date of registration”, causing `t('Date of registration', {ns: 'loris’})` to return an empty string. As a result, the comparison against the translated column name matched an empty column name instead of the intended date column, causing the date formatting logic to attempt to format a non-date value.

Before:
<img width="1708" height="950" alt="Untitled" src="https://github.com/user-attachments/assets/933de44a-35bd-48b6-b369-0185d31436ba" />

After:
<img width="1709" height="953" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/7624a17f-b84e-435d-bae6-a2d163921fb3" />

GeorgeMurad's comment on that same issue was addressed and requested changes were done. 

Also, I noticed that other values in `candidateListIndex.js` were hardcoded (Opened, Answered, Closed, Comment and None) and decided to translate them as part of the same PR. (I used AI for translations in hindi, japanese and chinese).


Note: I thought that the page would fall back entirely to English instead of being partially translated in Spanish (because of the loris namespaces). Since the candidate_list module does not provide a Spanish locale, the page is only partially translated, with some labels falling back to English, others appearing in Spanish, and some remaining empty due to missing translations.

#### Link(s) to related issue(s)

* Resolves #10566 (Reference the issue this fixes, if any.)
