### PR TITLE
[user_accounts] Disable own site and project self-edits

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -191,14 +191,6 @@ class Edit_User extends \NDB_Form
      */
     function _process($values)
     {
-        if ($this->_isEditingOwnAccount()) {
-            error_log(
-                "[user_accounts] Blocked self-edit attempt for user: "
-                . $this->identifier
-            );
-            return;
-        }
-
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
         $config  = $factory->config();
@@ -206,7 +198,8 @@ class Edit_User extends \NDB_Form
         //The arrays that contain the edited permissions
         $permissionsRemoved = [];
         $permissionsAdded   = [];
-        $editor = $factory->user();
+        $editor     = $factory->user();
+        $isSelfEdit = $this->_isEditingOwnAccount();
 
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
@@ -293,14 +286,16 @@ class Edit_User extends \NDB_Form
         }
         // multi-site UPDATE
         $uid           = $user->getId();
-        $us_curr_sites = $values['CenterIDs'];
-        $userNewCenterIDs = array_map(
-            function ($val) {
-                return \CenterID::singleton(intval($val));
-            },
-            $values['CenterIDs']
-        );
-        if (!$this->isCreatingNewUser()) {
+        $us_curr_sites = $values['CenterIDs'] ?? [];
+        $userNewCenterIDs = $isSelfEdit
+            ? $user->getCenterIDs()
+            : array_map(
+                function ($val) {
+                    return \CenterID::singleton(intval($val));
+                },
+                $us_curr_sites
+            );
+        if (!$this->isCreatingNewUser() && !$isSelfEdit) {
             // Prevent deletion of rules/sites editor may not have access to edit.
             if (!$editor->hasPermission('user_accounts_multisite')) {
                 // Collect CenterID(s) of user being modified.
@@ -336,8 +331,8 @@ class Edit_User extends \NDB_Form
         // END multi-site UPDATE
 
         // START PROJECT UPDATE
-        $us_curr_projects = $values['ProjectIDs'];
-        if (!$this->isCreatingNewUser()) {
+        $us_curr_projects = $values['ProjectIDs'] ?? [];
+        if (!$this->isCreatingNewUser() && !$isSelfEdit) {
             $DB->delete('user_project_rel', ["UserID" => $uid]);
             foreach ($us_curr_projects as $project) {
                 $DB->insert(
@@ -654,7 +649,6 @@ class Edit_User extends \NDB_Form
         if (!empty($matches[1])) {
             $this->identifier = $matches[1];
         }
-        $this->tpl_data['isSelfEdit'] = $this->_isEditingOwnAccount();
         $response = parent::handle($request);
         if (!empty($this->redirect)) {
             return $response
@@ -869,15 +863,20 @@ class Edit_User extends \NDB_Form
             }
         }
 
+        $siteAttributes = [
+            'class'    => 'form-control input-sm resizable',
+            'multiple' => 'multiple',
+            'required' => true,
+        ];
+        if ($this->_isEditingOwnAccount()) {
+            $siteAttributes['disabled'] = 'disabled';
+        }
+
         $this->addSelect(
             'CenterIDs',
             dngettext("loris", "Site", "Sites", count($siteOptions)),
             $siteOptions,
-            [
-                'class'    => 'form-control input-sm resizable',
-                'multiple' => 'multiple',
-                'required' => true,
-            ]
+            $siteAttributes
         );
 
         // START PROJECT SECTION
@@ -889,15 +888,20 @@ class Edit_User extends \NDB_Form
                 = $projects[$projectID->__toString()];
         }
 
+        $projectAttributes = [
+            'class'    => 'form-control input-sm resizable',
+            'multiple' => 'multiple',
+            'required' => true,
+        ];
+        if ($this->_isEditingOwnAccount()) {
+            $projectAttributes['disabled'] = 'disabled';
+        }
+
         $this->addSelect(
             'ProjectIDs',
             dngettext("loris", "Project", "Projects", count($projects)),
             $projectOptions,
-            [
-                'class'    => 'form-control input-sm resizable',
-                'multiple' => 'multiple',
-                'required' => true,
-            ]
+            $projectAttributes
         );
         // END PROJECT SECTION
 
@@ -1115,8 +1119,6 @@ class Edit_User extends \NDB_Form
         // unique key and password rules
         $this->form->addFormRule([&$this, '_validateEditUser']);
 
-        // Expose self-edit flag to the Smarty template.
-        $this->tpl_data['isSelfEdit'] = $this->_isEditingOwnAccount();
     }
 
     /**
@@ -1367,7 +1369,7 @@ class Edit_User extends \NDB_Form
         //           Validate Site
         //======================================
         // Ensure that at least one site is selected
-        if (empty($values['CenterIDs'])) {
+        if (!$this->_isEditingOwnAccount() && empty($values['CenterIDs'])) {
             $errors['sites_group'] = dgettext(
                 "user_accounts",
                 "You must select at least one site/affiliation"
@@ -1378,7 +1380,7 @@ class Edit_User extends \NDB_Form
         //           Validate Project
         //======================================
         // Ensure that at least one site is selected
-        if (empty($values['ProjectIDs'])) {
+        if (!$this->_isEditingOwnAccount() && empty($values['ProjectIDs'])) {
             $errors['projects_group'] = dgettext(
                 "user_accounts",
                 "You must select at least one project/affiliation"
@@ -1424,8 +1426,10 @@ class Edit_User extends \NDB_Form
         //    should be less or equal to the time to it will be active.
         //======================================
 
-        if (($values['active_to'] != null)
-            && ($values['active_from'] > $values['active_to'])
+        $activeFrom = $values['active_from'] ?? null;
+        $activeTo   = $values['active_to'] ?? null;
+        if (($activeTo != null)
+            && ($activeFrom > $activeTo)
         ) {
             $errors['active_timeWindows'] = dgettext(
                 "user_accounts",

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -25,15 +25,7 @@
     </div>
     <h3>{dgettext("user_accounts", "Add/Edit User")}</h3>
 
-    {if $isSelfEdit}
-    <div class="alert alert-warning" role="alert">
-        {dgettext("user_accounts", "You cannot edit your own account settings.")}
-        {dgettext("user_accounts", "To change your email or password, go to \"My Preferences\".")}
-        {dgettext("user_accounts", "For any other changes, contact an administrator.")}
-    </div>
-    {/if}
-
-    <fieldset {if $isSelfEdit}disabled="disabled"{/if}>
+    <fieldset>
 
 	    {if $form.errors.UserID_Group|default}
         <div class="row form-group has-error">
@@ -509,7 +501,12 @@
 
 <div class="row form-group form-inline">
    <div class="col-sm-2">
-      <input class="btn btn-sm btn-primary" name="fire_away" value="{dgettext("loris", "Save")}" type="submit" {if $isSelfEdit}disabled="disabled"{/if}/>
+      <input
+        class="btn btn-sm btn-primary"
+        name="fire_away"
+        value="{dgettext("loris", "Save")}"
+        type="submit"
+      />
   </div>
   <div class="col-sm-2">
     <input class="btn btn-sm btn-primary" value="{dgettext("loris", "Reset")}" type="reset"/>

--- a/modules/user_accounts/test/UserAccountsIntegrationTest.php
+++ b/modules/user_accounts/test/UserAccountsIntegrationTest.php
@@ -280,7 +280,9 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $field = $this->safeFindElement(WebDriverBy::Name('__ConfirmEmail'));
         $field->clear();
         $field->sendKeys('email@example.com');
-        $sitesElement = $this->safeFindElement(WebDriverBy::Name('CenterIDs[]'));
+        $sitesElement = $this->safeFindElement(
+            WebDriverBy::Name('CenterIDs[]')
+        );
         $sitesOption  = new WebDriverSelect($sitesElement);
         $sitesOption->selectByValue("1");
         $projectsElement = $this->safeFindElement(WebDriverBy::Name('ProjectIDs[]'));
@@ -338,7 +340,9 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function submit(): void
     {
-        $sitesElement = $this->safeFindElement(WebDriverBy::Name('CenterIDs[]'));
+        $sitesElement = $this->safeFindElement(
+            WebDriverBy::Name('CenterIDs[]')
+        );
         $sitesOption  = new WebDriverSelect($sitesElement);
         $sitesOption->selectByValue("1");
 
@@ -373,39 +377,45 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     }
 
     /**
-     * Verifies that when a user opens their own account page the form is
-     * entirely read-only: a warning banner is shown, all editable fields are
-     * disabled, and the Save button is disabled.
+     * Verifies that a user cannot remove their own project or site
+     * affiliations while editing their own account.
      *
      * @return void
      */
-    function testSelfEditFormIsReadOnly(): void
+    function testSelfEditDisablesProjectsAndSites(): void
     {
         $this->_accessUser(self::UNITTESTER_USERNAME);
 
-        // Warning message must be visible
-        $this->assertStringContainsString(
-            'You cannot edit your own account settings',
-            $this->getBody()
+        $sitesElement = $this->safeFindElement(
+            WebDriverBy::Name('CenterIDs[]')
+        );
+        $this->assertFalse(
+            $sitesElement->isEnabled(),
+            'Expected Sites to be disabled when editing own account'
         );
 
-        // Core fields must be disabled (fieldset-level disabled propagates to
-        // descendants; isEnabled() reflects the effective disabled state)
+        $projectsElement = $this->safeFindElement(
+            WebDriverBy::Name('ProjectIDs[]')
+        );
+        $this->assertFalse(
+            $projectsElement->isEnabled(),
+            'Expected Projects to be disabled when editing own account'
+        );
+
         foreach (['First_name', 'Last_name', 'Email'] as $fieldName) {
-            $this->assertFalse(
+            $this->assertTrue(
                 $this->safeFindElement(
                     WebDriverBy::Name($fieldName)
                 )->isEnabled(),
-                "Expected field '$fieldName' to be disabled when editing own account"
+                "Expected field '$fieldName' to stay enabled"
             );
         }
 
-        // Save button must be disabled (it carries an explicit disabled attr)
-        $this->assertNotNull(
+        $this->assertTrue(
             $this->safeFindElement(
                 WebDriverBy::Name('fire_away')
-            )->getAttribute('disabled'),
-            'Expected Save button to be disabled when editing own account'
+            )->isEnabled(),
+            'Expected Save to stay enabled'
         );
     }
 
@@ -548,4 +558,3 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         parent::tearDown();
     }
 }
-


### PR DESCRIPTION
## Brief summary of changes

- Disables the Sites and Projects multiselects when a user edits their own account.
- Preserves existing site/project assignments when those disabled fields are omitted from the submitted form.
- Keeps the rest of the edit-user form, including Save, available for normal self-editable fields.

#### Testing instructions

- Log in as `admin`.
- Open `http://localhost:8080/user_accounts/edit_user/admin`.
- Confirm Sites and Projects are disabled.
- Confirm fields such as First Name, Last Name, and Email remain enabled.
- Click Save and confirm no PHP warning appears and the existing site/project assignments are preserved.

#### Link(s) to related issue(s)

* Resolves #10323