### PR TITLE
[Policy_Tracker] Add admin frontend

### DIFF
--- a/SQL/0000-00-01-Modules.sql
+++ b/SQL/0000-00-01-Modules.sql
@@ -56,6 +56,6 @@ INSERT INTO modules (Name, Active) VALUES ('electrophysiology_uploader', 'N');
 INSERT INTO modules (Name, Active) VALUES ('dataquery', 'N');
 INSERT INTO modules (Name, Active) VALUES ('schedule_module', 'N');
 INSERT INTO modules (Name, Active) VALUES ('redcap', 'N');
-INSERT INTO modules (Name, Active) VALUES ('policy_tracker', 'N');
+INSERT INTO modules (Name, Active) VALUES ('policy_tracker', 'Y');
 
 ALTER TABLE issues ADD CONSTRAINT `fk_issues_7` FOREIGN KEY (`module`) REFERENCES `modules` (`ID`);

--- a/SQL/0000-00-02-Permission.sql
+++ b/SQL/0000-00-02-Permission.sql
@@ -179,6 +179,10 @@ INSERT INTO `permissions` (code, description, moduleID, categoryID) VALUES
     ('biobank_pool_create','Create Pools',(SELECT ID FROM modules WHERE Name='biobank'), '2'),
     ('biobank_fullsiteaccess','Full Site Access',(SELECT ID FROM modules WHERE Name='biobank'), '2'),
     ('biobank_fullprojectaccess','Full Project Access',(SELECT ID FROM modules WHERE Name='biobank'), '2'),
+    ('view_policy_decisions', 'Policy Decisions',
+        (SELECT ID FROM modules WHERE Name='policy_tracker'), 2),
+    ('edit_policies', 'Policies',
+        (SELECT ID FROM modules WHERE Name='policy_tracker'), 2),
     ('dataquery_view','Cross-Modality Data',(SELECT ID FROM modules WHERE Name='dataquery'),2);
 
 INSERT INTO `user_perm_rel` (userID, permID)
@@ -289,6 +293,9 @@ INSERT INTO `perm_perm_action_rel` (permID, actionID) VALUES
   ((SELECT permID FROM permissions WHERE code = 'biobank_pool_create'),2),
   ((SELECT permID FROM permissions WHERE code = 'biobank_fullsiteaccess'),1),
   ((SELECT permID FROM permissions WHERE code = 'biobank_fullprojectaccess'),1),
+  ((SELECT permID FROM permissions WHERE code = 'view_policy_decisions'),1),
+  ((SELECT permID FROM permissions WHERE code = 'edit_policies'),2),
+  ((SELECT permID FROM permissions WHERE code = 'edit_policies'),3),
   ((SELECT permID FROM permissions WHERE code = 'view_instrument_data'),1),
   ((SELECT permID FROM permissions WHERE code = 'dqt_view'),1),
   ((SELECT permID FROM permissions WHERE code = 'dqt_view'),8);

--- a/SQL/New_patches/2026-07-05-Activate-policy-tracker.sql
+++ b/SQL/New_patches/2026-07-05-Activate-policy-tracker.sql
@@ -1,0 +1,1 @@
+UPDATE modules SET Active='Y' WHERE Name='policy_tracker';

--- a/SQL/New_patches/2026-07-05-Activate-policy-tracker.sql
+++ b/SQL/New_patches/2026-07-05-Activate-policy-tracker.sql
@@ -1,1 +1,28 @@
 UPDATE modules SET Active='Y' WHERE Name='policy_tracker';
+
+INSERT IGNORE INTO permissions (code, description, moduleID, categoryID)
+SELECT 'view_policy_decisions', 'Policy Decisions', ID, 2
+FROM modules WHERE Name='policy_tracker';
+
+INSERT IGNORE INTO permissions (code, description, moduleID, categoryID)
+SELECT 'edit_policies', 'Policies', ID, 2
+FROM modules WHERE Name='policy_tracker';
+
+INSERT IGNORE INTO perm_perm_action_rel (permID, actionID)
+SELECT permID, 1
+FROM permissions
+WHERE code='view_policy_decisions';
+
+INSERT IGNORE INTO perm_perm_action_rel (permID, actionID)
+SELECT permissions.permID, permissions_action.ID
+FROM permissions
+CROSS JOIN permissions_action
+WHERE permissions.code='edit_policies'
+    AND permissions_action.name IN ('Create', 'Edit');
+
+INSERT IGNORE INTO user_perm_rel (userID, permID)
+SELECT users.ID, permissions.permID
+FROM users
+JOIN permissions
+    ON permissions.code IN ('view_policy_decisions', 'edit_policies')
+WHERE users.UserID='admin';

--- a/modules/policy_tracker/.gitignore
+++ b/modules/policy_tracker/.gitignore
@@ -1,0 +1,1 @@
+js/policyTrackerIndex.js

--- a/modules/policy_tracker/jsx/policyTrackerIndex.js
+++ b/modules/policy_tracker/jsx/policyTrackerIndex.js
@@ -10,6 +10,12 @@ import Loader from 'Loader';
 import Panel from 'Panel';
 import FilterableDataTable from 'FilterableDataTable';
 import lorisFetch from 'jslib/lorisFetch';
+import {
+  NumericElement,
+  SelectElement,
+  TextareaElement,
+  TextboxElement,
+} from 'jsx/Form';
 
 /**
  * Policy Tracker admin page.
@@ -235,10 +241,10 @@ class PolicyTrackerIndex extends Component {
   /**
    * Handle create-version form changes.
    *
-   * @param {object} event - Change event.
+   * @param {string} name - Field name.
+   * @param {string|number} value - Field value.
    */
-  handleVersionChange(event) {
-    const {name, value} = event.target;
+  handleVersionChange(name, value) {
     this.setState((state) => ({
       versionForm: {...state.versionForm, [name]: value},
     }));
@@ -247,10 +253,10 @@ class PolicyTrackerIndex extends Component {
   /**
    * Handle translation form changes.
    *
-   * @param {object} event - Change event.
+   * @param {string} name - Field name.
+   * @param {string|number} value - Field value.
    */
-  handleTranslationChange(event) {
-    const {name, value} = event.target;
+  handleTranslationChange(name, value) {
     this.setState((state) => ({
       translationForm: {...state.translationForm, [name]: value},
     }));
@@ -259,11 +265,12 @@ class PolicyTrackerIndex extends Component {
   /**
    * Change the source policy used by the create-version form.
    *
-   * @param {object} event - Change event.
+   * @param {string} name - Field name.
+   * @param {string|number} value - Selected policy ID.
    */
-  selectPolicy(event) {
+  selectPolicy(name, value) {
     const policy = this.state.options.policies.find((row) => {
-      return parseInt(row.PolicyID) === parseInt(event.target.value);
+      return parseInt(row.PolicyID) === parseInt(value);
     });
     this.setState({versionForm: this.getVersionForm(policy)});
   }
@@ -271,12 +278,13 @@ class PolicyTrackerIndex extends Component {
   /**
    * Change the policy or language used by the translation form.
    *
-   * @param {object} event - Change event.
+   * @param {string} name - Field name.
+   * @param {string|number} value - Selected field value.
    */
-  selectTranslation(event) {
+  selectTranslation(name, value) {
     const form = {
       ...this.state.translationForm,
-      [event.target.name]: event.target.value,
+      [name]: value,
     };
     const policy = this.state.options.policies.find((row) => {
       return parseInt(row.PolicyID) === parseInt(form.PolicyID);
@@ -339,111 +347,6 @@ class PolicyTrackerIndex extends Component {
         'error'
       );
     });
-  }
-
-  /**
-   * Render a select input.
-   *
-   * @param {string} name - Field name.
-   * @param {string} label - Field label.
-   * @param {object} options - Select options.
-   * @param {string|number} value - Selected value.
-   * @param {Function} onChange - Change handler.
-   * @param {string} idPrefix - Prefix for the input ID.
-   * @return {React.ReactNode}
-   */
-  renderSelect(name, label, options, value, onChange, idPrefix = 'version') {
-    const id = `${idPrefix}-${name}`;
-    return (
-      <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={id}>
-          {label}
-        </label>
-        <div className="col-sm-9">
-          <select
-            className="form-control"
-            id={id}
-            name={name}
-            value={value || ''}
-            onChange={onChange}
-          >
-            {Object.keys(options).map((key) => (
-              <option key={key} value={key}>{options[key]}</option>
-            ))}
-          </select>
-        </div>
-      </div>
-    );
-  }
-
-  /**
-   * Render a text or numeric input.
-   *
-   * @param {string} name - Field name.
-   * @param {string} label - Field label.
-   * @param {string|number} value - Field value.
-   * @param {Function} onChange - Change handler.
-   * @param {string} type - Input type.
-   * @param {string} idPrefix - Prefix for the input ID.
-   * @return {React.ReactNode}
-   */
-  renderInput(
-    name,
-    label,
-    value,
-    onChange,
-    type = 'text',
-    idPrefix = 'version'
-  ) {
-    const id = `${idPrefix}-${name}`;
-    return (
-      <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={id}>
-          {label}
-        </label>
-        <div className="col-sm-9">
-          <input
-            className="form-control"
-            id={id}
-            name={name}
-            type={type}
-            value={value || ''}
-            onChange={onChange}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  /**
-   * Render a textarea input.
-   *
-   * @param {string} name - Field name.
-   * @param {string} label - Field label.
-   * @param {string} value - Field value.
-   * @param {Function} onChange - Change handler.
-   * @param {string} idPrefix - Prefix for the input ID.
-   * @return {React.ReactNode}
-   */
-  renderTextarea(name, label, value, onChange, idPrefix = 'version') {
-    const id = `${idPrefix}-${name}`;
-    return (
-      <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={id}>
-          {label}
-        </label>
-        <div className="col-sm-9">
-          <textarea
-            className="form-control"
-            id={id}
-            name={name}
-            rows="8"
-            value={value || ''}
-            onChange={onChange}
-          />
-        </div>
-      </div>
-    );
   }
 
   /**
@@ -537,84 +440,111 @@ class PolicyTrackerIndex extends Component {
     return (
       <Panel title={t('Create New Policy Version', {ns: 'policy_tracker'})}>
         <form className="form-horizontal" onSubmit={this.saveNewVersion}>
-          {this.renderSelect(
-            'PolicyID',
-            t('Source Policy', {ns: 'policy_tracker'}),
-            policies,
-            this.state.versionForm.PolicyID,
-            this.selectPolicy
-          )}
-          {this.renderInput(
-            'Name',
-            t('Name', {ns: 'loris'}),
-            this.state.versionForm.Name,
-            this.handleVersionChange
-          )}
-          {this.renderSelect(
-            'ModuleID',
-            t('Module', {ns: 'loris'}),
-            modules,
-            this.state.versionForm.ModuleID,
-            this.handleVersionChange
-          )}
-          {this.renderInput(
-            'PolicyRenewalTime',
-            t('Days to Renew', {ns: 'policy_tracker'}),
-            this.state.versionForm.PolicyRenewalTime,
-            this.handleVersionChange,
-            'number'
-          )}
-          {this.renderSelect(
-            'PolicyRenewalTimeUnit',
-            t('Renewal Unit', {ns: 'policy_tracker'}),
-            renewalUnits,
-            this.state.versionForm.PolicyRenewalTimeUnit,
-            this.handleVersionChange
-          )}
-          {this.renderSelect(
-            'HeaderButton',
-            t('Header Button', {ns: 'policy_tracker'}),
-            yesNo,
-            this.state.versionForm.HeaderButton,
-            this.handleVersionChange
-          )}
-          {this.renderInput(
-            'HeaderButtonText',
-            t('Header Button Text', {ns: 'policy_tracker'}),
-            this.state.versionForm.HeaderButtonText,
-            this.handleVersionChange
-          )}
-          {this.renderSelect(
-            'Active',
-            t('Active', {ns: 'loris'}),
-            yesNo,
-            this.state.versionForm.Active,
-            this.handleVersionChange
-          )}
-          {this.renderInput(
-            'SwalTitle',
-            t('Modal Title', {ns: 'policy_tracker'}),
-            this.state.versionForm.SwalTitle,
-            this.handleVersionChange
-          )}
-          {this.renderInput(
-            'AcceptButtonText',
-            t('Accept Button Text', {ns: 'policy_tracker'}),
-            this.state.versionForm.AcceptButtonText,
-            this.handleVersionChange
-          )}
-          {this.renderInput(
-            'DeclineButtonText',
-            t('Decline Button Text', {ns: 'policy_tracker'}),
-            this.state.versionForm.DeclineButtonText,
-            this.handleVersionChange
-          )}
-          {this.renderTextarea(
-            'Content',
-            t('Content', {ns: 'loris'}),
-            this.state.versionForm.Content,
-            this.handleVersionChange
-          )}
+          <SelectElement
+            name="PolicyID"
+            id="version-PolicyID"
+            label={t('Source Policy', {ns: 'policy_tracker'})}
+            options={policies}
+            value={String(this.state.versionForm.PolicyID || '')}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.selectPolicy}
+          />
+          <TextboxElement
+            name="Name"
+            id="version-Name"
+            label={t('Name', {ns: 'loris'})}
+            value={this.state.versionForm.Name || ''}
+            onUserInput={this.handleVersionChange}
+          />
+          <SelectElement
+            name="ModuleID"
+            id="version-ModuleID"
+            label={t('Module', {ns: 'loris'})}
+            options={modules}
+            value={String(this.state.versionForm.ModuleID || '')}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.handleVersionChange}
+          />
+          <NumericElement
+            name="PolicyRenewalTime"
+            id="version-PolicyRenewalTime"
+            label={t('Days to Renew', {ns: 'policy_tracker'})}
+            value={String(this.state.versionForm.PolicyRenewalTime || '')}
+            onUserInput={this.handleVersionChange}
+          />
+          <SelectElement
+            name="PolicyRenewalTimeUnit"
+            id="version-PolicyRenewalTimeUnit"
+            label={t('Renewal Unit', {ns: 'policy_tracker'})}
+            options={renewalUnits}
+            value={this.state.versionForm.PolicyRenewalTimeUnit || ''}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.handleVersionChange}
+          />
+          <SelectElement
+            name="HeaderButton"
+            id="version-HeaderButton"
+            label={t('Header Button', {ns: 'policy_tracker'})}
+            options={yesNo}
+            value={this.state.versionForm.HeaderButton || ''}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.handleVersionChange}
+          />
+          <TextboxElement
+            name="HeaderButtonText"
+            id="version-HeaderButtonText"
+            label={t('Header Button Text', {ns: 'policy_tracker'})}
+            value={this.state.versionForm.HeaderButtonText || ''}
+            onUserInput={this.handleVersionChange}
+          />
+          <SelectElement
+            name="Active"
+            id="version-Active"
+            label={t('Active', {ns: 'loris'})}
+            options={yesNo}
+            value={this.state.versionForm.Active || ''}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.handleVersionChange}
+          />
+          <TextboxElement
+            name="SwalTitle"
+            id="version-SwalTitle"
+            label={t('Modal Title', {ns: 'policy_tracker'})}
+            value={this.state.versionForm.SwalTitle || ''}
+            onUserInput={this.handleVersionChange}
+          />
+          <TextboxElement
+            name="AcceptButtonText"
+            id="version-AcceptButtonText"
+            label={t('Accept Button Text', {ns: 'policy_tracker'})}
+            value={this.state.versionForm.AcceptButtonText || ''}
+            onUserInput={this.handleVersionChange}
+          />
+          <TextboxElement
+            name="DeclineButtonText"
+            id="version-DeclineButtonText"
+            label={t('Decline Button Text', {ns: 'policy_tracker'})}
+            value={this.state.versionForm.DeclineButtonText || ''}
+            onUserInput={this.handleVersionChange}
+          />
+          <TextareaElement
+            name="Content"
+            id="version-Content"
+            label={t('Content', {ns: 'loris'})}
+            rows={8}
+            value={this.state.versionForm.Content || ''}
+            onUserInput={this.handleVersionChange}
+          />
           <div className="form-group">
             <div className="col-sm-offset-3 col-sm-9">
               <button className="btn btn-primary" type="submit">
@@ -644,61 +574,64 @@ class PolicyTrackerIndex extends Component {
     return (
       <Panel title={t('Edit Policy Translation', {ns: 'policy_tracker'})}>
         <form className="form-horizontal" onSubmit={this.saveTranslation}>
-          {this.renderSelect(
-            'PolicyID',
-            t('Policy', {ns: 'policy_tracker'}),
-            policies,
-            this.state.translationForm.PolicyID,
-            this.selectTranslation,
-            'translation'
-          )}
-          {this.renderSelect(
-            'LanguageID',
-            t('Language', {ns: 'loris'}),
-            languages,
-            this.state.translationForm.LanguageID,
-            this.selectTranslation,
-            'translation'
-          )}
-          {this.renderInput(
-            'SwalTitle',
-            t('Modal Title', {ns: 'policy_tracker'}),
-            this.state.translationForm.SwalTitle,
-            this.handleTranslationChange,
-            'text',
-            'translation'
-          )}
-          {this.renderInput(
-            'HeaderButtonText',
-            t('Header Button Text', {ns: 'policy_tracker'}),
-            this.state.translationForm.HeaderButtonText,
-            this.handleTranslationChange,
-            'text',
-            'translation'
-          )}
-          {this.renderInput(
-            'AcceptButtonText',
-            t('Accept Button Text', {ns: 'policy_tracker'}),
-            this.state.translationForm.AcceptButtonText,
-            this.handleTranslationChange,
-            'text',
-            'translation'
-          )}
-          {this.renderInput(
-            'DeclineButtonText',
-            t('Decline Button Text', {ns: 'policy_tracker'}),
-            this.state.translationForm.DeclineButtonText,
-            this.handleTranslationChange,
-            'text',
-            'translation'
-          )}
-          {this.renderTextarea(
-            'Content',
-            t('Content', {ns: 'loris'}),
-            this.state.translationForm.Content,
-            this.handleTranslationChange,
-            'translation'
-          )}
+          <SelectElement
+            name="PolicyID"
+            id="translation-PolicyID"
+            label={t('Policy', {ns: 'policy_tracker'})}
+            options={policies}
+            value={String(this.state.translationForm.PolicyID || '')}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.selectTranslation}
+          />
+          <SelectElement
+            name="LanguageID"
+            id="translation-LanguageID"
+            label={t('Language', {ns: 'loris'})}
+            options={languages}
+            value={String(this.state.translationForm.LanguageID || '')}
+            emptyOption={false}
+            autoSelect={false}
+            sortByValue={false}
+            onUserInput={this.selectTranslation}
+          />
+          <TextboxElement
+            name="SwalTitle"
+            id="translation-SwalTitle"
+            label={t('Modal Title', {ns: 'policy_tracker'})}
+            value={this.state.translationForm.SwalTitle || ''}
+            onUserInput={this.handleTranslationChange}
+          />
+          <TextboxElement
+            name="HeaderButtonText"
+            id="translation-HeaderButtonText"
+            label={t('Header Button Text', {ns: 'policy_tracker'})}
+            value={this.state.translationForm.HeaderButtonText || ''}
+            onUserInput={this.handleTranslationChange}
+          />
+          <TextboxElement
+            name="AcceptButtonText"
+            id="translation-AcceptButtonText"
+            label={t('Accept Button Text', {ns: 'policy_tracker'})}
+            value={this.state.translationForm.AcceptButtonText || ''}
+            onUserInput={this.handleTranslationChange}
+          />
+          <TextboxElement
+            name="DeclineButtonText"
+            id="translation-DeclineButtonText"
+            label={t('Decline Button Text', {ns: 'policy_tracker'})}
+            value={this.state.translationForm.DeclineButtonText || ''}
+            onUserInput={this.handleTranslationChange}
+          />
+          <TextareaElement
+            name="Content"
+            id="translation-Content"
+            label={t('Content', {ns: 'loris'})}
+            rows={8}
+            value={this.state.translationForm.Content || ''}
+            onUserInput={this.handleTranslationChange}
+          />
           <div className="form-group">
             <div className="col-sm-offset-3 col-sm-9">
               <button className="btn btn-primary" type="submit">

--- a/modules/policy_tracker/jsx/policyTrackerIndex.js
+++ b/modules/policy_tracker/jsx/policyTrackerIndex.js
@@ -30,6 +30,8 @@ class PolicyTrackerIndex extends Component {
       },
       versionForm: {},
       translationForm: {},
+      canViewDecisions: false,
+      canEditPolicies: false,
       error: false,
       isLoaded: false,
     };
@@ -77,38 +79,65 @@ class PolicyTrackerIndex extends Component {
   }
 
   /**
+   * Format policy decision rows for the DataTable.
+   *
+   * @param {object} decisions - Raw decisions response.
+   * @return {object}
+   */
+  formatDecisions(decisions) {
+    return {
+      ...decisions,
+      Data: decisions.Data.map((row) => [
+        row.ID,
+        row.Username,
+        row.User,
+        row.Policy,
+        row.Version,
+        row.Module,
+        row.Decision,
+        row['Decision Date'],
+      ]),
+    };
+  }
+
+  /**
    * Fetch table rows and policy editor options.
    */
   fetchData() {
-    Promise.all([
-      this.requestJSON('decisions'),
-      this.requestJSON('options'),
-    ]).then(([decisions, options]) => {
-      this.setState({
-        decisions: {
-          ...decisions,
-          Data: decisions.Data.map((row) => [
-            row.ID,
-            row.Username,
-            row.User,
-            row.Policy,
-            row.Version,
-            row.Module,
-            row.Decision,
-            row['Decision Date'],
-          ]),
-        },
-        options,
-        versionForm: this.getVersionForm(options.policies[0]),
-        translationForm: this.getTranslationForm(
-          options.policies[0],
-          options.languages[0]
-        ),
-        error: false,
-        isLoaded: true,
+    this.requestJSON('decisions').then((decisions) => {
+      if (!decisions.canEditPolicies) {
+        this.setState({
+          decisions: this.formatDecisions(decisions),
+          canViewDecisions: decisions.canViewDecisions,
+          canEditPolicies: false,
+          error: false,
+          isLoaded: true,
+        });
+        return null;
+      }
+
+      return this.requestJSON('options').then((options) => {
+        this.setState({
+          decisions: this.formatDecisions(decisions),
+          options,
+          versionForm: this.getVersionForm(options.policies[0]),
+          translationForm: this.getTranslationForm(
+            options.policies[0],
+            options.languages[0],
+            options.translations
+          ),
+          canViewDecisions: decisions.canViewDecisions,
+          canEditPolicies: true,
+          error: false,
+          isLoaded: true,
+        });
+        return null;
       });
     }).catch((error) => {
-      this.setState({error: true, isLoaded: true});
+      this.setState({
+        error: true,
+        isLoaded: true,
+      });
       console.error(error);
     });
   }
@@ -144,13 +173,18 @@ class PolicyTrackerIndex extends Component {
    *
    * @param {object} policy - Policy row.
    * @param {object} language - Language row.
+   * @param {array} translations - Existing policy translations.
    * @return {object}
    */
-  getTranslationForm(policy, language) {
+  getTranslationForm(
+    policy,
+    language,
+    translations = this.state.options.translations
+  ) {
     if (!policy || !language) {
       return {};
     }
-    const translation = this.state.options.translations.find((row) => {
+    const translation = translations.find((row) => {
       return parseInt(row.PolicyID) === parseInt(policy.PolicyID) &&
         parseInt(row.LanguageID) === parseInt(language.language_id);
     }) || {};
@@ -158,13 +192,13 @@ class PolicyTrackerIndex extends Component {
     return {
       PolicyID: policy.PolicyID,
       LanguageID: language.language_id,
-      Content: translation.Content || policy.Content,
-      SwalTitle: translation.SwalTitle || policy.SwalTitle,
-      HeaderButtonText: translation.HeaderButtonText ||
+      Content: translation.Content ?? policy.Content,
+      SwalTitle: translation.SwalTitle ?? policy.SwalTitle,
+      HeaderButtonText: translation.HeaderButtonText ??
         policy.HeaderButtonText,
-      AcceptButtonText: translation.AcceptButtonText ||
+      AcceptButtonText: translation.AcceptButtonText ??
         policy.AcceptButtonText,
-      DeclineButtonText: translation.DeclineButtonText ||
+      DeclineButtonText: translation.DeclineButtonText ??
         policy.DeclineButtonText,
     };
   }
@@ -315,18 +349,20 @@ class PolicyTrackerIndex extends Component {
    * @param {object} options - Select options.
    * @param {string|number} value - Selected value.
    * @param {Function} onChange - Change handler.
+   * @param {string} idPrefix - Prefix for the input ID.
    * @return {React.ReactNode}
    */
-  renderSelect(name, label, options, value, onChange) {
+  renderSelect(name, label, options, value, onChange, idPrefix = 'version') {
+    const id = `${idPrefix}-${name}`;
     return (
       <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={name}>
+        <label className="col-sm-3 control-label" htmlFor={id}>
           {label}
         </label>
         <div className="col-sm-9">
           <select
             className="form-control"
-            id={name}
+            id={id}
             name={name}
             value={value || ''}
             onChange={onChange}
@@ -348,18 +384,27 @@ class PolicyTrackerIndex extends Component {
    * @param {string|number} value - Field value.
    * @param {Function} onChange - Change handler.
    * @param {string} type - Input type.
+   * @param {string} idPrefix - Prefix for the input ID.
    * @return {React.ReactNode}
    */
-  renderInput(name, label, value, onChange, type = 'text') {
+  renderInput(
+    name,
+    label,
+    value,
+    onChange,
+    type = 'text',
+    idPrefix = 'version'
+  ) {
+    const id = `${idPrefix}-${name}`;
     return (
       <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={name}>
+        <label className="col-sm-3 control-label" htmlFor={id}>
           {label}
         </label>
         <div className="col-sm-9">
           <input
             className="form-control"
-            id={name}
+            id={id}
             name={name}
             type={type}
             value={value || ''}
@@ -377,18 +422,20 @@ class PolicyTrackerIndex extends Component {
    * @param {string} label - Field label.
    * @param {string} value - Field value.
    * @param {Function} onChange - Change handler.
+   * @param {string} idPrefix - Prefix for the input ID.
    * @return {React.ReactNode}
    */
-  renderTextarea(name, label, value, onChange) {
+  renderTextarea(name, label, value, onChange, idPrefix = 'version') {
+    const id = `${idPrefix}-${name}`;
     return (
       <div className="form-group">
-        <label className="col-sm-3 control-label" htmlFor={name}>
+        <label className="col-sm-3 control-label" htmlFor={id}>
           {label}
         </label>
         <div className="col-sm-9">
           <textarea
             className="form-control"
-            id={name}
+            id={id}
             name={name}
             rows="8"
             value={value || ''}
@@ -602,44 +649,55 @@ class PolicyTrackerIndex extends Component {
             t('Policy', {ns: 'policy_tracker'}),
             policies,
             this.state.translationForm.PolicyID,
-            this.selectTranslation
+            this.selectTranslation,
+            'translation'
           )}
           {this.renderSelect(
             'LanguageID',
             t('Language', {ns: 'loris'}),
             languages,
             this.state.translationForm.LanguageID,
-            this.selectTranslation
+            this.selectTranslation,
+            'translation'
           )}
           {this.renderInput(
             'SwalTitle',
             t('Modal Title', {ns: 'policy_tracker'}),
             this.state.translationForm.SwalTitle,
-            this.handleTranslationChange
+            this.handleTranslationChange,
+            'text',
+            'translation'
           )}
           {this.renderInput(
             'HeaderButtonText',
             t('Header Button Text', {ns: 'policy_tracker'}),
             this.state.translationForm.HeaderButtonText,
-            this.handleTranslationChange
+            this.handleTranslationChange,
+            'text',
+            'translation'
           )}
           {this.renderInput(
             'AcceptButtonText',
             t('Accept Button Text', {ns: 'policy_tracker'}),
             this.state.translationForm.AcceptButtonText,
-            this.handleTranslationChange
+            this.handleTranslationChange,
+            'text',
+            'translation'
           )}
           {this.renderInput(
             'DeclineButtonText',
             t('Decline Button Text', {ns: 'policy_tracker'}),
             this.state.translationForm.DeclineButtonText,
-            this.handleTranslationChange
+            this.handleTranslationChange,
+            'text',
+            'translation'
           )}
           {this.renderTextarea(
             'Content',
             t('Content', {ns: 'loris'}),
             this.state.translationForm.Content,
-            this.handleTranslationChange
+            this.handleTranslationChange,
+            'translation'
           )}
           <div className="form-group">
             <div className="col-sm-offset-3 col-sm-9">
@@ -677,15 +735,17 @@ class PolicyTrackerIndex extends Component {
         <div className="page-header">
           <h2>{t('Policy Tracker', {ns: 'policy_tracker'})}</h2>
         </div>
-        {this.renderDecisionTable()}
-        <div className="row">
-          <div className="col-md-6">
-            {this.renderVersionForm()}
+        {this.state.canViewDecisions && this.renderDecisionTable()}
+        {this.state.canEditPolicies &&
+          <div className="row">
+            <div className="col-md-6">
+              {this.renderVersionForm()}
+            </div>
+            <div className="col-md-6">
+              {this.renderTranslationForm()}
+            </div>
           </div>
-          <div className="col-md-6">
-            {this.renderTranslationForm()}
-          </div>
-        </div>
+        }
       </div>
     );
   }

--- a/modules/policy_tracker/jsx/policyTrackerIndex.js
+++ b/modules/policy_tracker/jsx/policyTrackerIndex.js
@@ -1,0 +1,710 @@
+import {createRoot} from 'react-dom/client';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import i18n from 'I18nSetup';
+import {withTranslation} from 'react-i18next';
+
+import swal from 'sweetalert2';
+import Loader from 'Loader';
+import Panel from 'Panel';
+import FilterableDataTable from 'FilterableDataTable';
+import lorisFetch from 'jslib/lorisFetch';
+
+/**
+ * Policy Tracker admin page.
+ */
+class PolicyTrackerIndex extends Component {
+  /**
+   * @param {object} props - React props.
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      decisions: {Data: [], fieldOptions: {}},
+      options: {
+        modules: [],
+        policies: [],
+        languages: [],
+        translations: [],
+      },
+      versionForm: {},
+      translationForm: {},
+      error: false,
+      isLoaded: false,
+    };
+
+    this.fetchData = this.fetchData.bind(this);
+    this.handleVersionChange = this.handleVersionChange.bind(this);
+    this.handleTranslationChange = this.handleTranslationChange.bind(this);
+    this.saveNewVersion = this.saveNewVersion.bind(this);
+    this.saveTranslation = this.saveTranslation.bind(this);
+    this.selectPolicy = this.selectPolicy.bind(this);
+    this.selectTranslation = this.selectTranslation.bind(this);
+  }
+
+  /**
+   * Load page data.
+   */
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  /**
+   * Fetch JSON from a policy tracker endpoint.
+   *
+   * @param {string} path - Endpoint path.
+   * @param {object} options - Fetch options.
+   * @return {Promise<object>}
+   */
+  requestJSON(path, options = {}) {
+    return lorisFetch(`${this.props.baseURL}/policy_tracker/${path}`, {
+      credentials: 'same-origin',
+      headers: {'Content-Type': 'application/json'},
+      ...options,
+    }).then((response) => response.text().then((text) => {
+      let json = {};
+      try {
+        json = text ? JSON.parse(text) : {};
+      } catch (error) {
+        json = {error: response.statusText};
+      }
+      if (!response.ok) {
+        throw new Error(json.error || json.message || response.statusText);
+      }
+      return json;
+    }));
+  }
+
+  /**
+   * Fetch table rows and policy editor options.
+   */
+  fetchData() {
+    Promise.all([
+      this.requestJSON('decisions'),
+      this.requestJSON('options'),
+    ]).then(([decisions, options]) => {
+      this.setState({
+        decisions: {
+          ...decisions,
+          Data: decisions.Data.map((row) => [
+            row.ID,
+            row.Username,
+            row.User,
+            row.Policy,
+            row.Version,
+            row.Module,
+            row.Decision,
+            row['Decision Date'],
+          ]),
+        },
+        options,
+        versionForm: this.getVersionForm(options.policies[0]),
+        translationForm: this.getTranslationForm(
+          options.policies[0],
+          options.languages[0]
+        ),
+        error: false,
+        isLoaded: true,
+      });
+    }).catch((error) => {
+      this.setState({error: true, isLoaded: true});
+      console.error(error);
+    });
+  }
+
+  /**
+   * Build a create-version form state from a source policy.
+   *
+   * @param {object} policy - Policy row.
+   * @return {object}
+   */
+  getVersionForm(policy) {
+    if (!policy) {
+      return {};
+    }
+    return {
+      PolicyID: policy.PolicyID,
+      Name: policy.Name,
+      ModuleID: policy.ModuleID,
+      PolicyRenewalTime: policy.PolicyRenewalTime,
+      PolicyRenewalTimeUnit: policy.PolicyRenewalTimeUnit,
+      HeaderButton: policy.HeaderButton,
+      HeaderButtonText: policy.HeaderButtonText,
+      Active: policy.Active,
+      SwalTitle: policy.SwalTitle,
+      AcceptButtonText: policy.AcceptButtonText,
+      DeclineButtonText: policy.DeclineButtonText,
+      Content: policy.Content,
+    };
+  }
+
+  /**
+   * Build a translation form state from policy and language rows.
+   *
+   * @param {object} policy - Policy row.
+   * @param {object} language - Language row.
+   * @return {object}
+   */
+  getTranslationForm(policy, language) {
+    if (!policy || !language) {
+      return {};
+    }
+    const translation = this.state.options.translations.find((row) => {
+      return parseInt(row.PolicyID) === parseInt(policy.PolicyID) &&
+        parseInt(row.LanguageID) === parseInt(language.language_id);
+    }) || {};
+
+    return {
+      PolicyID: policy.PolicyID,
+      LanguageID: language.language_id,
+      Content: translation.Content || policy.Content,
+      SwalTitle: translation.SwalTitle || policy.SwalTitle,
+      HeaderButtonText: translation.HeaderButtonText ||
+        policy.HeaderButtonText,
+      AcceptButtonText: translation.AcceptButtonText ||
+        policy.AcceptButtonText,
+      DeclineButtonText: translation.DeclineButtonText ||
+        policy.DeclineButtonText,
+    };
+  }
+
+  /**
+   * Convert a list of rows into select options.
+   *
+   * @param {array} rows - Row list.
+   * @param {string} valueField - Value field name.
+   * @param {string} labelField - Label field name.
+   * @return {object}
+   */
+  toOptions(rows, valueField, labelField) {
+    return rows.reduce((options, row) => {
+      options[row[valueField]] = row[labelField];
+      return options;
+    }, {});
+  }
+
+  /**
+   * Convert policy rows into select options.
+   *
+   * @param {array} policies - Policy rows.
+   * @return {object}
+   */
+  policyOptions(policies) {
+    return policies.reduce((options, policy) => {
+      options[policy.PolicyID] = `${policy.Name} v${policy.Version}` +
+        ` (${policy.ModuleName})`;
+      return options;
+    }, {});
+  }
+
+  /**
+   * Handle create-version form changes.
+   *
+   * @param {object} event - Change event.
+   */
+  handleVersionChange(event) {
+    const {name, value} = event.target;
+    this.setState((state) => ({
+      versionForm: {...state.versionForm, [name]: value},
+    }));
+  }
+
+  /**
+   * Handle translation form changes.
+   *
+   * @param {object} event - Change event.
+   */
+  handleTranslationChange(event) {
+    const {name, value} = event.target;
+    this.setState((state) => ({
+      translationForm: {...state.translationForm, [name]: value},
+    }));
+  }
+
+  /**
+   * Change the source policy used by the create-version form.
+   *
+   * @param {object} event - Change event.
+   */
+  selectPolicy(event) {
+    const policy = this.state.options.policies.find((row) => {
+      return parseInt(row.PolicyID) === parseInt(event.target.value);
+    });
+    this.setState({versionForm: this.getVersionForm(policy)});
+  }
+
+  /**
+   * Change the policy or language used by the translation form.
+   *
+   * @param {object} event - Change event.
+   */
+  selectTranslation(event) {
+    const form = {
+      ...this.state.translationForm,
+      [event.target.name]: event.target.value,
+    };
+    const policy = this.state.options.policies.find((row) => {
+      return parseInt(row.PolicyID) === parseInt(form.PolicyID);
+    });
+    const language = this.state.options.languages.find((row) => {
+      return parseInt(row.language_id) === parseInt(form.LanguageID);
+    });
+    this.setState({
+      translationForm: this.getTranslationForm(policy, language),
+    });
+  }
+
+  /**
+   * Save a new policy version.
+   *
+   * @param {object} event - Submit event.
+   */
+  saveNewVersion(event) {
+    event.preventDefault();
+    this.requestJSON('new-version', {
+      method: 'POST',
+      body: JSON.stringify(this.state.versionForm),
+    }).then(() => {
+      swal.fire(
+        this.props.t('Saved', {ns: 'loris'}),
+        this.props.t('Policy version created', {ns: 'policy_tracker'}),
+        'success'
+      );
+      this.fetchData();
+    }).catch((error) => {
+      swal.fire(
+        this.props.t('Error', {ns: 'loris'}),
+        error.message,
+        'error'
+      );
+    });
+  }
+
+  /**
+   * Save translated policy text.
+   *
+   * @param {object} event - Submit event.
+   */
+  saveTranslation(event) {
+    event.preventDefault();
+    this.requestJSON('translation', {
+      method: 'POST',
+      body: JSON.stringify(this.state.translationForm),
+    }).then(() => {
+      swal.fire(
+        this.props.t('Saved', {ns: 'loris'}),
+        this.props.t('Policy translation saved', {ns: 'policy_tracker'}),
+        'success'
+      );
+      this.fetchData();
+    }).catch((error) => {
+      swal.fire(
+        this.props.t('Error', {ns: 'loris'}),
+        error.message,
+        'error'
+      );
+    });
+  }
+
+  /**
+   * Render a select input.
+   *
+   * @param {string} name - Field name.
+   * @param {string} label - Field label.
+   * @param {object} options - Select options.
+   * @param {string|number} value - Selected value.
+   * @param {Function} onChange - Change handler.
+   * @return {React.ReactNode}
+   */
+  renderSelect(name, label, options, value, onChange) {
+    return (
+      <div className="form-group">
+        <label className="col-sm-3 control-label" htmlFor={name}>
+          {label}
+        </label>
+        <div className="col-sm-9">
+          <select
+            className="form-control"
+            id={name}
+            name={name}
+            value={value || ''}
+            onChange={onChange}
+          >
+            {Object.keys(options).map((key) => (
+              <option key={key} value={key}>{options[key]}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Render a text or numeric input.
+   *
+   * @param {string} name - Field name.
+   * @param {string} label - Field label.
+   * @param {string|number} value - Field value.
+   * @param {Function} onChange - Change handler.
+   * @param {string} type - Input type.
+   * @return {React.ReactNode}
+   */
+  renderInput(name, label, value, onChange, type = 'text') {
+    return (
+      <div className="form-group">
+        <label className="col-sm-3 control-label" htmlFor={name}>
+          {label}
+        </label>
+        <div className="col-sm-9">
+          <input
+            className="form-control"
+            id={name}
+            name={name}
+            type={type}
+            value={value || ''}
+            onChange={onChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Render a textarea input.
+   *
+   * @param {string} name - Field name.
+   * @param {string} label - Field label.
+   * @param {string} value - Field value.
+   * @param {Function} onChange - Change handler.
+   * @return {React.ReactNode}
+   */
+  renderTextarea(name, label, value, onChange) {
+    return (
+      <div className="form-group">
+        <label className="col-sm-3 control-label" htmlFor={name}>
+          {label}
+        </label>
+        <div className="col-sm-9">
+          <textarea
+            className="form-control"
+            id={name}
+            name={name}
+            rows="8"
+            value={value || ''}
+            onChange={onChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Render the decisions table.
+   *
+   * @return {React.ReactNode}
+   */
+  renderDecisionTable() {
+    const {t} = this.props;
+    const options = this.state.decisions.fieldOptions;
+    const fields = [
+      {label: 'ID', show: false},
+      {
+        label: t('Username', {ns: 'loris'}),
+        show: true,
+        filter: {name: 'Username', type: 'text'},
+      },
+      {
+        label: t('User', {ns: 'loris'}),
+        show: true,
+        filter: {name: 'User', type: 'text'},
+      },
+      {
+        label: t('Policy', {ns: 'policy_tracker'}),
+        show: true,
+        filter: {
+          name: 'Policy',
+          type: 'select',
+          options: options.policies || {},
+        },
+      },
+      {
+        label: t('Version', {ns: 'policy_tracker'}),
+        show: true,
+        filter: {name: 'Version', type: 'text'},
+      },
+      {
+        label: t('Module', {ns: 'loris'}),
+        show: true,
+        filter: {
+          name: 'Module',
+          type: 'select',
+          options: options.modules || {},
+        },
+      },
+      {
+        label: t('Decision', {ns: 'policy_tracker'}),
+        show: true,
+        filter: {
+          name: 'Decision',
+          type: 'select',
+          options: options.decision || {},
+        },
+      },
+      {
+        label: t('Decision Date', {ns: 'policy_tracker'}),
+        show: true,
+        filter: {name: 'Decision Date', type: 'text'},
+      },
+    ];
+
+    return (
+      <FilterableDataTable
+        name="policyTrackerDecisionTable"
+        data={this.state.decisions.Data}
+        fields={fields}
+      />
+    );
+  }
+
+  /**
+   * Render the create-version form.
+   *
+   * @return {React.ReactNode}
+   */
+  renderVersionForm() {
+    const {t} = this.props;
+    const modules = this.toOptions(this.state.options.modules, 'ID', 'Name');
+    const policies = this.policyOptions(this.state.options.policies);
+    const renewalUnits = {
+      D: t('Days', {ns: 'policy_tracker'}),
+      M: t('Months', {ns: 'policy_tracker'}),
+      Y: t('Years', {ns: 'policy_tracker'}),
+      H: t('Hours', {ns: 'policy_tracker'}),
+    };
+    const yesNo = {
+      Y: t('Yes', {ns: 'loris'}),
+      N: t('No', {ns: 'loris'}),
+    };
+
+    return (
+      <Panel title={t('Create New Policy Version', {ns: 'policy_tracker'})}>
+        <form className="form-horizontal" onSubmit={this.saveNewVersion}>
+          {this.renderSelect(
+            'PolicyID',
+            t('Source Policy', {ns: 'policy_tracker'}),
+            policies,
+            this.state.versionForm.PolicyID,
+            this.selectPolicy
+          )}
+          {this.renderInput(
+            'Name',
+            t('Name', {ns: 'loris'}),
+            this.state.versionForm.Name,
+            this.handleVersionChange
+          )}
+          {this.renderSelect(
+            'ModuleID',
+            t('Module', {ns: 'loris'}),
+            modules,
+            this.state.versionForm.ModuleID,
+            this.handleVersionChange
+          )}
+          {this.renderInput(
+            'PolicyRenewalTime',
+            t('Days to Renew', {ns: 'policy_tracker'}),
+            this.state.versionForm.PolicyRenewalTime,
+            this.handleVersionChange,
+            'number'
+          )}
+          {this.renderSelect(
+            'PolicyRenewalTimeUnit',
+            t('Renewal Unit', {ns: 'policy_tracker'}),
+            renewalUnits,
+            this.state.versionForm.PolicyRenewalTimeUnit,
+            this.handleVersionChange
+          )}
+          {this.renderSelect(
+            'HeaderButton',
+            t('Header Button', {ns: 'policy_tracker'}),
+            yesNo,
+            this.state.versionForm.HeaderButton,
+            this.handleVersionChange
+          )}
+          {this.renderInput(
+            'HeaderButtonText',
+            t('Header Button Text', {ns: 'policy_tracker'}),
+            this.state.versionForm.HeaderButtonText,
+            this.handleVersionChange
+          )}
+          {this.renderSelect(
+            'Active',
+            t('Active', {ns: 'loris'}),
+            yesNo,
+            this.state.versionForm.Active,
+            this.handleVersionChange
+          )}
+          {this.renderInput(
+            'SwalTitle',
+            t('Modal Title', {ns: 'policy_tracker'}),
+            this.state.versionForm.SwalTitle,
+            this.handleVersionChange
+          )}
+          {this.renderInput(
+            'AcceptButtonText',
+            t('Accept Button Text', {ns: 'policy_tracker'}),
+            this.state.versionForm.AcceptButtonText,
+            this.handleVersionChange
+          )}
+          {this.renderInput(
+            'DeclineButtonText',
+            t('Decline Button Text', {ns: 'policy_tracker'}),
+            this.state.versionForm.DeclineButtonText,
+            this.handleVersionChange
+          )}
+          {this.renderTextarea(
+            'Content',
+            t('Content', {ns: 'loris'}),
+            this.state.versionForm.Content,
+            this.handleVersionChange
+          )}
+          <div className="form-group">
+            <div className="col-sm-offset-3 col-sm-9">
+              <button className="btn btn-primary" type="submit">
+                {t('Create Version', {ns: 'policy_tracker'})}
+              </button>
+            </div>
+          </div>
+        </form>
+      </Panel>
+    );
+  }
+
+  /**
+   * Render the translation form.
+   *
+   * @return {React.ReactNode}
+   */
+  renderTranslationForm() {
+    const {t} = this.props;
+    const policies = this.policyOptions(this.state.options.policies);
+    const languages = this.toOptions(
+      this.state.options.languages,
+      'language_id',
+      'language_label'
+    );
+
+    return (
+      <Panel title={t('Edit Policy Translation', {ns: 'policy_tracker'})}>
+        <form className="form-horizontal" onSubmit={this.saveTranslation}>
+          {this.renderSelect(
+            'PolicyID',
+            t('Policy', {ns: 'policy_tracker'}),
+            policies,
+            this.state.translationForm.PolicyID,
+            this.selectTranslation
+          )}
+          {this.renderSelect(
+            'LanguageID',
+            t('Language', {ns: 'loris'}),
+            languages,
+            this.state.translationForm.LanguageID,
+            this.selectTranslation
+          )}
+          {this.renderInput(
+            'SwalTitle',
+            t('Modal Title', {ns: 'policy_tracker'}),
+            this.state.translationForm.SwalTitle,
+            this.handleTranslationChange
+          )}
+          {this.renderInput(
+            'HeaderButtonText',
+            t('Header Button Text', {ns: 'policy_tracker'}),
+            this.state.translationForm.HeaderButtonText,
+            this.handleTranslationChange
+          )}
+          {this.renderInput(
+            'AcceptButtonText',
+            t('Accept Button Text', {ns: 'policy_tracker'}),
+            this.state.translationForm.AcceptButtonText,
+            this.handleTranslationChange
+          )}
+          {this.renderInput(
+            'DeclineButtonText',
+            t('Decline Button Text', {ns: 'policy_tracker'}),
+            this.state.translationForm.DeclineButtonText,
+            this.handleTranslationChange
+          )}
+          {this.renderTextarea(
+            'Content',
+            t('Content', {ns: 'loris'}),
+            this.state.translationForm.Content,
+            this.handleTranslationChange
+          )}
+          <div className="form-group">
+            <div className="col-sm-offset-3 col-sm-9">
+              <button className="btn btn-primary" type="submit">
+                {t('Save Translation', {ns: 'policy_tracker'})}
+              </button>
+            </div>
+          </div>
+        </form>
+      </Panel>
+    );
+  }
+
+  /**
+   * Render page.
+   *
+   * @return {React.ReactNode}
+   */
+  render() {
+    const {t} = this.props;
+    if (!this.state.isLoaded) {
+      return <Loader />;
+    }
+
+    if (this.state.error) {
+      return (
+        <div className="alert alert-danger">
+          {t('Could not load policy tracker data', {ns: 'policy_tracker'})}
+        </div>
+      );
+    }
+
+    return (
+      <div className="policy-tracker">
+        <div className="page-header">
+          <h2>{t('Policy Tracker', {ns: 'policy_tracker'})}</h2>
+        </div>
+        {this.renderDecisionTable()}
+        <div className="row">
+          <div className="col-md-6">
+            {this.renderVersionForm()}
+          </div>
+          <div className="col-md-6">
+            {this.renderTranslationForm()}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+PolicyTrackerIndex.propTypes = {
+  baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func,
+};
+
+window.addEventListener('load', () => {
+  i18n.addResourceBundle('ja', 'policy_tracker', {});
+  i18n.addResourceBundle('zh', 'policy_tracker', {});
+  i18n.addResourceBundle('fr', 'policy_tracker', {});
+  i18n.addResourceBundle('hi', 'policy_tracker', {});
+  const Index = withTranslation(
+    ['policy_tracker', 'loris']
+  )(PolicyTrackerIndex);
+  createRoot(
+    document.getElementById('lorisworkspace')
+  ).render(<Index baseURL={loris.BaseURL}/>);
+});

--- a/modules/policy_tracker/locale/policy_tracker.pot
+++ b/modules/policy_tracker/locale/policy_tracker.pot
@@ -1,0 +1,96 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2026
+# This file is distributed under the same license as the LORIS package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2026-07-10 14:09-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Policy Tracker"
+msgstr ""
+
+msgid "Accepted"
+msgstr ""
+
+msgid "Declined"
+msgstr ""
+
+msgid "Policy version created"
+msgstr ""
+
+msgid "Policy translation saved"
+msgstr ""
+
+msgid "Policy"
+msgstr ""
+
+msgid "Version"
+msgstr ""
+
+msgid "Decision"
+msgstr ""
+
+msgid "Decision Date"
+msgstr ""
+
+msgid "Days"
+msgstr ""
+
+msgid "Months"
+msgstr ""
+
+msgid "Years"
+msgstr ""
+
+msgid "Hours"
+msgstr ""
+
+msgid "Create New Policy Version"
+msgstr ""
+
+msgid "Source Policy"
+msgstr ""
+
+msgid "Days to Renew"
+msgstr ""
+
+msgid "Renewal Unit"
+msgstr ""
+
+msgid "Header Button"
+msgstr ""
+
+msgid "Header Button Text"
+msgstr ""
+
+msgid "Modal Title"
+msgstr ""
+
+msgid "Accept Button Text"
+msgstr ""
+
+msgid "Decline Button Text"
+msgstr ""
+
+msgid "Create Version"
+msgstr ""
+
+msgid "Edit Policy Translation"
+msgstr ""
+
+msgid "Save Translation"
+msgstr ""
+
+msgid "Could not load policy tracker data"
+msgstr ""

--- a/modules/policy_tracker/php/module.class.inc
+++ b/modules/policy_tracker/php/module.class.inc
@@ -30,10 +30,17 @@ use \Psr\Http\Message\ResponseInterface;
 class Module extends \Module
 {
     /**
-     * Implements the PSR15 RequestHandler interface for this module. The API
-     * module does some preliminary verification of the request, converts the
-     * version from the URL to a request attribute, and then falls back on the
-     * default LORIS page handler.
+     * {@inheritDoc}
+     *
+     * @return ?\LORIS\GUI\MenuCategory
+     */
+    public function getMenuCategory() : ?\LORIS\GUI\MenuCategory
+    {
+        return \LORIS\GUI\MenuCategory::singleton("Admin");
+    }
+
+    /**
+     * Route policy tracker page and JSON endpoints.
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
      *
@@ -41,28 +48,45 @@ class Module extends \Module
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $body = json_decode($request->getBody()->getContents(), true);
-        switch ($request->getMethod()) {
-        case 'POST':
-            $module = $this->loris->getModule($body['ModuleName'] ?? '');
-            $page   = new \NDB_Page(
-                $this->loris,
-                $module,
-                '',
-                '',
-                '',
+        $route       = $this->_getRoute($request);
+        $adminRoutes = ['decisions', 'options', 'new-version', 'translation'];
+        if (in_array($route, $adminRoutes, true)
+            && !$this->_hasConfigAccess($request)
+        ) {
+            return new \LORIS\Http\Response\JSON\Forbidden(
+                "Permission denied"
             );
-            $page->saveUserPolicyDecision(
-                $this->loris,
-                $body['PolicyName'] ?? '',
-                $body['decision'] ?? ''
-            );
-            return new \LORIS\Http\Response\JSON\OK(
-                ['message' => 'Policy decision saved successfully']
-            );
-        default:
+        }
+
+        if ($route === 'decisions' && $request->getMethod() === 'GET') {
+            return new \LORIS\Http\Response\JSON\OK($this->_getDecisionData());
+        }
+
+        if ($route === 'options' && $request->getMethod() === 'GET') {
+            return new \LORIS\Http\Response\JSON\OK($this->_getOptions());
+        }
+
+        if ($route === 'new-version' && $request->getMethod() === 'POST') {
+            return $this->_createNewPolicyVersion($request);
+        }
+
+        if ($route === 'translation' && $request->getMethod() === 'POST') {
+            return $this->_savePolicyTranslation($request);
+        }
+
+        if ($route === 'policies' && $request->getMethod() === 'POST') {
+            return $this->_savePolicyDecision($request);
+        }
+
+        if (in_array($route, ['decisions', 'options'], true)) {
+            return new \LORIS\Http\Response\JSON\MethodNotAllowed(['GET']);
+        }
+
+        if (in_array($route, ['new-version', 'translation', 'policies'], true)) {
             return new \LORIS\Http\Response\JSON\MethodNotAllowed(['POST']);
         }
+
+        return parent::handle($request);
     }
 
     /**
@@ -73,5 +97,381 @@ class Module extends \Module
     public function getLongName() : string
     {
         return dgettext("policy_tracker", "Policy Tracker");
+    }
+
+    /**
+     * Get the module-local route name from the request.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return string
+     */
+    private function _getRoute(ServerRequestInterface $request) : string
+    {
+        $moduleURI = $request->getAttribute("unhandledURI");
+        $path      = $moduleURI === null
+            ? $request->getUri()->getPath()
+            : $moduleURI->getPath();
+        return explode('/', trim($path, '/'))[0] ?? '';
+    }
+
+    /**
+     * Decode a JSON request body.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return array
+     */
+    private function _getJSONBody(ServerRequestInterface $request) : array
+    {
+        $body = json_decode($request->getBody()->getContents(), true);
+        return is_array($body) ? $body : [];
+    }
+
+    /**
+     * Check whether the request user can manage policies.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return bool
+     */
+    private function _hasConfigAccess(ServerRequestInterface $request) : bool
+    {
+        $user = $request->getAttribute("user");
+        return $user instanceof \User && $user->hasPermission('config');
+    }
+
+    /**
+     * Get the policy decisions used by the frontend table.
+     *
+     * @return array
+     */
+    private function _getDecisionData() : array
+    {
+        $db = $this->loris->getDatabaseConnection();
+        return [
+            'Data'         => iterator_to_array(
+                $db->pselect(
+                    "SELECT
+                        upd.ID,
+                        u.UserID AS Username,
+                        COALESCE(
+                            NULLIF(u.Real_name, ''),
+                            NULLIF(
+                                CONCAT_WS(' ', u.First_name, u.Last_name),
+                                ''
+                            ),
+                            u.UserID
+                        ) AS User,
+                        p.Name AS Policy,
+                        p.Version,
+                        m.Name AS Module,
+                        upd.Decision,
+                        upd.DecisionDate AS `Decision Date`
+                    FROM user_policy_decision upd
+                        JOIN users u ON u.ID=upd.UserID
+                        JOIN policies p ON p.PolicyID=upd.PolicyID
+                        JOIN modules m ON m.ID=p.ModuleID
+                    ORDER BY upd.DecisionDate DESC",
+                    []
+                )
+            ),
+            'fieldOptions' => [
+                'modules'  => $this->_getModuleOptions(),
+                'policies' => $this->_getPolicyNameOptions(),
+                'decision' => [
+                    'Accepted' => dgettext("policy_tracker", "Accepted"),
+                    'Declined' => dgettext("policy_tracker", "Declined"),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Get policy and translation options used by the editor forms.
+     *
+     * @return array
+     */
+    private function _getOptions() : array
+    {
+        $db = $this->loris->getDatabaseConnection();
+        return [
+            'modules'      => iterator_to_array(
+                $db->pselect(
+                    "SELECT ID, Name FROM modules ORDER BY Name",
+                    []
+                )
+            ),
+            'policies'     => iterator_to_array(
+                $db->pselect(
+                    "SELECT
+                        p.PolicyID,
+                        p.Name,
+                        p.Version,
+                        p.ModuleID,
+                        m.Name AS ModuleName,
+                        p.PolicyRenewalTime,
+                        p.PolicyRenewalTimeUnit,
+                        p.Content,
+                        p.SwalTitle,
+                        p.HeaderButton,
+                        p.HeaderButtonText,
+                        p.Active,
+                        p.AcceptButtonText,
+                        p.DeclineButtonText
+                    FROM policies p
+                        JOIN modules m ON m.ID=p.ModuleID
+                    ORDER BY p.Name, p.Version DESC",
+                    []
+                )
+            ),
+            'languages'    => iterator_to_array(
+                $db->pselect(
+                    "SELECT language_id, language_code, language_label
+                    FROM language
+                    ORDER BY language_label",
+                    []
+                )
+            ),
+            'translations' => iterator_to_array(
+                $db->pselect(
+                    "SELECT
+                        PolicyID,
+                        LanguageID,
+                        Content,
+                        SwalTitle,
+                        HeaderButtonText,
+                        AcceptButtonText,
+                        DeclineButtonText
+                    FROM policiesI18n",
+                    []
+                )
+            ),
+        ];
+    }
+
+    /**
+     * Persist a user's decision from the existing policy modal endpoint.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    private function _savePolicyDecision(
+        ServerRequestInterface $request
+    ) : ResponseInterface {
+        $body   = $this->_getJSONBody($request);
+        $module = $this->loris->getModule($body['ModuleName'] ?? '');
+        $page   = new \NDB_Page($this->loris, $module, '', '', '');
+        $page->saveUserPolicyDecision(
+            $this->loris,
+            $body['PolicyName'] ?? '',
+            $body['decision'] ?? ''
+        );
+        return new \LORIS\Http\Response\JSON\OK(
+            ['message' => 'Policy decision saved successfully']
+        );
+    }
+
+    /**
+     * Create a new version of an existing policy.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    private function _createNewPolicyVersion(
+        ServerRequestInterface $request
+    ) : ResponseInterface {
+        $body     = $this->_getJSONBody($request);
+        $policyID = intval($body['PolicyID'] ?? 0);
+        if ($policyID <= 0) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                "Missing policy"
+            );
+        }
+
+        $db     = $this->loris->getDatabaseConnection();
+        $policy = $this->_getPolicyByID($policyID);
+        if ($policy === null) {
+            return new \LORIS\Http\Response\JSON\NotFound(
+                "Policy not found"
+            );
+        }
+
+        $version = $this->_getNextPolicyVersion(
+            strval($body['Name'] ?? $policy['Name']),
+            intval($body['ModuleID'] ?? $policy['ModuleID'])
+        );
+
+        $db->unsafeinsert(
+            'policies',
+            [
+                'Name'                  => $body['Name'] ?? $policy['Name'],
+                'Version'               => $version,
+                'ModuleID'              => intval(
+                    $body['ModuleID'] ?? $policy['ModuleID']
+                ),
+                'PolicyRenewalTime'     => intval(
+                    $body['PolicyRenewalTime']
+                    ?? $policy['PolicyRenewalTime']
+                ),
+                'PolicyRenewalTimeUnit' => $this->_enumValue(
+                    $body['PolicyRenewalTimeUnit']
+                    ?? $policy['PolicyRenewalTimeUnit'],
+                    ['D', 'M', 'Y', 'H'],
+                    'D'
+                ),
+                'Content'               => $body['Content']
+                    ?? $policy['Content'],
+                'SwalTitle'             => $body['SwalTitle']
+                    ?? $policy['SwalTitle'],
+                'HeaderButton'          => $this->_enumValue(
+                    $body['HeaderButton'] ?? $policy['HeaderButton'],
+                    ['Y', 'N'],
+                    'Y'
+                ),
+                'HeaderButtonText'      => $body['HeaderButtonText']
+                    ?? $policy['HeaderButtonText'],
+                'Active'                => $this->_enumValue(
+                    $body['Active'] ?? $policy['Active'],
+                    ['Y', 'N'],
+                    'Y'
+                ),
+                'AcceptButtonText'      => $body['AcceptButtonText']
+                    ?? $policy['AcceptButtonText'],
+                'DeclineButtonText'     => $body['DeclineButtonText']
+                    ?? $policy['DeclineButtonText'],
+            ]
+        );
+
+        return new \LORIS\Http\Response\JSON\OK(
+            ['PolicyID' => $db->lastInsertID, 'Version' => $version]
+        );
+    }
+
+    /**
+     * Save the translated text for a policy.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    private function _savePolicyTranslation(
+        ServerRequestInterface $request
+    ) : ResponseInterface {
+        $body       = $this->_getJSONBody($request);
+        $policyID   = intval($body['PolicyID'] ?? 0);
+        $languageID = intval($body['LanguageID'] ?? 0);
+        if ($policyID <= 0 || $languageID <= 0) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                "Missing policy or language"
+            );
+        }
+
+        $this->loris->getDatabaseConnection()->unsafeInsertOnDuplicateUpdate(
+            'policiesI18n',
+            [
+                'PolicyID'          => $policyID,
+                'LanguageID'        => $languageID,
+                'Content'           => $body['Content'] ?? null,
+                'SwalTitle'         => $body['SwalTitle'] ?? null,
+                'HeaderButtonText'  => $body['HeaderButtonText'] ?? null,
+                'AcceptButtonText'  => $body['AcceptButtonText'] ?? null,
+                'DeclineButtonText' => $body['DeclineButtonText'] ?? null,
+            ]
+        );
+
+        return new \LORIS\Http\Response\JSON\OK(
+            ['message' => 'Policy translation saved successfully']
+        );
+    }
+
+    /**
+     * Fetch a policy row.
+     *
+     * @param int $policyID The policy ID
+     *
+     * @return ?array
+     */
+    private function _getPolicyByID(int $policyID) : ?array
+    {
+        $rows = iterator_to_array(
+            $this->loris->getDatabaseConnection()->pselect(
+                "SELECT * FROM policies WHERE PolicyID=:PolicyID",
+                ['PolicyID' => $policyID]
+            )
+        );
+        return $rows[0] ?? null;
+    }
+
+    /**
+     * Get the next version for a policy name and module.
+     *
+     * @param string $name     The policy name
+     * @param int    $moduleID The module ID
+     *
+     * @return int
+     */
+    private function _getNextPolicyVersion(string $name, int $moduleID) : int
+    {
+        $rows = iterator_to_array(
+            $this->loris->getDatabaseConnection()->pselect(
+                "SELECT COALESCE(MAX(Version), 0) + 1 AS NextVersion
+                FROM policies
+                WHERE Name=:Name AND ModuleID=:ModuleID",
+                ['Name' => $name, 'ModuleID' => $moduleID]
+            )
+        );
+        return intval($rows[0]['NextVersion'] ?? 1);
+    }
+
+    /**
+     * Return a whitelisted enum value.
+     *
+     * @param mixed  $value   The submitted value
+     * @param array  $allowed Allowed values
+     * @param string $default Default value
+     *
+     * @return string
+     */
+    private function _enumValue($value, array $allowed, string $default) : string
+    {
+        $value = strval($value);
+        return in_array($value, $allowed, true) ? $value : $default;
+    }
+
+    /**
+     * Get module filter options.
+     *
+     * @return array
+     */
+    private function _getModuleOptions() : array
+    {
+        $modules = [];
+        foreach ($this->loris->getDatabaseConnection()->pselect(
+            "SELECT Name FROM modules ORDER BY Name",
+            []
+        ) as $module) {
+            $modules[$module['Name']] = $module['Name'];
+        }
+        return $modules;
+    }
+
+    /**
+     * Get policy filter options.
+     *
+     * @return array
+     */
+    private function _getPolicyNameOptions() : array
+    {
+        $policies = [];
+        foreach ($this->loris->getDatabaseConnection()->pselect(
+            "SELECT DISTINCT Name FROM policies ORDER BY Name",
+            []
+        ) as $policy) {
+            $policies[$policy['Name']] = $policy['Name'];
+        }
+        return $policies;
     }
 }

--- a/modules/policy_tracker/php/module.class.inc
+++ b/modules/policy_tracker/php/module.class.inc
@@ -48,10 +48,20 @@ class Module extends \Module
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $route       = $this->_getRoute($request);
-        $adminRoutes = ['decisions', 'options', 'new-version', 'translation'];
-        if (in_array($route, $adminRoutes, true)
-            && !$this->_hasConfigAccess($request)
+        $route = $this->_getRoute($request);
+        if ($route === 'decisions'
+            && $request->getMethod() === 'GET'
+            && !$this->_hasDecisionAccess($request)
+            && !$this->_hasEditAccess($request)
+        ) {
+            return new \LORIS\Http\Response\JSON\Forbidden(
+                "Permission denied"
+            );
+        }
+
+        $editRoutes = ['options', 'new-version', 'translation'];
+        if (in_array($route, $editRoutes, true)
+            && !$this->_hasEditAccess($request)
         ) {
             return new \LORIS\Http\Response\JSON\Forbidden(
                 "Permission denied"
@@ -59,7 +69,9 @@ class Module extends \Module
         }
 
         if ($route === 'decisions' && $request->getMethod() === 'GET') {
-            return new \LORIS\Http\Response\JSON\OK($this->_getDecisionData());
+            return new \LORIS\Http\Response\JSON\OK(
+                $this->_getDecisionData($request)
+            );
         }
 
         if ($route === 'options' && $request->getMethod() === 'GET') {
@@ -129,28 +141,48 @@ class Module extends \Module
     }
 
     /**
-     * Check whether the request user can manage policies.
+     * Check whether the request user can view policy decisions.
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
      *
      * @return bool
      */
-    private function _hasConfigAccess(ServerRequestInterface $request) : bool
+    private function _hasDecisionAccess(ServerRequestInterface $request) : bool
     {
         $user = $request->getAttribute("user");
-        return $user instanceof \User && $user->hasPermission('config');
+        return $user instanceof \User
+            && $user->hasPermission('view_policy_decisions');
+    }
+
+    /**
+     * Check whether the request user can edit policies.
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return bool
+     */
+    private function _hasEditAccess(ServerRequestInterface $request) : bool
+    {
+        $user = $request->getAttribute("user");
+        return $user instanceof \User
+            && $user->hasPermission('edit_policies');
     }
 
     /**
      * Get the policy decisions used by the frontend table.
      *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
      * @return array
      */
-    private function _getDecisionData() : array
+    private function _getDecisionData(ServerRequestInterface $request) : array
     {
-        $db = $this->loris->getDatabaseConnection();
-        return [
-            'Data'         => iterator_to_array(
+        $canViewDecisions = $this->_hasDecisionAccess($request);
+        $decisions        = [];
+        $fieldOptions     = [];
+        if ($canViewDecisions) {
+            $db           = $this->loris->getDatabaseConnection();
+            $decisions    = iterator_to_array(
                 $db->pselect(
                     "SELECT
                         upd.ID,
@@ -175,15 +207,22 @@ class Module extends \Module
                     ORDER BY upd.DecisionDate DESC",
                     []
                 )
-            ),
-            'fieldOptions' => [
+            );
+            $fieldOptions = [
                 'modules'  => $this->_getModuleOptions(),
                 'policies' => $this->_getPolicyNameOptions(),
                 'decision' => [
                     'Accepted' => dgettext("policy_tracker", "Accepted"),
                     'Declined' => dgettext("policy_tracker", "Declined"),
                 ],
-            ],
+            ];
+        }
+
+        return [
+            'Data'             => $decisions,
+            'canViewDecisions' => $canViewDecisions,
+            'canEditPolicies'  => $this->_hasEditAccess($request),
+            'fieldOptions'     => $fieldOptions,
         ];
     }
 

--- a/modules/policy_tracker/php/policy_tracker.class.inc
+++ b/modules/policy_tracker/php/policy_tracker.class.inc
@@ -38,7 +38,8 @@ class Policy_Tracker extends \NDB_Page
     #[\Override]
     public function isAccessibleBy(\User $user) : bool
     {
-        return $user->hasPermission('config');
+        return $user->hasPermission('view_policy_decisions')
+            || $user->hasPermission('edit_policies');
     }
 
     /**

--- a/modules/policy_tracker/php/policy_tracker.class.inc
+++ b/modules/policy_tracker/php/policy_tracker.class.inc
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * Policy tracker frontend page.
+ *
+ * PHP Version 8
+ *
+ * @category   Core
+ * @package    Main
+ * @subpackage Admin
+ * @author     Loris Team <loris.mni@bic.mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\policy_tracker;
+
+/**
+ * Policy tracker frontend page.
+ *
+ * @category   Core
+ * @package    Main
+ * @subpackage Admin
+ * @author     Loris Team <loris.mni@bic.mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class Policy_Tracker extends \NDB_Page
+{
+    public $skipTemplate = true;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param \User $user The user whose access is being checked.
+     *
+     * @return bool whether access is granted
+     */
+    #[\Override]
+    public function isAccessibleBy(\User $user) : bool
+    {
+        return $user->hasPermission('config');
+    }
+
+    /**
+     * Include the policy tracker React entrypoint.
+     *
+     * @return array of JavaScript files to load
+     */
+    function getJSDependencies()
+    {
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            [$baseURL . "/policy_tracker/js/policyTrackerIndex.js"]
+        );
+    }
+}

--- a/raisinbread/RB_files/RB_perm_perm_action_rel.sql
+++ b/raisinbread/RB_files/RB_perm_perm_action_rel.sql
@@ -95,5 +95,8 @@ INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (86,1);
 INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (87,1);
 INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (88,1);
 INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (89,8);
+INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (92,1);
+INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (93,2);
+INSERT INTO `perm_perm_action_rel` (`permID`, `actionID`) VALUES (93,3);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -83,5 +83,7 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categor
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categoryID`) VALUES (89,'dqt_view','Cross-Modality Data (legacy)',44,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categoryID`) VALUES (90,'data_release_hide','Hide data release files',12,2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categoryID`) VALUES (91,'data_release_delete','Delete data release files',12,2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categoryID`) VALUES (92,'view_policy_decisions','Policy Decisions',51,2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `moduleID`, `categoryID`) VALUES (93,'edit_policies','Policies',51,2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_user_perm_rel.sql
+++ b/raisinbread/RB_files/RB_user_perm_rel.sql
@@ -80,5 +80,7 @@ INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,83);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,84);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,85);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,86);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,92);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,93);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -82,6 +82,7 @@ const lorisModules: Record<string, string[]> = {
   api_docs: ['swagger-ui_custom'],
   dashboard: ['welcome'],
   my_preferences: ['mfa'],
+  policy_tracker: ['policyTrackerIndex'],
 };
 
 /*


### PR DESCRIPTION
## Brief summary of changes

- Adds the Policy Tracker module to the Admin menu.
- Adds a React admin page for viewing policy decisions in a filterable table.
- Adds policy management forms for creating a new policy version and editing policy text per language.
- Adds JSON endpoints for policy decision data, policy options, new policy versions, and translations.

#### Testing instructions

- Open `http://localhost:8080/policy_tracker/` as a user with `config` permission.
- Confirm policy decisions load in the filterable table.
- Filter decisions by module and decision status.
- Create a new version from an existing policy and confirm it saves.
- Edit policy text for a language and confirm it saves.

#### Link(s) to related issue(s)

* Resolves #10609