### PR TITLE
[user_accounts] Add missing dgettext and fixed breadcrumbs and its translation

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -914,7 +914,7 @@ class Edit_User extends \NDB_Form
                 ]
             );
             $examinerGroup[] = $this->createLabel(
-                "Radiologist: "
+                dgettext("user_accounts", "Radiologist") . ": "
             );
             $examinerGroup[] = $this->createSelect(
                 "examiner_radiologist",

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1538,4 +1538,26 @@ class Edit_User extends \NDB_Form
             ]
         );
     }
+
+    /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        $label = $this->isCreatingNewUser() 
+            ? dgettext("user_accounts", "Add User")
+            : dgettext("user_accounts", "Edit User");
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb(
+                dgettext("user_accounts", "User Accounts"),
+                "/user_accounts/"
+            ),
+            new \LORIS\Breadcrumb(
+                $label,
+                ""
+            )
+        );
+    }
 }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1546,7 +1546,7 @@ class Edit_User extends \NDB_Form
      */
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
-        $label = $this->isCreatingNewUser() 
+        $label = $this->isCreatingNewUser()
             ? dgettext("user_accounts", "Add User")
             : dgettext("user_accounts", "Edit User");
         return new \LORIS\BreadcrumbTrail(


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bad translation that turned out to be a missing dgettext in `edit_user.class.inc`. I also noticed as part of my testing that the breadcrumbs were not translated properly because the function `getBreadcrumbs()` was not overridden in that module.  

#### Testing instructions (if applicable)

In every language excluding spanish (because the module isn't translated in spanish):

1. Go to 'Admin' -> 'User Accounts'
2. Verify that breadcrumbs is 'User Accounts'
3. Click on 'Add User'
4. Verify that breadcrumbs becomes 'User Accounts > Add User'
5. Go back to the previous page
6. Verify that breadcrumbs is 'User Accounts'
7. Click on an existing username
8. Verify that breadcrumbs becomes 'User Accounts > Edit User'

Note: Should the route be https://X.loris.ca/user_accounts/edit_user when adding a user? I am not sure if that should be changed or not.

#### Link(s) to related issue(s)

* Resolves #10572 (Reference the issue this fixes, if any.)
