### PR TITLE
[Biobank] Add missing French/Chinese translations

### DIFF
--- a/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
@@ -223,6 +223,34 @@ msgstr "Site actuel"
 msgid "Draw Site"
 msgstr "Site de prélèvement"
 
+#: jsx/specimenTab.js:140 jsx/specimenTab.js:325
+msgid "Container Barcode"
+msgstr "Code-barres du conteneur"
+
+#: jsx/specimenTab.js:275
+msgid "Age at Collection"
+msgstr "Âge au prélèvement"
+
+#: jsx/specimenTab.js:313
+msgid "Collection Date"
+msgstr "Date de prélèvement"
+
+#: jsx/specimenTab.js:317
+msgid "Collection Time"
+msgstr "Heure de prélèvement"
+
+#: jsx/specimenTab.js:321
+msgid "Preparation Time"
+msgstr "Heure de préparation"
+
+#: jsx/specimenTab.js:341 jsx/specimenTab.js:378
+msgid "Go To Specimen"
+msgstr "Aller à l'échantillon"
+
+#: jsx/specimenTab.js:346
+msgid "Add Specimen"
+msgstr "Ajouter un échantillon"
+
 #: jsx/container.js:54
 msgid "Checkout Child Containers"
 msgstr "Vérifier les conteneurs enfants"

--- a/modules/biobank/locale/zh/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/zh/LC_MESSAGES/biobank.po
@@ -220,6 +220,34 @@ msgstr "当前站点"
 msgid "Draw Site"
 msgstr "采样站点"
 
+#: jsx/specimenTab.js:140 jsx/specimenTab.js:325
+msgid "Container Barcode"
+msgstr "容器条形码"
+
+#: jsx/specimenTab.js:275
+msgid "Age at Collection"
+msgstr "采集时年龄"
+
+#: jsx/specimenTab.js:313
+msgid "Collection Date"
+msgstr "采集日期"
+
+#: jsx/specimenTab.js:317
+msgid "Collection Time"
+msgstr "采集时间"
+
+#: jsx/specimenTab.js:321
+msgid "Preparation Time"
+msgstr "制备时间"
+
+#: jsx/specimenTab.js:341 jsx/specimenTab.js:378
+msgid "Go To Specimen"
+msgstr "前往样本"
+
+#: jsx/specimenTab.js:346
+msgid "Add Specimen"
+msgstr "添加样本"
+
 #: jsx/container.js:54
 msgid "Checkout Child Containers"
 msgstr "检出子容器"


### PR DESCRIPTION
## Summary

Adds missing French (fr) and Chinese (zh) translations for the biobank specimen table.

Two commits:
- fr translations for the specimen table fields and Go To Specimen / Add Specimen buttons (addresses #10591)
- zh translations for the same strings

## Strings added

Container Barcode, Age at Collection, Collection Date, Collection Time, Preparation Time, Go To Specimen, Add Specimen.

## AI usage disclosure
Model: Claude (Anthropic). Used to translate the fr and zh msgstrs. I am familiar with french and verified the fr strings.