### PR TITLE
[genomic_browser] GenomicFileID column test plan fix

### DIFF
--- a/modules/genomic_browser/test/TestPlan.md
+++ b/modules/genomic_browser/test/TestPlan.md
@@ -159,7 +159,7 @@ The following permissions should be available in the database:
 
 Datatable columns:
 
-| No. | GenomicFileID | FileName | Description | FileType | Date Inserted | InsertedByUserID | Caveat | Notes |
+| No. | Name | Description | Type | Date | Inserted By User | Caveat | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | | | | | | | | | |
 


### PR DESCRIPTION
## Brief summary of changes
The columns in the GenomicFileID (under files section) differ from as mentioned in the test plan. As discussed, this PR changes the test plan so that it is uniform.

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to genomic_browser --> test --> TestPlan.md
2. confirm that the table layout is changed under the Files tab

#### Link(s) to related issue(s)

* Resolves #10672   (Reference the issue this fixes, if any.)
