### PR TITLE
Fix unintended auto-selection in multiselect filters

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -115,6 +115,7 @@ function Filter(props) {
             <SelectElement
               options={filter.options}
               sortByValue={filter.sortByValue}
+              autoSelect={false}
               multiple={true}
               emptyOption={false}
               disabled={filter.disabled}


### PR DESCRIPTION
## Brief summary of changes

This PR fixes an auto-selection issue affecting pages with multiselect filters that contain only one option. This filter is automatically selected when the page is first loaded, even though no selection was made by the user. The current workaround is to click “Clear Filters” each time the page is opened.

This change disables the auto selection by overriding the autoSelect field to `autoSelect={false}` because by default it's true.

#### Testing instructions (if applicable)

One of the pages affected by this issue that I caught on the 29.0-release branch:

1. Go to 'Biobank' -> 'Biospecimens'
2. Verify that the URL is not 'https://X.loris.ca/biobank/?diagnosis=1' anymore
3. It should be https://X.loris.ca/biobank/  instead

#### Link(s) to related issue(s)

* Resolves #10182 (Reference the issue this fixes, if any.)
