### PR TITLE
[mri_violations] Add missing translations (db and non-db)

### DIFF
--- a/modules/mri_violations/jsx/protocolModal.js
+++ b/modules/mri_violations/jsx/protocolModal.js
@@ -166,7 +166,7 @@ function ProtocolViolationModal(props) {
 
   const pushgroup = (name, tablerows) => {
     protocolgroups.push(<div>
-      <h3>{name}</h3>
+      <h3>{t('Default MRI protocol group', {ns: 'mri_protocol_group'})}</h3>
       <table className="table table-hover table-primary table-bordered">
         <thead>
           <tr>

--- a/modules/mri_violations/jsx/protocolModal.js
+++ b/modules/mri_violations/jsx/protocolModal.js
@@ -166,7 +166,7 @@ function ProtocolViolationModal(props) {
 
   const pushgroup = (name, tablerows) => {
     protocolgroups.push(<div>
-      <h3>{t('Default MRI protocol group', {ns: 'mri_protocol_group'})}</h3>
+      <h3>test</h3>
       <table className="table table-hover table-primary table-bordered">
         <thead>
           <tr>

--- a/modules/mri_violations/jsx/protocolModal.js
+++ b/modules/mri_violations/jsx/protocolModal.js
@@ -166,7 +166,7 @@ function ProtocolViolationModal(props) {
 
   const pushgroup = (name, tablerows) => {
     protocolgroups.push(<div>
-      <h3>test</h3>
+      <h3>{name}</h3>
       <table className="table table-hover table-primary table-bordered">
         <thead>
           <tr>

--- a/modules/mri_violations/locale/es/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/es/LC_MESSAGES/mri_violations.po
@@ -215,4 +215,4 @@ msgid "Can not implement filter on a resource type that has no projects."
 msgstr "No se puede implementar un filtro en un tipo de recurso que no tenga proyectos."
 
 msgid "Series Description Regex:"
-msgstr ""
+msgstr "Expresión regular de la descripción de la serie:"

--- a/modules/mri_violations/locale/es/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/es/LC_MESSAGES/mri_violations.po
@@ -213,3 +213,6 @@ msgstr "Rango de tiempo"
 
 msgid "Can not implement filter on a resource type that has no projects."
 msgstr "No se puede implementar un filtro en un tipo de recurso que no tenga proyectos."
+
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
@@ -193,7 +193,7 @@ msgid "Select Resolution"
 msgstr "Choisir la résolution"
 
 msgid "Image File"
-msgstr "Fichier de l'Image"
+msgstr "Fichier de l'image"
 
 #, fuzzy
 msgid "Must submit data in JSON format"

--- a/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
@@ -268,4 +268,4 @@ msgid "Time Range"
 msgstr "Intervalle de temps"
 
 msgid "Series Description Regex:"
-msgstr ""
+msgstr "Expression régulière de description de série :"

--- a/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/fr/LC_MESSAGES/mri_violations.po
@@ -266,3 +266,6 @@ msgstr "Intervalle du pas en Z"
 
 msgid "Time Range"
 msgstr "Intervalle de temps"
+
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/hi/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/hi/LC_MESSAGES/mri_violations.po
@@ -22,6 +22,11 @@ msgstr ""
 msgid "MRI Violated Scans"
 msgstr "एमआरआई उल्लंघन स्कैन"
 
+msgid "Violated scan"
+msgid_plural "Violated scans"
+msgstr[0] "प्रोटोकॉल का उल्लंघन करने वाला स्कैन"
+msgstr[1] "प्रोटोकॉल का उल्लंघन करने वाले स्कैन"
+
 msgid "Violations for SeriesUID"
 msgstr "सीरीज़UID के लिए उल्लंघन"
 
@@ -213,3 +218,6 @@ msgstr "समय सीमा"
 
 msgid "Can not implement filter on a resource type that has no projects."
 msgstr "ऐसे संसाधन प्रकार पर फ़िल्टर लागू नहीं किया जा सकता जिसमें कोई परियोजना नहीं है."
+
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/hi/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/hi/LC_MESSAGES/mri_violations.po
@@ -220,4 +220,4 @@ msgid "Can not implement filter on a resource type that has no projects."
 msgstr "ऐसे संसाधन प्रकार पर फ़िल्टर लागू नहीं किया जा सकता जिसमें कोई परियोजना नहीं है."
 
 msgid "Series Description Regex:"
-msgstr ""
+msgstr "सीरीज़ विवरण रेगुलर एक्सप्रेशन:"

--- a/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
@@ -218,4 +218,4 @@ msgid "Can not implement filter on a resource type that has no projects."
 msgstr "プロジェクトがないリソース タイプにフィルターを実装することはできません。"
 
 msgid "Series Description Regex:"
-msgstr シリーズ説明の正規表現:"
+msgstr "シリーズ説明の正規表現:"

--- a/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
@@ -218,4 +218,4 @@ msgid "Can not implement filter on a resource type that has no projects."
 msgstr "プロジェクトがないリソース タイプにフィルターを実装することはできません。"
 
 msgid "Series Description Regex:"
-msgstr ""
+msgstr シリーズ説明の正規表現:"

--- a/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/ja/LC_MESSAGES/mri_violations.po
@@ -217,3 +217,5 @@ msgstr "時間範囲"
 msgid "Can not implement filter on a resource type that has no projects."
 msgstr "プロジェクトがないリソース タイプにフィルターを実装することはできません。"
 
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/mri_violations.pot
+++ b/modules/mri_violations/locale/mri_violations.pot
@@ -229,3 +229,5 @@ msgstr ""
 msgid "Echo Number"
 msgstr ""
 
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/zh/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/zh/LC_MESSAGES/mri_violations.po
@@ -216,3 +216,6 @@ msgstr "时间范围"
 
 msgid "Can not implement filter on a resource type that has no projects."
 msgstr "无法对没有项目的资源类型实施筛选。"
+
+msgid "Series Description Regex:"
+msgstr ""

--- a/modules/mri_violations/locale/zh/LC_MESSAGES/mri_violations.po
+++ b/modules/mri_violations/locale/zh/LC_MESSAGES/mri_violations.po
@@ -218,4 +218,4 @@ msgid "Can not implement filter on a resource type that has no projects."
 msgstr "无法对没有项目的资源类型实施筛选。"
 
 msgid "Series Description Regex:"
-msgstr ""
+msgstr "序列描述正则表达式："

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -103,12 +103,21 @@ class Mri_Violations extends \DataFrameworkMenu
              ORDER BY mpg.MriProtocolGroupID ASC, p.MriScanTypeID ASC",
             []
         );
+        $protocols = iterator_to_array($protocols);
+        foreach ($protocols as &$protocol) {
+            $protocol['Protocol Group'] = dgettext(
+                'mri_protocol_group',
+                $protocol['Protocol Group']
+            );
+        }
+        unset($protocol);
+
         return [
             'projects'     => \Utility::getProjectList(),
             'cohorts'      => \Utility::getCohortList(),
             'sites'        => \Utility::getSiteList(),
             'problemtypes' => $problemTypes,
-            'protocols'    => iterator_to_array($protocols),
+            'protocols'    => $protocols,
         ];
     }
 

--- a/raisinbread/locale/fr/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/mri_protocol_group.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Default MRI protocol group"
+msgstr "Groupe de protocoles IRM par défaut"
+

--- a/raisinbread/locale/fr/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/mri_protocol_group.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/hi/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/mri_protocol_group.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/hi/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/mri_protocol_group.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Default MRI protocol group"
+msgstr "डिफ़ॉल्ट एमआरआई प्रोटोकॉल समूह"
+

--- a/raisinbread/locale/ja/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/mri_protocol_group.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/ja/LC_MESSAGES/mri_protocol_group.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/mri_protocol_group.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "Default MRI protocol group"
+msgstr "デフォルトのMRIプロトコルグループ"
+

--- a/raisinbread/locale/mri_protocol_group.pot
+++ b/raisinbread/locale/mri_protocol_group.pot
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Default MRI protocol group"
+msgstr ""
+

--- a/raisinbread/locale/mri_protocol_group.pot
+++ b/raisinbread/locale/mri_protocol_group.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing French translations to the mri_violations module. It includes both db and non-db translations.

#### Testing instructions (if applicable)

1. git checkout HachemJ/AddMissingTranslationsMriViolations
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Imaging' -> 'MRI Violated Scans'
6. Switch the language to 'French'
7. To verify that the only db translation went through, click on any entry from the 'Type of Problem' column and check that 'Default MRI Protocol Group' is translated.
8. Verify that everything in the module is translated and report any misses.

#### Link(s) to related issue(s)

* Resolves #10596 (Reference the issue this fixes, if any.)
