### PR TITLE
Remove Exclude Instruments from DD and DQT

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -159,6 +159,7 @@ CREATE TABLE `candidate` (
   `ExternalID` varchar(255) DEFAULT NULL,
   `DoB` date DEFAULT NULL,
   `DoD` date DEFAULT NULL,
+  `DoD_precision` enum('known_full','known_year_month','known_year','unknown') DEFAULT NULL,
   `EDC` date DEFAULT NULL,
   `Sex` varchar(255) DEFAULT NULL,
   `RegistrationCenterID` integer unsigned NOT NULL,

--- a/SQL/New_patches/2026-03-17-DoD-precision-field.sql
+++ b/SQL/New_patches/2026-03-17-DoD-precision-field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE candidate
+ADD COLUMN DoD_precision enum('known_full','known_year_month','known_year','unknown') DEFAULT NULL AFTER DoD;

--- a/composer.lock
+++ b/composer.lock
@@ -493,25 +493,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -520,8 +521,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -599,7 +601,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -615,28 +617,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -682,7 +685,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -698,7 +701,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",

--- a/composer.lock
+++ b/composer.lock
@@ -702,23 +702,25 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.2",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -799,7 +801,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -815,7 +817,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T22:58:15+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1628,16 +1630,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -1650,7 +1652,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1675,7 +1677,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1687,11 +1689,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1930,6 +1936,90 @@
                 }
             ],
             "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         }
     ],
     "packages-dev": [

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -630,14 +630,20 @@ function editCandidateDOB(\Database $db): void
 function editCandidateDOD(\Database $db): void
 {
     $candID       = new CandID($_POST['candID']);
-    $dod          = new DateTime($_POST['dod']);
+    $dod          = array_key_exists('dod', $_POST) ?
+        new DateTime($_POST['dod']) : null;
+    $precision    = $_POST['dod_precision'];
     $strippedDate = null;
     $dodString    = null;
 
-    if (!$dod) {
+    if (!$dod && $precision !== 'unknown') {
         throw new \LorisException('Date not valid.');
     }
+    if (!$precision) {
+        throw new \LorisException('Date of Death precision must be specified.');
+    }
 
+    $updateData = [];
     if (!empty($dod)) {
         $config    = \NDB_Config::singleton();
         $dodFormat = $config->getSetting('dodFormat');
@@ -646,10 +652,17 @@ function editCandidateDOD(\Database $db): void
         } else {
             $dodString = $dod->format('Y-m-d');
         }
+        $updateData['DoD'] = $strippedDate ?? $dodString;
+    } else {
+        $updateData['DoD'] = null;
+    }
+
+    if ($precision) {
+        $updateData['DoD_precision'] = $precision;
         $db->update(
             'candidate',
-            ['DoD' => $strippedDate ?? $dodString],
-            ['ID' => $candID->__toString()]
+            $updateData,
+            ['CandID' => $candID->__toString()]
         );
     }
 }

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -586,7 +586,13 @@ function getDODFields(): array
     $db     = \NDB_Factory::singleton()->database();
 
     $candidateData = $db->pselectRow(
-        'SELECT PSCID,DoD, DoB FROM candidate where CandID =:candid',
+        'SELECT
+            PSCID,
+            DoD,
+            DoD_precision,
+            DoB
+        FROM candidate
+        WHERE CandID =:candid',
         ['candid' => $candID]
     );
     if ($candidateData === null) {
@@ -614,11 +620,12 @@ function getDODFields(): array
     $dob = $dobDate ? $dobDate->format($dobProcessedFormat) : null;
 
     $result = [
-        'pscid'     => $candidateData['PSCID'],
-        'candID'    => $candID->__toString(),
-        'dod'       => $dod,
-        'dob'       => $dob,
-        'dodFormat' => $config->getSetting('dodFormat'),
+        'pscid'         => $candidateData['PSCID'],
+        'candID'        => $candID->__toString(),
+        'dod'           => $dod,
+        'dob'           => $dob,
+        'dod_precision' => $candidateData['DoD_precision'],
+        'dodFormat'     => $config->getSetting('dodFormat'),
     ];
     return $result;
 }

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -91,6 +91,12 @@ class CandidateDOB extends Component {
     }
 
     let dateFormat = this.state.data.dobFormat;
+
+    let dobValue = this.state.formData.dob || '';
+    if (dateFormat == 'Ym' && this.state.formData.dob) {
+      dobValue = dobValue.slice(0, 7);
+    }
+
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dob_edit')) {
@@ -126,7 +132,7 @@ class CandidateDOB extends Component {
           <DateElement
             label={t('DoB', {ns: 'loris'})}
             name='dob'
-            dateFormat={dateFormat}
+            dateFormat={dobValue}
             value={this.state.formData.dob}
             onUserInput={this.setFormData}
             disabled={disabled}

--- a/modules/candidate_parameters/jsx/CandidateDOD.js
+++ b/modules/candidate_parameters/jsx/CandidateDOD.js
@@ -9,6 +9,7 @@ import {
   StaticElement,
   DateElement,
   ButtonElement,
+  SelectElement,
 } from 'jsx/Form';
 
 /**
@@ -64,7 +65,13 @@ class CandidateDOD extends Component {
    * @param {*} value
    */
   setFormData(formElement, value) {
-    let formData = this.state.formData;
+    let formData = {...this.state.formData};
+
+    // Clear the DOD if indicated as unknown
+    if (formElement === 'dod_precision' && value === 'unknown') {
+      formData.dod = '';
+    }
+
     formData[formElement] = value;
     this.setState({
       formData: formData,
@@ -88,12 +95,28 @@ class CandidateDOD extends Component {
       return <Loader/>;
     }
 
-    let dateFormat = this.state.data.dodFormat;
     let disabled = true;
     let updateButton = null;
     if (loris.userHasPermission('candidate_dod_edit')) {
       disabled = false;
       updateButton = <ButtonElement label={t('Update', {ns: 'loris'})}/>;
+    }
+
+    let precisionOptions = {
+      'known_year_month': t('I know the year and month of death'),
+      'known_year': t('I know the year of death'),
+      'unknown': t('I do not know the date of death'),
+    };
+
+    let required = this.state.formData.dod_precision != 'unknown';
+
+    let dateFormat = this.state.data.dodFormat;
+
+    let dodValue = this.state.formData.dod || '';
+    if (dateFormat == 'Ymd') {
+      precisionOptions['known_full'] = t('I know the full date of death');
+    } else if (dateFormat == 'Ym' && this.state.formData.dod) {
+      dodValue = dodValue.slice(0, 7);
     }
 
     return (
@@ -121,14 +144,23 @@ class CandidateDOD extends Component {
             }
             class='form-control-static text-danger bg-danger col-sm-10'
           />
+          <SelectElement
+            label={t('Precision of date:')}
+            name='dod_precision'
+            options={precisionOptions}
+            value={this.state.formData.dod_precision}
+            onUserInput={this.setFormData}
+            disabled={disabled}
+            required={true}
+          />
           <DateElement
             label={t('Date Of Death:', {ns: 'candidate_parameters'})}
             name='dod'
             dateFormat={dateFormat}
-            value={this.state.formData.dod}
+            value={dodValue}
             onUserInput={this.setFormData}
-            disabled={disabled}
-            required={true}
+            disabled={disabled || !required}
+            required={required}
           />
           {updateButton}
         </FormElement>
@@ -194,7 +226,6 @@ class CandidateDOD extends Component {
     }
 
     formObject.append('tab', this.props.tabName);
-
     fetch(this.props.action, {
       method: 'POST',
       cache: 'no-cache',

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -227,3 +227,18 @@ msgstr ""
 
 msgid "Comments: "
 msgstr ""
+
+msgid "I know the year and month of death"
+msgstr ""
+
+msgid "I know the year of death"
+msgstr ""
+
+msgid "I do not know the date of death"
+msgstr ""
+
+msgid "I know the full date of death"
+msgstr ""
+
+msgid "Precision of date:"
+msgstr ""

--- a/modules/document_repository/jsx/DocumentRepositoryClient.js
+++ b/modules/document_repository/jsx/DocumentRepositoryClient.js
@@ -1,0 +1,27 @@
+import {Client} from 'jslib/http';
+
+/**
+ * Document repository JSON client.
+ */
+class DocumentRepositoryClient extends Client {
+  /**
+   * @constructor
+   */
+  constructor() {
+    super('document_repository');
+  }
+
+  /**
+   * Retrieve file metadata by ID.
+   *
+   * @param {string} id
+   * @return {Promise<any>}
+   */
+  getFileData(id) {
+    return this
+      .setSubEndpoint('Files/meta')
+      .getById(id);
+  }
+}
+
+export default DocumentRepositoryClient;

--- a/modules/document_repository/jsx/editForm.js
+++ b/modules/document_repository/jsx/editForm.js
@@ -11,6 +11,7 @@ import {
 } from 'jsx/Form';
 import i18n from 'I18nSetup';
 import {withTranslation} from 'react-i18next';
+import DocumentRepositoryClient from './DocumentRepositoryClient';
 
 import hiStrings from '../locale/hi/LC_MESSAGES/document_repository.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/document_repository.json';
@@ -48,6 +49,7 @@ class DocEditForm extends React.Component {
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.setFormData = this.setFormData.bind(this);
+    this.documentRepositoryClient = new DocumentRepositoryClient();
   }
 
   /**
@@ -64,8 +66,11 @@ class DocEditForm extends React.Component {
    * @return {Promise}
    */
   fetchData() {
-    return fetch(this.props.dataURL, {credentials: 'same-origin'})
-      .then((resp) => resp.json())
+    const fileID = this.props.dataURL.substring(
+      this.props.dataURL.lastIndexOf('/') + 1
+    );
+
+    return this.documentRepositoryClient.getFileData(fileID)
       .then((data) => {
         const formData = data.docData;
         this.setState({

--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -43,6 +43,17 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
 
         $rows = $DB->pselectCol("SELECT Test_name FROM test_names", []);
 
+        // Instruments in the excluded_instruments config setting should
+        // not be queryable through the data dictionary or DQT.
+        $excluded = [];
+        $config   = $this->loris->getConfiguration();
+        $setting  = $config->getSetting('excluded_instruments');
+        foreach ($setting as $instruments) {
+            foreach (\Utility::asArray($instruments) as $instrument) {
+                $excluded[$instrument] = $instrument;
+            }
+        }
+
         $dict = [];
 
         // Use the same option enums for all instruments
@@ -54,6 +65,9 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $scope       = new Scope(Scope::SESSION);
 
         foreach ($rows as $testname) {
+            if (isset($excluded[$testname])) {
+                continue;
+            }
             try {
                 $inst = \NDB_BVL_Instrument::factory(
                     $this->loris,

--- a/modules/redcap/CONFIGURATION.md
+++ b/modules/redcap/CONFIGURATION.md
@@ -15,6 +15,7 @@ The configuration is of the following form:
       <redcap-api-token>ABCDEFGGHIJKLMNOPQRSTUVWXYZ</redcap-api-token>
       <prefix-instrument-variable>false</prefix-instrument-variable>
       <redcap-participant-id>record_id</redcap-participant-id>
+      <redcap-repeat-id>repeat_instance</redcap-repeat-id>
       <candidate-id>pscid</candidate-id>
       <visit>
         <visit-label>visit_1</visit-label>
@@ -50,6 +51,7 @@ In a `project` entry, the configuration parameters are the following:
 - `redcap-api-token` (required): The REDCap API token used by LORIS to retrieve REDCap data for this project.
 - `prefix-instrument-variable` (optional): Whether or not the instrument field variable names are prefixed by their instrument name in REDCap. The two options are `true` or `false`. If not present, `false` is used.
 - `redcap-participant-id` (optional): The type of REDCap participant identifier used to map the REDCap participants with the LORIS candidates. The two options are `record_id` and `survey_participant_id`. If not present, `record_id` is used.
+- `redcap-repeat-id` (optional): only active when repeated instruments are in use. The type of REDCap repeat identifier (i.e. a REDCap instrument field) used to order repeated instrument records. The two options are `repeat_instance` and `timestamp`. If not present, `repeat_instance` is used.
 - `candidate-id` (optional): The type of LORIS candidate identifier used to map the REDCap participants with the LORIS candidates. The three options are `pscid`, `candid`, and `external_id`. If not present, `pscid` is used.
 - `visit` (optional, multiple allowed): A list of visit mappings that describe how REDCap arms and events are mapped to LORIS visits. If not present, the REDCap arms are ignored and the REDCap event names are matched to LORIS visit labels with the same name.
 

--- a/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
+++ b/modules/redcap/php/client/models/redcapdictionaryrecord.class.inc
@@ -242,9 +242,15 @@ class RedcapDictionaryRecord
         $field_type  = $this->field_type;
         $field_name  = $this->field_name;
         $field_label = str_replace(["\r\n", "\r", "\n"], '', $this->field_label);
+        // strip HTML-related content
+        $field_label = strip_tags($field_label);
+        // replace the non-breaking space in unicode-encoding (\xao)
+        // and UTF-8 encoding (\xc2)
+        $field_label = str_replace("\xc2\xa0", ' ', $field_label);
+        $field_label = preg_replace('/\s+/', ' ', $field_label);
+        $field_label = trim($field_label);
         $field_desc  = "$field_name{@}$field_label";
 
-        //
         switch ($field_type) {
         case 'text':
             // text maps directly to LORIS

--- a/modules/redcap/php/client/redcaphttpclient.class.inc
+++ b/modules/redcap/php/client/redcaphttpclient.class.inc
@@ -26,6 +26,7 @@ use LORIS\redcap\client\models\mappings\RedcapRepeatingInstrumentEvent;
 use LORIS\redcap\client\models\mappings\RedcapInstrumentEventMap;
 use LORIS\redcap\client\models\records\RedcapRecord;
 use LORIS\redcap\client\models\records\RedcapRepeatingRecord;
+use LORIS\redcap\config\RedcapConfigRepeatId;
 
 /**
  * A REDCap Client.
@@ -61,6 +62,11 @@ class RedcapHttpClient
     private Client $_client;
 
     /**
+     * REDCap repeated instrument field.
+     */
+    private RedcapConfigRepeatId $_repeat_index_field;
+
+    /**
      * A cache of all already done calls.
      *
      * @var array
@@ -70,13 +76,15 @@ class RedcapHttpClient
     /**
      * Create a new REDCap Client for a specific REDCap instance and project.
      *
-     * @param string $instance_url      A REDCap instance URL.
-     * @param string $project_api_token A REDCap project API token.
-     * @param bool   $verbose           Verbose mode.
+     * @param string               $instance_url      A REDCap instance URL.
+     * @param string               $project_api_token A REDCap project API token.
+     * @param RedcapConfigRepeatId $repeat_index      The REDCap repeated field.
+     * @param bool                 $verbose           Verbose mode.
      */
     public function __construct(
         string $instance_url,
         string $project_api_token,
+        RedcapConfigRepeatId $repeat_index,
         bool $verbose = false
     ) {
         $trimmed_url    = rtrim($instance_url, '/');
@@ -85,6 +93,9 @@ class RedcapHttpClient
         $this->_token   = $project_api_token;
         $this->_client  = new Client($api_url);
         $this->_verbose = $verbose;
+
+        // only useful when repeated instruments exist.
+        $this->_repeat_index_field = $repeat_index;
     }
 
     /**
@@ -721,28 +732,42 @@ class RedcapHttpClient
                 $unique_event_name
             )
         ) {
-            // TODO: ${instrument_name}_dtt seems to be HBCD-specific. The code
-            // could probably be cleaner with a single timestamp abstraction. The
-            // problem is that the repeating index depends on the order in which the
-            // records were filled. However, this index might also be obtainable
-            // from a field in the record. Investigation needed.
-            // Order the records by ${instrument_name}_dtt field value
-            usort(
-                $record_dicts,
-                function ($a, $b) use ($instrument_name) {
-                    $dttField = "{$instrument_name}_dtt";
-                    $a_date   = new \DateTimeImmutable($a[$dttField]);
-                    $b_date   = new \DateTimeImmutable($b[$dttField]);
-                    return $a_date <=> $b_date;
-                }
-            );
+            // If the record_id is null then all records have been imported.
+            // We need to group them by record_id to make sense and not have
+            // thousands of overlapping repeated records.
+            if ($record_id === null) {
+                // need to be grouped by record id = possibly multiple
+                // repeated records.
+                $record_groups = [];
+                foreach ($record_dicts as $record_dict) {
+                    $record_group_id = $record_dict["record_id"];
 
-            foreach ($record_dicts as $index => $record) {
-                $records[] = new RedcapRepeatingRecord(
+                    // group them by "record_id"
+                    if (array_key_exists($record_group_id, $record_groups)) {
+                        $record_groups[$record_group_id][] = $record_dict;
+                    } else {
+                        $record_groups[$record_group_id] = [$record_dict];
+                    }
+                }
+
+                // foreach group or record_id, parse them into RepeatedRecords
+                foreach ($record_groups as $record_group_id => $record_group) {
+                    $records = array_merge(
+                        $records,
+                        $this->_buildRepeatedRecords(
+                            strval($record_group_id),
+                            $instrument_name,
+                            $record_group
+                        )
+                    );
+                }
+            } else {
+                // does not neeed to group by record_id = only one RepeatedRecord
+                $records[] = $this->_buildRepeatedRecords(
+                    $record_id,
                     $instrument_name,
-                    $record,
-                    $index + 1
-                );
+                    $record_dicts
+                )[0];
             }
         } else {
             // Transform the record dictionaries into record objects.
@@ -780,6 +805,82 @@ class RedcapHttpClient
         }
 
         return $records;
+    }
+
+    /**
+     * Build a list of RepeatedRecord out of a array of record dictionaries.
+     * The build process takes the configuration::RedcapConfigRepeatId in account
+     * to either build with the redcap_repeat_instance or the timestamp field.
+     *
+     * @param string $record_id       A REDCap record_id.
+     * @param string $instrument_name A REDCap instrument name.
+     * @param array  $raw_records     An array of record dictionaries.
+     *
+     * @return RedcapRepeatingRecord[] an array of repeated records
+     */
+    private function _buildRepeatedRecords(
+        string $record_id,
+        string $instrument_name,
+        array $raw_records
+    ): array {
+        // log record_id
+        $tag = "[instrument:{$instrument_name}][record_id:{$record_id}]";
+        error_log("[redcap] {$tag} building repeated records");
+
+        $repeated_records = [];
+
+        // instrument repeat instance as the ordering point
+        if ($this->_repeat_index_field === RedcapConfigRepeatId::RepeatInstance) {
+            // sort based on the instance index number
+            usort(
+                $raw_records,
+                function ($a, $b) {
+                    $redcapRepeatIndex = "redcap_repeat_instance";
+                    return $a[$redcapRepeatIndex] <=> $b[$redcapRepeatIndex];
+                }
+            );
+
+            // build records
+            foreach ($raw_records as $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $record["redcap_repeat_instance"]
+                );
+            }
+        } else if ($this->_repeat_index_field === RedcapConfigRepeatId::Timestamp) {
+            // sort based on the record timestamp
+            usort(
+                $raw_records,
+                function ($a, $b) use ($instrument_name) {
+                    $tsField = "{$instrument_name}_timestamp";
+                    $ts_a    = new \DateTimeImmutable($a[$tsField]);
+                    $ts_b    = new \DateTimeImmutable($b[$tsField]);
+                    return $ts_a <=> $ts_b;
+                }
+            );
+
+            // build records
+            foreach ($raw_records as $index => $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $index + 1
+                );
+            }
+        } else {
+            // default process = iterate and increment record id.
+            foreach ($raw_records as $index => $record) {
+                $repeated_records[] = new RedcapRepeatingRecord(
+                    $instrument_name,
+                    $record,
+                    $index + 1
+                );
+            }
+        }
+
+        // built repeated records
+        return $repeated_records;
     }
 
     /**

--- a/modules/redcap/php/config/redcapconfig.class.inc
+++ b/modules/redcap/php/config/redcapconfig.class.inc
@@ -64,6 +64,14 @@ class RedcapConfig
     public readonly RedcapConfigLorisId $candidate_id;
 
     /**
+     * The type of REDCap repeated identifier to match against the LORIS repeated
+     * instrument index.
+     *
+     * @var RedcapConfigRepeatId
+     */
+    public readonly RedcapConfigRepeatId $redcap_repeat_id;
+
+    /**
      * The configuration parameters to map the REDCap arms and events to the LORIS
      * visits.
      *
@@ -86,6 +94,9 @@ class RedcapConfig
      *                                                         participant
      *                                                         identifier
      *                                                         configuration.
+     * @param RedcapConfigRepeatId $redcap_repeat_id           The REDCap LORIS
+     *                                                         repeat index
+     *                                                         identifier.
      * @param RedcapConfigLorisId  $candidate_id               The REDCap LORIS
      *                                                         candidate identifier
      *                                                         configuration.
@@ -98,6 +109,7 @@ class RedcapConfig
         string $redcap_api_token,
         bool $prefix_instrument_variable,
         RedcapConfigRedcapId $redcap_participant_id,
+        RedcapConfigRepeatId $redcap_repeat_id,
         RedcapConfigLorisId $candidate_id,
         ?array $visits,
     ) {
@@ -106,6 +118,7 @@ class RedcapConfig
         $this->redcap_api_token           = $redcap_api_token;
         $this->prefix_instrument_variable = $prefix_instrument_variable;
         $this->redcap_participant_id      = $redcap_participant_id;
+        $this->redcap_repeat_id           = $redcap_repeat_id;
         $this->candidate_id = $candidate_id;
         $this->visits       = $visits;
     }

--- a/modules/redcap/php/config/redcapconfigparser.class.inc
+++ b/modules/redcap/php/config/redcapconfigparser.class.inc
@@ -16,6 +16,7 @@ use LORIS\redcap\config\RedcapConfig;
 use LORIS\redcap\config\RedcapConfigLorisId;
 use LORIS\redcap\config\RedcapConfigRedcapId;
 use LORIS\redcap\config\RedcapConfigVisit;
+use LORIS\redcap\config\RedcapConfigRepeatId;
 
 /**
  * This represents a REDCap configuration parser.
@@ -117,6 +118,9 @@ class RedcapConfigParser
         $redcap_participant_id      = $this->_parseRedcapParticipantId(
             $project_node
         );
+        $redcap_repeat_id           = $this->_parseRedcapRepeatId(
+            $project_node
+        );
         $candidate_id = $this->_parseCandidateId($project_node);
         $visits       = $this->_parseVisits($project_node);
 
@@ -126,6 +130,7 @@ class RedcapConfigParser
             $redcap_api_token,
             $prefix_instrument_variable,
             $redcap_participant_id,
+            $redcap_repeat_id,
             $candidate_id,
             $visits,
         );
@@ -286,6 +291,35 @@ class RedcapConfigParser
                 . " found '$redcap_participant_id'."
             );
         }
+    }
+
+    /**
+     * Parse the REDCap repeat identifier configuration from a REDCap
+     * configuration project XML node.
+     *
+     * @param array $project_node The REDCap configuration project XML node.
+     *
+     * @return RedcapConfigRepeatId The REDCap repeat identifier.
+     */
+    private function _parseRedcapRepeatId(
+        array $project_node,
+    ): RedcapConfigRepeatId {
+        $redcap_repeat_id = $project_node['redcap-repeat-id'] ?? null;
+
+        // Default value.
+        if ($redcap_repeat_id === null) {
+            return RedcapConfigRepeatId::RepeatInstance;
+        }
+
+        return match ($redcap_repeat_id) {
+            "repeat_instance" => RedcapConfigRepeatId::RepeatInstance,
+            "timestamp"       => RedcapConfigRepeatId::Timestamp,
+            default           => throw $this->_exception(
+                "invalid REDCap repeat identifier type for the selected"
+                . " project, expected 'timestamp' or 'repeat_instance' but"
+                . " found '{$redcap_repeat_id}'."
+            )
+        };
     }
 
     /**

--- a/modules/redcap/php/config/redcapconfigrepeatid.class.inc
+++ b/modules/redcap/php/config/redcapconfigrepeatid.class.inc
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * PHP Version 8
+ *
+ * @category REDCap
+ * @package  Main
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\redcap\config;
+
+/**
+ * Enumeration that describes which kind of index is used to order repeating
+ * instrument records.
+ *
+ * @category REDCap
+ * @package  Main
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+enum RedcapConfigRepeatId
+{
+    /**
+     * REDCap repeated records are ordered by the "redcap_repeat_instance" field.
+     */
+    case RepeatInstance;
+
+    /**
+     * REDCap repeated records are ordered by the "timestamp" field.
+     */
+    case Timestamp;
+}

--- a/modules/redcap/php/endpoints/notifications.class.inc
+++ b/modules/redcap/php/endpoints/notifications.class.inc
@@ -170,6 +170,7 @@ class Notifications extends Endpoint
             $redcap_client = new RedcapHttpClient(
                 $config->redcap_instance_url,
                 $config->redcap_api_token,
+                $config->redcap_repeat_id
             );
 
             $notification_handler = new RedcapNotificationHandler(

--- a/modules/redcap/php/redcaprecordimporter.class.inc
+++ b/modules/redcap/php/redcaprecordimporter.class.inc
@@ -218,6 +218,8 @@ class RedcapRecordImporter
                 return !in_array(
                     $name,
                     [
+                        "redcap_repeat_instrument",
+                        "redcap_repeat_instance",
                         "record_id",
                         "redcap_data_access_group",
                         "redcap_event_name",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/fontawesome-free": "^5.11.2",
                 "base32": "^0.0.7",
                 "copy-webpack-plugin": "^14.0.0",
-                "dompurify": "^3.4.0",
+                "dompurify": "^3.4.11",
                 "hi-base32": "^0.5.1",
                 "i18next": "^25.0.0",
                 "i18next-conv": "^15.1.1",
@@ -4757,9 +4757,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "version": "3.4.11",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@fortawesome/fontawesome-free": "^5.11.2",
         "base32": "^0.0.7",
         "copy-webpack-plugin": "^14.0.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.11",
         "hi-base32": "^0.5.1",
         "i18next": "^25.0.0",
         "i18next-conv": "^15.1.1",

--- a/tools/import_redcap_records.php
+++ b/tools/import_redcap_records.php
@@ -76,6 +76,7 @@ if ($redcap_config === null) {
 $redcap_client = new RedcapHttpClient(
     $redcap_config->redcap_instance_url,
     $redcap_config->redcap_api_token,
+    $redcap_config->redcap_repeat_id,
 );
 
 $redcap_mapper = new RedcapMapper($lorisInstance, $redcap_client, $redcap_config);


### PR DESCRIPTION
## Brief summary of changes
Instruments added to the "Excluded instruments" configuration setting were
still queryable in the Data Dictionary module and the DQT. The
`excluded_instruments` setting was was not considered by the instrument query engine that both modules use.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)
1. Go to the Configuration module > Instruments and add an instrument
    to the "Excluded instruments" section, then save.
2. Open the Data Dictionary module: the excluded instrument should no longer
   appear as a category, and none of its fields should be listed.
3. Open the DQT and check the field browser under the instruments module:
   the excluded instrument and its fields should not be available for
   querying.
4. Return to the Configuration module, remove the instrument from the
   "Excluded instruments" list, and save.
5. Verify the instrument and its fields reappear in both the Data Dictionary
   and the DQT without any additional steps.

#### Link(s) to related issue(s)


