### PR TITLE
[Instruments] Remove Excluded Instruments from DD and DQT

### DIFF
--- a/modules/instruments/php/instrumentqueryengine.class.inc
+++ b/modules/instruments/php/instrumentqueryengine.class.inc
@@ -43,6 +43,17 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
 
         $rows = $DB->pselectCol("SELECT Test_name FROM test_names", []);
 
+        // Instruments in the excluded_instruments config setting should
+        // not be queryable through the data dictionary or DQT.
+        $excluded = [];
+        $config   = $this->loris->getConfiguration();
+        $setting  = $config->getSetting('excluded_instruments');
+        foreach ($setting as $instruments) {
+            foreach (\Utility::asArray($instruments) as $instrument) {
+                $excluded[$instrument] = $instrument;
+            }
+        }
+
         $dict = [];
 
         // Use the same option enums for all instruments
@@ -54,6 +65,9 @@ class InstrumentQueryEngine implements \LORIS\Data\Query\QueryEngine
         $scope       = new Scope(Scope::SESSION);
 
         foreach ($rows as $testname) {
+            if (isset($excluded[$testname])) {
+                continue;
+            }
             try {
                 $inst = \NDB_BVL_Instrument::factory(
                     $this->loris,


### PR DESCRIPTION
## Brief summary of changes
Instruments added to the "Excluded instruments" configuration setting were
still queryable in the Data Dictionary module and the DQT. The
`excluded_instruments` setting was was not considered by the instrument query engine that both modules use.


#### Testing instructions (if applicable)
1. Go to the Configuration module > Instruments and add an instrument
    to the "Excluded instruments" section, then save.
2. Open the Data Dictionary module: the excluded instrument should no longer
   appear as a category, and none of its fields should be listed.
3. Open the DQT and check the field browser under the instruments module:
   the excluded instrument and its fields should not be available for
   querying.
4. Return to the Configuration module, remove the instrument from the
   "Excluded instruments" list, and save.
5. Verify the instrument and its fields reappear in both the Data Dictionary
   and the DQT without any additional steps.

#### Link(s) to related issue(s)

* Resolves #10638 
