### PR TITLE
[new_profile] Fix non translated Project and Sites dropdowns 

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -59,10 +59,7 @@ class New_Profile extends \NDB_Form
         $site = \Utility::getSiteNameListByIDs($user_list_of_sites);
 
         // Get projects for the select dropdown
-        $projList = [];
-        foreach ($user->getProjects() as $project) {
-            $projList[$project->getName()] = $project->getName();
-        }
+        $projList = $user->getProjectNames();
 
         // Get setting through pscid
         $PSCIDsettings = $config->getSetting('PSCID');

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -207,12 +207,18 @@ class Utility
             $values[$para] = $siteID;
         }
 
-        return $DB->pselectColWithIndexKey(
+        $sites = $DB->pselectColWithIndexKey(
             "SELECT CenterID as ID, Name FROM psc WHERE CenterID in (" .
             implode(', ', $params) . ")",
             $values,
             'ID'
         );
+
+        $translatedSites = [];
+        foreach ($sites as $siteID => $siteName) {
+            $translatedSites[$siteID] = dgettext("psc", $siteName);
+        }
+        return $translatedSites;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the non translated Project and Sites dropdowns in the New Profile module by using the libraries (utility) functions `getProjectNames` and `getSiteNameListByIDs` that translate the values retrieved from the db.

#### Testing instructions (if applicable)

1. Go to 'Candidate' -> 'New Profile'
2. Switch the language to either 'French', 'Hindi' or 'Japanese' (the raisinbread locale languages so far)
3. Verify that the Project and Sites dropdowns are translated in the language selected.
4. (I think Optional) Try to add a new profile by filling the form using the new translated dropdowns and verify that it's working as expected.

#### Link(s) to related issue(s)

* Resolves #10776 (Reference the issue this fixes, if any.)
