### PR TITLE
[create_timepoint] Fix non translated Project and Sites dropdowns 

### DIFF
--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -211,7 +211,7 @@ class Project implements \JsonSerializable
      */
     public function getName(): string
     {
-        return $this->_projectName;
+        return dgettext('Project', $this->_projectName);
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -207,12 +207,18 @@ class Utility
             $values[$para] = $siteID;
         }
 
-        return $DB->pselectColWithIndexKey(
+        $sites = $DB->pselectColWithIndexKey(
             "SELECT CenterID as ID, Name FROM psc WHERE CenterID in (" .
             implode(', ', $params) . ")",
             $values,
             'ID'
         );
+
+        $translatedSites = [];
+        foreach ($sites as $siteID => $siteName) {
+            $translatedSites[$siteID] = dgettext("psc", $siteName);
+        }
+        return $translatedSites;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the non translated Project and Sites dropdowns in the New Profile module by using the libraries (utility) functions `getName` and `getSiteNameListByIDs` that translate the values retrieved from the db.

#### Testing instructions (if applicable)

1. Go to 'Candidate' -> 'Access Profile' -> 'Click on any candidate's PSCID' -> 'Click on Create Time point'
2. Switch the language to either 'French', 'Hindi' or 'Japanese' (the raisinbread locale languages so far)
3. Verify that the Project and Sites dropdowns are translated in the language selected.
4. (I think Optional) Try to add a new timepoint by filling the form using the new translated dropdowns and verify that it's working as expected.

#### Link(s) to related issue(s)

* Resolves #10777 (Reference the issue this fixes, if any.)
