### PR TITLE
[issue_tracker] Ability to delete unowned attachments - fix

### DIFF
--- a/modules/issue_tracker/jsx/index.js
+++ b/modules/issue_tracker/jsx/index.js
@@ -29,7 +29,7 @@ window.addEventListener('load', () => {
         + '/issue_tracker/Edit/'}
       issue={id}
       baseURL={loris.BaseURL}
-      userHasPermission={loris.userHasPermission('issue_tracker_all_issue')}
+      userHasPermission={loris.userHasPermission('superuser')}
     />
   );
 });

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -191,7 +191,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
         // Check if User shouldn't be able to Delete.
         if (empty($result)
             && !$user->hasPermission(
-                'issue_tracker_all_issue'
+                'superuser'
             )
         ) {
             return false;


### PR DESCRIPTION
https://github.com/aces/Loris/issues/10792


Behavior change base on Test plan:
User assigned to issue cannot delete attachments owned by another user (item 11)
Superuser can delete any attachment
Regular users with issue_tracker_all_issue permission can no longer delete unowned attachments