### PR TITLE
[my_preferences] Fix wrong error translation in french

### DIFF
--- a/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
@@ -48,7 +48,7 @@ msgid "Your password cannot be your username"
 msgstr "Votre mot de passe ne peut pas être votre nom d'utilisateur."
 
 msgid "The passwords do not match"
-msgstr "Non trouvé"
+msgstr "Les mots de passe ne sont pas identiques."
 
 msgid "New and old passwords are identical"
 msgstr "Les nouveaux et anciens mots de passe sont identiques."

--- a/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
@@ -86,3 +86,9 @@ msgstr "Valider le code"
 
 msgid "Successfully registered multifactor authenticator"
 msgstr "Authentificateur multifactoriel enregistré avec succès"
+
+msgid "Invalid code provided. MFA not registered."
+msgstr "Le code fourni est invalide. Le MFA n'est pas configuré."
+
+msgid "Missing code or secret to validate"
+msgstr "Code ou clé secrète à valider manquant."

--- a/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/fr/LC_MESSAGES/my_preferences.po
@@ -91,4 +91,4 @@ msgid "Invalid code provided. MFA not registered."
 msgstr "Le code fourni est invalide. Le MFA n'est pas configuré."
 
 msgid "Missing code or secret to validate"
-msgstr "Code ou clé secrète à valider manquant."
+msgstr "Code ou clé secrète de validation manquant."

--- a/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
@@ -78,3 +78,9 @@ msgstr "कोड सत्यापित करें"
 
 msgid "Successfully registered multifactor authenticator"
 msgstr "मल्टी-फ़ैक्टर ऑथेंटिकेटर सफलतापूर्वक पंजीकृत किया गया"
+
+msgid "Invalid code provided. MFA not registered."
+msgstr "दिया गया कोड अमान्य है। MFA कॉन्फ़िगर नहीं किया गया है।"
+
+msgid "Missing code or secret to validate"
+msgstr "सत्यापन के लिए कोड या गुप्त कुंजी उपलब्ध नहीं है।"

--- a/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
@@ -56,7 +56,7 @@ msgid "Configure multi-factor authentication (MFA)"
 msgstr "मल्टी-फ़ैक्टर प्रमाणीकरण (MFA) कॉन्फ़िगर करें"
 
 msgid "Configure MFA"
-msgstr "नया और पुराना पासवर्ड समान हैं।"
+msgstr "मल्टी-फ़ैक्टर प्रमाणीकरण (MFA) कॉन्फ़िगर करें"
 
 msgid "Manual MFA Setup"
 msgstr "मैन्युअल MFA सेटअप"

--- a/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/hi/LC_MESSAGES/my_preferences.po
@@ -52,5 +52,29 @@ msgstr "पासवर्ड मेल नहीं खाते।"
 msgid "New and old passwords are identical"
 msgstr "नया और पुराना पासवर्ड समान हैं।"
 
+msgid "Configure multi-factor authentication (MFA)"
+msgstr "मल्टी-फ़ैक्टर प्रमाणीकरण (MFA) कॉन्फ़िगर करें"
+
 msgid "Configure MFA"
 msgstr "नया और पुराना पासवर्ड समान हैं।"
+
+msgid "Manual MFA Setup"
+msgstr "मैन्युअल MFA सेटअप"
+
+msgid "Use the following key in your authenticator app: <0>{{code}}</0>"
+msgstr "अपने ऑथेंटिकेटर ऐप में निम्नलिखित कुंजी का उपयोग करें: <0>{{code}}</0>"
+
+msgid "Scan the following QR code below in your MFA authenticator and enter the code to validate."
+msgstr "अपने MFA ऑथेंटिकेटर ऐप से नीचे दिए गए QR कोड को स्कैन करें और सत्यापन के लिए कोड दर्ज करें।"
+
+msgid "Note that this will <0>overwrite</0> any previously setup MFA in LORIS!"
+msgstr "ध्यान दें कि इससे LORIS में पहले से कॉन्फ़िगर किया गया कोई भी MFA <0>अधिलेखित</0> हो जाएगा!"
+
+msgid "Can't scan the QR code? <0>Setup manually.</0>"
+msgstr "क्या आप QR कोड स्कैन नहीं कर पा रहे हैं? <0>मैन्युअल रूप से सेटअप करें।</0>"
+
+msgid "Validate Code"
+msgstr "कोड सत्यापित करें"
+
+msgid "Successfully registered multifactor authenticator"
+msgstr "मल्टी-फ़ैक्टर ऑथेंटिकेटर सफलतापूर्वक पंजीकृत किया गया"

--- a/modules/my_preferences/locale/ja/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/ja/LC_MESSAGES/my_preferences.po
@@ -78,3 +78,9 @@ msgstr "コードの検証"
 
 msgid "Successfully registered multifactor authenticator"
 msgstr "多要素認証の登録に成功しました"
+
+msgid "Invalid code provided. MFA not registered."
+msgstr "入力されたコードは無効です。MFA は設定されていません。"
+
+msgid "Missing code or secret to validate"
+msgstr "検証するコードまたはシークレットがありません。"

--- a/modules/my_preferences/locale/my_preferences.pot
+++ b/modules/my_preferences/locale/my_preferences.pot
@@ -78,3 +78,8 @@ msgstr ""
 msgid "Successfully registered multifactor authenticator"
 msgstr ""
 
+msgid "Invalid code provided. MFA not registered."
+msgstr ""
+
+msgid "Missing code or secret to validate"
+msgstr ""

--- a/modules/my_preferences/locale/zh/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/zh/LC_MESSAGES/my_preferences.po
@@ -64,13 +64,10 @@ msgstr "手动 MFA 设置"
 msgid "Use the following key in your authenticator app: <0>{{code}}</0>"
 msgstr "在您的身份验证器应用中使用以下密钥：<0> {{code}} </0>"
 
-msgid ""
-"Scan the following QR code below in your MFA authenticator and enter the "
-"code to validate."
+msgid "Scan the following QR code below in your MFA authenticator and enter the code to validate."
 msgstr "在 MFA 身份验证器中扫描下面的二维码并输入该代码进行验证。"
 
-msgid ""
-"Note that this will <0>overwrite</0> any previously setup MFA in LORIS!"
+msgid "Note that this will <0>overwrite</0> any previously setup MFA in LORIS!"
 msgstr "请注意，这将<0>覆盖</0>之前在 LORIS 中设置的任何 MFA！"
 
 msgid "Can't scan the QR code? <0>Setup manually.</0>"

--- a/modules/my_preferences/locale/zh/LC_MESSAGES/my_preferences.po
+++ b/modules/my_preferences/locale/zh/LC_MESSAGES/my_preferences.po
@@ -78,3 +78,9 @@ msgstr "验证码"
 
 msgid "Successfully registered multifactor authenticator"
 msgstr "已成功注册多因素身份验证器"
+
+msgid "Invalid code provided. MFA not registered."
+msgstr "提供的验证码无效。MFA 尚未配置。"
+
+msgid "Missing code or secret to validate"
+msgstr "缺少用于验证的验证码或密钥。"

--- a/modules/my_preferences/php/mfa.class.inc
+++ b/modules/my_preferences/php/mfa.class.inc
@@ -97,7 +97,10 @@ class MFA extends \NDB_Page
         $wantCode      = $validator->getCode($counter, 6);
         if ($wantCode !== strval($values['code'])) {
             return new \LORIS\Http\Response\JSON\BadRequest(
-                dgettext('my_preferences', 'Invalid code provided. MFA not registered.')
+                dgettext(
+                    'my_preferences',
+                    'Invalid code provided. MFA not registered.'
+                )
             );
         }
         $db = $this->loris->getDatabaseConnection();

--- a/modules/my_preferences/php/mfa.class.inc
+++ b/modules/my_preferences/php/mfa.class.inc
@@ -87,7 +87,7 @@ class MFA extends \NDB_Page
     {
         if (!isset($values['code']) || !isset($values['secret'])) {
             return new \LORIS\Http\Response\JSON\BadRequest(
-                'Missing code or secret to validate'
+                dgettext('my_preferences', 'Missing code or secret to validate')
             );
         }
         $base32Decoder = new Base32();
@@ -97,7 +97,7 @@ class MFA extends \NDB_Page
         $wantCode      = $validator->getCode($counter, 6);
         if ($wantCode !== strval($values['code'])) {
             return new \LORIS\Http\Response\JSON\BadRequest(
-                'Invalid code provided. MFA not registered.'
+                dgettext('my_preferences', 'Invalid code provided. MFA not registered.')
             );
         }
         $db = $this->loris->getDatabaseConnection();


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a wrong error translation in french for 'The passwords do not match' from 'Non trouvé' to 'Les mots de passe ne sont pas identiques.'.
This PR also adds missing translations for hindi and removes unnecessary line wrapping from the chinese translation file, as the 80 character line length limit do not apply to it as it would cause false positives in the language validation script that will be added to the CI pipeline https://github.com/aces/Loris/pull/10739 soon.

#### Link(s) to related issue(s)

* Resolves #10850 (Reference the issue this fixes, if any.)
