### PR TITLE
[candidate_profile] Fix Heavy Caching

### DIFF
--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -12,23 +12,22 @@ window.addEventListener('load', () => {
     let candidate = null;
 
     function fetchProfileData(url) {
-        let response = fetch(loris.BaseURL + '/api/v0.0.3/' + url, {
+        return fetch(loris.BaseURL + '/api/v0.0.3/' + url, {
             cache: 'no-cache',
             credentials: 'same-origin',
         });
-        if (!response.ok) {
-            throw new Error('Failed to load candidate (' + response.status + ')');
-        }
-        return response;
     }
 
     async function loadCandidate() {
         let response = await fetchProfileData(
             'candidates/{$candidate->getCandID()}'
         );
-        let data = await response.json();
-        candidate = data;
-        return data;
+        if (!response.ok) {
+            return new Error('Failed to load candidate (' + response.status + ')');
+        } else {
+            let data = await response.json();
+            return data;
+        }
     };
 
     async function loadVisits(candidate) {
@@ -37,7 +36,7 @@ window.addEventListener('load', () => {
                 'candidates/' + candidate.Meta.CandID + '/' + visit
             );
             if (!response.ok) {
-              return new Error('Permission denied');
+              return new Error('Failed to load visit (' + response.status + ')');
             } else {
               let data = await response.json();
               return data;

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -5,9 +5,9 @@
     <script src="{$widgets[widget]->getJSURL()}" type="text/javascript"></script>
 {/section}
 <script type="text/javascript">
-   // On page load, retrieve the candidate and all of its visits via the API so that
-   // y can be passed as properties to widgets. Nearly every widget uses them, so
-   // this saves them all having to make the same requests over and over again.
+{* On page load, retrieve the candidate and all of its visits via the API so that
+   they can be passed as properties to widgets. Nearly every widget uses them, so
+   this saves them all having to make the same requests over and over again. *}
 window.addEventListener('load', () => {
     let candidate = null;
 

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -26,7 +26,8 @@ window.addEventListener('load', () => {
             return new Error('Failed to load candidate (' + response.status + ')');
         } else {
             let data = await response.json();
-            return data;
+            candidate = data;
+            return candidate;
         }
     };
 
@@ -39,6 +40,7 @@ window.addEventListener('load', () => {
               return new Error('Failed to load visit (' + response.status + ')');
             } else {
               let data = await response.json();
+              console.log(data)
               return data;
             }
         });

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -12,15 +12,19 @@ window.addEventListener('load', () => {
     let candidate = null;
 
     function fetchProfileData(url) {
-        return fetch(url, {
+        let response = fetch(loris.BaseURL + '/api/v0.0.3/' + url, {
             cache: 'no-cache',
             credentials: 'same-origin',
         });
+        if (!response.ok) {
+            throw new Error('Failed to load candidate (' + response.status + ')');
+        }
+        return response;
     }
 
     async function loadCandidate() {
         let response = await fetchProfileData(
-            loris.BaseURL + '/api/v0.0.3/candidates/{$candidate->getCandID()}'
+            'candidates/{$candidate->getCandID()}'
         );
         let data = await response.json();
         candidate = data;
@@ -29,10 +33,8 @@ window.addEventListener('load', () => {
 
     async function loadVisits(candidate) {
         let visits = candidate.Visits.map(async function(visit) {
-            // FIXME: This shouldn't use the dev version. See #6058
             let response = await fetchProfileData(
-                loris.BaseURL + '/api/v0.0.3/candidates/'
-                + candidate.Meta.CandID + '/' + visit
+                'candidates/' + candidate.Meta.CandID + '/' + visit
             );
             if (!response.ok) {
               return new Error('Permission denied');

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -5,13 +5,23 @@
     <script src="{$widgets[widget]->getJSURL()}" type="text/javascript"></script>
 {/section}
 <script type="text/javascript">
-{* On page load, retrieve the candidate and all of its visits via the API so that
-   they can be passed as properties to widgets. Nearly every widget uses them, so
-   this saves them all having to make the same requests over and over again. *}
+   // On page load, retrieve the candidate and all of its visits via the API so that
+   // y can be passed as properties to widgets. Nearly every widget uses them, so
+   // this saves them all having to make the same requests over and over again.
 window.addEventListener('load', () => {
     let candidate = null;
+
+    function fetchProfileData(url) {
+        return fetch(url, {
+            cache: 'no-cache',
+            credentials: 'same-origin',
+        });
+    }
+
     async function loadCandidate() {
-        let response = await fetch(loris.BaseURL + '/api/v0.0.3/candidates/{$candidate->getCandID()}');
+        let response = await fetchProfileData(
+            loris.BaseURL + '/api/v0.0.3/candidates/{$candidate->getCandID()}'
+        );
         let data = await response.json();
         candidate = data;
         return data;
@@ -20,7 +30,10 @@ window.addEventListener('load', () => {
     async function loadVisits(candidate) {
         let visits = candidate.Visits.map(async function(visit) {
             // FIXME: This shouldn't use the dev version. See #6058
-            let response = await fetch(loris.BaseURL + '/api/v0.0.3/candidates/' + candidate.Meta.CandID + '/' + visit);
+            let response = await fetchProfileData(
+                loris.BaseURL + '/api/v0.0.3/candidates/'
+                + candidate.Meta.CandID + '/' + visit
+            );
             if (!response.ok) {
               return new Error('Permission denied');
             } else {


### PR DESCRIPTION
The API responses in candidate_profile were being cached, which made it so that if any new visits are created or modified, the changes would not appear in candidate_profile until cache is cleared.

Recreate the original problem by:
- Open candidate profile (New access profile beta) for a candidate
- Change the site or add a new timepoint from another window / terminal
- Refresh and see that nothing changes
- Open dev tools > network > disable cache and refresh
- See the change appear

Now add this PR and try again, but with cache enabled. See you do not have to disable cache for it to work.

Closes #10808