### PR TITLE
[login] Add missing translations

### DIFF
--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -195,7 +195,10 @@ class Login extends Component {
               if (data.error === 'password expired') {
                 // password expired
                 state.component.expiredPassword = {
-                  message: 'Password expired for user.',
+                  message: this.props.t(
+                    'Password expired for user.',
+                    {ns: 'login'}
+                  ),
                   username: state.form.value.username,
                 };
                 state.mode = 'expired';
@@ -336,7 +339,7 @@ class Login extends Component {
               </Panel>
               {partnerLogos.length > 0 ? (
                 <Panel
-                  title="Our Partners"
+                  title={this.props.t('Our Partners', {ns: 'login'})}
                   class="panel-default partner-container-desktop"
                   collapsing={false}
                   bold
@@ -364,7 +367,7 @@ class Login extends Component {
               </Panel>
               {partnerLogos.length > 0 ? (
                 <Panel
-                  title="Our Partners"
+                  title={this.props.t('Our Partners', {ns: 'login'})}
                   class="panel-default partner-container-mobile"
                   collapsing={false}
                   bold
@@ -423,7 +426,9 @@ class Login extends Component {
       {this.state.oidc.map((val) => {
         return <div>
           <a href={'/oidc/login?loginWith=' + val}>
-                    Login with {val}
+            {this.props.t('Login with {{provider}}', {
+              ns: 'openid_connect', provider: val,
+            })}
           </a>
         </div>;
       })}

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -175,7 +175,12 @@ class RequestAccount extends Component {
         <div className='g-recaptcha'
           data-sitekey={this.state.form.captcha}/>
         <span id='helpBlock' className='help-block'>
-          <b className='text-danger'>Please complete the reCaptcha!</b>
+          <b className='text-danger'>{
+            this.props.t(
+              'Please complete the reCaptcha!',
+              {ns: 'login'}
+            )
+          }</b>
         </span>
       </div>
     ) : null;

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -187,3 +187,30 @@ msgstr "Code manquant"
 
 msgid "Invalid MFA code"
 msgstr "Code MFA invalide"
+
+msgid "Error"
+msgstr "Erreur"
+
+msgid "password expired"
+msgstr "Le mot de passe a expiré."
+
+msgid "Can not use an empty password."
+msgstr "Le mot de passe ne peut pas être vide."
+
+msgid "You cannot keep the same password."
+msgstr "Vous ne pouvez pas conserver le même mot de passe."
+
+msgid "Server encountered an error."
+msgstr "Le serveur a rencontré une erreur."
+
+msgid "Sending reset email failed."
+msgstr "L'envoi du courriel de réinitialisation a échoué."
+
+msgid "Please complete the reCaptcha"
+msgstr "Veuillez compléter le reCAPTCHA."
+
+msgid "Email address can not contain the following characters: <,>,& and \""
+msgstr "L'adresse courriel ne peut pas contenir les caractères suivants : <, >, &, et \"."
+
+msgid "Please provide a valid email address!"
+msgstr "Veuillez fournir une adresse courriel valide."

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -220,3 +220,12 @@ msgstr "Utilisateur invalide."
 
 msgid "Please complete the reCaptcha!"
 msgstr "Veuillez compléter le reCAPTCHA !"
+
+msgid "Login with {{provider}}"
+msgstr "Se connecter avec {{provider}}"
+
+msgid "Our partners"
+msgstr "Nos partenaires"
+
+msgid "Password expired for user."
+msgstr "Le mot de passe de l'utilisateur a expiré."

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -181,3 +181,9 @@ msgid "Visit"
 msgid_plural "Visits"
 msgstr[0] "Visite"
 msgstr[1] "Visites"
+
+msgid "Missing code"
+msgstr "Code manquant"
+
+msgid "Invalid MFA code"
+msgstr "Code MFA invalide"

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -214,3 +214,9 @@ msgstr "L'adresse courriel ne peut pas contenir les caractères suivants : <, >,
 
 msgid "Please provide a valid email address!"
 msgstr "Veuillez fournir une adresse courriel valide."
+
+msgid "Not a valid user"
+msgstr "Utilisateur invalide."
+
+msgid "Please complete the reCaptcha!"
+msgstr "Veuillez compléter le reCAPTCHA !"

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -209,7 +209,7 @@ msgstr "L'envoi du courriel de réinitialisation a échoué."
 msgid "Please complete the reCaptcha"
 msgstr "Veuillez compléter le reCAPTCHA."
 
-msgid "Email address can not contain the following characters: <,>,& and \""
+msgid "Email address can not contain the following characters: <,>,& and \"."
 msgstr "L'adresse courriel ne peut pas contenir les caractères suivants : <, >, &, et \"."
 
 msgid "Please provide a valid email address!"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -181,3 +181,9 @@ msgstr "メールアドレスには次の文字を含めることはできませ
 
 msgid "Please provide a valid email address!"
 msgstr "有効なメールアドレスを入力してください。"
+
+msgid "Not a valid user"
+msgstr "有効なユーザーではありません。"
+
+msgid "Please complete the reCaptcha!"
+msgstr "reCAPTCHA を完了してください。"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -176,7 +176,7 @@ msgstr "パスワード再設定メールの送信に失敗しました。"
 msgid "Please complete the reCaptcha"
 msgstr "reCAPTCHA を完了してください。"
 
-msgid "Email address can not contain the following characters: <,>,& and \""
+msgid "Email address can not contain the following characters: <,>,& and \"."
 msgstr "メールアドレスには次の文字を含めることはできません: <, >, &, および \"。"
 
 msgid "Please provide a valid email address!"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -22,7 +22,6 @@ msgstr ""
 msgid "Login"
 msgstr "ログイン"
 
-
 msgid "Login to LORIS"
 msgstr "ロリスにログイン"
 
@@ -149,3 +148,9 @@ msgstr[0] "サイト"
 msgid "Visit"
 msgid_plural "Visits"
 msgstr[0] "訪問"
+
+msgid "Missing code"
+msgstr "コードがありません"
+
+msgid "Invalid MFA code"
+msgstr "MFAコードが無効です"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -154,3 +154,30 @@ msgstr "コードがありません"
 
 msgid "Invalid MFA code"
 msgstr "MFAコードが無効です"
+
+msgid "Error"
+msgstr "エラー"
+
+msgid "password expired"
+msgstr "パスワードの有効期限が切れています。"
+
+msgid "Can not use an empty password."
+msgstr "空のパスワードは使用できません。"
+
+msgid "You cannot keep the same password."
+msgstr "同じパスワードを使用し続けることはできません。"
+
+msgid "Server encountered an error."
+msgstr "サーバーでエラーが発生しました。"
+
+msgid "Sending reset email failed."
+msgstr "パスワード再設定メールの送信に失敗しました。"
+
+msgid "Please complete the reCaptcha"
+msgstr "reCAPTCHA を完了してください。"
+
+msgid "Email address can not contain the following characters: <,>,& and \""
+msgstr "メールアドレスには次の文字を含めることはできません: <, >, &, および \"。"
+
+msgid "Please provide a valid email address!"
+msgstr "有効なメールアドレスを入力してください。"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -187,3 +187,12 @@ msgstr "有効なユーザーではありません。"
 
 msgid "Please complete the reCaptcha!"
 msgstr "reCAPTCHA を完了してください。"
+
+msgid "Login with {{provider}}"
+msgstr "{{provider}} でログイン"
+
+msgid "Our partners"
+msgstr "パートナー"
+
+msgid "Password expired for user."
+msgstr "ユーザーのパスワードの有効期限が切れています。"

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -174,7 +174,7 @@ msgstr ""
 msgid "Please complete the reCaptcha"
 msgstr ""
 
-msgid "Email address can not contain the following characters: <,>,& and \""
+msgid "Email address can not contain the following characters: <,>,& and \"."
 msgstr ""
 
 msgid "Please provide a valid email address!"

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -152,3 +152,30 @@ msgstr ""
 
 msgid "Invalid MFA code"
 msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "password expired"
+msgstr ""
+
+msgid "Can not use an empty password."
+msgstr ""
+
+msgid "You cannot keep the same password."
+msgstr ""
+
+msgid "Server encountered an error."
+msgstr ""
+
+msgid "Sending reset email failed."
+msgstr ""
+
+msgid "Please complete the reCaptcha"
+msgstr ""
+
+msgid "Email address can not contain the following characters: <,>,& and \""
+msgstr ""
+
+msgid "Please provide a valid email address!"
+msgstr ""

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -179,3 +179,9 @@ msgstr ""
 
 msgid "Please provide a valid email address!"
 msgstr ""
+
+msgid "Not a valid user"
+msgstr ""
+
+msgid "Please complete the reCaptcha!"
+msgstr ""

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -146,3 +146,9 @@ msgstr[0] ""
 msgid "Visit"
 msgid_plural "Visits"
 msgstr[0] ""
+
+msgid "Missing code"
+msgstr ""
+
+msgid "Invalid MFA code"
+msgstr ""

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -185,3 +185,12 @@ msgstr ""
 
 msgid "Please complete the reCaptcha!"
 msgstr ""
+
+msgid "Login with {{provider}}"
+msgstr ""
+
+msgid "Our partners"
+msgstr ""
+
+msgid "Password expired for user."
+msgstr ""

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -173,7 +173,7 @@ msgstr "发送密码重置邮件失败。"
 msgid "Please complete the reCaptcha"
 msgstr "请完成 reCAPTCHA 验证。"
 
-msgid "Email address can not contain the following characters: <,>,& and \""
+msgid "Email address can not contain the following characters: <,>,& and \"."
 msgstr "电子邮件地址不能包含以下字符：<、>、& 和 \"。"
 
 msgid "Please provide a valid email address!"

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -151,3 +151,30 @@ msgstr "缺少验证码"
 
 msgid "Invalid MFA code"
 msgstr "MFA 验证码无效"
+
+msgid "Error"
+msgstr "错误"
+
+msgid "password expired"
+msgstr "密码已过期。"
+
+msgid "Can not use an empty password."
+msgstr "密码不能为空。"
+
+msgid "You cannot keep the same password."
+msgstr "不能继续使用相同的密码。"
+
+msgid "Server encountered an error."
+msgstr "服务器遇到错误。"
+
+msgid "Sending reset email failed."
+msgstr "发送密码重置邮件失败。"
+
+msgid "Please complete the reCaptcha"
+msgstr "请完成 reCAPTCHA 验证。"
+
+msgid "Email address can not contain the following characters: <,>,& and \""
+msgstr "电子邮件地址不能包含以下字符：<、>、& 和 \"。"
+
+msgid "Please provide a valid email address!"
+msgstr "请输入有效的电子邮件地址！"

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -40,8 +40,7 @@ msgstr "输入下面验证器应用程序中的代码以继续。"
 msgid "Data in LORIS:"
 msgstr "LORIS 中的数据："
 
-msgid ""
-"Please enter your username below, and a new password will be sent to you."
+msgid "Please enter your username below, and a new password will be sent to you."
 msgstr "请在下面输入您的用户名，新密码将发送给您。"
 
 msgid "Back to login page"
@@ -98,9 +97,7 @@ msgstr "放射科医生"
 msgid "Examiner role"
 msgstr "考官角色"
 
-msgid ""
-"Please fill in the form below to request a LORIS account. We will contact "
-"you once your account has been approved."
+msgid "Please fill in the form below to request a LORIS account. We will contact you once your account has been approved."
 msgstr "请填写下面的表格来申请 LORIS 帐户。您的帐户获得批准后，我们​​将与您联系。"
 
 msgid "Your request for an account has been received successfully."
@@ -148,3 +145,9 @@ msgstr[0] "中心"
 msgid "Visit"
 msgid_plural "Visits"
 msgstr[0] "访视"
+
+msgid "Missing code"
+msgstr "缺少验证码"
+
+msgid "Invalid MFA code"
+msgstr "MFA 验证码无效"

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -178,3 +178,9 @@ msgstr "电子邮件地址不能包含以下字符：<、>、& 和 \"。"
 
 msgid "Please provide a valid email address!"
 msgstr "请输入有效的电子邮件地址！"
+
+msgid "Not a valid user"
+msgstr "无效用户。"
+
+msgid "Please complete the reCaptcha!"
+msgstr "请完成 reCAPTCHA 验证！"

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -184,3 +184,12 @@ msgstr "无效用户。"
 
 msgid "Please complete the reCaptcha!"
 msgstr "请完成 reCAPTCHA 验证！"
+
+msgid "Login with {{provider}}"
+msgstr "使用 {{provider}} 登录"
+
+msgid "Our partners"
+msgstr "我们的合作伙伴"
+
+msgid "Password expired for user."
+msgstr "用户密码已过期。"

--- a/modules/login/php/authentication.class.inc
+++ b/modules/login/php/authentication.class.inc
@@ -79,7 +79,7 @@ class Authentication extends \NDB_Page implements ETagCalculator
         }
 
         return new \LORIS\Http\Response\JSON\BadRequest(
-            'Error'
+            dgettext('login', 'Error')
         );
     }
 
@@ -176,12 +176,12 @@ class Authentication extends \NDB_Page implements ETagCalculator
             $login->setState();
         } else if ($login->passwordChangeRequired()) {
             return new \LORIS\Http\Response\JSON\Conflict(
-                'password expired'
+                dgettext('login', 'password expired')
             );
         } else {
             // login error.
             return new \LORIS\Http\Response\JSON\Conflict(
-                (string) $login->_lastError
+                dgettext('login', (string) $login->_lastError)
             );
         }
 

--- a/modules/login/php/expired.class.inc
+++ b/modules/login/php/expired.class.inc
@@ -59,7 +59,7 @@ class Expired extends \NDB_Page implements ETagCalculator
         }
 
         return new \LORIS\Http\Response\JSON\BadRequest(
-            'Error'
+            dgettext('login', 'Error')
         );
     }
 
@@ -78,7 +78,7 @@ class Expired extends \NDB_Page implements ETagCalculator
         // Check if password is not empty.
         if (empty($values['password']) || empty($values['confirm'])) {
             return new \LORIS\Http\Response\JSON\Conflict(
-                'Can not use an empty password.'
+                dgettext('login', 'Can not use an empty password.')
             );
         }
         // Update the user password.
@@ -88,7 +88,7 @@ class Expired extends \NDB_Page implements ETagCalculator
             // Check if new password is same as old password.
             if (!$user->isPasswordDifferent($plaintext)) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    'You cannot keep the same password.'
+                    dgettext('login', 'You cannot keep the same password.')
                 );
             }
             // Update password
@@ -101,12 +101,12 @@ class Expired extends \NDB_Page implements ETagCalculator
                 unset($_SESSION['PasswordExpiredForUser']);
             } catch (\InvalidArgumentException $e) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    $e->getMessage()
+                    dgettext('login', $e->getMessage())
                 );
             }
         } else {
             return new \LORIS\Http\Response\JSON\Conflict(
-                'Server encountered an error.'
+                dgettext('login', 'Server encountered an error.')
             );
         }
         return new \LORIS\Http\Response\JsonResponse(

--- a/modules/login/php/expired.class.inc
+++ b/modules/login/php/expired.class.inc
@@ -101,7 +101,7 @@ class Expired extends \NDB_Page implements ETagCalculator
                 unset($_SESSION['PasswordExpiredForUser']);
             } catch (\InvalidArgumentException $e) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    dgettext('login', $e->getMessage())
+                    $e->getMessage()
                 );
             }
         } else {

--- a/modules/login/php/mfa.class.inc
+++ b/modules/login/php/mfa.class.inc
@@ -85,7 +85,7 @@ class MFA extends \NDB_Page
         $requestdata = json_decode((string )$request->getBody(), true);
         $user        = $request->getAttribute("user");
         if (!isset($requestdata['code'])) {
-            return new \LORIS\Http\Response\JSON\Unauthorized("Missing code");
+            return new \LORIS\Http\Response\JSON\Unauthorized(dgettext("login", "Missing code"));
         }
 
         $validator = $user->getTOTPValidator();
@@ -96,7 +96,7 @@ class MFA extends \NDB_Page
             $login->setPassedMFA();
             return new \LORIS\Http\Response\JSON\OK(["success" => "validated code"]);
         } else {
-            return new \LORIS\Http\Response\JSON\Unauthorized("Invalid MFA code");
+            return new \LORIS\Http\Response\JSON\Unauthorized(dgettext("login", "Invalid MFA code"));
         }
     }
 

--- a/modules/login/php/mfa.class.inc
+++ b/modules/login/php/mfa.class.inc
@@ -85,7 +85,12 @@ class MFA extends \NDB_Page
         $requestdata = json_decode((string )$request->getBody(), true);
         $user        = $request->getAttribute("user");
         if (!isset($requestdata['code'])) {
-            return new \LORIS\Http\Response\JSON\Unauthorized(dgettext("login", "Missing code"));
+            return new \LORIS\Http\Response\JSON\Unauthorized(
+                dgettext(
+                    "login",
+                    "Missing code"
+                )
+            );
         }
 
         $validator = $user->getTOTPValidator();
@@ -96,7 +101,12 @@ class MFA extends \NDB_Page
             $login->setPassedMFA();
             return new \LORIS\Http\Response\JSON\OK(["success" => "validated code"]);
         } else {
-            return new \LORIS\Http\Response\JSON\Unauthorized(dgettext("login", "Invalid MFA code"));
+            return new \LORIS\Http\Response\JSON\Unauthorized(
+                dgettext(
+                    "login",
+                    "Invalid MFA code"
+                )
+            );
         }
     }
 

--- a/modules/login/php/reset.class.inc
+++ b/modules/login/php/reset.class.inc
@@ -59,7 +59,7 @@ class Reset extends \NDB_Page implements ETagCalculator
         }
 
         return new \LORIS\Http\Response\JSON\BadRequest(
-            'Error'
+            dgettext('login', 'Error')
         );
     }
 
@@ -88,7 +88,7 @@ class Reset extends \NDB_Page implements ETagCalculator
             $email = $user->getEmail();
             if (empty($email)) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    'Not a valid user'
+                    dgettext('login', 'Not a valid user')
                 );
             }
 
@@ -123,13 +123,13 @@ class Reset extends \NDB_Page implements ETagCalculator
                         . ' attempted to reset password for ' . $username
                     );
                     return new \LORIS\Http\Response\JSON\Conflict(
-                        'Sending reset email failed.'
+                        dgettext('login', 'Sending reset email failed.')
                     );
                 }
             } catch (\LorisException $e) {
                 error_log($e->getMessage());
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    'Sending reset email failed.'
+                    dgettext('login', 'Sending reset email failed.')
                 );
             }
         }

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -140,7 +140,11 @@ class Signup extends \NDB_Page implements ETagCalculator
             // current HTML escaping method, it is better to reject email
             // addresses containing them
             return new \LORIS\Http\Response\JSON\Conflict(
-                dgettext('login', 'Email address can not contain the following characters: <,>,& and ".')
+                dgettext(
+                    'login',
+                    'Email address can not contain the following'
+                    + 'characters: <,>,& and ".'
+                )
             );
         }
         if (!filter_var($from, FILTER_VALIDATE_EMAIL)) {

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -140,7 +140,7 @@ class Signup extends \NDB_Page implements ETagCalculator
             // current HTML escaping method, it is better to reject email
             // addresses containing them
             return new \LORIS\Http\Response\JSON\Conflict(
-                dgettext('login', 'Email address can not contain the following characters: <,>,& and "')
+                dgettext('login', 'Email address can not contain the following characters: <,>,& and ".')
             );
         }
         if (!filter_var($from, FILTER_VALIDATE_EMAIL)) {

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -58,7 +58,7 @@ class Signup extends \NDB_Page implements ETagCalculator
             return $this->requestAccount($request);
         }
         return new \LORIS\Http\Response\JSON\BadRequest(
-            'Error'
+            dgettext('login', 'Error')
         );
     }
 
@@ -86,7 +86,7 @@ class Signup extends \NDB_Page implements ETagCalculator
             );
             if (!$resp->isSuccess()) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    'Please complete the reCaptcha!'
+                    dgettext('login', 'Please complete the reCaptcha!')
                 );
             }
         }
@@ -140,14 +140,13 @@ class Signup extends \NDB_Page implements ETagCalculator
             // current HTML escaping method, it is better to reject email
             // addresses containing them
             return new \LORIS\Http\Response\JSON\Conflict(
-                'Email address can not contain the following' .
-                ' characters: <,>,& and "'
+                dgettext('login', 'Email address can not contain the following characters: <,>,& and "')
             );
         }
         if (!filter_var($from, FILTER_VALIDATE_EMAIL)) {
             // Invalid email address.
             return new \LORIS\Http\Response\JSON\Conflict(
-                'Please provide a valid email address!'
+                dgettext('login', 'Please provide a valid email address!')
             );
         }
 

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -143,7 +143,7 @@ class Signup extends \NDB_Page implements ETagCalculator
                 dgettext(
                     'login',
                     'Email address can not contain the following'
-                    + 'characters: <,>,& and ".'
+                    . 'characters: <,>,& and ".'
                 )
             );
         }


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing translations mainly of error messages. It also removes unnecessary line wrapping from the chinese translation file, as the 80 character line length limit do not apply to it as it would cause false positives in the language validation script that will be added to the CI pipeline https://github.com/aces/Loris/pull/10739 soon.

#### Link(s) to related issue(s)

* Resolves #10849
* Resolves #10635
