### PR TITLE
[publication] Fix submission notification text to attribute the submitter

### DIFF
--- a/smarty/templates/email/notifier_publication_submission.tpl
+++ b/smarty/templates/email/notifier_publication_submission.tpl
@@ -1,10 +1,9 @@
-Subject: [LORIS] Project proposal submission confirmation
+Subject: [LORIS] A project proposal has been submitted
 
 Hello,
 
-This is to confirm the project proposal "{$Title}" received on {$Date}.
-We will notify you once this proposal has been reviewed. In the mean time, you
-can view the project proposal in the loris website.
+The project proposal "{$Title}" has been submitted by {$User} on {$Date}.
+You can view the project proposal in the loris website.
 
 Thank you,
 The {$ProjectName} Team

--- a/test/unittests/PublicationSubmissionNotificationTemplateTest.php
+++ b/test/unittests/PublicationSubmissionNotificationTemplateTest.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+/**
+ * Unit test for the publication module's submission notification email
+ * template.
+ *
+ * PHP Version 8
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Cryptoteep <bigmommyta@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that the text of the "publication submission" notification email
+ * correctly identifies who submitted the proposal, instead of reading like
+ * a confirmation sent to the submitter themselves.
+ *
+ * See https://github.com/aces/Loris/issues/10852 : a user who enabled
+ * "notify me of new publication submissions" received an email that read
+ * as if *they* had submitted the proposal, even when a different user was
+ * the actual submitter.
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Cryptoteep <bigmommyta@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class PublicationSubmissionNotificationTemplateTest extends TestCase
+{
+    /**
+     * Path to the smarty template under test.
+     *
+     * @var string
+     */
+    private string $_templatePath;
+
+    /**
+     * Sets up the path to the template file before each test.
+     *
+     * @return void
+     */
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->_templatePath = __DIR__
+            . '/../../smarty/templates/email/notifier_publication_submission.tpl';
+    }
+
+    /**
+     * Renders the raw template using the same {$Var} substitution syntax
+     * used by Smarty, without requiring a full Smarty/DB bootstrap.
+     *
+     * @param array<string,string> $vars variables to substitute
+     *
+     * @return string the rendered template
+     */
+    private function _renderTemplate(array $vars): string
+    {
+        $template = file_get_contents($this->_templatePath);
+        $this->assertIsString(
+            $template,
+            'Could not read notifier_publication_submission.tpl'
+        );
+
+        foreach ($vars as $name => $value) {
+            $template = str_replace('{$' . $name . '}', $value, $template);
+        }
+
+        return $template;
+    }
+
+    /**
+     * Ensures the rendered notification attributes the submission to the
+     * actual submitting user, not to whoever receives the notification.
+     *
+     * @return void
+     */
+    function testNotificationAttributesSubmissionToSubmitter(): void
+    {
+        $rendered = $this->_renderTemplate(
+            [
+                'Title'       => 'A Great Study Of Things',
+                'Date'        => '2026-07-10',
+                'User'        => 'Jane Submitter',
+                'ProjectName' => 'MyProject',
+            ]
+        );
+
+        $this->assertStringContainsString(
+            'submitted by Jane Submitter',
+            $rendered,
+            'Notification email must name the user who actually submitted '.
+            'the proposal.'
+        );
+    }
+
+    /**
+     * Ensures the notification no longer reads as a first-person
+     * confirmation to the recipient (the bug from issue #10852), which
+     * misled notified users into thinking they were the submitter.
+     *
+     * @return void
+     */
+    function testNotificationIsNotWordedAsSubmitterConfirmation(): void
+    {
+        $rendered = $this->_renderTemplate(
+            [
+                'Title'       => 'A Great Study Of Things',
+                'Date'        => '2026-07-10',
+                'User'        => 'Jane Submitter',
+                'ProjectName' => 'MyProject',
+            ]
+        );
+
+        $this->assertStringNotContainsStringIgnoringCase(
+            'this is to confirm',
+            $rendered,
+            'Notification email should not be worded as a confirmation to '.
+            'the recipient, since the recipient is not necessarily the '.
+            'user who submitted the proposal.'
+        );
+    }
+
+    /**
+     * Ensures the template still exposes all placeholders expected by the
+     * data assembled in modules/publication/ajax/FileUpload.php::notify().
+     *
+     * @return void
+     */
+    function testNotificationUsesExpectedPlaceholders(): void
+    {
+        $template = file_get_contents($this->_templatePath);
+        $this->assertIsString($template);
+
+        foreach (['Title', 'Date', 'User', 'ProjectName'] as $placeholder) {
+            $this->assertStringContainsString(
+                '{$' . $placeholder . '}',
+                $template,
+                "Template is missing the {\$$placeholder} placeholder."
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #10852.

When a user enables "notify me of new publication submissions" in
`my_preferences` and a *different* user submits a new publication
proposal, the notification email received by the first user was worded
as a first-person confirmation:

> This is to confirm the project proposal "..." received on ...
> We will notify you once this proposal has been reviewed.

This reads as though the recipient themselves submitted the proposal,
which is confusing/incorrect when the recipient is actually being
notified about someone else's submission.

`modules/publication/ajax/FileUpload.php`'s `notify()` function already
builds a `User` value (the submitter's full name) and passes it into the
template data for `notifier_publication_submission.tpl`, but the
template never used that variable. This mirrors the existing
`notifier_publication_edit.tpl`, which correctly says "... has been
edited by {$User}."

## Changes

- `smarty/templates/email/notifier_publication_submission.tpl`: reword
  the notification to state who submitted the proposal, using the
  already-available `{$User}` variable, and drop the "This is to
  confirm ... we will notify you" phrasing that implied the recipient
  was the submitter.
- `test/unittests/PublicationSubmissionNotificationTemplateTest.php`:
  new unit test that renders the template's placeholders with sample
  data and asserts:
  - the rendered text attributes the submission to the actual
    submitter's name,
  - the misleading "this is to confirm" wording is gone,
  - all placeholders expected by `FileUpload.php::notify()` (`Title`,
    `Date`, `User`, `ProjectName`) are still present in the template.

No PHP logic changed — `FileUpload.php` already assembled and passed
the `User` value; only the template text was wrong.

## Test plan

- [x] Added `test/unittests/PublicationSubmissionNotificationTemplateTest.php`,
      a pure-PHP unit test (no DB/Smarty bootstrap required) that
      simulates the `{$Var}` substitution performed by `Email::send()`
      and asserts on the resulting text.
- [ ] Could not execute `vendor/bin/phpunit` / `composer test` in the
      sandbox used to prepare this PR (no PHP/composer toolchain
      available in that environment). The test was manually verified by
      reproducing the same substitution logic in a standalone script
      against the real template file, confirming the assertions pass.
      Please run the LORIS unit test suite (`test/unittests.sh` /
      `phpunit --testsuite LorisUnitTests`) in CI to confirm.