### PR TITLE
[My Preferences] Reject emoji and other unsupported characters to prevent crash

### DIFF
--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -15,6 +15,14 @@ class My_Preferences extends \NDB_Form
     private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match';
     private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are identical';
 
+    // The `users` table is stored using MySQL's legacy 3-byte `utf8`
+    // character set, which cannot store characters outside the Basic
+    // Multilingual Plane (e.g. most emoji). Attempting to save such a
+    // character causes an uncaught database error. This pattern is used
+    // to reject those characters client- and server-side before they
+    // ever reach the database.
+    private const NO_SUPPLEMENTARY_CHARS_REGEX = '/^[^\x{10000}-\x{10FFFF}]*$/u';
+
     /**
      * Computes the initial values this page will be filled with.
      *
@@ -247,6 +255,19 @@ class My_Preferences extends \NDB_Form
                 'required'  => true,
             ]
         );
+        // Emoji and other characters outside the Basic Multilingual Plane
+        // cannot be stored in the `users` table and must be rejected here
+        // instead of causing a database error on save.
+        $this->addRule(
+            'First_name',
+            dgettext(
+                'my_preferences',
+                'First name may not contain emoji or other unsupported '
+                . 'special characters'
+            ),
+            'regex',
+            self::NO_SUPPLEMENTARY_CHARS_REGEX
+        );
         // The supplied pattern is:
         //   - must have at least one non-whitespace characters (i.e. required)
         //   - once leading and trailing spaces are stripped, the field should
@@ -265,6 +286,17 @@ class My_Preferences extends \NDB_Form
                 'pattern'   => '^\s*\S.{0,119}\s*$',
                 'required'  => true,
             ]
+        );
+        // See comment above the equivalent 'First_name' rule.
+        $this->addRule(
+            'Last_name',
+            dgettext(
+                'my_preferences',
+                'Last name may not contain emoji or other unsupported '
+                . 'special characters'
+            ),
+            'regex',
+            self::NO_SUPPLEMENTARY_CHARS_REGEX
         );
 
         // email address
@@ -290,6 +322,17 @@ class My_Preferences extends \NDB_Form
                 'Email address is required'
             ),
             'required'
+        );
+        // See comment above the equivalent 'First_name' rule.
+        $this->addRule(
+            'Email',
+            dgettext(
+                'my_preferences',
+                'Email address may not contain emoji or other unsupported '
+                . 'special characters'
+            ),
+            'regex',
+            self::NO_SUPPLEMENTARY_CHARS_REGEX
         );
         $this->addRule(
             'Email',

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1556,6 +1556,69 @@ class LorisForms_Test extends TestCase
     }
 
     /**
+     * Test that a 'regex' rule rejects a value containing a character
+     * outside the Basic Multilingual Plane (e.g. an emoji). This is a
+     * regression test for the my_preferences module, whose First_name,
+     * Last_name and Email fields use this exact pattern to reject values
+     * that would otherwise crash the page when saved to the database
+     * (the `users` table uses MySQL's 3-byte `utf8` charset, which cannot
+     * store such characters).
+     *
+     * @covers LorisForm::validate
+     * @return void
+     */
+    function testRegexRuleRejectsSupplementaryPlaneCharacters()
+    {
+        $this->form->addText("First_name", "First name", []);
+        $this->form->addRule(
+            "First_name",
+            "First name may not contain emoji or other unsupported "
+            . "special characters",
+            "regex",
+            '/^[^\x{10000}-\x{10FFFF}]*$/u'
+        );
+
+        $_POST    = ["First_name" => "Jane \u{1F600}"];
+        $_REQUEST = $_POST;
+
+        $this->assertFalse($this->form->validate());
+        $this->assertEquals(
+            "First name may not contain emoji or other unsupported "
+            . "special characters",
+            $this->form->getElementError("First_name")
+        );
+
+        unset($_POST, $_REQUEST);
+    }
+
+    /**
+     * Test that a 'regex' rule accepts an ordinary value which only
+     * contains Basic Multilingual Plane characters (i.e. no emoji).
+     *
+     * @covers LorisForm::validate
+     * @return void
+     */
+    function testRegexRuleAllowsBasicMultilingualPlaneCharacters()
+    {
+        $this->form->addText("First_name", "First name", []);
+        $this->form->addRule(
+            "First_name",
+            "First name may not contain emoji or other unsupported "
+            . "special characters",
+            "regex",
+            '/^[^\x{10000}-\x{10FFFF}]*$/u'
+        );
+
+        $_POST    = ["First_name" => "Jane"];
+        $_REQUEST = $_POST;
+
+        $this->assertTrue($this->form->validate());
+        $this->assertEquals("", $this->form->getElementError("First_name"));
+
+        unset($_POST, $_REQUEST);
+    }
+
+    /**
      * Test that isSubmitted returns true/false if the $_POST array
      * is set or not set
      *


### PR DESCRIPTION
## Summary

Fixes #10848.

Saving a First name, Last name, or Email address containing an emoji (or
any other character outside the Unicode Basic Multilingual Plane, i.e. a
4-byte UTF-8 character) on the My Preferences page crashes the site.

### Root cause

The `users` table (see `SQL/0000-00-00-schema.sql`) is defined with
`DEFAULT CHARSET=utf8`, which is MySQL's legacy 3-byte `utf8` charset.
It can only store Unicode code points up to `U+FFFF` (the Basic
Multilingual Plane). Most emoji (e.g. `U+1F600 😀`) are encoded with 4
UTF-8 bytes and are outside that range, so when `My_Preferences::_process()`
calls `$user->update($set)` with such a value, the database throws an
uncaught error (`Incorrect string value ...`), which crashes the page
instead of showing a normal validation error.

A full migration of the `users` table (and every other `utf8` table) to
`utf8mb4` would be a large, unrelated, non-backwards-compatible schema
change, so per the reporter's own suggestion in the issue, this PR adds
front/back-end validation to reject the unsupported characters before
they ever reach the database.

### Fix

`modules/my_preferences/php/my_preferences.class.inc`:
- Adds a `NO_SUPPLEMENTARY_CHARS_REGEX` constant matching any string that
  does not contain a character outside the Basic Multilingual Plane.
- Registers this pattern as a `regex` rule (an existing `LorisForm`
  validation type, enforced both via the browser's native `pattern`
  regex validation and server-side in `LorisForm::validate()`) on the
  `First_name`, `Last_name`, and `Email` fields, the three fields
  mentioned in the issue.
- If a user submits a value containing such a character, they now see a
  normal inline validation error ("... may not contain emoji or other
  unsupported special characters") instead of the page crashing.

This is a minimal, targeted fix scoped to the fields reported in the
issue; it does not touch the database schema, other modules, or other
`my_preferences` fields.

## Test plan

- [x] `test/unittests/LorisForms_Test.php`: added two regression tests,
  `testRegexRuleRejectsSupplementaryPlaneCharacters` and
  `testRegexRuleAllowsBasicMultilingualPlaneCharacters`, which exercise
  the exact `regex` rule mechanism (and pattern) used by the fix through
  `LorisForm::validate()`, confirming an emoji-bearing value is rejected
  with the expected error message and an ordinary value passes.
- [x] Ran the full `test/unittests/LorisForms_Test.php` suite locally
  (PHP 8.4 / PHPUnit 12.5.8, via `composer install`): **118 tests, 185
  assertions, all passing** (116 pre-existing + 2 new).
- [x] `php -l` on both changed files: no syntax errors.
- [ ] Could not run the full `LorisUnitTests`/integration suites, which
  require the LORIS installer-generated `project/libraries` files and a
  live MySQL database that aren't available in this environment; the
  changed code path (`LorisForm::addRule`/`validate`) has no DB
  dependency, so the unit tests above exercise it directly.

## AI Policy Disclosure

Per `CONTRIBUTING.md`'s AI Policy: this change (root-cause analysis, the
code fix, and the added unit tests) was produced with the assistance of
Claude (Anthropic), model `claude-sonnet-5`, based on a manual reading of
the issue and of `modules/my_preferences/php/my_preferences.class.inc`
and `php/libraries/LorisForm.class.inc`. The fix was verified by running
`php -l` and the PHPUnit unit test suite described above (all passing),
and by manually re-reading the diff against LORIS's existing `regex`
validation rule mechanism to confirm it is used the same way elsewhere
in the codebase (e.g. the `Email` `maxlength` rule right below it).