### PR TITLE
[document_repository] Fix typo in french

### DIFF
--- a/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
@@ -166,7 +166,7 @@ msgid "File Name"
 msgstr "Nom du fichier"
 
 msgid "Uploaded By"
-msgstr "Téléverser par"
+msgstr "Téléversé par"
 
 #, fuzzy
 msgid "For Site"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a typo in french. 'Uploaded By' should translate to 'Téléversé par' instead of 'Téléverser par'.

#### Link(s) to related issue(s)

* Resolves #10868 (Reference the issue this fixes, if any.)
