### PR TITLE
[instrument_list] Translate instrument group heading

### DIFF
--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -212,7 +212,11 @@
     <!-- print the sub group header row -->
     <thead>
     <tr class="info">
-	    <th>{dgettext("loris", $instrument_groups[group].title)}
+	    <th>{if $instrument_groups[group].title == "Instruments"}
+	         {dngettext("loris", "Instrument", "Instruments", 2)}
+	       {else}
+	         {dgettext("loris", $instrument_groups[group].title)}
+	       {/if}
 	       <!-- show the instruction only one time -->
 	       {if $smarty.section.group.iteration == 1}
 	       <br />({dgettext("timepoint_list", "Click to Open")})


### PR DESCRIPTION
## Brief summary of changes

- Uses the existing plural-aware translation for the “Instruments” subgroup heading.
- Preserves the existing translation behavior for other subgroup headings such as “Imaging.”

#### Testing instructions

- Open `http://localhost:8080/instrument_list/?candID=300001&sessionID=1`.
- Change the language to Japanese and confirm “Instruments” appears as `楽器`.
- Change the language to Hindi and confirm “Instruments” appears as `उपकरण`.
- Confirm the “Imaging” subgroup remains translated.

#### Link(s) to related issue(s)

- Resolves #10269