### PR TITLE
[biobank] Fix fatal errors on shipment submission

### DIFF
--- a/modules/biobank/php/log.class.inc
+++ b/modules/biobank/php/log.class.inc
@@ -63,13 +63,18 @@ class Log implements \JsonSerializable, \LORIS\Data\DataInstance
     function __construct(array $data)
     {
         $this->barcode     = $data['barcode'] ?? null;
-        $this->centerId    = new \CenterID($data['centerId'] ?? null);
+        $this->centerId    = isset($data['centerId'])
+            ? new \CenterID((string)$data['centerId'])
+            : null;
         $this->status      = $data['status'] ?? null;
         $this->user        = $data['user'] ?? null;
         $this->temperature = $data['temperature'] ?? null;
-        $this->date        = new \DateTime($data['date'] ?? null);
-        $this->time        = new \DateTime($data['time'] ?? null);
-        $this->comments    = $data['comments'] ?? null;
+        $this->date        = isset($data['date'])
+            ? new \DateTime($data['date'])
+            : null;
+        $this->time        = isset($data['time'])
+            ? new \DateTime($data['time'])
+            : null;
     }
 
     /**
@@ -87,7 +92,7 @@ class Log implements \JsonSerializable, \LORIS\Data\DataInstance
      *
      * @return \CenterID
      */
-    public function getCenterId() : \CenterID
+    public function getCenterId() : ?\CenterID
     {
         return $this->centerId;
     }

--- a/modules/biobank/php/log.class.inc
+++ b/modules/biobank/php/log.class.inc
@@ -90,7 +90,7 @@ class Log implements \JsonSerializable, \LORIS\Data\DataInstance
     /**
      * Get the center for this log
      *
-     * @return \CenterID
+     * @return ?\CenterID
      */
     public function getCenterId() : ?\CenterID
     {

--- a/modules/biobank/php/shipment.class.inc
+++ b/modules/biobank/php/shipment.class.inc
@@ -66,12 +66,12 @@ class Shipment implements
         $this->id      = $data['id'] ?? null;
         $this->barcode = $data['barcode'] ?? null;
         $this->type    = $data['type'] ?? null;
-        $this->destinationCenterId = new \CenterID(
-            $data['destinationCenterId'] ?? null
-        );
+        $this->destinationCenterId = isset($data['destinationCenterId'])
+            ? new \CenterID((string)$data['destinationCenterId'])
+            : null;
         $this->containerIds        = $data['containerIds'] ?? null;
         $this->containerBarcodes   = $data['containerBarcodes'] ?? null;
-        $this->_setLogs($data['logs']) ?? null;
+        $this->_setLogs($data['logs']);
     }
 
     /**
@@ -133,7 +133,7 @@ class Shipment implements
      *
      * @return \CenterID
      */
-    public function getDestinationCenterId() : \CenterID
+    public function getDestinationCenterId() : ?\CenterID
     {
         return $this->destinationCenterId;
     }

--- a/modules/biobank/php/shipment.class.inc
+++ b/modules/biobank/php/shipment.class.inc
@@ -131,7 +131,7 @@ class Shipment implements
     /**
      * Gets the destination center of the shipment
      *
-     * @return \CenterID
+     * @return ?\CenterID
      */
     public function getDestinationCenterId() : ?\CenterID
     {

--- a/modules/biobank/php/shipments.class.inc
+++ b/modules/biobank/php/shipments.class.inc
@@ -43,6 +43,7 @@ class Shipments implements RequestHandlerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isAccessibleBy(\User $user) : bool
     {
         return true;

--- a/modules/biobank/php/shipments.class.inc
+++ b/modules/biobank/php/shipments.class.inc
@@ -43,7 +43,6 @@ class Shipments implements RequestHandlerInterface
      *
      * @return bool
      */
-    #[\Override]
     public function isAccessibleBy(\User $user) : bool
     {
         return true;


### PR DESCRIPTION
## Brief summary of changes

Fixes two fatal errors in the biobank shipments module that occurred when submitting a shipment.

The main bug: when a shipment was submitted without a center (for example when no containers were selected, so no `centerId` could be derived on the frontend) the raw `null` was passed straight into the `CenterID` constructor. `CenterID` extends `ValidatableIdentifier`, whose constructor requires a non-null string, so this threw a `TypeError` and returned a 500 before the shipment handler's validation could run. Because construction happened before validation, the existing `_validate()` logic was never reached.

The `CenterID` construction in both the `Shipment` and `Log` entity constructors is now guarded with `isset`, so a null center is stored as `null` and caught by the existing validator, which returns the intended field-level error to the user rather than a fatal. `DateTime` construction in `Log` was guarded the same way, since it had the same latent issue with null date/time values.

Separately, the `#[\Override]` attribute was removed from `Shipments::isAccessibleBy()`. The method has no matching parent method, so under PHP 8.3's override enforcement it threw its own fatal error on every request to the module.

Resolves #10761 and #10183 — the non-intuitive save behaviour in that issue was this failure path: submitting without containers threw the fatal instead of showing a graceful error. With this fix the submission returns the proper field validation errors.

## Testing instructions

1. Go to Biobank -> Biospecimen -> Shipments
2. Click Add Shipment
3. Without selecting any containers, fill in (or leave blank) the shipment fields and click Save
4. Confirm the request returns field-level validation errors (including "Center is required" and "Atleast 1 container must be selected.") rather than a 500 / blank failure
5. Confirm a normal shipment with containers selected still saves correctly