### PR TITLE
[timepoint_list] Candidate Info Button disappears on permission

### DIFF
--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -75,6 +75,13 @@ Class TimePoint_List_ControlPanel extends \Candidate
                 'imaging_browser_phantom_ownsite'
             ]
         );
+        
+       $this->tpl_data['hasCandidateParameterAccess'] = $user->hasAnyPermission(
+            [
+                'candidate_parameter_view',
+                'candidate_parameter_edit'
+            ]
+        );
 
         //set the baseurl of the tpl_data
         $factory  = \NDB_Factory::singleton();
@@ -87,4 +94,3 @@ Class TimePoint_List_ControlPanel extends \Candidate
         return $html;
     }
 }
-

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -75,8 +75,8 @@ Class TimePoint_List_ControlPanel extends \Candidate
                 'imaging_browser_phantom_ownsite'
             ]
         );
-        
-       $this->tpl_data['hasCandidateParameterAccess'] = $user->hasAnyPermission(
+
+        $this->tpl_data['hasCandidateParameterAccess'] = $user->hasAnyPermission(
             [
                 'candidate_parameter_view',
                 'candidate_parameter_edit'

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -1,14 +1,16 @@
-{if $isDataEntryPerson || $isImagingPerson}
+{if $isDataEntryPerson || $isImagingPerson || $hasCandidateParameterAccess}
     <!-- <div class="col-xs-1"> -->
         <h3>{dgettext("timepoint_list", "Actions:")}&nbsp&nbsp</h3>
     <!-- </div> -->
     <!-- <div class="col-xs-4"> -->
     {if $isDataEntryPerson}
         <a class="btn btn-default" role="button" href="{$baseurl}/create_timepoint/?candID={$candID}&identifier={$candID}">{dgettext("timepoint_list", "Create time point")}</a>
-        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">{dgettext("timepoint_list", "Candidate Info")}</a>
     {/if}
     {if $isImagingPerson}
         <a class="btn btn-default" role="button" href="{$baseurl}/imaging_browser/?DCCID={$candID}">{dgettext("timepoint_list", "View Imaging datasets")}</a>
+    {/if}
+    {if $hasCandidateParameterAccess}
+        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">{dgettext("timepoint_list", "Candidate Info")}</a>
     {/if}
     <!-- </div> -->
 {/if}


### PR DESCRIPTION
## Brief summary of changes

- a new smarty variable "hasCandidateParameterAccess" was added in order to isolate the display of the `Candidate Info` Button. The .tpl file was adjusted accordingly 

- [ ] Have you updated related documentation? Not yet

## Testing instructions 

### User permissions settings:
- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
- [ ] Candidate Parameters: View Candidate Information
- [ ] Candidate Parameters: Edit Candidate Information
- go to : https://<your_instance.loris.ca/CandID  and click a timepoint.
- Asssert that there is no `Candidate Info` Button

### 
- [x] Access Profile: View/Create Candidates and Timepoints - Own Sites
- [x] Candidate Parameters: View Candidate Information
- [  ] Candidate Parameters: Edit Candidate Information 
- Save and Refresh the window with your user's account, and assert that the `Candidate Info` button appears.

### Link(s) to related issue(s)[](
https://github.com/aces/Loris/issues/9585#issuecomment-2718407731)
* Resolves 9585  (Reference the issue this fixes, if any.)
