### PR TITLE
[instrument_manager] Fix permission dropdown

### DIFF
--- a/modules/instrument_manager/jsx/instrumentManagerIndex.js
+++ b/modules/instrument_manager/jsx/instrumentManagerIndex.js
@@ -328,6 +328,16 @@ function PermissionSelect(props) {
     isMulti={true}
     options={options}
     value={values}
+    menuPortalTarget={document.body}
+    styles={{menuPortal:
+            /**
+             * Required for rendering properly on top of window.
+             *
+             * @param {object} base - The base from React Select
+             * @returns {object} - The new CSS object
+             */
+            (base) => ({...base, zIndex: 9999})}
+    }
     onChange={(newValue) => {
       props.modifySelected(newValue.map((row) => row.value));
     }}


### PR DESCRIPTION
## Brief summary of changes
Permission dropdown was rendering inside of the modal window causing a weird interaction.

Changes : rendered it outside of the modal and attached it to the body. Then applied a higher z to place it above the modal window. (took the code directly from another similar case in `modules/dataquery/jsx/definefilters.addfiltermodal.tsx`)

#### Testing instructions (if applicable)

1. Run `target=instrument_manager run npm compile`
2. Go to `instrument_manager`
3. Click on `Add Permissions`
4. See that the dropdown works well and that there is no weird interaction
<img width="792" height="593" alt="image" src="https://github.com/user-attachments/assets/6c262ff9-6f12-4485-8058-1e6245a6e2b5" />


#### Link(s) to related issue(s)

* Resolves [10809](https://github.com/aces/Loris/issues/10809)  (Reference the issue this fixes, if any.)
