### PR TITLE
[media] 500 - upload file does not work. - fix

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -211,6 +211,8 @@ function uploadFile()
         return;
     }
 
+    $phpFileUploadError = $_FILES["file"]["error"] ?? UPLOAD_ERR_OK;
+
     if (move_uploaded_file($_FILES["file"]["tmp_name"], $dstfile)) {
         try {
             // Insert or override db record if file_name already exists
@@ -249,7 +251,17 @@ function uploadFile()
             echo showMediaError("Could not upload the file. Please try again!", 500);
         }
     } else {
-        echo showMediaError("File too Large!", 500);
+        $msg = match (true) {
+            $phpFileUploadError === UPLOAD_ERR_INI_SIZE
+                || $phpFileUploadError === UPLOAD_ERR_FORM_SIZE
+                => "File exceeds maximum upload size",
+            !is_writable($mediaPath)
+                => "Upload directory is not writable",
+            default
+                => "Could not save uploaded file."
+                . " Check directory permissions and disk space",
+        };
+        echo showMediaError($msg, 500);
     }
 }
 
@@ -482,3 +494,4 @@ function checkDateTaken($dateTaken)
         }
     }
 }
+


### PR DESCRIPTION
fix 500 error (https://github.com/aces/Loris/issues/10862)
add more error messages
The upload folder was changed to one without proper permissions. I switched it back to a valid folder, and uploads are working now. The error message was misleading, so I created a new PR to improve it.
<img width="1062" height="665" alt="截屏2026-07-13 下午2 56 21" src="https://github.com/user-attachments/assets/d8d9589d-22ea-4e68-b6cb-cc7faaad4b54" />
<img width="1109" height="644" alt="截屏2026-07-13 下午2 55 44" src="https://github.com/user-attachments/assets/846b8bff-f627-42ed-b5f9-c812e7c598ea" />