### PR TITLE
[imaging_browser] Fix number of files displayed on view session page.

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -6,7 +6,8 @@
 <div class="panel panel-default">
     <div class="panel-heading" id="panel-main-heading">
 {if $files|@count}
-        <h3 class="panel-title">{dgettext("imaging_browser","%1 file(s) displayed.")|replace:"%1":$files|@count}</h3>
+        {assign var="file_count" value=$files|@count}
+        <h3 class="panel-title">{dgettext("imaging_browser","%1 file(s) displayed.")|replace:"%1":$file_count}</h3>
         <span class="pull-right clickable mri-arrow glyphicon glyphicon-chevron-up"></span>
     </div> <!-- closing panel-heading div-->
     <div class="panel-body">


### PR DESCRIPTION
## Brief summary of changes
`form_viewSession.tpl ` fixed to properly show the value. The main issue was that the value is an array and we need to make it a number before showing it. 

#### Testing instructions (if applicable)

1. Please go to the imaging browser and note that the issues reported in #10806 don't longer exit.  

#### Link(s) to related issue(s)

* Resolves #10806 
