### PR TITLE
[dataquery] Fix mistake in French translation

### DIFF
--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -508,7 +508,7 @@ msgstr "(Exécuter sur {{runTime}})"
 
 #, fuzzy
 msgid "You ran this query on {{runTime}}"
-msgstr "Vous avez exécuté cette requête sur {{runTime}}"
+msgstr "Vous avez exécuté cette requête le {{runTime}}"
 
 #, fuzzy
 msgid "You ran this query"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the following translation in French in the dataquery module.
'Vous avez exécuté cette requête **_sur_** {{runTime}}' -> 'Vous avez exécuté cette requête _**le**_ {{runTime}}'

e.g. 'Vous avez exécuté cette requête **_le_** 6 juillet 2026' instead of 'Vous avez exécuté cette requête **_sur_** 6 juillet 2026'

#### Link(s) to related issue(s)

* Resolves #10895 (Reference the issue this fixes, if any.)
