### PR TITLE
Fix EDC Age Column Alignment in Instrument Header

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -76,16 +76,12 @@
   <!-- candidate data -->
   <tbody>
   <tr>
-    {if $dob_age!=""}
-      <td>
-        {$dob_age}
-      </td>
-    {/if}
-    {if $edc_age!=""}
-      <td>
-        {$edc_age}
-      </td>
-    {/if}
+    <td>
+      {$dob_age|default}
+    </td>
+    <td>
+      {$edc_age|default}
+    </td>
     <td>
       {$candidate.Sex}
     </td>


### PR DESCRIPTION
## Brief summary of changes

The EDC Age field is displaying the participant's sex (e.g., "Male") instead of the calculated EDC age. The field should display the derived age value based on the EDC, but it is incorrectly showing the value from the Sex field.

#### Testing instructions (if applicable)

1. Go to 'acess profile' -> -> mri_parameter_form
2. Choose PSCID: DCC0703 -> V03
3. Choose mri_parameter_form form
4. See error on the top table

#### Link(s) to related issue(s)
- https://github.com/aces/Loris/issues/10775
