### PR TITLE
[bvl_feedback] error/success message added   

### DIFF
--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -2,6 +2,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import swal from 'sweetalert2';
 
 import {withTranslation} from 'react-i18next';
 import i18n from 'I18nSetup';
@@ -739,15 +740,37 @@ class NewThreadPanel extends Component {
       }).then((response) => {
         if (!response.ok) {
           console.error(response.status + ': ' + response.statusText);
+          swal.fire({
+            title: this.props.t('Error!', {ns: 'loris'}),
+            type: 'error',
+            text: this.props.t(
+              'Failed to create thread',
+              {ns: 'bvl_feedback'}
+            ),
+            allowOutsideClick: false,
+            allowEscapeKey: false,
+            showConfirmButton: true,
+          });
           return;
         }
 
         response.json().then((data) => {
-          this.setState({
-            message: this.props.t(
-              'The new thread has been submitted!',
-              {ns: 'bvl_feedback'},
+          swal.fire({
+            title: this.props.t(
+              'Thread created!',
+              {ns: 'bvl_feedback'}
             ),
+            type: 'success',
+            text: this.props.t(
+              'The new thread has been submitted!',
+              {ns: 'bvl_feedback'}
+            ),
+            timer: 2000,
+            allowOutsideClick: false,
+            allowEscapeKey: false,
+            showConfirmButton: false,
+          });
+          this.setState({
             textValue: '',
           });
           this.props.addThread(data);
@@ -755,6 +778,17 @@ class NewThreadPanel extends Component {
         });
       }).catch((error) => {
         console.error(error);
+        swal.fire({
+          title: this.props.t('Error!', {ns: 'loris'}),
+          type: 'error',
+          text: this.props.t(
+            'Failed to create thread',
+            {ns: 'bvl_feedback'}
+          ),
+          allowOutsideClick: false,
+          allowEscapeKey: false,
+          showConfirmButton: true,
+        });
       });
     }
   }

--- a/modules/bvl_feedback/locale/bvl_feedback.pot
+++ b/modules/bvl_feedback/locale/bvl_feedback.pot
@@ -83,7 +83,13 @@ msgstr ""
 msgid "Create thread"
 msgstr ""
 
+msgid "Thread created!"
+msgstr ""
+
 msgid "The new thread has been submitted!"
+msgstr ""
+
+msgid "Failed to create thread"
 msgstr ""
 
 msgid "Across All Fields"

--- a/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
@@ -93,8 +93,16 @@ msgid "Create thread"
 msgstr "Créer un fil de discussion"
 
 #, fuzzy
+msgid "Thread created!"
+msgstr "Fil de discussion créé !"
+
+#, fuzzy
 msgid "The new thread has been submitted!"
 msgstr "Le nouveau fil de discussion a été soumis !"
+
+#, fuzzy
+msgid "Failed to create thread"
+msgstr "Impossible de créer le fil de discussion"
 
 #, fuzzy
 msgid "Across All Fields"

--- a/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
@@ -83,8 +83,14 @@ msgstr "提出する"
 msgid "Create thread"
 msgstr "スレッドを作成"
 
+msgid "Thread created!"
+msgstr "スレッドが作成されました！"
+
 msgid "The new thread has been submitted!"
 msgstr "新しいスレッドが送信されました!"
+
+msgid "Failed to create thread"
+msgstr "スレッドの作成に失敗しました"
 
 msgid "Across All Fields"
 msgstr "あらゆる分野にわたって"

--- a/modules/bvl_feedback/locale/zh/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/zh/LC_MESSAGES/bvl_feedback.po
@@ -83,8 +83,14 @@ msgstr "提交"
 msgid "Create thread"
 msgstr "创建反馈"
 
+msgid "Thread created!"
+msgstr "反馈已创建！"
+
 msgid "The new thread has been submitted!"
 msgstr "新反馈已提交"
+
+msgid "Failed to create thread"
+msgstr "创建反馈失败"
 
 msgid "Across All Fields"
 msgstr "所有字段"


### PR DESCRIPTION
## Brief summary of changes
Added error/success message whenever create thread is selected

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Select Clinic -> Behavioural Quality Control - > Behavioural Feedback
2. Select an instrument
3. Create thread
4. The success/error message should appear


#### Link(s) to related issue(s)

* Resolves #10728   (Reference the issue this fixes, if any.)
