### PR TITLE
[instrument_list] Fix bad translation for main button in instrument list

### DIFF
--- a/modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/es/LC_MESSAGES/instrument_list.po
@@ -49,5 +49,5 @@ msgstr "No acciones"
 msgid "Stage: %s"
 msgstr "Etapa: %s"
 
-msgid "Start %s Stage"
-msgstr "Iniciar %s Etapa"
+msgid "Start the \"%s\" Stage"
+msgstr "Iniciar la etapa \"%s\""

--- a/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
@@ -49,7 +49,7 @@ msgid "No actions"
 msgstr "Aucune action"
 
 msgid "Stage: %s"
-msgstr "Stade: %s"
+msgstr "Étape: %s"
 
 msgid "Start the \"%s\" Stage"
 msgstr "Débuter l'étape de la « %s »"

--- a/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
@@ -51,5 +51,5 @@ msgstr "Aucune action"
 msgid "Stage: %s"
 msgstr "Stade: %s"
 
-msgid "Start %s Stage"
-msgstr "Démarrer %s Stade"
+msgid "Start the \"%s\" Stage"
+msgstr "Débuter l'étape de la « %s »"

--- a/modules/instrument_list/locale/hi/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/hi/LC_MESSAGES/instrument_list.po
@@ -49,5 +49,5 @@ msgstr "कोई कार्रवाई नहीं"
 msgid "Stage: %s"
 msgstr "चरण: %s"
 
-msgid "Start %s Stage"
-msgstr "%s चरण प्रारंभ करें"
+msgid "Start the \"%s\" Stage"
+msgstr "\"%s\" चरण प्रारंभ करें"

--- a/modules/instrument_list/locale/instrument_list.pot
+++ b/modules/instrument_list/locale/instrument_list.pot
@@ -48,5 +48,5 @@ msgstr ""
 msgid "Stage: %s"
 msgstr ""
 
-msgid "Start %s Stage"
+msgid "Start the \"%s\" Stage"
 msgstr ""

--- a/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/ja/LC_MESSAGES/instrument_list.po
@@ -49,6 +49,6 @@ msgstr "アクションなし"
 msgid "Stage: %s"
 msgstr "ステージ: %s"
 
-msgid "Start %s Stage"
-msgstr "%s ステージを開始"
+msgid "Start the \"%s\" Stage"
+msgstr "「%s」ステージを開始"
 

--- a/modules/instrument_list/locale/zh/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/zh/LC_MESSAGES/instrument_list.po
@@ -49,5 +49,5 @@ msgstr "没有动作"
 msgid "Stage: %s"
 msgstr "阶段：%s"
 
-msgid "Start %s Stage"
-msgstr "启动%s阶段"
+msgid "Start the \"%s\" Stage"
+msgstr "启动“%s”阶段"

--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -3,7 +3,7 @@
 	    	<li>
 		{if $access.next_stage}
                         <i class="fas fa-folder-open fa-sm" width="12" height="12"></i>&nbsp;<a
-				href="{$baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">{sprintf(dgettext("instrument_list", "Start %s Stage"), dgettext("loris", $next_stage))}</a>
+				href="{$baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">{sprintf(dgettext("instrument_list", "Start the \"%s\" Stage"), dgettext("loris", $next_stage))}</a>
 {else}
                         <small>({dgettext("instrument_list", "No actions")})</small>
 {/if}


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bad translation for the main button 'Start Visit Stage' in the instrument_list module.

#### Link(s) to related issue(s)

* Resolves #10621 (Reference the issue this fixes, if any.)
