### PR TITLE
[document_repository] Add  missing field rename SQL patch

### DIFF
--- a/SQL/New_patches/2026-06-14_rename_hide_video_field_document_repository.sql
+++ b/SQL/New_patches/2026-06-14_rename_hide_video_field_document_repository.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `document_repository` 
+CHANGE COLUMN `hide_video` `hide_file` TINYINT(1) NULL DEFAULT '0';
+


### PR DESCRIPTION
Related to #10867

### FYI
The `hide_file` field was added, and the `hide_video` field was removed from SQL/0000-00-00-schema.sql, but the SQL patch required to rename the existing field was never added. As a result, the database schema may be out of sync, which could explain why you're unable to save changes to the file.

### To Test
1. Check the `document_repository` table if `hide_file` field exists.  If it doesn't exist, goto step 2; otherwise, goto step 3 
2. Run patch `SQL/New_patches/2026-06-14_rename_hide_video_field_document_repository.sql`, then go to 4.
3. If the `hide_file` field exists in the `document_repository`, see if you can reproduce the bug reported [here](https://github.com/aces/Loris/issues/10867)
4. See if you can modify a file and save it as instructed [here](https://github.com/aces/Loris/issues/10867)