### PR TITLE
[imaging browser] fix files display always return 1

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -6,7 +6,8 @@
 <div class="panel panel-default">
     <div class="panel-heading" id="panel-main-heading">
 {if $files|@count}
-        <h3 class="panel-title">{dgettext("imaging_browser","%1 file(s) displayed.")|replace:"%1":$files|@count}</h3>
+{assign var="fileCount" value=$files|@count}
+        <h3 class="panel-title">{dgettext("imaging_browser","%1 file(s) displayed.")|replace:"%1":$fileCount}</h3>
         <span class="pull-right clickable mri-arrow glyphicon glyphicon-chevron-up"></span>
     </div> <!-- closing panel-heading div-->
     <div class="panel-body">


### PR DESCRIPTION
[Imaging_browser] viewSession always return "1" as files displayed
 #10914
before
<img width="658" height="480" alt="截屏2026-07-15 下午2 26 54" src="https://github.com/user-attachments/assets/c973dfd5-c7ec-4a9d-b804-cf4a284b0732" />
after
<img width="390" height="352" alt="截屏2026-07-15 下午2 25 10" src="https://github.com/user-attachments/assets/4a747f64-642b-4f69-930a-a156155e3f9a" />