### PR TITLE
[redcap] Add `redcap{@}true` to imported REDCap instruments meta

### DIFF
--- a/modules/redcap/README.md
+++ b/modules/redcap/README.md
@@ -91,8 +91,3 @@ To be importable, the LORIS version of a REDCap instrument must:
 - Have a database definition, that is, have an entry in the `test_names`, `session`, and `test_battery` tables.
 - Have a visit that corresponds to a REDCap event name, or use a visit mapping in the REDCap module configuration.
 - Have a started visit with a populated battery, or use the automatic session creation feature in the REDCap module configuration.
-
-## REDCap instrument naming
-
-Because the REDCap module imports REDCap instruments as LORIS LINST instruments, REDCap instruments must adhere to a few naming requirements to be LINST-compatible:
-- A field name should not finish with `_status`.

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -25,6 +25,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     protected $jsonData = false;
 
     /**
+     * Whether the instrument was imported from REDCap.
+     *
+     * REDCap field names are not subject to LORIS's special handling of
+     * fields whose names end in "_status".
+     */
+    protected bool $isRedcap = false;
+
+    /**
      * Variable defining the type of form in use
      *
      * Note: this seems to always be defined as 'XIN'
@@ -743,6 +751,18 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
+     * Determine whether a field is a LORIS response-status field.
+     *
+     * @param string $field The field name
+     *
+     * @return bool
+     */
+    protected function isStatusField(string $field): bool
+    {
+        return !$this->isRedcap && str_ends_with($field, '_status');
+    }
+
+    /**
      * This removes all the value of any field which has its accompagning
      * _status field set.
      *
@@ -755,7 +775,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     {
         //Remove the values of all fields who have had statuses assigned
         foreach (array_keys($values) AS $field) {
-            if (substr($field, -7)=="_status") {
+            if ($this->isStatusField($field)) {
                 if (!empty($values[$field])) {
                     $baseField          = substr($field, 0, (strlen($field)-7));
                     $values[$baseField] = "";
@@ -1223,7 +1243,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     if (is_array($result)) {
                         $errors += $result;
                     }
-                } else if (substr($elname, -7) != "_status"
+                } else if (!$this->isStatusField($elname)
                     && !in_array($elname, ["page", "subtest"])
                 ) {
                     $errors[$elname] = "Required.";
@@ -2442,7 +2462,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 		    JOIN test_names tn ON (tn.ID=f.TestID)
                     JOIN session s ON (f.SessionID=s.ID)
                     JOIN candidate c ON (s.CandidateID=c.ID)
-                     
+
 		    $where";
             \Profiler::checkpoint("Running query (table instrument): " . $query);
             $data = $db->pselect($query, $params);
@@ -2941,8 +2961,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $Responses = $this->getInstanceData();
 
         foreach ($tpl_data['questions'] as $key => &$row) {
-            $isStatusField = $row['SourceField']
-                === $tpl_data['questions'][$key-1]['SourceField']."_status";
+            $isStatusField = false;
+            if ($key > 0 && $this->isStatusField($row['SourceField'])) {
+                $previousQuestion    = $tpl_data['questions'][$key-1];
+                $previousSourceField = $previousQuestion['SourceField'];
+                $isStatusField       = $row['SourceField']
+                    === $previousSourceField . '_status';
+            }
+
             if (isset($Responses[$row['SourceField']])) {
                 // Consider status fields
                 if ($isStatusField) {
@@ -3090,7 +3116,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             }
             unset($formArray['elements'][$name]);
         }
-        if (strpos($name, "_status") === false) {
+        if (!$this->isStatusField($name)) {
             $this->_toJSONParseSmarty($element);
         } else {
             unset($formArray['elements'][$name]);

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -226,7 +226,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $errors += $result;
                         }
                     }
-                } else if (substr($elname, -7) != "_status"
+                } else if (!$this->isStatusField($elname)
                     && !in_array($elname, ["page", "subtest"])
                 ) {
                     // Check if element part of a group.
@@ -400,7 +400,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
                 $type      = $pieces[0];
                 $fieldname = isset($pieces[1]) ? $pieces[1] : null;
-                if (strpos($fieldname, "_status") !== false) {
+                if ($fieldname && $this->isStatusField($fieldname)) {
                     continue;
                 }
                 if ($fieldname == 'Date_taken'
@@ -930,6 +930,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             case 'norules':
                 $this->skipRules = trim($pieces[1]) === 'true';
                 break;
+            case 'redcap':
+                $this->isRedcap = trim($pieces[1]) === 'true';
+                break;
             default:
                 break;
             }
@@ -1042,7 +1045,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         $pageTitle  = 'Top';
 
         foreach ($this->LinstLines as $value) {
-            if (strpos($value[1], "_status") !== false) {
+            if ($value[0] === 'redcap') {
+                continue;
+            }
+            if ($this->isStatusField($value[1])) {
                 $lastIndex = count($elements) - 1;
                 $elements[$lastIndex]['Options']['RequireResponse'] = true;
             } else {

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -167,6 +167,7 @@ foreach ($instruments AS $instrument) {
             break;
         case "jsondata":
         case "norules":
+        case "redcap":
             break;
         //for HTML_QuickForm versions of standard HTML Form Elements...
         default:

--- a/tools/redcap2linst.php
+++ b/tools/redcap2linst.php
@@ -267,7 +267,8 @@ function writeLINSTFile(
     fwrite($fp_meta, "testname{@}$instrument_name\n");
     fwrite($fp_meta, "table{@}$instrument_name\n");
     fwrite($fp_meta, "jsondata{@}true\n");
-    fwrite($fp_meta, "norules{@}true");
+    fwrite($fp_meta, "norules{@}true\n");
+    fwrite($fp_meta, "redcap{@}true");
     fclose($fp_meta);
 }
 


### PR DESCRIPTION
Implementation of https://github.com/aces/CBIGR/issues/831

Differentiate REDCap instruments from non-REDCap instruments by adding `redcap{@}true` to the formers meta file.