### PR TITLE
[dictionary] Fixes filters multilingual bug.

### DIFF
--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -206,8 +206,8 @@ class DataDictIndex extends Component {
           onClick={this.editSwal(rowData)}>
         </i>);
       }
-      if (rowData[t('Description Status', {ns: 'dictionary'})] ===
-       t('Modified', {ns: 'dictionary'})) {
+
+      if (rowData[t('Description Status', {ns: 'dictionary'})] === 'Modified') {
         edited = <span>({t('edited', {ns: 'dictionary'})})</span>;
       }
       return <td>{cell}

--- a/modules/dictionary/php/datadictrowprovisioner.class.inc
+++ b/modules/dictionary/php/datadictrowprovisioner.class.inc
@@ -57,16 +57,16 @@ class DataDictRowProvisioner extends \LORIS\Data\ProvisionerInstance
 
                 foreach ($cat->getItems() as $item) {
                     $name   = $item->getName();
-                    $status = dgettext('dictionary', 'Unchanged');
+                    $status = 'Unchanged';
                     if (isset($overrides[$name])) {
                         $desc   = $overrides[$name]['Description'];
-                        $status = dgettext('dictionary', 'Modified');
+                        $status = 'Modified';
                     } else {
                         $desc = $item->getDescription();
                     }
 
                     if ($desc == '') {
-                        $status = dgettext('dictionary', 'Empty');
+                        $status = 'Empty';
                     }
 
                     $cohorts = $DB->pselectCol(


### PR DESCRIPTION
## Brief summary of changes
The main issues was the translated terms was been compared with raw (untranslated ones). Fixed to properly translated raw vs raw.

#### Testing instructions (if applicable)
Please go to the imaging browser and note that the issues reported in #10837 don't longer exits.

1. Go to 'Data Dictionary'.
2. Leave the page in the English language, then try to change the filter Description Status, and you will see it returns results.
3. Change the Language from English and try to change the filter Description Status, and you will see that now it properly return results.
4. The rest of functionalities should remain unchanged.

<img width="1300" height="532" alt="image" src="https://github.com/user-attachments/assets/289fcfda-b56b-482b-ad66-1eb15016c94b" />

#### Link(s) to related issue(s)

* Resolves #10837 
