### PR TITLE
[SQL] Fix 9999-99-99-drop_tables.sql script error

### DIFF
--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -259,8 +259,8 @@ DROP TABLE IF EXISTS `physiological_task_event_history`;
 DROP TABLE IF EXISTS `hed_tag_history`;
 DROP TABLE IF EXISTS `hed_tag_endorsement_history`;
 DROP TABLE IF EXISTS `hed_tag_endorsement`;
-DROP TABLE IF EXISTS `cached_data_type`;
 DROP TABLE IF EXISTS `cached_data`;
+DROP TABLE IF EXISTS `cached_data_type`;
 
 DROP TABLE IF EXISTS `candidate_diagnosis_evolution_rel`;
 DROP TABLE IF EXISTS `diagnosis_evolution`;


### PR DESCRIPTION
## Brief summary of changes

This PR changes the order in which the `cached_data_type` and `cached_data` tables are dropped.

#### Testing instructions (if applicable)

1. Source the raisinbread database (242 tables)
<img width="423" height="330" alt="image" src="https://github.com/user-attachments/assets/7ad08253-92e6-43d4-9a94-643546dd36c3" />

2. Run `mysql < 9999-99-99-drop_tables.sql`
3. Verify that it runs without any errors
4. `show tables;` in mysql should now return an empty set
<img width="393" height="16" alt="image" src="https://github.com/user-attachments/assets/d8d3f71c-a9f4-41f4-8fbb-61a9ee4dfea0" />

#### Link(s) to related issue(s)

* Resolves #10928 (Reference the issue this fixes, if any.)
