### PR TITLE
[statistics] Add missing translations in the statistics module (non-db only)

### DIFF
--- a/modules/statistics/jsx/widgets/recruitment.js
+++ b/modules/statistics/jsx/widgets/recruitment.js
@@ -240,7 +240,10 @@ const Recruitment = (props) => {
                     </div>
                   </>
                 ) : (
-                  <p>{t('There have been no candidates registered yet.', {ns: 'statistics'})}</p>
+                  <p>{t(
+                    'There have been no candidates registered yet.',
+                    {ns: 'statistics'}
+                  )}</p>
                 ),
             title: title('Site Breakdown'),
             subtitle: t(

--- a/modules/statistics/jsx/widgets/recruitment.js
+++ b/modules/statistics/jsx/widgets/recruitment.js
@@ -31,7 +31,7 @@ const Recruitment = (props) => {
           filters: '',
           chartType: 'pie',
           dataType: 'pie',
-          label: 'Age (Years)',
+          label: t('Age (Years)', {ns: 'statistics'}),
           options: {pie: 'pie', bar: 'bar'},
           yLabel: t('Candidates registered', {ns: 'statistics'}),
           legend: 'under',
@@ -42,7 +42,7 @@ const Recruitment = (props) => {
           filters: '',
           chartType: 'pie',
           dataType: 'pie',
-          label: 'Ethnicity',
+          label: t('Ethnicity', {ns: 'loris'}),
           options: {pie: 'pie', bar: 'bar'},
           yLabel: t('Candidates registered', {ns: 'statistics'}),
           legend: 'under',
@@ -55,7 +55,7 @@ const Recruitment = (props) => {
           filters: '',
           chartType: 'pie',
           dataType: 'pie',
-          label: 'Participants',
+          label: t('Participants', {ns: 'statistics'}),
           legend: '',
           options: {pie: 'pie', bar: 'bar'},
           yLabel: t('Candidates registered', {ns: 'statistics'}),
@@ -240,7 +240,7 @@ const Recruitment = (props) => {
                     </div>
                   </>
                 ) : (
-                  <p>There have been no candidates registered yet.</p>
+                  <p>{t('There have been no candidates registered yet.', {ns: 'statistics'})}</p>
                 ),
             title: title('Site Breakdown'),
             subtitle: t(

--- a/modules/statistics/jsx/widgets/studyprogression.js
+++ b/modules/statistics/jsx/widgets/studyprogression.js
@@ -127,7 +127,7 @@ const StudyProgression = (props) => {
   const filterLabel = (hide) => hide ?
     t('Hide Filters', {ns: 'loris'})
     : t('Show Filters', {ns: 'loris'});
-  return loading ? <Panel title='Study Progression'><Loader/></Panel> : (
+  return loading ? <Panel title={t('Study Progression', {ns: 'statistics'})}><Loader/></Panel> : (
     <>
       <Panel
         title={t('Study Progression', {ns: 'statistics'})}

--- a/modules/statistics/jsx/widgets/studyprogression.js
+++ b/modules/statistics/jsx/widgets/studyprogression.js
@@ -127,7 +127,8 @@ const StudyProgression = (props) => {
   const filterLabel = (hide) => hide ?
     t('Hide Filters', {ns: 'loris'})
     : t('Show Filters', {ns: 'loris'});
-  return loading ? <Panel title={t('Study Progression', {ns: 'statistics'})}><Loader/></Panel> : (
+  return loading ? <Panel title={t('Study Progression', {ns: 'statistics'})}>
+    <Loader /></Panel> : (
     <>
       <Panel
         title={t('Study Progression', {ns: 'statistics'})}

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -351,3 +351,9 @@ msgstr "L'onglet %sStatistiques comportementales%s présente actuellement des st
 
 msgid "The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site."
 msgstr "L'onglet %sStatistiques IRM%s affiche actuellement le nombre d'acquisitions insérées par site ainsi que leur état de contrôle de la qualité (QC). Pour les différents types d'acquisition d'une étude, selon les données saisies dans le formulaire des paramètres IRM, une répartition des acquisitions complétées est disponible par site, cohorte et point temporel. Il est également possible de masquer les libellés de visite afin d'afficher uniquement le nombre total de visites par site."
+
+msgid "Incomplete"
+msgstr "Incomplet"
+
+msgid "Data Entry Completion Status for %s"
+msgstr "État d'avancement de la saisie des données pour %s"

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -165,3 +165,108 @@ msgstr "Circulaire"
 
 msgid "Bar"
 msgstr "Barre"
+
+msgid "General Description"
+msgstr "Description générale"
+
+msgid "General Demographic Statistics"
+msgstr "Statistiques démographiques générales"
+
+msgid "Behavioural Statistics"
+msgstr "Statistiques comportementales"
+
+msgid "Welcome to the statistics page"
+msgstr "Bienvenue sur la page des statistiques"
+
+msgid "This page will display statistics related to data acquisition, data processing and data entry as it relates to both the behavioural and imaging aspects of this study."
+msgstr "Cette page affiche des statistiques relatives à l'acquisition des données, au traitement des données et à la saisie des données, couvrant les aspects comportementaux et d'imagerie de cette étude."
+
+msgid "Demographics Statistics"
+msgstr "Statistiques démographiques"
+
+msgid "MRI Statistics"
+msgstr "Statistiques IRM"
+
+msgid "General Statistics with QC Status"
+msgstr "Statistiques générales avec état du contrôle qualité"
+
+msgid "All Scan Types"
+msgstr "Tous les types d'acquisition"
+
+msgid "Submit Query"
+msgstr "Exécuter la requête"
+
+msgid "Scan Type"
+msgstr "Type d'acquisition"
+
+msgid "QC Status"
+msgstr "État du contrôle qualité"
+
+msgid "Scans Inserted"
+msgstr "Acquisitions importées"
+
+msgid "Passed"
+msgstr "Réussi"
+
+msgid "Failed"
+msgstr "Échoué"
+
+msgid "Not QCed"
+msgstr "Contrôle qualité non effectué"
+
+msgid "Oops"
+msgstr "Oups"
+
+msgid "Per Instrument Stats"
+msgstr "Statistiques par instrument"
+
+msgid "View Details"
+msgstr "Voir les détails"
+
+msgid "Completed"
+msgstr "Complété"
+
+msgid "Completed (%)"
+msgstr "Complété (%)"
+
+msgid "Demographics"
+msgstr "Démographie"
+
+msgid "No defined cohort"
+msgstr "Aucune cohorte définie"
+
+msgid "Registered candidates"
+msgstr "Candidats enregistrés"
+
+msgid "Inactive"
+msgstr "Inactif"
+
+msgid "Age Average (months)"
+msgstr "Âge moyen (mois)"
+
+msgid "Completion Count"
+msgstr "Nombre de complétions"
+
+msgid "Incomplete Candidates"
+msgstr "Candidats incomplets"
+
+msgid "Issue type"
+msgstr "Type de problème"
+
+msgid "Incomplete Entries"
+msgstr "Entrées incomplètes"
+
+msgid "Total Across Cohorts"
+msgstr "Total toutes cohortes confondues"
+
+msgid "Categories"
+msgstr "Catégories"
+
+msgid "Site Total Across All Visits"
+msgstr "Total du site pour toutes les visites"
+
+msgid "Grand Total"
+msgstr "Total général"
+
+msgid "Ethnicity"
+msgstr "Origine ethnique"

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -319,8 +319,35 @@ msgstr "Tout sélectionner"
 msgid "%s Double Data Entry Completion Statistics %s"
 msgstr "%s Statistiques d’achèvement de la double saisie des données %s"
 
-msgid "Completion Statistics"
-msgstr "Statistiques d’achèvement"
+msgid "%s Completion Statistics"
+msgstr "Statistiques d’achèvement de %s"
 
 msgid "All Completion Statistics"
 msgstr "Toutes les statistiques d’achèvement"
+
+msgid "QC Status"
+msgstr "État du contrôle qualité"
+
+msgid "Click to minimize"
+msgstr "Cliquez pour réduire"
+
+msgid "It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database."
+msgstr "Il semble que le type d'acquisition sélectionné ne possède pas de colonne correspondante dans la table mri_parameter_form de la base de données."
+
+msgid "In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done"
+msgstr "Pour afficher les statistiques de ce type d'acquisition, assurez-vous que la table mri_parameter_form contient une colonne dont le nom respecte exactement le format SCANTYPE_Scan_done."
+
+msgid "It seems like the \"mri_parameter_form\" table is missing in the database currently in use."
+msgstr "Il semble que la table « mri_parameter_form » soit absente de la base de données actuellement utilisée."
+
+msgid "This table is necessary in order to compute the Breakdown table of the MRI statistics page."
+msgstr "Cette table est nécessaire pour générer le tableau de répartition de la page des statistiques IRM."
+
+msgid "The %sDemographics Statistics%s tab currently includes general statistics relating to the number of candidates registered in each cohort as well as customizable categories displaying statistics relating to candidate demographics (participant status, sex, age etc.). You may also view statistics broken down per instrument, displaying the number of complete and incomplete instruments per site, as it pertains to each visit label and cohort by selecting an instrument from the dropdown menu with the option to hide visit labels to only display total visit counts per site."
+msgstr "L'onglet %sStatistiques démographiques%s présente actuellement des statistiques générales sur le nombre de participants inscrits dans chaque cohorte, ainsi que des catégories personnalisables affichant des statistiques relatives aux caractéristiques démographiques des participants (statut du participant, sexe, âge, etc.). Vous pouvez également consulter des statistiques ventilées par instrument, indiquant le nombre d'instruments complets et incomplets par site pour chaque libellé de visite et chaque cohorte, en sélectionnant un instrument dans le menu déroulant. Il est également possible de masquer les libellés de visite afin d'afficher uniquement le nombre total de visites par site."
+
+msgid "The %sBehavioural Statistics%s tab currently includes data entry statistics relating to the number of candidates who have completed each instrument per site and timepoint. As well, there is an option to view the data entry statistics per instrument as well a breakdown per participant, which will reveal an in-depth table, listing candidate PSCIDs, completion count, and incomplete candidates. The same statistics are also available for double data entry."
+msgstr "L'onglet %sStatistiques comportementales%s présente actuellement des statistiques de saisie de données relatives au nombre de participants ayant complété chaque instrument par site et par point temporel. Il est également possible de consulter les statistiques de saisie de données par instrument, ainsi qu'une répartition par participant, qui affiche un tableau détaillé répertoriant les PSCID des participants, le nombre d'instruments complétés et les participants ayant des instruments incomplets. Les mêmes statistiques sont également disponibles pour la double saisie des données."
+
+msgid "The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site."
+msgstr "L'onglet %sStatistiques IRM%s affiche actuellement le nombre d'acquisitions insérées par site ainsi que leur état de contrôle de la qualité (QC). Pour les différents types d'acquisition d'une étude, selon les données saisies dans le formulaire des paramètres IRM, une répartition des acquisitions complétées est disponible par site, cohorte et point temporel. Il est également possible de masquer les libellés de visite afin d'afficher uniquement le nombre total de visites par site."

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -319,11 +319,11 @@ msgstr "Tout sélectionner"
 msgid "%s Double Data Entry Completion Statistics %s"
 msgstr "%s Statistiques d’achèvement de la double saisie des données %s"
 
-msgid "%s Completion Statistics"
-msgstr "Statistiques d’achèvement de %s"
-
 msgid "All Completion Statistics"
 msgstr "Toutes les statistiques d’achèvement"
+
+msgid "%s Completion Statistics"
+msgstr "Statistiques d’achèvement de %s"
 
 msgid "QC Status"
 msgstr "État du contrôle qualité"
@@ -357,3 +357,6 @@ msgstr "Incomplet"
 
 msgid "Data Entry Completion Status for %s"
 msgstr "État d'avancement de la saisie des données pour %s"
+
+msgid "%s Breakdown"
+msgstr ""

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -270,3 +270,39 @@ msgstr "Total général"
 
 msgid "Ethnicity"
 msgstr "Origine ethnique"
+
+msgid "All sites"
+msgstr "Tous les sites"
+
+msgid "All Projects"
+msgstr "Tous les projets"
+
+msgid "Breakdown of Registered Candidates"
+msgstr "Répartition des candidats inscrits"
+
+msgid "Breakdown by Sex"
+msgstr "Répartition par sexe"
+
+msgid "Recruit Breakdown by Sex"
+msgstr "Répartition des recrues par sexe"
+
+msgid "Show Visit Labels"
+msgstr "Afficher les libellés des visites"
+
+msgid "Double Data Entry Statistics"
+msgstr "Statistiques de la double saisie des données"
+
+msgid "Click here for breakdown per participant"
+msgstr "Cliquez ici pour la répartition par participant"
+
+msgid "Breakdown By Scan Type"
+msgstr "Répartition par type de scan"
+
+msgid "Partial run"
+msgstr "Exécution partielle"
+
+msgid "No Scan"
+msgstr "Aucun scan"
+
+msgid "Data Entry Statistics"
+msgstr "Statistiques de saisie des données"

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -191,19 +191,19 @@ msgid "General Statistics with QC Status"
 msgstr "Statistiques générales avec état du contrôle qualité"
 
 msgid "All Scan Types"
-msgstr "Tous les types d'acquisition"
+msgstr "Tous les types de scan"
 
 msgid "Submit Query"
 msgstr "Exécuter la requête"
 
 msgid "Scan Type"
-msgstr "Type d'acquisition"
+msgstr "Type de scan"
 
 msgid "QC status"
 msgstr "État du contrôle qualité"
 
 msgid "Scans Inserted"
-msgstr "Acquisitions importées"
+msgstr "Scans importées"
 
 msgid "Passed"
 msgstr "Réussi"
@@ -284,7 +284,7 @@ msgid "Breakdown by Sex"
 msgstr "Répartition par sexe"
 
 msgid "Recruit Breakdown by Sex"
-msgstr "Répartition des recrues par sexe"
+msgstr "Répartition des participants recrutés par sexe"
 
 msgid "Show Visit Labels"
 msgstr "Afficher les libellés des visites"
@@ -332,10 +332,10 @@ msgid "Click to minimize"
 msgstr "Cliquez pour réduire"
 
 msgid "It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database."
-msgstr "Il semble que le type d'acquisition sélectionné ne possède pas de colonne correspondante dans la table mri_parameter_form de la base de données."
+msgstr "Il semble que le type de scan sélectionné ne possède pas de colonne correspondante dans la table mri_parameter_form de la base de données."
 
 msgid "In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done"
-msgstr "Pour afficher les statistiques de ce type d'acquisition, assurez-vous que la table mri_parameter_form contient une colonne dont le nom respecte exactement le format SCANTYPE_Scan_done."
+msgstr "Pour afficher les statistiques de ce type de scan, assurez-vous que la table mri_parameter_form contient une colonne dont le nom respecte exactement le format SCANTYPE_Scan_done."
 
 msgid "It seems like the \"mri_parameter_form\" table is missing in the database currently in use."
 msgstr "Il semble que la table « mri_parameter_form » soit absente de la base de données actuellement utilisée."
@@ -350,7 +350,7 @@ msgid "The %sBehavioural Statistics%s tab currently includes data entry statisti
 msgstr "L'onglet %sStatistiques comportementales%s présente actuellement des statistiques de saisie de données relatives au nombre de participants ayant complété chaque instrument par site et par point temporel. Il est également possible de consulter les statistiques de saisie de données par instrument, ainsi qu'une répartition par participant, qui affiche un tableau détaillé répertoriant les PSCID des participants, le nombre d'instruments complétés et les participants ayant des instruments incomplets. Les mêmes statistiques sont également disponibles pour la double saisie des données."
 
 msgid "The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site."
-msgstr "L'onglet %sStatistiques IRM%s affiche actuellement le nombre d'acquisitions insérées par site ainsi que leur état de contrôle de la qualité (QC). Pour les différents types d'acquisition d'une étude, selon les données saisies dans le formulaire des paramètres IRM, une répartition des acquisitions complétées est disponible par site, cohorte et point temporel. Il est également possible de masquer les libellés de visite afin d'afficher uniquement le nombre total de visites par site."
+msgstr "L'onglet %sStatistiques IRM%s affiche actuellement le nombre de scans insérées par site ainsi que leur état de contrôle de la qualité (QC). Pour les différents types de scan d'une étude, selon les données saisies dans le formulaire des paramètres IRM, une répartition des scans complétées est disponible par site, cohorte et point temporel. Il est également possible de masquer les libellés de visite afin d'afficher uniquement le nombre total de visites par site."
 
 msgid "Incomplete"
 msgstr "Incomplet"
@@ -359,4 +359,4 @@ msgid "Data Entry Completion Status for %s"
 msgstr "État d'avancement de la saisie des données pour %s"
 
 msgid "%s Breakdown"
-msgstr ""
+msgstr "Répartition des %s"

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -199,7 +199,7 @@ msgstr "Exécuter la requête"
 msgid "Scan Type"
 msgstr "Type d'acquisition"
 
-msgid "QC Status"
+msgid "QC status"
 msgstr "État du contrôle qualité"
 
 msgid "Scans Inserted"
@@ -245,7 +245,7 @@ msgid "Age Average (months)"
 msgstr "Âge moyen (mois)"
 
 msgid "Completion Count"
-msgstr "Nombre de complétions"
+msgstr "Nombre de formulaires complétés"
 
 msgid "Incomplete Candidates"
 msgstr "Candidats incomplets"
@@ -295,10 +295,16 @@ msgstr "Statistiques de la double saisie des données"
 msgid "Click here for breakdown per participant"
 msgstr "Cliquez ici pour la répartition par participant"
 
+msgid "Click here for breakdown per participant%s%s"
+msgstr "Cliquez ici pour la répartition par participant%s%s"
+
+msgid " for %s"
+msgstr " pour %s"
+
 msgid "Breakdown By Scan Type"
 msgstr "Répartition par type de scan"
 
-msgid "Partial run"
+msgid "Partial Run"
 msgstr "Exécution partielle"
 
 msgid "No Scan"
@@ -306,3 +312,15 @@ msgstr "Aucun scan"
 
 msgid "Data Entry Statistics"
 msgstr "Statistiques de saisie des données"
+
+msgid "Select All"
+msgstr "Tout sélectionner"
+
+msgid "%s Double Data Entry Completion Statistics %s"
+msgstr "%s Statistiques d’achèvement de la double saisie des données %s"
+
+msgid "Completion Statistics"
+msgstr "Statistiques d’achèvement"
+
+msgid "All Completion Statistics"
+msgstr "Toutes les statistiques d’achèvement"

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -267,3 +267,39 @@ msgstr ""
 
 msgid "Ethnicity"
 msgstr ""
+
+msgid "All sites"
+msgstr ""
+
+msgid "All Projects"
+msgstr ""
+
+msgid "Breakdown of Registered Candidates"
+msgstr ""
+
+msgid "Breakdown by Sex"
+msgstr ""
+
+msgid "Recruit Breakdown by Sex"
+msgstr ""
+
+msgid "Show Visit Labels"
+msgstr ""
+
+msgid "Double Data Entry Statistics"
+msgstr ""
+
+msgid "Click here for breakdown per participant"
+msgstr ""
+
+msgid "Breakdown By Scan Type"
+msgstr ""
+
+msgid "Partial run"
+msgstr ""
+
+msgid "No Scan"
+msgstr ""
+
+msgid "Data Entry Statistics"
+msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -348,3 +348,9 @@ msgstr ""
 
 msgid "The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site."
 msgstr ""
+
+msgid "Incomplete"
+msgstr ""
+
+msgid "Data Entry Completion Status for %s"
+msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -196,7 +196,7 @@ msgstr ""
 msgid "Scan Type"
 msgstr ""
 
-msgid "QC Status"
+msgid "QC status"
 msgstr ""
 
 msgid "Scans Inserted"
@@ -292,14 +292,32 @@ msgstr ""
 msgid "Click here for breakdown per participant"
 msgstr ""
 
+msgid "Click here for breakdown per participant%s%s"
+msgstr ""
+
+msgid " for %s"
+msgstr ""
+
 msgid "Breakdown By Scan Type"
 msgstr ""
 
-msgid "Partial run"
+msgid "Partial Run"
 msgstr ""
 
 msgid "No Scan"
 msgstr ""
 
 msgid "Data Entry Statistics"
+msgstr ""
+
+msgid "Select All"
+msgstr ""
+
+msgid "%s Double Data Entry Completion Statistics %s"
+msgstr ""
+
+msgid "Completion Statistics"
+msgstr ""
+
+msgid "All Completion Statistics"
 msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -162,3 +162,108 @@ msgstr ""
 
 msgid "Bar"
 msgstr ""
+
+msgid "General Description"
+msgstr ""
+
+msgid "General Demographic Statistics"
+msgstr ""
+
+msgid "Behavioural Statistics"
+msgstr ""
+
+msgid "Welcome to the statistics page"
+msgstr ""
+
+msgid "This page will display statistics related to data acquisition, data processing and data entry as it relates to both the behavioural and imaging aspects of this study."
+msgstr ""
+
+msgid "Demographics Statistics"
+msgstr ""
+
+msgid "MRI Statistics"
+msgstr ""
+
+msgid "General Statistics with QC Status"
+msgstr ""
+
+msgid "All Scan Types"
+msgstr ""
+
+msgid "Submit Query"
+msgstr ""
+
+msgid "Scan Type"
+msgstr ""
+
+msgid "QC Status"
+msgstr ""
+
+msgid "Scans Inserted"
+msgstr ""
+
+msgid "Passed"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Not QCed"
+msgstr ""
+
+msgid "Oops"
+msgstr ""
+
+msgid "Per Instrument Stats"
+msgstr ""
+
+msgid "View Details"
+msgstr ""
+
+msgid "Completed"
+msgstr ""
+
+msgid "Completed (%)"
+msgstr ""
+
+msgid "Demographics"
+msgstr ""
+
+msgid "No defined cohort"
+msgstr ""
+
+msgid "Registered candidates"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Age Average (months)"
+msgstr ""
+
+msgid "Completion Count"
+msgstr ""
+
+msgid "Incomplete Candidates"
+msgstr ""
+
+msgid "Issue type"
+msgstr ""
+
+msgid "Incomplete Entries"
+msgstr ""
+
+msgid "Total Across Cohorts"
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Site Total Across All Visits"
+msgstr ""
+
+msgid "Grand Total"
+msgstr ""
+
+msgid "Ethnicity"
+msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -316,8 +316,35 @@ msgstr ""
 msgid "%s Double Data Entry Completion Statistics %s"
 msgstr ""
 
-msgid "Completion Statistics"
+msgid "%s Completion Statistics"
 msgstr ""
 
 msgid "All Completion Statistics"
+msgstr ""
+
+msgid "QC Status"
+msgstr ""
+
+msgid "Click to minimize"
+msgstr ""
+
+msgid "It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database."
+msgstr ""
+
+msgid "In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done"
+msgstr ""
+
+msgid "It seems like the \"mri_parameter_form\" table is missing in the database currently in use."
+msgstr ""
+
+msgid "This table is necessary in order to compute the Breakdown table of the MRI statistics page."
+msgstr ""
+
+msgid "The %sDemographics Statistics%s tab currently includes general statistics relating to the number of candidates registered in each cohort as well as customizable categories displaying statistics relating to candidate demographics (participant status, sex, age etc.). You may also view statistics broken down per instrument, displaying the number of complete and incomplete instruments per site, as it pertains to each visit label and cohort by selecting an instrument from the dropdown menu with the option to hide visit labels to only display total visit counts per site."
+msgstr ""
+
+msgid "The %sBehavioural Statistics%s tab currently includes data entry statistics relating to the number of candidates who have completed each instrument per site and timepoint. As well, there is an option to view the data entry statistics per instrument as well a breakdown per participant, which will reveal an in-depth table, listing candidate PSCIDs, completion count, and incomplete candidates. The same statistics are also available for double data entry."
+msgstr ""
+
+msgid "The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site."
 msgstr ""

--- a/modules/statistics/locale/statistics.pot
+++ b/modules/statistics/locale/statistics.pot
@@ -354,3 +354,6 @@ msgstr ""
 
 msgid "Data Entry Completion Status for %s"
 msgstr ""
+
+msgid "%s Breakdown"
+msgstr ""

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -101,7 +101,7 @@ class Stats_Behavioural extends \NDB_Form
         // PROJECTS
         $allProjectList = \Utility::getProjectList();
         $projects       = [];
-        $projects['']   = 'All Projects';
+        $projects['']   = dgettext('statistics', 'All Projects');
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -543,8 +543,8 @@ class Stats_Demographic extends \NDB_Form
                 false
             );
             $subcategories         = [
-                'Complete',
-                'Incomplete',
+                dgettext('loris', 'Complete'),
+                dgettext('statistics', 'Incomplete'),
             ];
             $result = iterator_to_array(
                 $db->pselect(
@@ -594,8 +594,13 @@ class Stats_Demographic extends \NDB_Form
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 dgettext('statistics', 'Breakdown of Registered Candidates'),
-                'Data Entry Completion Status for '.
-                    $instrumentList[$demographicInstrument],
+                sprintf(
+                    dgettext(
+                        'statistics',
+                        'Data Entry Completion Status for %s'
+                    ),
+                    $instrumentList[$demographicInstrument]
+                ),
                 $subcategories,
                 $visits,
                 'DemographicInstrument',

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -314,7 +314,7 @@ class Stats_Demographic extends \NDB_Form
         );
 
         $sites     = [];
-        $sites[''] =dgettext('statistics', 'All sites');
+        $sites[''] = dgettext('statistics', 'All sites');
 
         if (!empty($centers)) {
             foreach ($centers as $row) {
@@ -530,7 +530,7 @@ class Stats_Demographic extends \NDB_Form
         //START BIG TABLE
         $instrumentList = \Utility::getAllInstruments();
         $instDropdown   = array_merge(
-            [ '' => dgettext('statistics','Recruit Breakdown by Sex')],
+            [ '' => dgettext('statistics', 'Recruit Breakdown by Sex')],
             $instrumentList
         );
         $this->tpl_data['all_instruments'] = $instrumentList;

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -609,8 +609,8 @@ class Stats_Demographic extends \NDB_Form
             );
         } else {
             $subcategories = [
-                dngettext('statistics', 'Male', 'Males', 1),
-                dngettext('statistics', 'Female', 'Females', 1)
+                dngettext('loris', 'Male', 'Males', 1),
+                dngettext('loris', 'Female', 'Females', 1)
             ];
             $result        = iterator_to_array(
                 $db->pselect(

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -233,7 +233,7 @@ class Stats_Demographic extends \NDB_Form
         $allProjectList = \Utility::getProjectList();
 
         $projects     = [];
-        $projects[''] = 'All Projects';
+        $projects[''] = dgettext('statistics', 'All Projects');
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
@@ -314,7 +314,7 @@ class Stats_Demographic extends \NDB_Form
         );
 
         $sites     = [];
-        $sites[''] ='All sites';
+        $sites[''] =dgettext('statistics', 'All sites');
 
         if (!empty($centers)) {
             foreach ($centers as $row) {
@@ -530,7 +530,7 @@ class Stats_Demographic extends \NDB_Form
         //START BIG TABLE
         $instrumentList = \Utility::getAllInstruments();
         $instDropdown   = array_merge(
-            [ '' => 'Recruit Breakdown by Sex'],
+            [ '' => dgettext('statistics','Recruit Breakdown by Sex')],
             $instrumentList
         );
         $this->tpl_data['all_instruments'] = $instrumentList;
@@ -593,7 +593,7 @@ class Stats_Demographic extends \NDB_Form
                 )
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
-                'Breakdown of Registered Candidates',
+                dgettext('statistics', 'Breakdown of Registered Candidates'),
                 'Data Entry Completion Status for '.
                     $instrumentList[$demographicInstrument],
                 $subcategories,
@@ -609,8 +609,8 @@ class Stats_Demographic extends \NDB_Form
             );
         } else {
             $subcategories = [
-                'Male',
-                'Female',
+                dngettext('statistics', 'Male', 'Males', 1),
+                dngettext('statistics', 'Female', 'Females', 1)
             ];
             $result        = iterator_to_array(
                 $db->pselect(
@@ -634,8 +634,8 @@ class Stats_Demographic extends \NDB_Form
                 )
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
-                'Breakdown of Registered Candidates',
-                'Breakdown by Sex',
+                dgettext('statistics', 'Breakdown of Registered Candidates'),
+                dgettext('statistics', 'Breakdown by Sex'),
                 $subcategories,
                 $visits,
                 'DemographicInstrument',

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -370,9 +370,9 @@ class Stats_MRI extends \NDB_Form
             return;
         }
         $MRISubcategories = [
-            dgettext('loris','Complete'),
-            dgettext('statistics','Partial Run'),
-            dgettext('statistics','No Scan'),
+            dgettext('loris', 'Complete'),
+            dgettext('statistics', 'Partial Run'),
+            dgettext('statistics', 'No Scan'),
         ];
 
         //Check if a specific scan is requested otherwise display first
@@ -429,7 +429,7 @@ class Stats_MRI extends \NDB_Form
 
         $M_Visits = \Utility::getVisitList($currentProject);
         $this->tpl_data['MRI_Done_Table'] = $this->renderStatsTable(
-            dgettext('statistics',"Breakdown By Scan Type"),
+            dgettext('statistics', "Breakdown By Scan Type"),
             $MRIHeader,
             $MRISubcategories,
             $M_Visits,

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -384,7 +384,7 @@ class Stats_MRI extends \NDB_Form
         }
 
         $MRI_Type_Field = $MRI_Type . "_Scan_Done";
-        $MRIHeader      = "$MRI_Type Breakdown";
+        $MRIHeader      = sprintf(dgettext('statistics', "%s Breakdown"), $MRI_Type);
         $CaseStatement  = "
                           CASE($MRI_Type_Field)
                           WHEN 'Partial' THEN 'Partial Run'

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -239,7 +239,7 @@ class Stats_MRI extends \NDB_Form
         $allProjectList = \Utility::getProjectList();
 
         $projects     = [];
-        $projects[''] = 'All Projects';
+        $projects[''] = dgettext('statistics', 'All Projects');
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
@@ -315,7 +315,7 @@ class Stats_MRI extends \NDB_Form
             )
         );
         $sites     = [];
-        $sites[''] ="All sites";
+        $sites[''] = dgettext('statistics', 'All sites');
         foreach ($centers as $row) {
             $sites[$row['NumericID']] = $row['ShortName'];
             if (isset($_REQUEST['MRIsite'])
@@ -370,9 +370,9 @@ class Stats_MRI extends \NDB_Form
             return;
         }
         $MRISubcategories = [
-            'Complete',
-            'Partial Run',
-            'No Scan',
+            dgettext('loris','Complete'),
+            dgettext('statistics','Partial Run'),
+            dgettext('statistics','No Scan'),
         ];
 
         //Check if a specific scan is requested otherwise display first
@@ -429,7 +429,7 @@ class Stats_MRI extends \NDB_Form
 
         $M_Visits = \Utility::getVisitList($currentProject);
         $this->tpl_data['MRI_Done_Table'] = $this->renderStatsTable(
-            "Breakdown By Scan Type",
+            dgettext('statistics',"Breakdown By Scan Type"),
             $MRIHeader,
             $MRISubcategories,
             $M_Visits,

--- a/modules/statistics/templates/form_statistics.tpl
+++ b/modules/statistics/templates/form_statistics.tpl
@@ -10,7 +10,7 @@
     </div>
     <div class="visible-xs visible-sm panel panel-primary">
         <div class="panel-heading" onclick="toggleTabs()">
-            <label id="hiddenTabs">General Description</label>
+            <label id="hiddenTabs">{dgettext('statistics', 'General Description')}</label>
             <span class="glyphicon glyphicon-chevron-down pull-right" id="down"></span>
             <span class="glyphicon glyphicon-chevron-up pull-right" id="up" style="display:none"></span>
         </div>

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -9,7 +9,7 @@
         </div>
     <br><br>
     <div id="scancheckbox">
-        <input type="checkbox" id="selectall" style="margin-bottom: 8px;"/> Select All
+        <input type="checkbox" id="selectall" style="margin-bottom: 8px;"/> {dgettext('statistics', 'Select All')}
         {html_checkboxes id="MRIScans" options=$scan_types name="MRIScans" selected=$Scans_sel_box class="timesheet-daily-checkbox" style="margin: 4px 0 4px;"}
         {*<input type="checkbox" name="all" value="bla" checked><b>{dgettext('statistics', 'All Scan Types')}</b>
         {foreach item=scan key=scanid from=$scan_types}

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -1,6 +1,6 @@
 <div id="mri">
     <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_MRI.js"></script>
-    <h2 class="statsH2">General Statistics with QC Status</h2>
+    <h2 class="statsH2">{dgettext('statistics', 'General Statistics with QC Status')}</h2>
     <div class="col-sm-2">
         {html_options id="MRIsite" options=$Sites name="MRIsite" selected=$CurrentSite.ID|default class="form-control"}
     </div>
@@ -11,31 +11,31 @@
     <div id="scancheckbox">
         <input type="checkbox" id="selectall" style="margin-bottom: 8px;"/> Select All
         {html_checkboxes id="MRIScans" options=$scan_types name="MRIScans" selected=$Scans_sel_box class="timesheet-daily-checkbox" style="margin: 4px 0 4px;"}
-        {*<input type="checkbox" name="all" value="bla" checked><b>All Scan Types</b>
+        {*<input type="checkbox" name="all" value="bla" checked><b>{dgettext('statistics', 'All Scan Types')}</b>
         {foreach item=scan key=scanid from=$scan_types}
             <input type="checkbox" name="{$scan}" value="{$scanid}" class="timesheet-daily-checkbox">{$scan}
         {/foreach}
         *}
     </div>
     <br><br>
-    <button onClick="updateMRITab()" class="btn btn-primary btn-small">Submit Query</button>
+    <button onClick="updateMRITab()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
     <br><br>
         <table id="scandata" class="table table-primary table-bordered dynamictable">
             <thead>
             <tr class="info">
-                <th id="scantype">Scan Type</th>
-                <th colspan="2">QC Status</th>
+                <th id="scantype">{dgettext('statistics', 'Scan Type')}</th>
+                <th colspan="2">{dgettext('statistics', 'QC Status')}</th>
                 {foreach from=$Cohorts item=name key=proj}
                     <th>{$name}</th>
                 {/foreach}
-                <th class="data">Total</th>
+                <th class="data">{dgettext('loris', 'Total')}</th>
             </tr>
             </thead>
             <tbody>
             {foreach item=scan key=scanid from=$Scans_selected}
                 <tr>
                     <td rowspan="4" style="vertical-align:middle" >{$scan}</td>
-                    <td colspan="2"><b>Scans Inserted</b></td>
+                    <td colspan="2"><b>{dgettext('statistics', 'Scans Inserted')}</b></td>
                     {foreach from=$Cohorts item=name key=proj}
                         {if $scan_data_results[$scanid].insert_count[$proj] > 0}
                             <td><b>{$scan_data_results[$scanid].insert_count[$proj]}</b></td>
@@ -47,8 +47,8 @@
 
                 </tr>
                 <tr class="pass">
-                    <td rowspan="3" style="vertical-align:middle; background-color: #FFFFFF">QC status</td>
-                    <td>Passed</td>
+                    <td rowspan="3" style="vertical-align:middle; background-color: #FFFFFF">{dgettext('statistics', 'QC status')}</td>
+                    <td>{dgettext('statistics', 'Passed')}</td>
                     {foreach from=$Cohorts item=name key=proj}
                         {if $scan_data_results[$scanid].qc_pass_count[$proj] > 0}
                             <td>{$scan_data_results[$scanid].qc_pass_count[$proj]}</td>
@@ -59,7 +59,7 @@
                     <td class="total">{$scan_data_results[$scanid].qc_pass_count.total}</td>
                 </tr>
                 <tr class="fail">
-                    <td>Failed</td>
+                    <td>{dgettext('statistics', 'Failed')}</td>
                     {foreach from=$Cohorts item=name key=proj}
                         {if $scan_data_results[$scanid].qc_fail_count[$proj] > 0}
                             <td>{$scan_data_results[$scanid].qc_fail_count[$proj]}</td>
@@ -70,7 +70,7 @@
                     <td class="total">{$scan_data_results[$scanid].qc_fail_count.total}</td>
                 </tr>
                 <tr class="noqc">
-                    <td>Not QCed</td>
+                    <td>{dgettext('statistics', 'Not QCed')}</td>
                     {foreach from=$Cohorts item=name key=proj}
                         {if $scan_data_results[$scanid].no_qc_count[$proj] > 0}
                             <td>{$scan_data_results[$scanid].no_qc_count[$proj]}</td>
@@ -87,7 +87,7 @@
       {$MRI_Done_Table}
     {else}
         <br><br>
-        <h2>Oops</h2>
+        <h2>{dgettext('statistics', 'Oops')}</h2>
         <p> It seems like the "mri_parameter_form" table is missing in the database currently in use. <br>
             This table is necessary in order to compute the Breakdown table of the MRI statistics page.</p>
     {/if}

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -88,8 +88,9 @@
     {else}
         <br><br>
         <h2>{dgettext('statistics', 'Oops')}</h2>
-        <p> It seems like the "mri_parameter_form" table is missing in the database currently in use. <br>
-            This table is necessary in order to compute the Breakdown table of the MRI statistics page.</p>
+        <p> {dgettext('statistics', 'It seems like the "mri_parameter_form" table is missing in the database currently in use.')}<br>
+            {dgettext('statistics', 'This table is necessary in order to compute the Breakdown table of the MRI statistics page.')}
+        </p>
     {/if}
 </div>
 

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -12,7 +12,7 @@
         <tr class="info">
             <th class="   spacer"> </th>
             {foreach from=$Centers item=center key=centername}
-                <th id='{$center.ID}' class="centers tip" colspan="2" onclick="hideStats(this)" data-toggle="tooltip" data-placement="bottom" data-container="body" title="Click to minimize">
+                <th id='{$center.ID}' class="centers tip" colspan="2" onclick="hideStats(this)" data-toggle="tooltip" data-placement="bottom" data-container="body" title={dgettext('statistics', 'Click to minimize')}>
                     {$center.LongName}
                 </th>
             {/foreach}
@@ -54,7 +54,21 @@
     </table>
 
 
+    {assign var=siteText value=''}
+    {if $CurrentSite|default}
+    {assign var=siteText value=sprintf(
+    dgettext('statistics', ' for %s'),
+    dgettext('psc', $CurrentSite.Name|default)
+    )}
+    {/if}
 
+    {assign var=projectText value=''}
+    {if $CurrentProject|default}
+    {assign var=projectText value=sprintf(
+    dgettext('statistics', ' for %s'),
+    dgettext('Project', $CurrentProject.Name|default)
+    )}
+    {/if}
     <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}'
             target="_blank"
         >
@@ -63,22 +77,8 @@
                     'statistics',  
                     'Click here for breakdown per participant%s%s'  
                 ),   
-                {if $CurrentSite|default}
-                    sprintf(  
-                        dgettext('statistics', ' for %s'),  
-                        dgettext('psc', $CurrentSite.Name|default)  
-                    )   
-                {else}
-                    ''
-                {/if}  
-                {if $CurrentProject|default  }
-                    sprintf(
-                        dgettext('statistics', ' for %s'),
-                        dgettext('Project', $CurrentProject.Name|default)
-                    )
-                {else}
-                    ''
-                {/if}
+                $siteText,
+                $projectText
             )}
         </a>
     </b>
@@ -133,7 +133,19 @@
         </tbody>
     </table>
     <div>
-        <b><a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'Click here for breakdown per participant')} {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
-    </div>
+    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}'
+        target="_blank"
+        >
+            {sprintf(
+                dgettext(
+                    'statistics',
+                    'Click here for breakdown per participant%s%s'
+                ),
+                $siteText,
+                $projectText
+            )}
+        </a>
+    </b>
+</div>
 </div>
 

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -4,7 +4,7 @@
         <div class="col-sm-2">
             {html_options id="BehaviouralProject" options=$Projects name="BehaviouralProject" selected=$CurrentProject.ID|default class="form-control"}
         </div>
-        <button class="btn btn-primary btn-sm" onClick="updateBehaviouralTab()">Submit Query</button>
+        <button class="btn btn-primary btn-sm" onClick="updateBehaviouralTab()">{dgettext('statistics', 'Submit Query')}</button>
         <br><br>
 
     <table class="data table table-primary table-bordered dynamictable">
@@ -18,10 +18,10 @@
             {/foreach}
         </tr>
         <tr class="info">
-            <th class="  ">Visit</th>
+            <th class="  ">{dgettext('loris', 'Visit')}</th>
             {foreach from=$Centers item=center}
-                <th class='{$center.ID}'>Completed (%)</th>
-                <th class='{$center.ID}'>Created</th>
+                <th class='{$center.ID}'>{dgettext('statistics', 'Completed (%)')}</th>
+                <th class='{$center.ID}'>{dgettext('statistics', 'Created')}</th>
             {/foreach}
         </tr>
         </thead>
@@ -36,17 +36,17 @@
             </tr>
         {/foreach}
         <tr>
-            <td class="total">Total</td>
+            <td class="total">{dgettext('statistics', 'Total')}</td>
             {foreach from=$Centers item=center key=centername}
                 <td class='{$center.ID} visit_complete total'>{$behaviour[$center.ID].all.complete|default:"0"} ({$behaviour[$center.ID].all.percent|default:"0"}%)</td>
                 <td class='{$center.ID} total '>{$behaviour[$center.ID].all.total|default:"0"}</td>
             {/foreach}
         </tr>
         <tr>
-            <td class="   pis">Per Instrument Stats</td>
+            <td class="   pis">{dgettext('statistics', 'Per Instrument Stats')}</td>
             {foreach from=$Centers item=center key=centername}
                 <td id='{$center.ID}PIS' class="pis" colspan="2">
-                    <a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">View Details</a>
+                    <a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'View Details')}</a>
                 </td>
             {/foreach}
         </tr>
@@ -57,7 +57,7 @@
 
     <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">Click here for breakdown per participant {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
     <br><br>
-    <h2 class="statsH2">Double Data Entry Statistics:</h2>
+    <h2 class="statsH2">{dgettext('statistics', 'Double Data Entry Statistics')}</h2>
 
     <table class="data table table-primary table-bordered dynamictable">
         <thead>
@@ -68,14 +68,14 @@
                   {$center.LongName}
                 </th>
             {/foreach}
-            <!--  <th colspan="3" id='total'>Total</th>
+            <!--  <th colspan="3" id='total'>{dgettext('statistics', 'Total')}</th>
              <th rowspan="2"></th> -->
         </tr>
         <tr class="info">
-            <th class="  DD">Visit</th>
+            <th class="  DD">{dgettext('loris', 'Visit')}</th>
             {foreach from=$Centers item=center}
-                <th class='{$center.ID}DD'>Completed</th>
-                <th class='{$center.ID}DD'>Created</th>
+                <th class='{$center.ID}DD'>{dgettext('statistics', 'Completed')}</th>
+                <th class='{$center.ID}DD'>{dgettext('loris', 'Created')}</th>
             {/foreach}
         </tr>
         </thead>
@@ -90,17 +90,17 @@
 
             {/foreach}
         <tr>
-            <td class="total">Total</td>
+            <td class="total">{dgettext('loris', 'Total')}</td>
             {foreach from=$Centers item=center key=centername}
                 <td class='{$center.ID}DD visit_complete total'>{$dde[$center.ID].all.complete|default:"0"} ({$dde[$center.ID].all.percent|default:"0"}%)</td>
                 <td class='{$center.ID}DD total'>{$dde[$center.ID].all.total|default:"0"}</td>
             {/foreach}
         </tr>
         <tr>
-            <td class=" pis">Per Instrument Stats</td>
+            <td class=" pis">{dgettext('statistics', 'Per Instrument Stats')}</td>
             {foreach from=$Centers item=center key=centername}
                 <td id='{$center.ID}DDPIS' class="pis" colspan="2">
-                    <a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">View Details</a>
+                    <a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'View Details')}</a>
                 </td>
             {/foreach}
         </tr>

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -1,5 +1,5 @@
 <div id="data_entry">
-    <h2 class="statsH2">Data Entry Statistics  {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
+    <h2 class="statsH2">{dgettext('statistics', 'Data Entry Statistics')} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
     <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_behavioural.js"></script>
         <div class="col-sm-2">
             {html_options id="BehaviouralProject" options=$Projects name="BehaviouralProject" selected=$CurrentProject.ID|default class="form-control"}
@@ -55,7 +55,7 @@
 
 
 
-    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">Click here for breakdown per participant {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
+    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'Click here for breakdown per participant')} {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
     <br><br>
     <h2 class="statsH2">{dgettext('statistics', 'Double Data Entry Statistics')}</h2>
 
@@ -107,7 +107,7 @@
         </tbody>
     </table>
     <div>
-        <b><a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">Click here for breakdown per participant{if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
+        <b><a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'Click here for breakdown per participant')} {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
     </div>
 </div>
 

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -55,7 +55,33 @@
 
 
 
-    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">{dgettext('statistics', 'Click here for breakdown per participant')} {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
+    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}'
+            target="_blank"
+        >
+            {sprintf(    
+                dgettext(   
+                    'statistics',  
+                    'Click here for breakdown per participant%s%s'  
+                ),   
+                {if $CurrentSite|default}
+                    sprintf(  
+                        dgettext('statistics', ' for %s'),  
+                        dgettext('psc', $CurrentSite.Name|default)  
+                    )   
+                {else}
+                    ''
+                {/if}  
+                {if $CurrentProject|default  }
+                    sprintf(
+                        dgettext('statistics', ' for %s'),
+                        dgettext('Project', $CurrentProject.Name|default)
+                    )
+                {else}
+                    ''
+                {/if}
+            )}
+        </a>
+    </b>
     <br><br>
     <h2 class="statsH2">{dgettext('statistics', 'Double Data Entry Statistics')}</h2>
 

--- a/modules/statistics/templates/form_stats_demographic.tpl
+++ b/modules/statistics/templates/form_stats_demographic.tpl
@@ -1,5 +1,5 @@
 <div id="demographics">
-    <h2 class="statsH2">General Demographic Statistics{if $CurrentSite|default} for {$CurrentSite.Name|default}{/if}
+    <h2 class="statsH2">{dgettext('statistics', 'General Demographic Statistics')}{if $CurrentSite|default} for {$CurrentSite.Name|default}{/if}
         {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
 
     <div class="col-sm-2">
@@ -9,24 +9,24 @@
         {html_options id="DemographicProject" options=$Projects name="DemographicProject" selected=$CurrentProject.ID|default class="form-control"}
     </div>
     <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_demographic.js"></script>
-    <button  onClick="updateDemographicTab()" class="btn btn-primary btn-small">Submit Query</button>
+    <button  onClick="updateDemographicTab()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
     <br><br>
     <table id="generalDemographics" class="data generalStats table table-primary table-bordered dynamictable">
         <thead>
         <tr>
-            <th colspan="2" id="demog">Demographics</th>
+            <th colspan="2" id="demog">{dgettext('statistics', 'Demographics')}</th>
             {if {$CurrentProject.ID|default > 0}}
-                <th>No defined cohort</th>
+                <th>{dgettext('statistics', 'No defined cohort')}</th>
             {/if}
             {foreach from=$Cohorts|default item=name key=proj}
                 <th>{$name}</th>
             {/foreach}
-            <th class="data">Total</th>
+            <th class="data">{dgettext('loris', 'Total')}</th>
         </tr>
         </thead>
         <tbody align="right">
         <tr>
-            <td colspan="2" align="left">Registered candidates</td>
+            <td colspan="2" align="left">{dgettext('statistics', 'Registered candidates')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$keyid]|default}>0}
                     <td><b>{$registered[NULL]}</b></td>
@@ -44,8 +44,8 @@
             <td class="total">{$registered.total}</td>
         </tr>
         <tr >
-            <td rowspan="2" align="left" style="vertical-align:middle;background-color: #FFFFFF;">Participant Status</td>
-            <td align="left" class="status_active">Active</td>
+            <td rowspan="2" align="left" style="vertical-align:middle;background-color: #FFFFFF;">{dgettext('loris', 'Participant Status')}</td>
+            <td align="left" class="status_active">{dgettext('loris', 'Active')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$NULL]|default}>0}
                     {if {$ps_active[$NULL]|default}>0}
@@ -79,7 +79,7 @@
             {/if}
         </tr>
         <tr class="status_inactive">
-            <td align="left" class="status_inactive">Inactive</td>
+            <td align="left" class="status_inactive">{dgettext('statistics', 'Inactive')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$NULL]|default}>0}
                     {if {$ps_inactive[$NULL]|default}>0}
@@ -115,8 +115,8 @@
 
         </tr>
         <tr>
-            <td rowspan="2" align="left" style="vertical-align:middle">Sex</td>
-            <td align="left" >Male</td>
+            <td rowspan="2" align="left" style="vertical-align:middle">{dgettext('loris', 'Sex')}</td>
+            <td align="left" >{dngettext('statistics', 'Male', 'Males', 1)}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]|default}>0}
                     {if {$sex_male[$NULL]|default}>0}
@@ -151,7 +151,7 @@
 
         </tr>
         <tr>
-            <td align="left">Female</td>
+            <td align="left">{dngettext('loris', 'Female', 'Females', 1)}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]|default}>0}
                     {if {$sex_female[$NULL]|default}>0}
@@ -187,7 +187,7 @@
 
         </tr>
         <tr>
-            <td colspan="2" align="left" style="vertical-align:middle">Age Average (months)</td>
+            <td colspan="2" align="left" style="vertical-align:middle">{dgettext('statistics', 'Age Average (months)')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$age_avg[$NULL]|default}>0}
                     <td>{$age_avg[$NULL]}</td>
@@ -202,7 +202,7 @@
                     <td>0</td>
                 {/if}
             {/foreach}
-            <td class="total">N/A</td>
+            <td class="total">{dgettext('loris', 'N/A')}</td>
         </tr>
         </tbody>
     </table>

--- a/modules/statistics/templates/form_stats_general.tpl
+++ b/modules/statistics/templates/form_stats_general.tpl
@@ -1,17 +1,29 @@
 <h1>{dgettext('statistics', 'Welcome to the statistics page')}</h1>
 <p>{dgettext('statistics', 'This page will display statistics related to data acquisition, data processing and data entry as it relates to both the behavioural and imaging aspects of this study.')}</p>
 <h3>{dgettext('statistics', 'Demographics Statistics')}</h3>
-The <b>Demographics Statistics</b> tab currently includes general statistics relating to the number of candidates
-registered in each cohort as well as customizable categories displaying statistics relating to candidate demographics
-(participant status, sex, age etc.). You may also view statistics broken down per instrument, displaying the number
-of complete and incomplete instruments per site, as it pertains to each visit label and cohort by selecting an
-instrument from the dropdown menu with the option to hide visit labels to only display total visit counts per site.
+{sprintf(
+    dgettext(
+        'statistics',
+        'The %sDemographics Statistics%s tab currently includes general statistics relating to the number of candidates registered in each cohort as well as customizable categories displaying statistics relating to candidate demographics (participant status, sex, age etc.). You may also view statistics broken down per instrument, displaying the number of complete and incomplete instruments per site, as it pertains to each visit label and cohort by selecting an instrument from the dropdown menu with the option to hide visit labels to only display total visit counts per site.'
+    ),
+    '<b>',
+    '</b>'
+)}
 <h3>{dgettext('statistics', 'Behavioural Statistics')}</h3>
-The <b>Behavioural Statistics</b> tab currently includes data entry statistics relating to the number of candidates who
-have completed each instrument per site and timepoint. As well, there is an option to view the data entry statistics per
-instrument as well a breakdown per participant, which will reveal an in-depth table, listing candidate PSCIDs, completion
-count, and incomplete candidates. The same statistics are also available for double data entry.
+{sprintf(
+    dgettext(
+        'statistics',
+        'The %sBehavioural Statistics%s tab currently includes data entry statistics relating to the number of candidates who have completed each instrument per site and timepoint. As well, there is an option to view the data entry statistics per instrument as well a breakdown per participant, which will reveal an in-depth table, listing candidate PSCIDs, completion count, and incomplete candidates. The same statistics are also available for double data entry.'
+    ),
+    '<b>',
+    '</b>'
+)}
 <h3>{dgettext('statistics', 'MRI Statistics')}</h3>
-The <b>MRI statistics</b> tab currently displays the number of scans inserted per site as well as their QC (Quality Control)
-status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion,
-arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site.
+{sprintf(
+    dgettext(
+        'statistics',
+        'The %sMRI statistics%s tab currently displays the number of scans inserted per site as well as their QC (Quality Control) status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion, arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site.'
+    ),
+    '<b>',
+    '</b>'
+)}

--- a/modules/statistics/templates/form_stats_general.tpl
+++ b/modules/statistics/templates/form_stats_general.tpl
@@ -1,18 +1,17 @@
-<h1>Welcome to the statistics page</h1>
-<p>This page will display statistics related to data acquisition, data processing and data entry as it relates to both the
-behavioural and imaging aspects of this study.</p>
-<h3>Demographics Statistics</h3>
+<h1>{dgettext('statistics', 'Welcome to the statistics page')}</h1>
+<p>{dgettext('statistics', 'This page will display statistics related to data acquisition, data processing and data entry as it relates to both the behavioural and imaging aspects of this study.')}</p>
+<h3>{dgettext('statistics', 'Demographics Statistics')}</h3>
 The <b>Demographics Statistics</b> tab currently includes general statistics relating to the number of candidates
 registered in each cohort as well as customizable categories displaying statistics relating to candidate demographics
 (participant status, sex, age etc.). You may also view statistics broken down per instrument, displaying the number
 of complete and incomplete instruments per site, as it pertains to each visit label and cohort by selecting an
 instrument from the dropdown menu with the option to hide visit labels to only display total visit counts per site.
-<h3>Behavioural Statistics</h3>
+<h3>{dgettext('statistics', 'Behavioural Statistics')}</h3>
 The <b>Behavioural Statistics</b> tab currently includes data entry statistics relating to the number of candidates who
 have completed each instrument per site and timepoint. As well, there is an option to view the data entry statistics per
 instrument as well a breakdown per participant, which will reveal an in-depth table, listing candidate PSCIDs, completion
 count, and incomplete candidates. The same statistics are also available for double data entry.
-<h3>MRI Statistics</h3>
+<h3>{dgettext('statistics', 'MRI Statistics')}</h3>
 The <b>MRI statistics</b> tab currently displays the number of scans inserted per site as well as their QC (Quality Control)
 status. For various scans within a study based on the MRI parameter form entries, there is a breakdown of scan completion,
 arranged by site, cohort and timepoint, with the option to hide visit labels to only display total visit counts per site.

--- a/modules/statistics/templates/menu_statistics_dd_site.tpl
+++ b/modules/statistics/templates/menu_statistics_dd_site.tpl
@@ -1,9 +1,9 @@
 <h2 class="statsH2">{$SiteName} Double Data Entry Completion Statistics {$CurrentProject.Name}</h2>
 <table class="fancytable dynamictable" width="100%">
    <tr>
-      <th>Instrument</th>
-      <th>Completion Count</th>
-      <th colspan="{$NumVisitLabels}" width="80%">Incomplete Candidates</th>
+      <th>{dngettext('loris', 'Instrument', 'Instruments', 1)}</th>
+      <th>{dgettext('statistics', 'Completion Count')}</th>
+      <th colspan="{$NumVisitLabels}" width="80%">{dgettext('statistics', 'Incomplete Candidates')}</th>
    </tr>
    <tr>
       <th>&nbsp;</th>

--- a/modules/statistics/templates/menu_statistics_dd_site.tpl
+++ b/modules/statistics/templates/menu_statistics_dd_site.tpl
@@ -1,4 +1,4 @@
-<h2 class="statsH2">{$SiteName} Double Data Entry Completion Statistics {$CurrentProject.Name}</h2>
+<h2 class="statsH2">sprintf(dgettext('statistics', '%s Double Data Entry Completion Statistics %s'), {dgettext('loris', $SiteName, $CurrentProject.Name)</h2>
 <table class="fancytable dynamictable" width="100%">
    <tr>
       <th>{dngettext('loris', 'Instrument', 'Instruments', 1)}</th>

--- a/modules/statistics/templates/menu_statistics_mri_site.tpl
+++ b/modules/statistics/templates/menu_statistics_mri_site.tpl
@@ -13,8 +13,8 @@
 <h2>{$SiteName} MRI Integrity Statistics</h2>
 <table class="fancytable" width="100%">
     <tr>
-        <th width="10%">Issue type</th>
-        <th colspan="{$NumVisitLabels}" width="80%">Incomplete Entries</th>
+        <th width="10%">{dgettext('statistics', 'Issue type')}</th>
+        <th colspan="{$NumVisitLabels}" width="80%">{dgettext('statistics', 'Incomplete Entries')}</th>
     </tr>
     <tr>
         <th>&nbsp;</th>

--- a/modules/statistics/templates/menu_statistics_site.tpl
+++ b/modules/statistics/templates/menu_statistics_site.tpl
@@ -1,9 +1,9 @@
 <h2>{$SiteName} Completion Statistics</h2>
 <table class="fancytable dynamictable" width="100%">
    <tr>
-      <th>Instrument</th>
-      <th>Completion Count</th>
-      <th colspan="{$NumVisitLabels}" width="80%">Incomplete Candidates</th>
+      <th>{dngettext('loris', 'Instrument', 'Instruments', 1)}</th>
+      <th>{dgettext('statistics', 'Completion Count')}</th>
+      <th colspan="{$NumVisitLabels}" width="80%">{dgettext('statistics', 'Incomplete Candidates')}</th>
    </tr>
    <tr>
       <th>&nbsp;</th>

--- a/modules/statistics/templates/menu_statistics_site.tpl
+++ b/modules/statistics/templates/menu_statistics_site.tpl
@@ -1,4 +1,4 @@
-<h2>{$SiteName} Completion Statistics</h2>
+<h2>{sprintf(dgettext('statistics', '%s Completion Statistics'), dgettext('psc', $SiteName))}</h2>
 <table class="fancytable dynamictable" width="100%">
    <tr>
       <th>{dngettext('loris', 'Instrument', 'Instruments', 1)}</th>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -31,7 +31,7 @@
       {html_options id="mri_type" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
     </div>
     <input type="checkbox" id="showVL" checked/> Show Visit Labels
-    <button onClick="updateMRITable()" class="btn btn-primary btn-small">Submit Query</button>
+    <button onClick="updateMRITable()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
   {/if}
 
   {if $Subsection=="data_entry" }
@@ -48,15 +48,15 @@
   <table id="bigtable" class="data table table-primary table-bordered dynamictable">
     <thead>
     <tr>
-      <th rowspan="1" id="tpcol">Cohort</th>
+      <th rowspan="1" id="tpcol">{dngettext('statistics', 'Cohort', 'Cohorts', 1)}</th>
       {assign var='colspan' value=count($Subcategories)}
       {foreach key=proj item=name from=$Cohorts}
         <th colspan="{$colspan}">{$name|capitalize}</th>
       {/foreach}
-      <th colspan="{$colspan}">Total Across Cohorts</th>
+      <th colspan="{$colspan}">{dgettext('statistics', 'Total Across Cohorts')}</th>
     </tr>
     <tr>
-      <th>Categories</th>
+      <th>{dgettext('statistics', 'Categories')}</th>
       {foreach key=proj item=name from=$Cohorts}
         {* Go through each category once, and add the total
            for each cohort *}
@@ -123,7 +123,7 @@
       </tr>
     {/foreach}
     <tr>
-      <td class="subtotal">Site Total Across All Visits</td>
+      <td class="subtotal">{dgettext('statistics', 'Site Total Across All Visits')}</td>
       {assign var="totalsitetotal" value="0"}
       {foreach key=proj item=value from=$Cohorts}
         {assign var="sitetotal" value="0"}
@@ -164,7 +164,7 @@
     {* Totals at the bottom *}
     <tr>
       {assign var='colspan' value=(count($Subcategories))*(count($Cohorts)+1)}
-      <th>Total</th>
+      <th>{dgettext('loris', 'Total')}</th>
       <th colspan="{$colspan}" width="50%"></th>
     </tr>
     {foreach from=$Visits item=visit key=title}
@@ -206,7 +206,7 @@
     {/foreach}
 
     <tr>
-      <td class="total">Grand Total</td>
+      <td class="total">{dgettext('statistics', 'Grand Total')}</td>
       {foreach key=proj item=name from=$Cohorts}
         {* Calculate the total instead of just looking it up, because of the potential
            for invalid visit labels throwing off the lookup, or some visits intentionally
@@ -248,7 +248,7 @@
 {elseif $Subsection=="mri"}
   {*The rendertable was set to false, which means there is a problem preventing the table from rendering. In the case of MRI, the problem is the ScanDone column not existing in the database*}
   <br><br>
-  <h2>Oops</h2>
+  <h2>{dgettext('statistics', 'Oops')}</h2>
   <p> It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database.<br>
     In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done</p>
 {/if}

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -39,7 +39,7 @@
       {html_options id="BehaviouralInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
     </div>
     <input type="checkbox" id="showVL" checked/> {dgettext('statistics', 'Show Visit Labels')}
-    <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">{dgettext('statistics, 'Submit Query')}</button>
+    <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
   {/if}
 </div>
 <br>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -22,15 +22,15 @@
     <div class="col-sm-4">
       {html_options id="DemographicInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
     </div>
-    <input type="checkbox" id="showVL" checked/> Show Visit Labels
-    <button onClick="updateDemographicInstrument()" class="btn btn-primary btn-small">Submit Query</button>
+    <input type="checkbox" id="showVL" checked/> {dgettext('statistics', 'Show Visit Labels')}
+    <button onClick="updateDemographicInstrument()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
   {/if}
 
   {if $Subsection=="mri" }
     <div class="col-sm-2">
       {html_options id="mri_type" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
     </div>
-    <input type="checkbox" id="showVL" checked/> Show Visit Labels
+    <input type="checkbox" id="showVL" checked/>{dgettext('statistics', 'Show Visit Labels')}
     <button onClick="updateMRITable()" class="btn btn-primary btn-small">{dgettext('statistics', 'Submit Query')}</button>
   {/if}
 
@@ -38,8 +38,8 @@
     <div class="col-sm-2">
       {html_options id="BehaviouralInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
     </div>
-    <input type="checkbox" id="showVL" checked/> Show Visit Labels
-    <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">Submit Query</button>
+    <input type="checkbox" id="showVL" checked/> {dgettext('statistics', 'Show Visit Labels')}
+    <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">{dgettext('statistics, 'Submit Query')}</button>
   {/if}
 </div>
 <br>
@@ -48,7 +48,7 @@
   <table id="bigtable" class="data table table-primary table-bordered dynamictable">
     <thead>
     <tr>
-      <th rowspan="1" id="tpcol">{dngettext('statistics', 'Cohort', 'Cohorts', 1)}</th>
+      <th rowspan="1" id="tpcol">{dngettext('loris', 'Cohort', 'Cohorts', 1)}</th>
       {assign var='colspan' value=count($Subcategories)}
       {foreach key=proj item=name from=$Cohorts}
         <th colspan="{$colspan}">{$name|capitalize}</th>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -249,6 +249,7 @@
   {*The rendertable was set to false, which means there is a problem preventing the table from rendering. In the case of MRI, the problem is the ScanDone column not existing in the database*}
   <br><br>
   <h2>{dgettext('statistics', 'Oops')}</h2>
-  <p> It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database.<br>
-    In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done</p>
+  <p> {dgettext('statistics', 'It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database.')}<br>
+    {dgettext('statistics', 'In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done')}
+  </p>
 {/if}


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing translations in the statistics module in French. It only includes non-db translations (hardcoded in js and php files).

Note: I used AI for translations but double-checked them as a fluent French speaker.

#### Link(s) to related issue(s)

* Resolves #10885 (Reference the issue this fixes, if any.)
