### PR TITLE
[statistics] Add missing translations in the statistics module (db translations only)

### DIFF
--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -49,13 +49,22 @@ class Statistics extends \NDB_Form
         parent::setup();
 
         $DB = $this->loris->getDatabaseConnection();
-        $this->tpl_data['StatsTabs'] = $DB->pselect(
-            "SELECT ModuleName, SubModuleName, Description
-                 FROM StatisticsTabs
-                 ORDER BY OrderNo",
-            []
+        $this->tpl_data['StatsTabs'] = iterator_to_array(
+            $DB->pselect(
+                "SELECT ModuleName, SubModuleName, Description
+                     FROM StatisticsTabs
+                     ORDER BY OrderNo",
+                []
+            )
         );
 
+        foreach ($this->tpl_data['StatsTabs'] as &$tab) {
+            $tab['Description'] = dgettext(
+                'StatisticsTabs',
+                $tab['Description']
+            );
+        }
+        unset($tab);
     }
 
     /**

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -319,7 +319,7 @@ class Statistics_Site extends \NDB_Menu
                     $results[$row['Visit_label']][] = $arrayVar;
                 }
                 $data[] = [
-                    'name'        => $label,
+                    'name'        => dgettext('test_names', $label),
                     'count'       => $complete_count,
                     'incompletes' => $results,
                 ];

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -106,7 +106,7 @@ class Stats_Behavioural extends \NDB_Form
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
             $projects[$ProjectID->__toString()]
-                = $allProjectList[$ProjectID->__toString()];
+                = dgettext('Project', $allProjectList[$ProjectID->__toString()]);
         }
 
         $this->tpl_data['Projects'] = $projects;

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -237,7 +237,10 @@ class Stats_Demographic extends \NDB_Form
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects["$ProjectID"] = dgettext('Project', $allProjectList["$ProjectID"]);
+            $projects["$ProjectID"] = dgettext(
+                'Project',
+                $allProjectList["$ProjectID"]
+            );
         }
 
         if ($user->hasPermission('access_all_profiles')) {
@@ -318,7 +321,10 @@ class Stats_Demographic extends \NDB_Form
 
         if (!empty($centers)) {
             foreach ($centers as $row) {
-                $sites[$row['NumericID']] = dgettext('psc', $row['ShortName']);
+                $sites[$row['NumericID']] = dgettext(
+                    'psc',
+                    $row['ShortName']
+                );
                 if ($demographicSite == $row['NumericID']) {
                     $this->tpl_data['CurrentSite'] = [
                         'ID'   => $row['NumericID'],

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -237,7 +237,7 @@ class Stats_Demographic extends \NDB_Form
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects["$ProjectID"] = $allProjectList["$ProjectID"];
+            $projects["$ProjectID"] = dgettext('Project', $allProjectList["$ProjectID"]);
         }
 
         if ($user->hasPermission('access_all_profiles')) {
@@ -318,7 +318,7 @@ class Stats_Demographic extends \NDB_Form
 
         if (!empty($centers)) {
             foreach ($centers as $row) {
-                $sites[$row['NumericID']] = $row['ShortName'];
+                $sites[$row['NumericID']] = dgettext('psc', $row['ShortName']);
                 if ($demographicSite == $row['NumericID']) {
                     $this->tpl_data['CurrentSite'] = [
                         'ID'   => $row['NumericID'],

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -243,7 +243,7 @@ class Stats_MRI extends \NDB_Form
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects["$ProjectID"] = $allProjectList["$ProjectID"];
+            $projects["$ProjectID"] = dgettext('Project', $allProjectList["$ProjectID"]);
         }
 
         $currentProject = null;
@@ -317,7 +317,7 @@ class Stats_MRI extends \NDB_Form
         $sites     = [];
         $sites[''] ="All sites";
         foreach ($centers as $row) {
-            $sites[$row['NumericID']] = $row['ShortName'];
+            $sites[$row['NumericID']] = dgettext('psc', $row['ShortName']);
             if (isset($_REQUEST['MRIsite'])
                 && $_REQUEST['MRIsite'] == $row['NumericID']
             ) {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -243,7 +243,10 @@ class Stats_MRI extends \NDB_Form
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects["$ProjectID"] = dgettext('Project', $allProjectList["$ProjectID"]);
+            $projects["$ProjectID"] = dgettext(
+                'Project',
+                $allProjectList["$ProjectID"]
+            );
         }
 
         $currentProject = null;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -569,7 +569,10 @@ class Utility
         $instruments   = [];
         foreach ($instruments_q as $row) {
             if (isset($row['Test_name']) && isset($row['Full_name'])) {
-                $instruments[$row['Test_name']] = dgettext('test_names', $row['Full_name']);
+                $instruments[$row['Test_name']] = dgettext(
+                    'test_names',
+                    $row['Full_name']
+                );
             }
         }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -569,7 +569,7 @@ class Utility
         $instruments   = [];
         foreach ($instruments_q as $row) {
             if (isset($row['Test_name']) && isset($row['Full_name'])) {
-                $instruments[$row['Test_name']] =$row['Full_name'];
+                $instruments[$row['Test_name']] = dgettext('test_names', $row['Full_name']);
             }
         }
 

--- a/raisinbread/locale/StatisticsTabs.pot
+++ b/raisinbread/locale/StatisticsTabs.pot
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "General Description"
+msgstr ""
+
+msgid "Demographic Statistics"
+msgstr ""
+
+msgid "Behavioural Statistics"
+msgstr ""
+
+msgid "Imaging Statistics"
+msgstr ""

--- a/raisinbread/locale/fr/LC_MESSAGES/StatisticsTabs.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/StatisticsTabs.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "General Description"
+msgstr "Description générale"
+
+msgid "Demographic Statistics"
+msgstr "Statistiques démographiques"
+
+msgid "Behavioural Statistics"
+msgstr "Statistiques comportementales"
+
+msgid "Imaging Statistics"
+msgstr "Statistiques d'imagerie"

--- a/raisinbread/locale/fr/LC_MESSAGES/test_names.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/test_names.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "aosi"
+msgstr "AOSI"
+
+msgid "BMI Calculator"
+msgstr "Calculateur d'IMC"
+
+msgid "MRI Parameter Form"
+msgstr "Formulaire des paramètres d'IRM"
+
+msgid "Medical History"
+msgstr "Antécédents médicaux"
+
+msgid "Radiology review"
+msgstr "Examen radiologique"

--- a/raisinbread/locale/hi/LC_MESSAGES/StatisticsTabs.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/StatisticsTabs.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "General Description"
+msgstr "सामान्य विवरण"
+
+msgid "Demographic Statistics"
+msgstr "जनसांख्यिकीय सांख्यिकी"
+
+msgid "Behavioural Statistics"
+msgstr "व्यवहारिक सांख्यिकी"
+
+msgid "Imaging Statistics"
+msgstr "इमेजिंग सांख्यिकी"

--- a/raisinbread/locale/hi/LC_MESSAGES/test_names.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/test_names.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "aosi"
+msgstr "AOSI"
+
+msgid "BMI Calculator"
+msgstr "बीएमआई कैलकुलेटर"
+
+msgid "MRI Parameter Form"
+msgstr "एमआरआई पैरामीटर फ़ॉर्म"
+
+msgid "Medical History"
+msgstr "चिकित्सा इतिहास"
+
+msgid "Radiology review"
+msgstr "रेडियोलॉजी समीक्षा"

--- a/raisinbread/locale/ja/LC_MESSAGES/StatisticsTabs.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/StatisticsTabs.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "General Description"
+msgstr "概要"
+
+msgid "Demographic Statistics"
+msgstr "人口統計情報"
+
+msgid "Behavioural Statistics"
+msgstr "行動統計"
+
+msgid "Imaging Statistics"
+msgstr "画像統計"

--- a/raisinbread/locale/ja/LC_MESSAGES/test_names.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/test_names.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "AOSI"
+msgstr "AOSI"
+
+msgid "BMI Calculator"
+msgstr "BMI計算機"
+
+msgid "MRI Parameter Form"
+msgstr "MRIパラメータフォーム"
+
+msgid "Medical History"
+msgstr "病歴"
+
+msgid "Radiology review"
+msgstr "放射線画像レビュー"

--- a/raisinbread/locale/test_names.pot
+++ b/raisinbread/locale/test_names.pot
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "aosi"
+msgstr ""
+
+msgid "BMI Calculator"
+msgstr ""
+
+msgid "MRI Parameter Form"
+msgstr ""
+
+msgid "Medical History"
+msgstr ""
+
+msgid "Radiology review"
+msgstr ""


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing translations in the statistics module. It only includes db translations.

Note: I used AI for translations but double-checked the *FRENCH* ones as a fluent French speaker.

#### Testing instructions (if applicable)

1. git checkout HachemJ/AddMissingDbTranslationsInStatistics
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Reports' -> 'Statistics'
6. Switch the language to 'French'
7. Verify that all db translations are displayed correctly, including the statistics page tab names and all dropdown values (e.g., Instrument, Site, and Project).

#### Link(s) to related issue(s)

* Resolves #10885 (Reference the issue this fixes, if any.)
