### PR TITLE
[user_accounts] Add permission names and actions translations in French

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -564,10 +564,7 @@ class Edit_User extends \NDB_Form
                     if (!(in_array($permID, $current_permissionids))) {
                         $user->insertIntoUserAccountHistory($permID, 'I');
                         $permissionsAdded[]
-                            = dgettext(
-                                'permissions',
-                                $this->getDescriptionUsingPermID($permID)
-                            );
+                            = $this->getDescriptionUsingPermID($permID);
                     }
                 }
             }
@@ -579,10 +576,7 @@ class Edit_User extends \NDB_Form
                     if (!in_array($currentPermID, $permIDs)) {
                         $user->insertIntoUserAccountHistory($currentPermID, 'D');
                         $permissionsRemoved[]
-                            = dgettext(
-                                'permissions',
-                                $this->getDescriptionUsingPermID($currentPermID)
-                            );
+                            = $this->getDescriptionUsingPermID($currentPermID);
                     }
                 }
             }
@@ -1499,10 +1493,12 @@ class Edit_User extends \NDB_Form
         $db_factory = \NDB_Factory::singleton();
         $db         = $db_factory->database();
 
-        return $db->pselectOne(
+        return dgettext('permissions', $db->pselectOne(
             "SELECT Description FROM permissions WHERE permID =:pID",
             ['pID' => $permID]
-        );
+        ));
+
+
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -563,7 +563,6 @@ class Edit_User extends \NDB_Form
                      */
                     if (!(in_array($permID, $current_permissionids))) {
                         $user->insertIntoUserAccountHistory($permID, 'I');
-                        error_log('Permission description: [' . $this->getDescriptionUsingPermID($permID) . ']');
                         $permissionsAdded[]
                             = dgettext(
                                 'permissions',

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -563,8 +563,12 @@ class Edit_User extends \NDB_Form
                      */
                     if (!(in_array($permID, $current_permissionids))) {
                         $user->insertIntoUserAccountHistory($permID, 'I');
+                        error_log('Permission description: [' . $this->getDescriptionUsingPermID($permID) . ']');
                         $permissionsAdded[]
-                            = $this->getDescriptionUsingPermID($permID);
+                            = dgettext(
+                                'permissions',
+                                $this->getDescriptionUsingPermID($permID)
+                            );
                     }
                 }
             }
@@ -576,7 +580,10 @@ class Edit_User extends \NDB_Form
                     if (!in_array($currentPermID, $permIDs)) {
                         $user->insertIntoUserAccountHistory($currentPermID, 'D');
                         $permissionsRemoved[]
-                            = $this->getDescriptionUsingPermID($currentPermID);
+                            = dgettext(
+                                'permissions',
+                                $this->getDescriptionUsingPermID($currentPermID)
+                            );
                     }
                 }
             }
@@ -1018,7 +1025,7 @@ class Edit_User extends \NDB_Form
                     . "<h3 id=\"header_$lastRole\" "
                     . "class=\"perm_header button\" "
                     . "style=\"text-align: center; margin-top: 5px;\">"
-                    . ucwords($row['type'])
+                    . ucwords(dgettext('permissions_category', $row['type']))
                     . '</h3>'
                     . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">"
                 );

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1493,12 +1493,13 @@ class Edit_User extends \NDB_Form
         $db_factory = \NDB_Factory::singleton();
         $db         = $db_factory->database();
 
-        return dgettext('permissions', $db->pselectOne(
-            "SELECT Description FROM permissions WHERE permID =:pID",
-            ['pID' => $permID]
-        ));
-
-
+        return dgettext(
+            'permissions',
+            $db->pselectOne(
+                "SELECT Description FROM permissions WHERE permID =:pID",
+                ['pID' => $permID]
+            )
+        );
     }
 
     /**

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -343,13 +343,16 @@ class UserPermissions
             }
             $translatedAction = '';
             if (!empty($perm['action'])) {
-                $actions = explode('/', $perm['action']);
+                $actions           = explode('/', $perm['action']);
                 $translatedActions = [];
                 foreach ($actions as $action) {
-                    $translatedActions[] = dgettext('permissions_action', trim($action));
+                    $translatedActions[] = dgettext(
+                        'permissions_action',
+                        trim($action)
+                    );
                 }
                 $translatedAction = implode('/', $translatedActions);
-            }   
+            }
 
             $newDesc .= empty($translatedAction) ? "" : $translatedAction . " ";
             $newDesc .= dgettext('permissions', $perm['description']);

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -341,8 +341,18 @@ class UserPermissions
             if (!empty($perm['moduleID'])) {
                 $newDesc = $modules[$perm['moduleID']]->getLongName() . ": ";
             }
-            $newDesc .= empty($perm['action']) ? "" : $perm['action'] . " ";
-            $newDesc .= $perm['description'];
+            $translatedAction = '';
+            if (!empty($perm['action'])) {
+                $actions = explode('/', $perm['action']);
+                $translatedActions = [];
+                foreach ($actions as $action) {
+                    $translatedActions[] = dgettext('permissions_action', trim($action));
+                }
+                $translatedAction = implode('/', $translatedActions);
+            }   
+
+            $newDesc .= empty($translatedAction) ? "" : $translatedAction . " ";
+            $newDesc .= dgettext('permissions', $perm['description']);
 
             $results[$key]          = $perm;
             $results[$key]['label'] = $newDesc;

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions.po
@@ -56,16 +56,16 @@ msgid "Cross-Modality Data"
 msgstr "Données multimodales"
 
 msgid "Hide data release files"
-msgstr "Masquer les fichiers de diffusion des données"
+msgstr "Masquer les publications de données"
 
 msgid "Delete data release files"
-msgstr "Supprimer les fichiers de diffusion des données"
+msgstr "Supprimer les publications de données"
 
 msgid "Release Files"
-msgstr "Fichiers de diffusion"
+msgstr "Fichiers de publication"
 
 msgid "Grant Other Users Access to Releases"
-msgstr "Accorder à d'autres utilisateurs l'accès aux diffusions"
+msgstr "Accorder à d'autres utilisateurs l'accès aux publications"
 
 msgid "DICOMs - All Sites"
 msgstr "DICOM - Tous les sites"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions.po
@@ -1,0 +1,221 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Superuser - supersedes all permissions"
+msgstr "Superutilisateur - remplace toutes les autorisations"
+
+msgid "Feedback Threads"
+msgstr "Fils de discussion des commentaires"
+
+msgid "Candidates and Timepoints - Own Sites"
+msgstr "Participants et points temporels - Sites attribués"
+
+msgid "Acknowledgee List"
+msgstr "Liste des personnes à remercier"
+
+msgid "LORIS API Manual"
+msgstr "Manuel de l'API LORIS"
+
+msgid "Battery Entries"
+msgstr "Saisies de batteries"
+
+msgid "Flagged Behavioural Entries"
+msgstr "Saisies comportementales signalées"
+
+msgid "Candidates and Timepoints - All Sites"
+msgstr "Participants et points temporels - Tous les sites"
+
+msgid "Candidate Information"
+msgstr "Informations sur les participants"
+
+msgid "Dates of Birth"
+msgstr "Dates de naissance"
+
+msgid "Dates of Death"
+msgstr "Dates de décès"
+
+msgid "Settings"
+msgstr "Paramètres"
+
+msgid "Resolve Conflicts"
+msgstr "Résoudre les conflits"
+
+msgid "Cross-Modality Data"
+msgstr "Données multimodales"
+
+msgid "Hide data release files"
+msgstr "Masquer les fichiers de diffusion des données"
+
+msgid "Delete data release files"
+msgstr "Supprimer les fichiers de diffusion des données"
+
+msgid "Release Files"
+msgstr "Fichiers de diffusion"
+
+msgid "Grant Other Users Access to Releases"
+msgstr "Accorder à d'autres utilisateurs l'accès aux diffusions"
+
+msgid "DICOMs - All Sites"
+msgstr "DICOM - Tous les sites"
+
+msgid "DICOMs - Own Sites"
+msgstr "DICOM - Sites attribués"
+
+msgid "DICOMs with no session ID"
+msgstr "DICOM sans identifiant de session"
+
+msgid "Parameter Type Descriptions"
+msgstr "Descriptions des types de paramètres"
+
+msgid "Categories"
+msgstr "Catégories"
+
+msgid "Documents"
+msgstr "Documents"
+
+msgid "Restricted files"
+msgstr "Fichiers restreints"
+
+msgid "Admin dataquery queries"
+msgstr "Requêtes DataQuery administrateur"
+
+msgid "Cross-Modality Data (legacy)"
+msgstr "Données multimodales (ancienne version)"
+
+msgid "Annotations"
+msgstr "Annotations"
+
+msgid "EEG - All Sites"
+msgstr "EEG - Tous les sites"
+
+msgid "EEG - Own Sites"
+msgstr "EEG - Sites attribués"
+
+msgid "Monitor EEG uploads"
+msgstr "Surveiller les téléversements EEG"
+
+msgid "Add and Certify Examiners - All Sites"
+msgstr "Ajouter et certifier des examinateurs - Tous les sites"
+
+msgid "Add and Certify Examiners - Own Sites"
+msgstr "Ajouter et certifier des examinateurs - Sites attribués"
+
+msgid "Genomic Data - All Sites"
+msgstr "Données génomiques - Tous les sites"
+
+msgid "Genomic Data - Own Sites"
+msgstr "Données génomiques - Sites attribués"
+
+msgid "Genomic Files"
+msgstr "Fichiers génomiques"
+
+msgid "Help documentation"
+msgstr "Documentation d'aide"
+
+msgid "Imaging Scans - All Sites"
+msgstr "Acquisitions d'imagerie - Tous les sites"
+
+msgid "Imaging Scans - Own Sites"
+msgstr "Acquisitions d'imagerie - Sites attribués"
+
+msgid "Phantom Scans - All Sites"
+msgstr "Acquisitions fantôme - Tous les sites"
+
+msgid "Phantom Scans - Own Sites"
+msgstr "Acquisitions fantôme - Sites attribués"
+
+msgid "Status"
+msgstr "Statut"
+
+msgid "Flagged Imaging Entries"
+msgstr "Saisies d'imagerie signalées"
+
+msgid "Imaging Scans with no session ID"
+msgstr "Acquisitions d'imagerie sans identifiant de session"
+
+msgid "Data"
+msgstr "Données"
+
+msgid "Instrument Forms"
+msgstr "Formulaires d'instruments"
+
+msgid "Reverse Send from DCC"
+msgstr "Envoi inverse depuis le DCC"
+
+msgid "Send to DCC"
+msgstr "Envoyer au DCC"
+
+msgid "Installed Instruments"
+msgstr "Instruments installés"
+
+msgid "Upload and Install Instruments"
+msgstr "Téléverser et installer des instruments"
+
+msgid "Issues - All Sites"
+msgstr "Incidents - Tous les sites"
+
+msgid "Issues - Own"
+msgstr "Mes incidents"
+
+msgid "Issues - Own Sites"
+msgstr "Incidents - Sites attribués"
+
+msgid "Candidate Media Files"
+msgstr "Fichiers multimédias des participants"
+
+msgid "Access to recently uploaded media notifications digest."
+msgstr "Accès au résumé des notifications des fichiers multimédias récemment téléversés."
+
+msgid "Installed Modules"
+msgstr "Modules installés"
+
+msgid "Violated Scans - All Sites"
+msgstr "Acquisitions en violation - Tous les sites"
+
+msgid "Violated Scans - Own Sites"
+msgstr "Acquisitions en violation - Sites attribués"
+
+msgid "View Containers"
+msgstr "Afficher les conteneurs"
+
+msgid "View Pools"
+msgstr "Afficher les pools"
+
+msgid "View Specimens"
+msgstr "Afficher les spécimens"
+
+msgid "Accept/Reject Publication Projects"
+msgstr "Accepter/Rejeter les projets de publication"
+
+msgid "Propose Publication Projects"
+msgstr "Proposer des projets de publication"
+
+msgid "Publication Projects"
+msgstr "Projets de publication"
+
+msgid "Schedule Module: edit and delete appointment"
+msgstr "Module de planification : modifier et supprimer un rendez-vous"
+
+msgid "Processes"
+msgstr "Processus"
+
+msgid "Candidate Surveys"
+msgstr "Questionnaires des participants"
+
+msgid "User Accounts - All Sites"
+msgstr "Comptes utilisateurs - Tous les sites"
+
+msgid "User Accounts - Own Sites"
+msgstr "Comptes utilisateurs - Sites attribués"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions.po
@@ -182,10 +182,10 @@ msgid "Installed Modules"
 msgstr "Modules installés"
 
 msgid "Violated Scans - All Sites"
-msgstr "Acquisitions en violation - Tous les sites"
+msgstr "Scans non conformes - Tous les sites"
 
 msgid "Violated Scans - Own Sites"
-msgstr "Acquisitions en violation - Sites attribués"
+msgstr "Scans non conformes - Sites attribués"
 
 msgid "View Containers"
 msgstr "Afficher les conteneurs"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions_action.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions_action.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions_action.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions_action.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Close"
+msgstr "Fermer"
+
+msgid "Comment"
+msgstr "Commenter"
+
+msgid "Create"
+msgstr "Créer"
+
+msgid "Delete"
+msgstr "Supprimer"
+
+msgid "Download"
+msgstr "Télécharger"
+
+msgid "Edit"
+msgstr "Modifier"
+
+msgid "Hide"
+msgstr "Masquer"
+
+msgid "Upload"
+msgstr "Téléverser"
+
+msgid "View"
+msgstr "Afficher"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions_category.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions_category.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/fr/LC_MESSAGES/permissions_category.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/permissions_category.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Roles"
+msgstr "Rôles"
+
+msgid "Permission"
+msgstr "Autorisation"

--- a/raisinbread/locale/permissions.pot
+++ b/raisinbread/locale/permissions.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/permissions.pot
+++ b/raisinbread/locale/permissions.pot
@@ -1,0 +1,220 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Superuser - supersedes all permissions"
+msgstr ""
+
+msgid "Feedback Threads"
+msgstr ""
+
+msgid "Candidates and Timepoints - Own Sites"
+msgstr ""
+
+msgid "Acknowledgee List"
+msgstr ""
+
+msgid "LORIS API Manual"
+msgstr ""
+
+msgid "Battery Entries"
+msgstr ""
+
+msgid "Flagged Behavioural Entries"
+msgstr ""
+
+msgid "Candidates and Timepoints - All Sites"
+msgstr ""
+
+msgid "Candidate Information"
+msgstr ""
+
+msgid "Dates of Birth"
+msgstr ""
+
+msgid "Dates of Death"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Resolve Conflicts"
+msgstr ""
+
+msgid "Cross-Modality Data"
+msgstr ""
+
+msgid "Hide data release files"
+msgstr ""
+
+msgid "Delete data release files"
+msgstr ""
+
+msgid "Release Files"
+msgstr ""
+
+msgid "Grant Other Users Access to Releases"
+msgstr ""
+
+msgid "DICOMs - All Sites"
+msgstr ""
+
+msgid "DICOMs - Own Sites"
+msgstr ""
+
+msgid "DICOMs with no session ID"
+msgstr ""
+
+msgid "Parameter Type Descriptions"
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Documents"
+msgstr ""
+
+msgid "Restricted files"
+msgstr ""
+
+msgid "Admin dataquery queries"
+msgstr ""
+
+msgid "Cross-Modality Data (legacy)"
+msgstr ""
+
+msgid "Annotations"
+msgstr ""
+
+msgid "EEG - All Sites"
+msgstr ""
+
+msgid "EEG - Own Sites"
+msgstr ""
+
+msgid "Monitor EEG uploads"
+msgstr ""
+
+msgid "Add and Certify Examiners - All Sites"
+msgstr ""
+
+msgid "Add and Certify Examiners - Own Sites"
+msgstr ""
+
+msgid "Genomic Data - All Sites"
+msgstr ""
+
+msgid "Genomic Data - Own Sites"
+msgstr ""
+
+msgid "Genomic Files"
+msgstr ""
+
+msgid "Help documentation"
+msgstr ""
+
+msgid "Imaging Scans - All Sites"
+msgstr ""
+
+msgid "Imaging Scans - Own Sites"
+msgstr ""
+
+msgid "Phantom Scans - All Sites"
+msgstr ""
+
+msgid "Phantom Scans - Own Sites"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Flagged Imaging Entries"
+msgstr ""
+
+msgid "Imaging Scans with no session ID"
+msgstr ""
+
+msgid "Data"
+msgstr ""
+
+msgid "Instrument Forms"
+msgstr ""
+
+msgid "Reverse Send from DCC"
+msgstr ""
+
+msgid "Send to DCC"
+msgstr ""
+
+msgid "Installed Instruments"
+msgstr ""
+
+msgid "Upload and Install Instruments"
+msgstr ""
+
+msgid "Issues - All Sites"
+msgstr ""
+
+msgid "Issues - Own"
+msgstr ""
+
+msgid "Issues - Own Sites"
+msgstr ""
+
+msgid "Candidate Media Files"
+msgstr ""
+
+msgid "Access to recently uploaded media notifications digest."
+msgstr ""
+
+msgid "Installed Modules"
+msgstr ""
+
+msgid "Violated Scans - All Sites"
+msgstr ""
+
+msgid "Violated Scans - Own Sites"
+msgstr ""
+
+msgid "View Containers"
+msgstr ""
+
+msgid "View Pools"
+msgstr ""
+
+msgid "View Specimens"
+msgstr ""
+
+msgid "Accept/Reject Publication Projects"
+msgstr ""
+
+msgid "Propose Publication Projects"
+msgstr ""
+
+msgid "Publication Projects"
+msgstr ""
+
+msgid "Schedule Module: edit and delete appointment"
+msgstr ""
+
+msgid "Processes"
+msgstr ""
+
+msgid "Candidate Surveys"
+msgstr ""
+
+msgid "User Accounts - All Sites"
+msgstr ""
+
+msgid "User Accounts - Own Sites"
+msgstr ""

--- a/raisinbread/locale/permissions_action.pot
+++ b/raisinbread/locale/permissions_action.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/permissions_action.pot
+++ b/raisinbread/locale/permissions_action.pot
@@ -1,0 +1,40 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Close"
+msgstr ""
+
+msgid "Comment"
+msgstr ""
+
+msgid "Create"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Hide"
+msgstr ""
+
+msgid "Upload"
+msgstr ""
+
+msgid "View"
+msgstr ""

--- a/raisinbread/locale/permissions_category.pot
+++ b/raisinbread/locale/permissions_category.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Roles"
+msgstr ""
+
+msgid "Permission"
+msgstr ""

--- a/raisinbread/locale/permissions_category.pot
+++ b/raisinbread/locale/permissions_category.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
## Brief summary of changes

This PR adds permission names and actions translations in French.

Note: I used AI for translations but double-checked them as a fluent French speaker.

#### Testing instructions (if applicable)

1. git checkout HachemJ/TranslatePermissionNamesAndActionsUserAccounts
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Admin' -> 'User Accounts'
6. Click on the username of any user in the table
7. Switch the language to 'French'
8. Scroll down and verify that the permission names and associated actions are correctly translated in French.

Before:

https://github.com/user-attachments/assets/3bb9b65f-8708-4533-8f5e-16e9f17535cb

After:

https://github.com/user-attachments/assets/187d8a6f-dd6a-4276-a718-8e9e72da8296

#### Link(s) to related issue(s)

* Resolves #10574 (Reference the issue this fixes, if any.)
