### PR TITLE
[genomic_browser] Translate genomic_browser module (non-db translations only)

### DIFF
--- a/modules/genomic_browser/jsx/genomicBrowserIndex.js
+++ b/modules/genomic_browser/jsx/genomicBrowserIndex.js
@@ -13,6 +13,8 @@ import CNV from './tabs_content/cnv';
 import Methylation from './tabs_content/methylation';
 import Files from './tabs_content/files';
 
+import frStrings from '../locale/fr/LC_MESSAGES/genomic_browser.json';
+
 /**
  * Genomic Browser.
  *
@@ -23,13 +25,14 @@ import Files from './tabs_content/files';
  * @version 1.0.0
  */
 const GenomicBrowser = (props) => {
+  const {t} = props;
   const tabList = [
-    {id: 'tabProfiles', label: 'Profiles'},
-    {id: 'tabGWAS', label: 'GWAS'},
-    {id: 'tabSNP', label: 'SNP'},
-    {id: 'tabCNV', label: 'CNV'},
-    {id: 'tabMethylation', label: 'Methylation'},
-    {id: 'tabFiles', label: 'Files'},
+    {id: 'tabProfiles', label: t('Profiles', {ns: 'genomic_browser'})},
+    {id: 'tabGWAS', label: t('GWAS', {ns: 'genomic_browser'})},
+    {id: 'tabSNP', label: t('SNP', {ns: 'genomic_browser'})},
+    {id: 'tabCNV', label: t('CNV', {ns: 'genomic_browser'})},
+    {id: 'tabMethylation', label: t('Methylation', {ns: 'genomic_browser'})},
+    {id: 'tabFiles', label: t('Files', {ns: 'genomic_browser', count: 99})},
   ];
 
   /**
@@ -64,21 +67,23 @@ const GenomicBrowser = (props) => {
 };
 GenomicBrowser.propTypes = {
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
 /**
  * Render Genomic Browser on page load.
  */
 window.addEventListener('load', () => {
+  i18n.addResourceBundle('fr', 'genomic_browser', frStrings);
   i18n.addResourceBundle('ja', 'genomic_browser', {});
   i18n.addResourceBundle('zh', 'genomic_browser', {});
-  const GenomicB = withTranslation(
+  const TranslatedGenomicB = withTranslation(
     ['genomic_browser', 'loris']
   )(GenomicBrowser);
   createRoot(
     document.getElementById('lorisworkspace')
   ).render(
-    <GenomicB
+    <TranslatedGenomicB
       baseURL={loris.BaseURL}
     />
   );

--- a/modules/genomic_browser/jsx/tabs_content/cnv.js
+++ b/modules/genomic_browser/jsx/tabs_content/cnv.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import FilterableDataTable from 'jsx/FilterableDataTable';
 import Loader from 'jsx/Loader';
+import {withTranslation} from 'react-i18next';
 
 /**
  * CNV Component.
@@ -96,6 +97,7 @@ class CNV extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -107,7 +109,7 @@ class CNV extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'Site',
+        label: t('Site', {ns: 'loris', count: 1}),
         show: false,
         filter: {
           name: 'Site',
@@ -116,7 +118,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'DCCID',
+        label: t('DCCID', {ns: 'loris'}),
         show: false,
         filter: {
           name: 'DCCID',
@@ -124,7 +126,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'PSCID',
+        label: t('PSCID', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'PSCID',
@@ -132,7 +134,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Sex',
+        label: t('Sex', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'Sex',
@@ -141,7 +143,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Cohort',
+        label: t('Cohort', {ns: 'loris', count: 1}),
         show: true,
         filter: {
           name: 'Cohort',
@@ -150,11 +152,11 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Date of Birth',
+        label: t('Date of Birth', {ns: 'loris'}),
         show: false,
       },
       {
-        label: 'External ID',
+        label: t('External ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'External ID',
@@ -162,7 +164,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Build',
+        label: t('Build', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'File',
@@ -171,7 +173,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Strand',
+        label: t('Strand', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Strand',
@@ -183,27 +185,27 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Start Loc',
+        label: t('Start Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'End Loc',
+        label: t('End Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Location',
+        label: t('Location', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Gene',
+        label: t('Gene', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Gene Name',
+        label: t('Gene Name', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Description',
+        label: t('Description', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Description',
@@ -211,20 +213,20 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Type',
+        label: t('Type', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Type',
           type: 'select',
           options: {
-            gain: 'gain',
-            loss: 'loss',
-            unknown: 'Unknown',
+            gain: t('gain', {ns: 'genomic_browser'}),
+            loss: t('loss', {ns: 'genomic_browser'}),
+            unknown: t('Unknown', {ns: 'genomic_browser'}),
           },
         },
       },
       {
-        label: 'Copy Number Change',
+        label: t('Copy Number Change', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Copy Number Change',
@@ -232,7 +234,7 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Event Name',
+        label: t('Event Name', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Event Name',
@@ -240,64 +242,64 @@ class CNV extends Component {
         },
       },
       {
-        label: 'Common',
+        label: t('Common', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Common',
           type: 'select',
           options: {
-            Y: 'Yes',
-            N: 'No',
+            Y: t('Yes', {ns: 'loris'}),
+            N: t('No', {ns: 'loris'}),
           },
         },
       },
       {
-        label: 'Characteristics',
+        label: t('Characteristics', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Characteristics',
           type: 'select',
           options: {
-            Benign: 'Benign',
-            Pathogenic: 'Pathogenic',
-            Unknown: 'Unknown',
+            Benign: t('Benign', {ns: 'genomic_browser'}),
+            Pathogenic: t('Pathogenic', {ns: 'genomic_browser'}),
+            Unknown: t('Unknown', {ns: 'genomic_browser'}),
           },
         },
       },
       {
-        label: 'Inheritance',
+        label: t('Inheritance', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Inheritance',
           type: 'select',
           options: {
-            'de novo': 'de novo',
-            'maternal': 'maternal',
-            'paternal': 'paternal',
-            'unclassified': 'unclassified',
-            'unknown': 'unknown',
+            'de novo': t('de novo', {ns: 'genomic_browser'}),
+            'maternal': t('maternal', {ns: 'genomic_browser'}),
+            'paternal': t('paternal', {ns: 'genomic_browser'}),
+            'unclassified': t('unclassified', {ns: 'genomic_browser'}),
+            'unknown': t('unknown', {ns: 'genomic_browser'}),
             'NA': 'NA',
           },
         },
       },
       {
-        label: 'Array Report',
+        label: t('Array Report', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Markers',
+        label: t('Markers', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Validation Method',
+        label: t('Validation Method', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Validation Method',
+        label: t('Validation Method', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Platform',
+        label: t('Platform', {ns: 'genomic_browser'}),
         show: true,
       },
     ];
@@ -321,6 +323,7 @@ CNV.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default CNV;
+export default withTranslation(['genomic_browser', 'loris'])(CNV);

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -11,6 +11,7 @@ import {
   ButtonElement,
 } from 'jsx/Form';
 import swal from 'sweetalert2';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Genomic Upload Form
@@ -82,6 +83,7 @@ class GenomicUploadForm extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
+    const {t} = this.props;
     // Waiting for data to load
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -222,6 +224,7 @@ GenomicUploadForm.propTypes = {
   permissions: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
   closeFileUploadModal: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default GenomicUploadForm;
+export default withTranslation('genomic_browser', 'loris')(GenomicUploadForm);

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -179,6 +179,7 @@ class GenomicUploadForm extends Component {
    * Uploads the file to the server
    */
   uploadFile() {
+    const {t} = this.props;
     // Set form data and upload the media file
     const state = Object.assign({}, this.state);
     let formObj = new FormData();
@@ -203,14 +204,15 @@ class GenomicUploadForm extends Component {
           }, // reset form data after successful file upload
           uploadProgress: -1,
         });
-        swal.fire('Upload Successful!', '', 'success');
+        swal.fire(t('Upload Successful!', {ns: 'genomic_browser'}), '',
+          'success');
         this.props.closeFileUploadModal();
       }
       ).catch((error) => {
         console.error(error);
         const msg = error.responseJSON ?
           error.responseJSON.message
-          : 'Upload error!';
+          : t('Upload error!', {ns: 'genomic_browser'});
         this.setState({
           errorMessage: msg,
           uploadProgress: -1,

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -101,7 +101,7 @@ class GenomicUploadForm extends Component {
     ) ? (
         <CheckboxElement
           name='pscidColumn'
-          label='Use PSCID in column headers'
+          label={t('Use PSCID in column headers', {ns: 'genomic_browser'})}
           id='pscidColumn'
           value={this.state.pscidColumn}
           onUserInput={this.setFileUploadFormData}
@@ -117,13 +117,13 @@ class GenomicUploadForm extends Component {
             id='mediaUploadEl'
             onUserInput={this.setFileUploadFormData}
             ref='file'
-            label='File to upload'
+            label={t('File to upload', {ns: 'loris'})}
             required={true}
             value={this.state.formData.file}
           />
           <TextareaElement
             name='fileDescription'
-            label='Description'
+            label={t('Description', {ns: 'genomic_browser'})}
             value={this.state.formData.fileDescription}
             required={false}
             onUserInput={this.setFileUploadFormData}
@@ -134,7 +134,7 @@ class GenomicUploadForm extends Component {
               <ProgressBar value={this.state.uploadProgress}/>
             </div>
           </div>
-          <ButtonElement label='Upload File'/>
+          <ButtonElement label={t('Upload File', {ns: 'genomic_browser'})}/>
         </React.Fragment>
       ) : null;
 
@@ -149,7 +149,7 @@ class GenomicUploadForm extends Component {
           >
             <SelectElement
               name='fileType'
-              label='File type'
+              label={t('File type', {ns: 'genomic_browser'})}
               options={this.state.options.fileTypes}
               onUserInput={this.setFileUploadFormData}
               ref='fileType'

--- a/modules/genomic_browser/jsx/tabs_content/files.js
+++ b/modules/genomic_browser/jsx/tabs_content/files.js
@@ -4,6 +4,7 @@ import Modal from 'jsx/Modal';
 import FilterableDataTable from 'jsx/FilterableDataTable';
 import GenomicUploadForm from './filemanager/uploadForm';
 import Loader from 'jsx/Loader';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Files Component.
@@ -155,6 +156,7 @@ class Files extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -166,11 +168,11 @@ class Files extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'ID',
+        label: t('ID', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Name',
+        label: t('Name', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Name',
@@ -178,7 +180,7 @@ class Files extends Component {
         },
       },
       {
-        label: 'Description',
+        label: t('Description', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Description',
@@ -186,7 +188,7 @@ class Files extends Component {
         },
       },
       {
-        label: 'Type',
+        label: t('Type', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Type',
@@ -194,7 +196,7 @@ class Files extends Component {
         },
       },
       {
-        label: 'Date',
+        label: t('Date', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'Date',
@@ -202,11 +204,11 @@ class Files extends Component {
         },
       },
       {
-        label: 'Inserted by User',
+        label: t('Inserted by User', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Caveat',
+        label: t('Caveat', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Caveat',
@@ -215,7 +217,7 @@ class Files extends Component {
         },
       },
       {
-        label: 'Notes',
+        label: t('Notes', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Notes',
@@ -226,14 +228,14 @@ class Files extends Component {
 
     const actions = [{
       name: 'uploadFile',
-      label: 'Upload File',
+      label: t('Upload File', {ns: 'genomic_browser'}),
       action: this.openFileUploadModal,
     }];
 
     return (
       <React.Fragment>
         <Modal
-          title='Upload File'
+          title={t('Upload File', {ns: 'genomic_browser'})}
           onClose={this.closeFileUploadModal}
           show={this.state.showFileUploadModal}
         >
@@ -264,6 +266,7 @@ Files.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default Files;
+export default withTranslation(['genomic_browser', 'loris'])(Files);

--- a/modules/genomic_browser/jsx/tabs_content/gwas.js
+++ b/modules/genomic_browser/jsx/tabs_content/gwas.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import FilterableDataTable from 'jsx/FilterableDataTable';
 import Loader from 'jsx/Loader';
+import {withTranslation} from 'react-i18next';
 
 /**
  * GWAS Component.
@@ -104,6 +105,7 @@ class GWAS extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -112,7 +114,7 @@ class GWAS extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'SNP ID',
+        label: t('SNP ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'SNP ID',
@@ -120,7 +122,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'Chromosome',
+        label: t('Chromosome', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Chromosome',
@@ -128,7 +130,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'BP Position',
+        label: t('BP Position', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'BP Position',
@@ -136,7 +138,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'Major Allele',
+        label: t('Major Allele', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Major Allele',
@@ -150,7 +152,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'Minor Allele',
+        label: t('Minor Allele', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Minor Allele',
@@ -164,7 +166,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'MAF',
+        label: t('MAF', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'MAF',
@@ -172,7 +174,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'Estimate',
+        label: t('Estimate', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Estimate',
@@ -180,7 +182,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'Std Err',
+        label: t('Std Err', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Std Err',
@@ -188,7 +190,7 @@ class GWAS extends Component {
         },
       },
       {
-        label: 'P-value',
+        label: t('P-value', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'P-value',
@@ -216,6 +218,7 @@ GWAS.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default GWAS;
+export default withTranslation(['genomic_browser', 'loris'])(GWAS);

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import FilterableDataTable from 'jsx/FilterableDataTable';
 import Loader from 'jsx/Loader';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Methylation Component.
@@ -97,6 +98,7 @@ class Methylation extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -108,7 +110,7 @@ class Methylation extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'Site',
+        label: t('Site', {ns: 'loris', count: 1}),
         show: false,
         filter: {
           name: 'Site',
@@ -117,7 +119,7 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'DCCID',
+        label: t('DCCID', {ns: 'loris'}),
         show: false,
         filter: {
           name: 'DCCID',
@@ -125,7 +127,7 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'PSCID',
+        label: t('PSCID', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'PSCID',
@@ -133,7 +135,7 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Sex',
+        label: t('Sex', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'Sex',
@@ -142,7 +144,7 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Cohort',
+        label: t('Cohort', {ns: 'loris', count: 1}),
         show: false,
         filter: {
           name: 'Cohort',
@@ -151,15 +153,15 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Date of Birth',
+        label: t('Date of Birth', {ns: 'loris'}),
         show: false,
       },
       {
-        label: 'Sample',
+        label: t('Sample', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'CPG Name',
+        label: t('CPG Name', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'File',
@@ -167,15 +169,15 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Beta value',
+        label: t('Beta value', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Chromosome',
+        label: t('Chromosome', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Strand',
+        label: t('Strand', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Strand',
@@ -187,27 +189,27 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Start Loc',
+        label: t('Start Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Probe Loc A',
+        label: t('Probe Loc A', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Probe Seq A',
+        label: t('Probe Seq A', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Probe Loc B',
+        label: t('Probe Loc B', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Probe Seq B',
+        label: t('Probe Seq B', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Infinium design',
+        label: t('Infinium design', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Infinium design',
@@ -219,19 +221,19 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Color',
+        label: t('Color', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Color',
           type: 'select',
           options: {
-            Grn: 'Green',
-            Red: 'Red',
+            Grn: t('Green', {ns: 'genomic_browser'}),
+            Red: t('Red', {ns: 'genomic_browser'}),
           },
         },
       },
       {
-        label: 'Build',
+        label: t('Build', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Build',
@@ -242,27 +244,27 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'SNP',
+        label: t('SNP', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'SNP',
           type: 'select',
           options: {
-            'NULL': 'No',
-            '_': 'Yes',
+            'NULL': t('No', 'loris'),
+            '_': t('Yes', 'loris'),
           },
         },
       },
       {
-        label: 'Gene',
+        label: t('Gene', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Accession number',
+        label: t('Accession number', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Position',
+        label: t('Position', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Position',
@@ -278,42 +280,42 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'Island Loc',
+        label: t('Island Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Context',
+        label: t('Context', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Promoter',
+        label: t('Promoter', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'DMR',
+        label: t('DMR', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Enhancer',
+        label: t('Enhancer', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Enhancer',
           type: 'select',
           options: {
-            1: 'Yes',
+            1: t('Yes', {ns: 'loris'}),
           },
         },
       },
       {
-        label: 'HMM Island',
+        label: t('HMM Island', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Reg Feature Loc',
+        label: t('Reg Feature Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Regulatory feat.:',
+        label: t('Regulatory feat.:', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Regulatory feat.:',
@@ -322,11 +324,11 @@ class Methylation extends Component {
         },
       },
       {
-        label: 'DHS',
+        label: t('DHS', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Platform',
+        label: t('Platform', {ns: 'genomic_browser'}),
         show: false,
       },
     ];
@@ -350,6 +352,7 @@ Methylation.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default Methylation;
+export default withTranslation(['genomic_browser', 'loris'])(Methylation);

--- a/modules/genomic_browser/jsx/tabs_content/profiles.js
+++ b/modules/genomic_browser/jsx/tabs_content/profiles.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'jsx/Loader';
 import FilterableDataTable from 'jsx/FilterableDataTable';
+import {withTranslation} from 'react-i18next';
 
 /**
  * Profiles Component.
@@ -128,6 +129,7 @@ class Profiles extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -138,7 +140,7 @@ class Profiles extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'Site',
+        label: t('Site', {ns: 'loris', count: 1}),
         show: false,
         filter: {
           name: 'Site',
@@ -147,7 +149,7 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'DCCID',
+        label: t('DCCID', {ns: 'loris'}),
         show: false,
         filter: {
           name: 'DCCID',
@@ -155,7 +157,7 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'PSCID',
+        label: t('PSCID', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'PSCID',
@@ -163,7 +165,7 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'Sex',
+        label: t('Sex', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'Sex',
@@ -172,7 +174,7 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'Cohort',
+        label: t('Cohort', {ns: 'loris', count: 1}),
         show: true,
         filter: {
           name: 'Cohort',
@@ -181,7 +183,7 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'External ID',
+        label: t('External ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'External ID',
@@ -189,50 +191,50 @@ class Profiles extends Component {
         },
       },
       {
-        label: 'File',
+        label: t('File', {ns: 'genomic_browser', count: 1}),
         show: true,
         filter: {
           name: 'File',
           type: 'select',
           options: {
-            Y: 'Yes',
-            N: 'No',
+            Y: t('Yes', {ns: 'loris'}),
+            N: t('No', {ns: 'loris'}),
           },
         },
       },
       {
-        label: 'SNPs found',
+        label: t('SNPs found', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'SNPs found',
           type: 'select',
           options: {
-            Y: 'Yes',
-            N: 'No',
+            Y: t('Yes', {ns: 'loris'}),
+            N: t('No', {ns: 'loris'}),
           },
         },
       },
       {
-        label: 'CNVs found',
+        label: t('CNVs found', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'CNVs found',
           type: 'select',
           options: {
-            Y: 'Yes',
-            N: 'No',
+            Y: t('Yes', {ns: 'loris'}),
+            N: t('No', {ns: 'loris'}),
           },
         },
       },
       {
-        label: 'CPGs found',
+        label: t('CPGs found', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'CPGs found',
           type: 'select',
           options: {
-            Y: 'Yes',
-            N: 'No',
+            Y: t('Yes', {ns: 'loris'}),
+            N: t('No', {ns: 'loris'}),
           },
         },
       },
@@ -257,6 +259,7 @@ Profiles.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default Profiles;
+export default withTranslation(['genomic_browser', 'loris'])(Profiles);

--- a/modules/genomic_browser/jsx/tabs_content/snp.js
+++ b/modules/genomic_browser/jsx/tabs_content/snp.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import FilterableDataTable from 'jsx/FilterableDataTable';
 import Loader from 'jsx/Loader';
+import {withTranslation} from 'react-i18next';
 
 /**
  * SNP Component.
@@ -97,6 +98,7 @@ class SNP extends Component {
    * @return {DOMRect}
    */
   render() {
+    const {t} = this.props;
     // Waiting for async data to load.
     if (!this.state.isLoaded) {
       return <Loader/>;
@@ -108,7 +110,7 @@ class SNP extends Component {
     // The fields configured for display/hide.
     let fields = [
       {
-        label: 'Site',
+        label: t('Site', {ns: 'loris', count: 1}),
         show: false,
         filter: {
           name: 'Site',
@@ -117,7 +119,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'DCCID',
+        label: t('DCCID', {ns: 'loris'}),
         show: false,
         filter: {
           name: 'DCCID',
@@ -125,7 +127,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'PSCID',
+        label: t('PSCID', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'PSCID',
@@ -133,7 +135,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Sex',
+        label: t('Sex', {ns: 'loris'}),
         show: true,
         filter: {
           name: 'Sex',
@@ -142,7 +144,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Cohort',
+        label: t('Cohort', {ns: 'loris', count: 1}),
         show: true,
         filter: {
           name: 'Cohort',
@@ -151,11 +153,11 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Date of Birth',
+        label: t('Date of Birth', {ns: 'loris'}),
         show: false,
       },
       {
-        label: 'External ID',
+        label: t('External ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'External ID',
@@ -163,7 +165,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Build',
+        label: t('Build', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Build',
@@ -174,7 +176,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Strand',
+        label: t('Strand', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Strand',
@@ -186,19 +188,19 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Start Loc',
+        label: t('Start Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'End Loc',
+        label: t('End Loc', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Gene',
+        label: t('Gene', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Gene Name',
+        label: t('Gene Name', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Gene Name',
@@ -206,7 +208,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Platform',
+        label: t('Platform', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Platform',
@@ -215,7 +217,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'rsID',
+        label: t('rsID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'rsID',
@@ -223,7 +225,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'SNP Name',
+        label: t('SNP Name', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'SNP Name',
@@ -231,7 +233,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Description',
+        label: t('Description', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Description',
@@ -239,7 +241,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'External Source',
+        label: t('External Source', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'External Source',
@@ -247,7 +249,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Allele A',
+        label: t('Allele A', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Allele A',
@@ -261,7 +263,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Allele B',
+        label: t('Allele B', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Allele B',
@@ -275,7 +277,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Reference Base',
+        label: t('Reference Base', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Reference Base',
@@ -289,7 +291,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Minor Allele',
+        label: t('Minor Allele', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Minor Allele',
@@ -303,29 +305,29 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Array Report',
+        label: t('Array Report', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Array Report',
           type: 'select',
           options: {
-            Abnormal: 'Abnormal',
-            Normal: 'Normal',
-            Pending: 'Pending',
-            Uncertain: 'Uncertain',
+            Abnormal: t('Abnormal', {ns: 'genomic_browser'}),
+            Normal: t('Normal', {ns: 'genomic_browser'}),
+            Pending: t('Pending', {ns: 'loris'}),
+            Uncertain: t('Uncertain', {ns: 'genomic_browser'}),
           },
         },
       },
       {
-        label: 'Markers',
+        label: t('Markers', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Validation Method',
+        label: t('Validation Method', {ns: 'genomic_browser'}),
         show: false,
       },
       {
-        label: 'Validated',
+        label: t('Validated', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Validated',
@@ -337,22 +339,22 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Function Prediction',
+        label: t('Function Prediction', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Function Prediction',
           type: 'select',
           options: {
-            exonic: 'exonic',
-            ncRNAexonic: 'ncRNAexonic',
-            splicing: 'splicing',
-            UTR3: 'UTR3',
-            UTR5: 'UTR5',
+            exonic: t('exonic', {ns: 'genomic_browser'}),
+            ncRNAexonic: t('ncRNAexonic', {ns: 'genomic_browser'}),
+            splicing: t('splicing', {ns: 'genomic_browser'}),
+            UTR3: t('UTR3', {ns: 'genomic_browser'}),
+            UTR5: t('UTR5', {ns: 'genomic_browser'}),
           },
         },
       },
       {
-        label: 'Damaging',
+        label: t('Damaging', {ns: 'genomic_browser'}),
         show: true,
         filter: {
           name: 'Damaging',
@@ -364,11 +366,11 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Genotype Quality',
+        label: t('Genotype Quality', {ns: 'genomic_browser'}),
         show: true,
       },
       {
-        label: 'Exonic Function',
+        label: t('Exonic Function', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Exonic Function',
@@ -376,7 +378,7 @@ class SNP extends Component {
         },
       },
       {
-        label: 'Genomic Range',
+        label: t('Genomic Range', {ns: 'genomic_browser'}),
         show: false,
         filter: {
           name: 'Genomic Range',
@@ -404,6 +406,7 @@ SNP.propTypes = {
   display: PropTypes.bool,
   data: PropTypes.object,
   baseURL: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired,
 };
 
-export default SNP;
+export default withTranslation(['genomic_browser', 'loris'])(SNP);

--- a/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
+++ b/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
@@ -317,3 +317,9 @@ msgstr "non classé"
 
 msgid "unknown"
 msgstr "inconnu"
+
+msgid "Upload Successful!"
+msgstr "Téléversement réussi !"
+
+msgid "Upload error!"
+msgstr "Erreur de téléversement !"

--- a/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
+++ b/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
@@ -21,3 +21,299 @@ msgstr ""
 
 msgid "Genomic Browser"
 msgstr "Navigateur Génomique"
+
+msgid "Use PSCID in column headers"
+msgstr "Utiliser le PSCID dans les en-têtes de colonnes"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Upload File"
+msgstr "Téléverser un fichier"
+
+msgid "File type"
+msgstr "Type de fichier"
+
+msgid "Profiles"
+msgstr "Profils"
+
+msgid "GWAS"
+msgstr "GWAS"
+
+msgid "SNP"
+msgstr "SNP"
+
+msgid "CNV"
+msgstr "CNV"
+
+msgid "Methylation"
+msgstr "Méthylation"
+
+msgid "File"
+msgid_plural "Files"
+msgstr[0] "Fichier"
+msgstr[1] "Fichiers"
+
+msgid "External ID"
+msgstr "Identifiant externe"
+
+msgid "Build"
+msgstr "Version du génome"
+
+msgid "Strand"
+msgstr "Brin"
+
+msgid "Start Loc"
+msgstr "Position de début"
+
+msgid "End Loc"
+msgstr "Position de fin"
+
+msgid "Location"
+msgstr "Emplacement"
+
+msgid "Gene"
+msgstr "Gène"
+
+msgid "Gene Name"
+msgstr "Nom du gène"
+
+msgid "Type"
+msgstr "Type"
+
+msgid "Copy Number Change"
+msgstr "Variation du nombre de copies"
+
+msgid "Event Name"
+msgstr "Nom de l'événement"
+
+msgid "Common"
+msgstr "Commun"
+
+msgid "Characteristics"
+msgstr "Caractéristiques"
+
+msgid "Inheritance"
+msgstr "Hérédité"
+
+msgid "Array Report"
+msgstr "Rapport de puce"
+
+msgid "Markers"
+msgstr "Marqueurs"
+
+msgid "Validation Method"
+msgstr "Méthode de validation"
+
+msgid "Platform"
+msgstr "Plateforme"
+
+msgid "ID"
+msgstr "Identifiant"
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "Inserted by User"
+msgstr "Ajouté par l'utilisateur"
+
+msgid "Caveat"
+msgstr "Mise en garde"
+
+msgid "Notes"
+msgstr "Notes"
+
+msgid "SNP ID"
+msgstr "Identifiant SNP"
+
+msgid "Chromosome"
+msgstr "Chromosome"
+
+msgid "BP Position"
+msgstr "Position (pb)"
+
+msgid "Major Allele"
+msgstr "Allèle majeur"
+
+msgid "Minor Allele"
+msgstr "Allèle mineur"
+
+msgid "MAF"
+msgstr "MAF"
+
+msgid "Estimate"
+msgstr "Estimation"
+
+msgid "Std Err"
+msgstr "Erreur type"
+
+msgid "P-value"
+msgstr "Valeur p"
+
+msgid "Sample"
+msgstr "Échantillon"
+
+msgid "CPG Name"
+msgstr "Nom du CpG"
+
+msgid "Beta value"
+msgstr "Valeur bêta"
+
+msgid "Probe Loc A"
+msgstr "Position de la sonde A"
+
+msgid "Probe Seq A"
+msgstr "Séquence de la sonde A"
+
+msgid "Probe Loc B"
+msgstr "Position de la sonde B"
+
+msgid "Probe Seq B"
+msgstr "Séquence de la sonde B"
+
+msgid "Infinium design"
+msgstr "Conception Infinium"
+
+msgid "Color"
+msgstr "Couleur"
+
+msgid "Accession number"
+msgstr "Numéro d'accession"
+
+msgid "Position"
+msgstr "Position"
+
+msgid "Island Loc"
+msgstr "Position de l'îlot"
+
+msgid "Context"
+msgstr "Contexte"
+
+msgid "Promoter"
+msgstr "Promoteur"
+
+msgid "DMR"
+msgstr "DMR"
+
+msgid "Enhancer"
+msgstr "Amplificateur"
+
+msgid "HMM Island"
+msgstr "Îlot HMM"
+
+msgid "Reg Feature Loc"
+msgstr "Position de l'élément régulateur"
+
+msgid "Regulatory feat.:"
+msgstr "Élément régulateur :"
+
+msgid "DHS"
+msgstr "DHS"
+
+msgid "SNPs found"
+msgstr "SNP trouvés"
+
+msgid "CNVs found"
+msgstr "CNV trouvés"
+
+msgid "CPGs found"
+msgstr "CpG trouvés"
+
+msgid "rsID"
+msgstr "rsID"
+
+msgid "SNP Name"
+msgstr "Nom du SNP"
+
+msgid "External Source"
+msgstr "Source externe"
+
+msgid "Allele A"
+msgstr "Allèle A"
+
+msgid "Allele B"
+msgstr "Allèle B"
+
+msgid "Reference Base"
+msgstr "Base de référence"
+
+msgid "Validated"
+msgstr "Validé"
+
+msgid "Function Prediction"
+msgstr "Prédiction fonctionnelle"
+
+msgid "Damaging"
+msgstr "Délétère"
+
+msgid "Genotype Quality"
+msgstr "Qualité du génotype"
+
+msgid "Exonic Function"
+msgstr "Fonction exonique"
+
+msgid "Genomic Range"
+msgstr "Intervalle génomique"
+
+msgid "Unsupported filetype: %s"
+msgstr "Type de fichier non pris en charge : %s"
+
+msgid "gain"
+msgstr "gain"
+
+msgid "loss"
+msgstr "perte"
+
+msgid "Unknown"
+msgstr "Inconnu"
+
+msgid "Benign"
+msgstr "Bénin"
+
+msgid "Pathogenic"
+msgstr "Pathogène"
+
+msgid "Green"
+msgstr "Vert"
+
+msgid "Red"
+msgstr "Rouge"
+
+msgid "Abnormal"
+msgstr "Anormal"
+
+msgid "Normal"
+msgstr "Normal"
+
+msgid "Uncertain"
+msgstr "Incertain"
+
+msgid "exonic"
+msgstr "exonique"
+
+msgid "ncRNAexonic"
+msgstr "ARNnc exonique"
+
+msgid "splicing"
+msgstr "épissage"
+
+msgid "UTR3"
+msgstr "UTR3"
+
+msgid "UTR5"
+msgstr "UTR5"
+
+msgid "de novo"
+msgstr "de novo"
+
+msgid "maternal"
+msgstr "maternel"
+
+msgid "paternal"
+msgstr "paternel"
+
+msgid "unclassified"
+msgstr "non classé"
+
+msgid "unknown"
+msgstr "inconnu"

--- a/modules/genomic_browser/locale/genomic_browser.pot
+++ b/modules/genomic_browser/locale/genomic_browser.pot
@@ -21,3 +21,297 @@ msgstr ""
 msgid "Genomic Browser"
 msgstr ""
 
+msgid "Use PSCID in column headers"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Upload File"
+msgstr ""
+
+msgid "File type"
+msgstr ""
+
+msgid "Profiles"
+msgstr ""
+
+msgid "GWAS"
+msgstr ""
+
+msgid "SNP"
+msgstr ""
+
+msgid "CNV"
+msgstr ""
+
+msgid "Methylation"
+msgstr ""
+
+msgid "File"
+msgid_plural "Files"
+msgstr[0] ""
+
+msgid "External ID"
+msgstr ""
+
+msgid "Build"
+msgstr ""
+
+msgid "Strand"
+msgstr ""
+
+msgid "Start Loc"
+msgstr ""
+
+msgid "End Loc"
+msgstr ""
+
+msgid "Location"
+msgstr ""
+
+msgid "Gene"
+msgstr ""
+
+msgid "Gene Name"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Copy Number Change"
+msgstr ""
+
+msgid "Event Name"
+msgstr ""
+
+msgid "Common"
+msgstr ""
+
+msgid "Characteristics"
+msgstr ""
+
+msgid "Inheritance"
+msgstr ""
+
+msgid "Array Report"
+msgstr ""
+
+msgid "Markers"
+msgstr ""
+
+msgid "Validation Method"
+msgstr ""
+
+msgid "Platform"
+msgstr ""
+
+msgid "ID"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Inserted by User"
+msgstr ""
+
+msgid "Caveat"
+msgstr ""
+
+msgid "Notes"
+msgstr ""
+
+msgid "SNP ID"
+msgstr ""
+
+msgid "Chromosome"
+msgstr ""
+
+msgid "BP Position"
+msgstr ""
+
+msgid "Major Allele"
+msgstr ""
+
+msgid "Minor Allele"
+msgstr ""
+
+msgid "MAF"
+msgstr ""
+
+msgid "Estimate"
+msgstr ""
+
+msgid "Std Err"
+msgstr ""
+
+msgid "P-value"
+msgstr ""
+
+msgid "Sample"
+msgstr ""
+
+msgid "CPG Name"
+msgstr ""
+
+msgid "Beta value"
+msgstr ""
+
+msgid "Probe Loc A"
+msgstr ""
+
+msgid "Probe Seq A"
+msgstr ""
+
+msgid "Probe Loc B"
+msgstr ""
+
+msgid "Probe Seq B"
+msgstr ""
+
+msgid "Infinium design"
+msgstr ""
+
+msgid "Color"
+msgstr ""
+
+msgid "Accession number"
+msgstr ""
+
+msgid "Position"
+msgstr ""
+
+msgid "Island Loc"
+msgstr ""
+
+msgid "Context"
+msgstr ""
+
+msgid "Promoter"
+msgstr ""
+
+msgid "DMR"
+msgstr ""
+
+msgid "Enhancer"
+msgstr ""
+
+msgid "HMM Island"
+msgstr ""
+
+msgid "Reg Feature Loc"
+msgstr ""
+
+msgid "Regulatory feat.:"
+msgstr ""
+
+msgid "DHS"
+msgstr ""
+
+msgid "SNPs found"
+msgstr ""
+
+msgid "CNVs found"
+msgstr ""
+
+msgid "CPGs found"
+msgstr ""
+
+msgid "rsID"
+msgstr ""
+
+msgid "SNP Name"
+msgstr ""
+
+msgid "External Source"
+msgstr ""
+
+msgid "Allele A"
+msgstr ""
+
+msgid "Allele B"
+msgstr ""
+
+msgid "Reference Base"
+msgstr ""
+
+msgid "Validated"
+msgstr ""
+
+msgid "Function Prediction"
+msgstr ""
+
+msgid "Damaging"
+msgstr ""
+
+msgid "Genotype Quality"
+msgstr ""
+
+msgid "Exonic Function"
+msgstr ""
+
+msgid "Genomic Range"
+msgstr ""
+
+msgid "Unsupported filetype: %s"
+msgstr ""
+
+msgid "gain"
+msgstr ""
+
+msgid "loss"
+msgstr ""
+
+msgid "Unknown"
+msgstr ""
+
+msgid "Benign"
+msgstr ""
+
+msgid "Pathogenic"
+msgstr ""
+
+msgid "Green"
+msgstr ""
+
+msgid "Red"
+msgstr ""
+
+msgid "Abnormal"
+msgstr ""
+
+msgid "Normal"
+msgstr ""
+
+msgid "Uncertain"
+msgstr ""
+
+msgid "exonic"
+msgstr ""
+
+msgid "ncRNAexonic"
+msgstr ""
+
+msgid "splicing"
+msgstr ""
+
+msgid "UTR3"
+msgstr ""
+
+msgid "UTR5"
+msgstr ""
+
+msgid "de novo"
+msgstr ""
+
+msgid "maternal"
+msgstr ""
+
+msgid "paternal"
+msgstr ""
+
+msgid "unclassified"
+msgstr ""
+
+msgid "unknown"
+msgstr ""

--- a/modules/genomic_browser/locale/genomic_browser.pot
+++ b/modules/genomic_browser/locale/genomic_browser.pot
@@ -315,3 +315,9 @@ msgstr ""
 
 msgid "unknown"
 msgstr ""
+
+msgid "Upload Successful!"
+msgstr ""
+
+msgid "Upload error!"
+msgstr ""

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -98,13 +98,13 @@ class Genomicfile
         default:
             $unsupported = $this->_fileToUpload->genomic_file_type;
             return [
-                'message'  => "Unsupported filetype: $unsupported",
+                'message'  => sprintf(dgettext("genomic_browser", "Unsupported filetype: %s"), $unsupported),
                 'progress' => 100,
                 'error'    => true,
             ];
         }
 
-        return $this->reportProgress(100, 'Complete');
+        return $this->reportProgress(100, dgettext("loris", "Complete"));
     }
 
     /**

--- a/modules/genomic_browser/php/uploading/genomicfile.class.inc
+++ b/modules/genomic_browser/php/uploading/genomicfile.class.inc
@@ -98,7 +98,14 @@ class Genomicfile
         default:
             $unsupported = $this->_fileToUpload->genomic_file_type;
             return [
-                'message'  => sprintf(dgettext("genomic_browser", "Unsupported filetype: %s"), $unsupported),
+                'message'  =>
+                    sprintf(
+                        dgettext(
+                            "genomic_browser",
+                            "Unsupported filetype: %s"
+                        ),
+                        $unsupported
+                    ),
                 'progress' => 100,
                 'error'    => true,
             ];


### PR DESCRIPTION
## Brief summary of changes

This PR translates the genomic_browser module in French. It only includes non-db translations (hardcoded in js and php files).

I figured it would be better to separate non-db from db for readability. Let me know if you want me to fix db related translations in this PR.

Note: I used AI for translations but double-checked them as a French speaker.

#### Link(s) to related issue(s)

* Resolves #10924 (Reference the issue this fixes, if any.)
