### PR TITLE
[publication] fix empty value of version or Citation will break the page

### DIFF
--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -318,8 +318,8 @@ function getFiles($id) : array
     $results = [];
     foreach ($files as $key => $f) {
         $val = [];
-        $val['Citation'] = htmlspecialchars_decode($f['Citation']);
-        $val['Version']  = htmlspecialchars_decode($f['Version']);
+        $val['Citation'] = htmlspecialchars_decode($f['Citation'] ?? '');
+        $val['Version']  = htmlspecialchars_decode($f['Version'] ?? '');
 
         $results[$key] = $val;
     }


### PR DESCRIPTION
[publication] fix empty value of version or Citation will break the page
Issue: https://github.com/aces/Loris/issues/10899
[publication] Cannot see newly created project

when create a new project. if version or Citation leave blank, next time can't load the new project. 
[pid 27168:tid 27168] [client 192.168.122.1:32934] PHP Fatal error:  Uncaught TypeError: htmlspecialchars_decode(): Argument #1 ($string) must be of type string, null given in /var/www/Loris/modules/publication/ajax/getData.php:321\nStack trace:\n#0 /var/www/Loris/modules/publication/ajax/getData.php(321): htmlspecialchars_decode()\n#1 /var/www/Loris/modules/publication/ajax/getData.php(164): getFiles()\n#2 /var/www/Loris/modules/publication/ajax/getData.php(38): getProjectData()\n#3 /var/www/Loris/htdocs/AjaxHelper.php(120): require('...')\n#4 {main}\n  thrown in /var/www/Loris/modules/publication/ajax/getData.php on line 321, referer: https://test-dev-270.loris.ca/publication/view_project?id=8
