### PR TITLE
[instrument_list] [instruments] Fix tooltip for instrument status

### DIFF
--- a/smarty/templates/instrumentstatus_controlpanel.tpl
+++ b/smarty/templates/instrumentstatus_controlpanel.tpl
@@ -48,7 +48,7 @@
                 <a href="?commentID={$commentID}&candID={$candID}&sessionID={$sessionID}&setDataEntry={$data_entry[item].label}&test_name={$test_name}">{dgettext("loris", $data_entry[item].label)}</a>
             {else}
                 {if $data_entry[item].tooltip}
-                    <span data-toggle="tooltip" data-placement="right" title="{$data_entry[item].tooltip}">
+                    <span data-toggle="tooltip" data-placement="bottom" title="{$data_entry[item].tooltip}">
                       {dgettext("loris", $data_entry[item].label)}
                     </span>
                 {else}


### PR DESCRIPTION
## Brief summary of changes
Issue mentioned a resizable left panel but after discussion we decided to simply show the tooltip message under the status label instead of to the right.

This allows for a better visualization of long tooltip messages.

<img width="1222" height="527" alt="image" src="https://github.com/user-attachments/assets/4137a5fe-2b4a-4daf-930d-6af28147ed91" />

#### Testing instructions (if applicable)

1. Log in as an administrator or as a user of a clinical site that has access to MRI Forms.
2. Go to Candidate -> Access Profile.
3. Click on a PSCID that has an MRI Parameter Form.
4. Hover the cursor over the "Complete" status.
5. Observe that the tooltip is correctly displayed.


#### Link(s) to related issue(s)

* Resolves [#10932](https://github.com/aces/Loris/issues/10932)  (Reference the issue this fixes, if any.)
