### PR TITLE
[issue_tracker] Fix broken PSCID & Visit links

### DIFF
--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -107,7 +107,7 @@ class IssueTrackerIndex extends Component {
     const siteKey = t('Site', {ns: 'loris', count: 1});
     const pscidKey = t('PSCID', {ns: 'loris'});
     const visitLabelKey = t('Visit Label', {ns: 'loris'});
-    const sessionIDKey = t('Session ID', {ns: 'loris'});
+    const sessionIDKey = t('SessionID', {ns: 'loris'});
     const dccidKey = t('DCCID', {ns: 'loris'});
     const statusKey = t('Status', {ns: 'loris'});
     const categoryKey = t('Category', {ns: 'issue_tracker'});

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -48,6 +48,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                i.dateCreated,
                i.lastUpdate,
                s.ID AS sessionId,
+               c.CandID as dccid,
                w.userID AS userId
         FROM issues AS i
         LEFT JOIN modules m ON m.ID = i.module


### PR DESCRIPTION
## Brief summary of changes
This resolves the issue of PSCID and Visit Label links that would previously lead to 500/404 errors because the values for dccid and sessionID were null/undefined. 
<img width="1430" height="778" alt="Screenshot 2026-07-21 at 3 24 14 PM" src="https://github.com/user-attachments/assets/ff5c32b9-614e-4a47-8ad8-344c56ed8819" />

#### Testing instructions (if applicable)

1. In the issue tracker, click on the PSCID and Visit Label links in the table and verify they both lead to the appropriate pages / verify that the links contain the right candIDs and sessionIDs (i.e. these values are not null/undefined)

#### Link(s) to related issue(s)

* Resolves #10603 
