### PR TITLE
[imaging_uploader] Add missing translations

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -649,3 +649,6 @@ msgstr "État du contrôle qualité"
 
 msgid "TarchiveID"
 msgstr "Identifiant de tarchive"
+
+msgid "Upload successful!"
+msgstr "Téléversement réussi!"

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -584,3 +584,6 @@ msgstr "QC स्थिति"
 
 msgid "TarchiveID"
 msgstr "टीआर्काइवआईडी"
+
+msgid "Upload successful!"
+msgstr "अपलोड सफल!"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -608,3 +608,6 @@ msgstr "品質管理状況"
 
 msgid "TarchiveID"
 msgstr "TarchiveID"
+
+msgid "Upload successful!"
+msgstr "アップロード成功しました!"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -618,4 +618,6 @@ msgid "QC Status"
 msgstr ""
 
 msgid "TarchiveID"
+
+msgid "Upload successful!"
 msgstr ""

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -589,3 +589,6 @@ msgstr "质量控制状态"
 
 msgid "TarchiveID"
 msgstr "档案ID"
+
+msgid "Upload successful!"
+msgstr "上传成功！"

--- a/modules/data_release/jsx/uploadFileForm.js
+++ b/modules/data_release/jsx/uploadFileForm.js
@@ -228,7 +228,7 @@ class UploadFileForm extends Component {
         console.error(msg);
       } else {
         swal.fire({
-          text: t('Upload Successful!', {ns: 'data_release'}),
+          text: t('Upload successful!', {ns: 'loris'}),
           title: '',
           type: 'success',
           confirmButtonText: t('OK', {ns: 'loris'}),

--- a/modules/data_release/locale/data_release.pot
+++ b/modules/data_release/locale/data_release.pot
@@ -69,9 +69,6 @@ msgstr ""
 msgid "Upload error!"
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "A file with this name already exists!"
 msgstr ""
 

--- a/modules/data_release/locale/fr/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/fr/LC_MESSAGES/data_release.po
@@ -73,9 +73,6 @@ msgstr "Erreur"
 msgid "Upload error!"
 msgstr "Erreur de téléversement!"
 
-msgid "Upload Successful!"
-msgstr "Téléversement réussi!"
-
 msgid "A file with this name already exists!"
 msgstr "Un fichier portant ce nom existe déjà!"
 

--- a/modules/data_release/locale/hi/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/hi/LC_MESSAGES/data_release.po
@@ -70,9 +70,6 @@ msgstr "त्रुटि"
 msgid "Upload error!"
 msgstr "अपलोड त्रुटि!"
 
-msgid "Upload Successful!"
-msgstr "अपलोड सफल!"
-
 msgid "A file with this name already exists!"
 msgstr "इस नाम की फ़ाइल पहले से मौजूद है!"
 

--- a/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/ja/LC_MESSAGES/data_release.po
@@ -70,9 +70,6 @@ msgstr "エラー"
 msgid "Upload error!"
 msgstr "アップロードエラー"
 
-msgid "Upload Successful!"
-msgstr "アップロード成功しました!"
-
 msgid "A file with this name already exists!"
 msgstr "この名前のファイルは既に存在します。"
 

--- a/modules/data_release/locale/zh/LC_MESSAGES/data_release.po
+++ b/modules/data_release/locale/zh/LC_MESSAGES/data_release.po
@@ -70,9 +70,6 @@ msgstr "错误"
 msgid "Upload error!"
 msgstr "上传错误！"
 
-msgid "Upload Successful!"
-msgstr "上传成功！"
-
 msgid "A file with this name already exists!"
 msgstr "同名的文件已存在！"
 

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -234,8 +234,8 @@ class DocUploadForm extends Component {
             resp.json().then((data) => {
               if (data.error_count === 0) {
                 swal.fire(
-                  this.props.t('Upload Successful!',
-                    {ns: 'document_repository'}),
+                  this.props.t('Upload successful!',
+                    {ns: 'loris'}),
                   '',
                   'success'
                 ).then((result) => {

--- a/modules/document_repository/locale/document_repository.pot
+++ b/modules/document_repository/locale/document_repository.pot
@@ -51,9 +51,6 @@ msgstr ""
 msgid "Uploading..."
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "Upload Incomplete"
 msgstr ""
 

--- a/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
@@ -54,10 +54,6 @@ msgstr "Téléverser fichier(s)"
 msgid "Uploading..."
 msgstr "Téléversement..."
 
-#, fuzzy
-msgid "Upload Successful!"
-msgstr "Téléversement réussi!"
-
 msgid "Upload Incomplete"
 msgstr "Téléversement incomplet"
 

--- a/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
@@ -51,9 +51,6 @@ msgstr "फ़ाइल(ें) अपलोड करें"
 msgid "Uploading..."
 msgstr "अपलोड हो रहा है..."
 
-msgid "Upload Successful!"
-msgstr "अपलोड सफल रहा!"
-
 msgid "Upload Incomplete"
 msgstr "अपलोड अधूरा है"
 

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -52,9 +52,6 @@ msgstr "ファイルをアップロード"
 msgid "Uploading..."
 msgstr "アップロード中..."
 
-msgid "Upload Successful!"
-msgstr "アップロード成功しました!"
-
 msgid "Upload Incomplete"
 msgstr "アップロードが不完全です"
 

--- a/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
@@ -52,9 +52,6 @@ msgstr "上传文件"
 msgid "Uploading..."
 msgstr "正在上传..."
 
-msgid "Upload Successful!"
-msgstr "上传成功！"
-
 msgid "Upload Incomplete"
 msgstr "上传不完整"
 

--- a/modules/electrophysiology_uploader/jsx/UploadForm.js
+++ b/modules/electrophysiology_uploader/jsx/UploadForm.js
@@ -163,8 +163,8 @@ export default function UploadForm(props) {
             {ns: 'electrophysiology_uploader'});
         }
         swal.fire({
-          title: t('Upload Successful!',
-            {ns: 'electrophysiology_uploader'}),
+          title: t('Upload successful!',
+            {ns: 'loris'}),
           text: text,
           type: 'success',
         }).then((result) => {

--- a/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
+++ b/modules/electrophysiology_uploader/locale/electrophysiology_uploader.pot
@@ -57,9 +57,6 @@ msgstr ""
 msgid "The file does not respect name convention"
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "Processing of this file by the EEG pipeline has started"
 msgstr ""
 

--- a/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/fr/LC_MESSAGES/electrophysiology_uploader.po
@@ -68,10 +68,6 @@ msgid "The file does not respect name convention"
 msgstr "Le fichier ne respecte pas la convention de nomenclature."
 
 #, fuzzy
-msgid "Upload Successful!"
-msgstr "Téléversement réussi!"
-
-#, fuzzy
 msgid "Processing of this file by the EEG pipeline has started"
 msgstr "Le traitement de ce fichier par le pipeline EEG a commencé."
 

--- a/modules/electrophysiology_uploader/locale/hi/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/hi/LC_MESSAGES/electrophysiology_uploader.po
@@ -58,9 +58,6 @@ msgstr "फ़ाइलनाम इस रूप में होना चा�
 msgid "The file does not respect name convention"
 msgstr "फ़ाइल नाम परंपरा का पालन नहीं करती है"
 
-msgid "Upload Successful!"
-msgstr "अपलोड सफल!"
-
 msgid "Processing of this file by the EEG pipeline has started"
 msgstr "EEG पाइपलाइन द्वारा इस फ़ाइल की प्रोसेसिंग शुरू हो गई है"
 

--- a/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/ja/LC_MESSAGES/electrophysiology_uploader.po
@@ -58,9 +58,6 @@ msgstr "ファイル名は次の形式である必要があります"
 msgid "The file does not respect name convention"
 msgstr "ファイルは命名規則に従っていません"
 
-msgid "Upload Successful!"
-msgstr "アップロード成功しました!"
-
 msgid "Processing of this file by the EEG pipeline has started"
 msgstr "電気生理学パイプラインによるこのファイルの処理が開始されました。"
 

--- a/modules/electrophysiology_uploader/locale/zh/LC_MESSAGES/electrophysiology_uploader.po
+++ b/modules/electrophysiology_uploader/locale/zh/LC_MESSAGES/electrophysiology_uploader.po
@@ -58,9 +58,6 @@ msgstr "文件名应采用以下形式"
 msgid "The file does not respect name convention"
 msgstr "该文件不遵守名称约定"
 
-msgid "Upload Successful!"
-msgstr "上传成功！"
-
 msgid "Processing of this file by the EEG pipeline has started"
 msgstr "EEG 管道已开始处理此文件"
 

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -204,8 +204,7 @@ class GenomicUploadForm extends Component {
           }, // reset form data after successful file upload
           uploadProgress: -1,
         });
-        swal.fire(t('Upload Successful!', {ns: 'genomic_browser'}), '',
-          'success');
+        swal.fire('Upload successful!', '', 'success');
         this.props.closeFileUploadModal();
       }
       ).catch((error) => {

--- a/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
+++ b/modules/genomic_browser/jsx/tabs_content/filemanager/uploadForm.js
@@ -204,7 +204,7 @@ class GenomicUploadForm extends Component {
           }, // reset form data after successful file upload
           uploadProgress: -1,
         });
-        swal.fire('Upload successful!', '', 'success');
+        swal.fire(t('Upload successful!', {ns: 'loris'}), '', 'success');
         this.props.closeFileUploadModal();
       }
       ).catch((error) => {

--- a/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
+++ b/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
@@ -318,8 +318,5 @@ msgstr "non classé"
 msgid "unknown"
 msgstr "inconnu"
 
-msgid "Upload Successful!"
-msgstr "Téléversement réussi !"
-
 msgid "Upload error!"
 msgstr "Erreur de téléversement !"

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -18,7 +18,6 @@ class ImagingUploader extends Component {
    * @param {object} props - React Component properties
    */
   constructor(props) {
-    const {t} = props;
     super(props);
 
     this.state = {

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -18,6 +18,7 @@ class ImagingUploader extends Component {
    * @param {object} props - React Component properties
    */
   constructor(props) {
+    const {t} = props;
     super(props);
 
     this.state = {

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -512,7 +512,7 @@ class UploadForm extends Component {
             />
             <FileElement
               name='mriFile'
-              label={t('File to Upload', {ns: 'imaging_uploader'})}
+              label={t('File to upload', {ns: 'loris'})}
               onUserInput={this.onFormChange}
               required={true}
               errorMessage={this.state.errorMessage.mriFile}

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -327,7 +327,7 @@ class UploadForm extends Component {
                 {ns: 'imaging_uploader'});
         }
         swal.fire({
-          title: t('Upload Successful!', {ns: 'imaging_uploader'}),
+          title: t('Upload successful!', {ns: 'loris'}),
           text: text,
           type: 'success',
           confirmButtonText: t('OK', {ns: 'loris'}),

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -148,7 +148,7 @@ msgstr "Détaillé"
 
 #, fuzzy
 msgid "<select a row in the table below to view the upload logs>"
-msgstr "<select a row in the table below to view the upload logs>"
+msgstr "<sélectionnez une ligne dans le tableau ci-dessous pour afficher les journaux de téléversement>"
 
 #, fuzzy
 msgid "Number Of Files Created"

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -30,10 +30,6 @@ msgstr "Téléverser un scan d'imagerie"
 msgid "Phantom Scans"
 msgstr "Scans fantômes"
 
-#, fuzzy
-msgid "File to Upload"
-msgstr "Sélectionner un fichier à téléverser"
-
 msgid "Notes"
 msgstr "Notes"
 

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -106,10 +106,6 @@ msgid "A file with this name has been uploaded but has not yet been processed by
 msgstr "Un fichier portant ce nom a été téléversé, mais n'a pas encore été traité par le pipeline IRM. Souhaitez-vous remplacer le fichier existant ?"
 
 #, fuzzy
-msgid "Upload Successful!"
-msgstr "Téléversement réussi !"
-
-#, fuzzy
 msgid "Processing of this file by the MRI pipeline has started"
 msgstr "Le traitement de ce fichier par le pipeline IRM a commencé."
 

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -28,9 +28,6 @@ msgstr "इमेजिंग स्कैन अपलोड करें"
 msgid "Phantom Scans"
 msgstr "फैंटम स्कैन"
 
-msgid "File to Upload"
-msgstr "अपलोड करने के लिए फ़ाइल"
-
 msgid "Notes"
 msgstr "नोट्स"
 

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -85,9 +85,6 @@ msgstr "आपका अपलोड रद्द कर दिया गया 
 msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
 msgstr "इस नाम की फ़ाइल अपलोड की गई है लेकिन अभी MRI पाइपलाइन द्वारा प्रोसेस नहीं हुई है। क्या आप मौजूदा फ़ाइल को अधिलेखित करना चाहेंगे?"
 
-msgid "Upload Successful!"
-msgstr "अपलोड सफल!"
-
 msgid "Processing of this file by the MRI pipeline has started"
 msgstr "इस फ़ाइल का MRI पाइपलाइन द्वारा प्रोसेसिंग शुरू हो गई है"
 

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -27,9 +27,6 @@ msgstr ""
 msgid "Phantom Scans"
 msgstr ""
 
-msgid "File to Upload"
-msgstr ""
-
 msgid "Notes"
 msgstr ""
 

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -84,9 +84,6 @@ msgstr ""
 msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "Processing of this file by the MRI pipeline has started"
 msgstr ""
 

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -28,9 +28,6 @@ msgstr "画像スキャンをアップロードする"
 msgid "Phantom Scans"
 msgstr "ファントムスキャン"
 
-msgid "File to Upload"
-msgstr "アップロードするファイル"
-
 msgid "Notes"
 msgstr "注記"
 

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -85,9 +85,6 @@ msgstr "アップロードはキャンセルされました。"
 msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
 msgstr "この名前のファイルはアップロードされていますが、MRIパイプラインでまだ処理されていません。既存のファイルを上書きしますか？"
 
-msgid "Upload Successful!"
-msgstr "アップロード成功しました!"
-
 msgid "Processing of this file by the MRI pipeline has started"
 msgstr "MRIパイプラインによるこのファイルの処理が開始されました"
 

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -107,7 +107,7 @@ msgid "Log Viewer"
 msgstr "ログビューア"
 
 msgid "Logs to display"
-msgstr "表示する"
+msgstr "表示するログ"
 
 msgid "Summary"
 msgstr "まとめ"

--- a/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
@@ -28,9 +28,6 @@ msgstr "上传影像扫描"
 msgid "Phantom Scans"
 msgstr "幻影扫描"
 
-msgid "File to Upload"
-msgstr "要上传的文件"
-
 msgid "Notes"
 msgstr "笔记"
 

--- a/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
@@ -85,9 +85,6 @@ msgstr "您的上传已被取消。"
 msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
 msgstr "具有此名称的文件已上传，但尚未由 MRI 管道处理。您想覆盖现有文件吗？"
 
-msgid "Upload Successful!"
-msgstr "上传成功！"
-
 msgid "Processing of this file by the MRI pipeline has started"
 msgstr "MRI 管道已开始处理此文件"
 

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -168,7 +168,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $this->addBasicText('candID', dgettext('loris', 'DCCID'));
         $this->addBasicText('pSCID', 'PSCID');
         $this->addSelect('visitLabel', 'Visit Label', $visitlabels);
-        $this->addFile('mriFile', 'File to Upload');
+        $this->addFile('mriFile', 'File to upload');
         ///////////////////////////////////////////////////////////////////////
         //////////////////Upload-related Error messages ///////////////////////
         ///////////////////////////////////////////////////////////////////////

--- a/modules/imaging_uploader/test/ImagingUploaderTestIntegrationTest.php
+++ b/modules/imaging_uploader/test/ImagingUploaderTestIntegrationTest.php
@@ -118,7 +118,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
             "selector" => "#upload",
         ],
         [
-            "label"    => "File to Upload",
+            "label"    => "File to upload",
             "selector" => "#upload",
         ],
     ];

--- a/modules/imaging_uploader/test/TestPlan.md
+++ b/modules/imaging_uploader/test/TestPlan.md
@@ -60,8 +60,8 @@
 
     [Manual Testing]
 
-4. Test validations for 'File to Upload' in the 'Upload' tab and ensure that the appropriate
-    error messages are displayed under the 'File to Upload' element.
+4. Test validations for 'File to upload' in the 'Upload' tab and ensure that the appropriate
+    error messages are displayed under the 'File to upload' element.
 
     Set Phantom Scans to 'Yes' and try to upload a file for each scenario below:
     - A file that is not of type `.tgz` or `tar.gz` or `.zip` (e.g. a `.jpg` or `.txt`)

--- a/modules/instrument_manager/jsx/uploadForm.js
+++ b/modules/instrument_manager/jsx/uploadForm.js
@@ -63,7 +63,7 @@ class InstrumentUploadForm extends Component {
       .then((data) => {
         if (data.message) {
           swal.fire({
-            title: t('Upload Successful!', {ns: 'instrument_manager'}),
+            title: t('Upload successful!', {ns: 'loris'}),
             type: t('success', {ns: 'instrument_manager'}),
             text: data.message,
           }).then(function() {

--- a/modules/instrument_manager/locale/fr/LC_MESSAGES/instrument_manager.po
+++ b/modules/instrument_manager/locale/fr/LC_MESSAGES/instrument_manager.po
@@ -85,9 +85,6 @@ msgstr "Installation réussie!"
 msgid "success"
 msgstr "succès"
 
-msgid "Upload Successful!"
-msgstr "Téléversement réussi!"
-
 msgid "Instrument file"
 msgstr "Fichier d'instrument"
 

--- a/modules/instrument_manager/locale/instrument_manager.pot
+++ b/modules/instrument_manager/locale/instrument_manager.pot
@@ -84,9 +84,6 @@ msgstr ""
 msgid "success"
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "Instrument file"
 msgstr ""
 

--- a/modules/issue_tracker/jsx/attachments/uploadForm.js
+++ b/modules/issue_tracker/jsx/attachments/uploadForm.js
@@ -101,8 +101,8 @@ class IssueUploadAttachmentForm extends Component {
             uploadProgress: -1,
           });
           swal.fire(
-            this.props.t('Upload Successful!',
-              {ns: 'issue_tracker'}),
+            this.props.t('Upload successful!',
+              {ns: 'loris'}),
             '',
             'success'
           );

--- a/modules/issue_tracker/locale/fr/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/fr/LC_MESSAGES/issue_tracker.po
@@ -226,9 +226,6 @@ msgstr "Aucun incident ne correspond aux filtres sélectionnés."
 msgid "Please confirm the request to delete the \"{{fileName}}\" attachment."
 msgstr "Veuillez confirmer la demande de suppression de la pièce jointe « {{fileName}} »."
 
-msgid "Upload Successful!"
-msgstr "Téléversement réussi !"
-
 msgid "Upload error!"
 msgstr "Erreur lors du téléversement !"
 

--- a/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/hi/LC_MESSAGES/issue_tracker.po
@@ -298,9 +298,6 @@ msgstr "संलग्नक इतिहास"
 msgid "Please confirm the request to delete the \"{{fileName}}\" attachment."
 msgstr "कृपया \"{{fileName}}\" संलग्नक को हटाने के अनुरोध की पुष्टि करें"
 
-msgid "Upload Successful!"
-msgstr "अपलोड सफल!"
-
 msgid "Upload error!"
 msgstr "अपलोड त्रुटि!"
 

--- a/modules/issue_tracker/locale/issue_tracker.pot
+++ b/modules/issue_tracker/locale/issue_tracker.pot
@@ -210,9 +210,6 @@ msgstr[0] ""
 msgid "Please confirm the request to delete the \"{{fileName}}\" attachment."
 msgstr ""
 
-msgid "Upload Successful!"
-msgstr ""
-
 msgid "Upload error!"
 msgstr ""
 

--- a/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/ja/LC_MESSAGES/issue_tracker.po
@@ -214,9 +214,6 @@ msgstr[0] "{{count}} 件のコメント"
 msgid "Please confirm the request to delete the \"{{fileName}}\" attachment."
 msgstr "添付ファイル「{{fileName}}」の削除リクエストを確認してください。"
 
-msgid "Upload Successful!"
-msgstr "アップロードに成功しました！"
-
 msgid "Upload error!"
 msgstr "アップロードエラー！"
 

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -216,7 +216,7 @@ class MediaEditForm extends Component {
     let xhr = new XMLHttpRequest();
     xhr.addEventListener('load', () => {
       if (xhr.status < 400) {
-        swal.fire(t('Upload Successful!', {ns: 'media'}),
+        swal.fire(t('Upload successful!', {ns: 'loris'}),
           '', 'success');
         this.props.fetchData();
       } else {


### PR DESCRIPTION
## Brief summary of changes

This PR adds the missing translations requested in the corresponding issue except for the Spanish ones. I decided not to include any Spanish translations because the Spanish locale does not exist in this module and it is outside the scope of the 29.0.0 release.

#### Testing instructions (if applicable)

1. Go to 'Imaging' -> 'Imaging Uploader'
2. Switch the language to French, Japanese and Chinese
3. Verify the added translations and report missing ones if found while reviewing the PR.

#### Issue ID: closes #10952 
