### PR TITLE
[modules | new_profile] fix for enabling default unique options for Site and Project

### DIFF
--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -213,10 +213,9 @@ class NewProfileIndex extends React.Component {
    * @param {string} value - selected value for corresponding form element
    */
   setFormData(formElement, value) {
-    let formData = Object.assign({}, this.state.formData);
-    formData[formElement] = value;
-
-    this.setState({formData: formData});
+    this.setState((prevState) => ({
+      formData: Object.assign({}, prevState.formData, {[formElement]: value}),
+    }));
   }
 
   /**
@@ -294,6 +293,7 @@ class NewProfileIndex extends React.Component {
           onUserInput = {this.setFormData}
           value = {this.state.formData.site}
           required = {true}
+          autoSelect = {true}
         />;
     }
     const fields = [
@@ -364,6 +364,7 @@ class NewProfileIndex extends React.Component {
             onUserInput = {this.setFormData}
             value = {this.state.formData.project}
             required = {true}
+            autoSelect = {true}
           />
         ),
       },


### PR DESCRIPTION
**Situation:**
When a user creates a candidate on the `new_profile` page and clicks "Recruit another candidate", the page reloads. For users with a single unique Site or Project affiliation, these dropdowns were failing to automatically select the only available option, in case of uniqueness.

**Task:**
To ensure that form dropdowns with exactly one available option (such as Site and Project) are automatically selected, and ensure that parallel state updates from multiple auto-selecting fields do not overwrite one another.

**Action:**
- Added the `autoSelect={true}` property to the Site and Project `<SelectElement>` components in `NewProfileIndex.js` so they naturally default to their single options.
- Refactored the `setFormData` method to use React's functional state updates (`prevState`). Previously, it read the state synchronously, causing a race condition where the `Project` element would read stale state and overwrite the selection made by the `Site` element fraction of a second prior.

**Result:**
The form now auto-selects unique affiliations upon page load. Users with restricted access can see their unique Site and Project and if there are multiple sites and projects, auto-select will not happen.

As in the screenshot attached, there is only one site and one project after clicking on "Recruit another candidate"
<img width="1090" height="596" alt="image" src="https://github.com/user-attachments/assets/d9cfbd9e-37ba-42d3-aac5-c2441ef75bff" />


This PR closes #10901 
