### PR TITLE
[timepoint_list/instrument_list] Remove "y / " " m" hack from template 

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -366,6 +366,9 @@ msgstr "{{months}} meses"
 msgid "{{years}} years old"
 msgstr "{{years}} años"
 
+msgid "%d y / %d m"
+msgstr "%d a / %d m"
+
 # Other generic terms
 msgid "Loading..."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -587,6 +587,10 @@ msgstr "{{months}} mois"
 msgid "{{years}} years old"
 msgstr "{{years}} ans"
 
+msgid "%d y / %d m"
+msgstr "%d a / %d m"
+
+
 # Other generic terms
 msgid "Loading..."
 msgstr "Chargement en cours..."

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -520,6 +520,9 @@ msgstr "{{months}} महीने का/की"
 msgid "{{years}} years old"
 msgstr "{{years}} वर्ष का"
 
+msgid "%d y / %d m"
+msgstr "%d व / %d म"
+
 # Other generic terms
 msgid "Loading..."
 msgstr "लोड हो रहा है..."

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -546,6 +546,9 @@ msgstr "{{months}}ヶ月"
 msgid "{{years}} years old"
 msgstr "{{years}}歳"
 
+msgid "%d y / %d m"
+msgstr "%d年%dヶ月"
+
 # Other generic terms
 msgid "Loading..."
 msgstr "読み込み中..."

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -558,6 +558,9 @@ msgstr ""
 msgid "{{years}} years old"
 msgstr ""
 
+msgid "%d y / %d m"
+msgstr ""
+
 # Other generic terms
 msgid "Loading..."
 msgstr ""

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -537,7 +537,7 @@ msgstr "{{months}} 月龄"
 msgid "{{years}} years old"
 msgstr "{{years}} 岁"
 
-msgid "%d y / %d"
+msgid "%d y / %d m"
 msgstr "%d 年 / %d 月"
 
 # Other generic terms

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -538,7 +538,7 @@ msgid "{{years}} years old"
 msgstr "{{years}} 岁"
 
 msgid "%d y / %d m"
-msgstr "%d 年 / %d 月"
+msgstr "%d年%d月"
 
 # Other generic terms
 msgid "Loading..."

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -537,6 +537,9 @@ msgstr "{{months}} 月龄"
 msgid "{{years}} years old"
 msgstr "{{years}} 岁"
 
+msgid "%d y / %d"
+msgstr "%d 年 / %d 月"
+
 # Other generic terms
 msgid "Loading..."
 msgstr "加载中..."

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -333,7 +333,11 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $dob_year     = abs($current_date->diff($dob_date)->y);
             $dob_month    = abs($current_date->diff($dob_date)->m);
-            $dob_age      = sprintf(dgettext("loris", "%d y / %d m"), $dob_year,  $dob_month);
+            $dob_age      = sprintf(
+                dgettext("loris", "%d y / %d m"),
+                $dob_year,
+                $dob_month,
+            );
             $this->tpl_data['dob_age'] = $dob_age;
         }
         // EDC to EDC Age
@@ -343,7 +347,11 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $edc_year     = abs($current_date->diff($edc_date)->y);
             $edc_month    = abs($current_date->diff($edc_date)->m);
-            $edc_age      = sprintf(dgettext("loris", "%d y / %d m"), $edc_year,  $edc_month);
+            $edc_age      = sprintf(
+                dgettext("loris", "%d y / %d m"),
+                $edc_year,
+                $edc_month,
+            );
             $this->tpl_data['edc_age'] = $edc_age;
         }
     }

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -333,8 +333,7 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $dob_year     = abs($current_date->diff($dob_date)->y);
             $dob_month    = abs($current_date->diff($dob_date)->m);
-            $dob_age      = $dob_year . dgettext("timepoint_list", " y / ")
-                . $dob_month . dgettext("timepoint_list", " m");
+            $dob_age      = sprintf(dgettext("loris", "%d y / %d m"), $dob_year,  $dob_month);
             $this->tpl_data['dob_age'] = $dob_age;
         }
         // EDC to EDC Age
@@ -344,8 +343,7 @@ class Instrument_List extends \NDB_Menu_Filter
             $current_date = new \DateTime();
             $edc_year     = abs($current_date->diff($edc_date)->y);
             $edc_month    = abs($current_date->diff($edc_date)->m);
-            $edc_age      = $edc_year . dgettext("timepoint_list", " y / ")
-                . $edc_month . dgettext("timepoint_list", " m");
+            $edc_age      = sprintf(dgettext("loris", "%d y / %d m"), $edc_year,  $edc_month);
             $this->tpl_data['edc_age'] = $edc_age;
         }
     }

--- a/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/es/LC_MESSAGES/timepoint_list.po
@@ -70,12 +70,6 @@ msgstr "Sexo Biológico"
 msgid "You do not have access to any timepoints registered for this candidate."
 msgstr "Usted no tiene ningún Punto de Tiempo registrado para este candidato."
 
-msgid " y / "
-msgstr " a / "
-
-msgid " m"
-msgstr " m"
-
 msgid "Not Done"
 msgstr "No Hecha"
 

--- a/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
@@ -73,12 +73,6 @@ msgstr "Sexe biologique"
 msgid "You do not have access to any timepoints registered for this candidate."
 msgstr "Vous n'avez pas accès aux temps d'acquisitions enregistrés pour ce candidat."
 
-msgid " y / "
-msgstr " y / "
-
-msgid " m"
-msgstr " m"
-
 msgid "Not Done"
 msgstr "Non réalisé"
 

--- a/modules/timepoint_list/locale/hi/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/hi/LC_MESSAGES/timepoint_list.po
@@ -70,12 +70,6 @@ msgstr "जैविक लिंग"
 msgid "You do not have access to any timepoints registered for this candidate."
 msgstr "आपको इस उम्मीदवार के लिए पंजीकृत किसी भी टाइमपॉइंट तक पहुँच नहीं है।"
 
-msgid " y / "
-msgstr " व / "
-
-msgid " m"
-msgstr " म"
-
 msgid "Not Done"
 msgstr "पूरा नहीं हुआ"
 

--- a/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/ja/LC_MESSAGES/timepoint_list.po
@@ -71,12 +71,6 @@ msgstr "生物学的性別"
 msgid "You do not have access to any timepoints registered for this candidate."
 msgstr "この候補者に対して登録されたタイムポイントにアクセスできません。"
 
-msgid " y / "
-msgstr ""
-
-msgid " m"
-msgstr ""
-
 msgid "Not Done"
 msgstr "未完了"
 

--- a/modules/timepoint_list/locale/timepoint_list.pot
+++ b/modules/timepoint_list/locale/timepoint_list.pot
@@ -69,12 +69,6 @@ msgstr ""
 msgid "You do not have access to any timepoints registered for this candidate."
 msgstr ""
 
-msgid " y / "
-msgstr ""
-
-msgid " m"
-msgstr ""
-
 msgid "Not Done"
 msgstr ""
 

--- a/modules/timepoint_list/locale/zh/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/zh/LC_MESSAGES/timepoint_list.po
@@ -71,12 +71,6 @@ msgid ""
 "You do not have access to any timepoints registered for this candidate."
 msgstr "您无权访问为此候选人注册的任何时间点。"
 
-msgid " y / "
-msgstr "年 /"
-
-msgid " m"
-msgstr "月"
-
 msgid "Not Done"
 msgstr "未完成"
 

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -90,8 +90,7 @@ class Timepoint_List extends \NDB_Menu
                 $current_date = new \DateTime();
                 $dob_year     = abs($current_date->diff($dob_date)->y);
                 $dob_month    = abs($current_date->diff($dob_date)->m);
-                $dob_age      = $dob_year . dgettext("timepoint_list", " y / ")
-                    . $dob_month . dgettext("timepoint_list", " m");
+                $dob_age      = sprintf(dgettext("loris", "%d y / %d m"), $dob_year,  $dob_month);
                 $this->tpl_data['dob_age'] = $dob_age;
             }
 
@@ -104,8 +103,7 @@ class Timepoint_List extends \NDB_Menu
                 $current_date = new \DateTime();
                 $edc_year     = abs($current_date->diff($edc_date)->y);
                 $edc_month    = abs($current_date->diff($edc_date)->m);
-                $edc_age      = $edc_year . dgettext("timepoint_list", " y / ")
-                    . $edc_month . dgettext("timepoint_list", " m");
+                $edc_age      = sprintf(dgettext("loris", "%d y / %d m"), $edc_year,  $edc_month);
                 $this->tpl_data['edc_age'] = $edc_age;
             }
         }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -90,7 +90,11 @@ class Timepoint_List extends \NDB_Menu
                 $current_date = new \DateTime();
                 $dob_year     = abs($current_date->diff($dob_date)->y);
                 $dob_month    = abs($current_date->diff($dob_date)->m);
-                $dob_age      = sprintf(dgettext("loris", "%d y / %d m"), $dob_year,  $dob_month);
+                $dob_age      = sprintf(
+                    dgettext("loris", "%d y / %d m"),
+                    $dob_year,
+                    $dob_month,
+                );
                 $this->tpl_data['dob_age'] = $dob_age;
             }
 
@@ -103,7 +107,11 @@ class Timepoint_List extends \NDB_Menu
                 $current_date = new \DateTime();
                 $edc_year     = abs($current_date->diff($edc_date)->y);
                 $edc_month    = abs($current_date->diff($edc_date)->m);
-                $edc_age      = sprintf(dgettext("loris", "%d y / %d m"), $edc_year,  $edc_month);
+                $edc_age      = sprintf(
+                    dgettext("loris", "%d y / %d m"),
+                    $edc_year,
+                    $edc_month,
+                );
                 $this->tpl_data['edc_age'] = $edc_age;
             }
         }


### PR DESCRIPTION
This removes the hack where "y / " and " m" are translated in the header
of the timepoint and instrument list pages as individual strings, by interpolating
both into a string so that they can be translated as a unit.