### PR TITLE
[imaging_uploader] Fixes for a couple of imaging uploader bugs

### DIFF
--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -19,7 +19,6 @@ class ImagingUploader extends Component {
    */
   constructor(props) {
     super(props);
-    loris.hiddenHeaders = ['PatientName', 'SessionID'];
 
     this.state = {
       isLoaded: false,
@@ -102,17 +101,6 @@ class ImagingUploader extends Component {
    * @return {*} a formatted table cell for a given column
    */
   formatColumn(column, cell, rowData, rowHeaders) {
-    // If a column if set as hidden, don't display it
-    if (loris.hiddenHeaders.indexOf(column) > -1) {
-      return null;
-    }
-
-    // Create the mapping between rowHeaders and rowData in a row object.
-    let row = {};
-    rowHeaders.forEach((header, index) => {
-      row[header] = rowData[index];
-    }, this);
-
     // Default cell style
     const cellStyle = {whiteSpace: 'nowrap'};
     const {t} = this.props;
@@ -122,6 +110,7 @@ class ImagingUploader extends Component {
     const filesInsertedKey = t('Number Of Files Inserted',
       {ns: 'imaging_uploader'});
     const tarchiveInfoKey = t('Tarchive Info', {ns: 'imaging_uploader'});
+
     const failureText = t('Failure', {ns: 'loris'});
     const inProgressText = t('In Progress', {ns: 'loris'}) + '...';
     const successText = t('Success', {ns: 'loris'});
@@ -147,8 +136,8 @@ class ImagingUploader extends Component {
       }
 
       if (cell === 'Success') {
-        const created = row[filesCreatedKey];
-        const inserted = row[filesInsertedKey];
+        const created = rowData[filesCreatedKey];
+        const inserted = rowData[filesInsertedKey];
         return (
           <td style={cellStyle}>
             {t('{{successText}} ({{inserted}} out of {{created}})',
@@ -187,7 +176,7 @@ class ImagingUploader extends Component {
       if (cell > 0) {
         const url = loris.BaseURL
                     + '/imaging_browser/viewSession/?sessionID='
-                    + row.SessionID;
+                    + rowData['SessionID'];
         return (
           <td style={cellStyle}>
             <a href={url}>{cell}</a>
@@ -199,15 +188,15 @@ class ImagingUploader extends Component {
     if (column === filesCreatedKey) {
       let violatedScans;
       if (
-        row[filesCreatedKey] - row[filesInsertedKey] > 0
+        rowData[filesCreatedKey] - rowData[filesInsertedKey] > 0
       ) {
         let numViolatedScans =
-             row[filesCreatedKey] - row[filesInsertedKey];
+            rowData[filesCreatedKey] - rowData[filesInsertedKey];
 
         const violUrl = loris.BaseURL +
-                         '/mri_violations/?patientName=' + row.PatientName;
+            '/mri_violations/?patientName=' + rowData['PatientName'];
         violatedScans = <a href={violUrl}>
-          {this.props.t('{{numViolatedScans}} violated scans',
+          {this.props.t('({{numViolatedScans}} violated scans)',
             {ns: 'imaging_uploader', numViolatedScans: numViolatedScans}
           )}
         </a>;
@@ -293,7 +282,7 @@ class ImagingUploader extends Component {
                   }
                   return {
                     label: t(header, {ns: ['imaging_uploader', 'loris']}),
-                    show: true,
+                    show: (header !== 'SessionID' && header !== 'PatientName'),
                     filter: filter,
                   };
                 }

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -45,10 +45,10 @@ msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr "Le fichier doit être en format .tgz, tar.gz ou .zip."
 
 #, fuzzy
-msgid "For files that are not Phantom Scans, file name must begin with"
+msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr ""
 "Pour les fichiers qui ne sont pas des scans fantômes, le nom du fichier doit "
-"commencer par"
+"commencer par <0>{{prefix}}</0>"
 
 #, fuzzy
 msgid ""

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Imaging Uploader"
 msgstr "Téléverseur d'images"
@@ -51,12 +52,8 @@ msgstr ""
 "commencer par <0>{{prefix}}</0>"
 
 #, fuzzy
-msgid ""
-"For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label "
-"{{visitLabel}} the file name should be prefixed by: {{prefix}}"
-msgstr ""
-"Par exemple, pour DCCID {{dccid}}, PSCID {{pscid}} et Libellé de visite "
-"{{visitLabel}}, le nom du fichier doit être préfixé par : {{prefix}}"
+msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"
+msgstr "Par exemple, pour DCCID {{dccid}}, PSCID {{pscid}} et libellé de visite {{visitLabel}}, le nom du fichier doit être préfixé par : {{prefix}}"
 
 #, fuzzy
 msgid "The file {{fileName}} must be of type .tgz, .tar.gz or .zip."
@@ -96,12 +93,8 @@ msgstr ""
 "pipeline IRM !"
 
 #, fuzzy
-msgid ""
-"A file with this name already exists! Would you like to overwrite the "
-"existing file?"
-msgstr ""
-"Un fichier portant ce nom existe déjà ! Voulez-vous remplacer le fichier "
-"existant ?"
+msgid "A file with this name already exists! Would you like to overwrite the existing file?"
+msgstr "Un fichier portant ce nom existe déjà ! Voulez-vous remplacer le fichier existant ?"
 
 msgid "Cancelled"
 msgstr "Annulé"
@@ -109,12 +102,8 @@ msgstr "Annulé"
 msgid "Your upload has been cancelled."
 msgstr "Votre téléversement a été annulé."
 
-msgid ""
-"A file with this name has been uploaded but has not yet been processed by "
-"the MRI pipeline. Would you like to overwrite the existing file?"
-msgstr ""
-"Un fichier portant ce nom a été téléversé, mais n'a pas encore été traité "
-"par le pipeline IRM. Souhaitez-vous remplacer le fichier existant ?"
+msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
+msgstr "Un fichier portant ce nom a été téléversé, mais n'a pas encore été traité par le pipeline IRM. Souhaitez-vous remplacer le fichier existant ?"
 
 #, fuzzy
 msgid "Upload Successful!"

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Imaging Uploader"
 msgstr "Téléverseur d'images"
@@ -46,14 +45,18 @@ msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr "Le fichier doit être en format .tgz, tar.gz ou .zip."
 
 #, fuzzy
-msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
+msgid "For files that are not Phantom Scans, file name must begin with"
 msgstr ""
 "Pour les fichiers qui ne sont pas des scans fantômes, le nom du fichier doit "
-"commencer par <0>{{prefix}}</0>"
+"commencer par"
 
 #, fuzzy
-msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"
-msgstr "Par exemple, pour DCCID {{dccid}}, PSCID {{pscid}} et libellé de visite {{visitLabel}}, le nom du fichier doit être préfixé par : {{prefix}}"
+msgid ""
+"For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label "
+"{{visitLabel}} the file name should be prefixed by: {{prefix}}"
+msgstr ""
+"Par exemple, pour DCCID {{dccid}}, PSCID {{pscid}} et Libellé de visite "
+"{{visitLabel}}, le nom du fichier doit être préfixé par : {{prefix}}"
 
 #, fuzzy
 msgid "The file {{fileName}} must be of type .tgz, .tar.gz or .zip."
@@ -93,8 +96,12 @@ msgstr ""
 "pipeline IRM !"
 
 #, fuzzy
-msgid "A file with this name already exists! Would you like to overwrite the existing file?"
-msgstr "Un fichier portant ce nom existe déjà ! Voulez-vous remplacer le fichier existant ?"
+msgid ""
+"A file with this name already exists! Would you like to overwrite the "
+"existing file?"
+msgstr ""
+"Un fichier portant ce nom existe déjà ! Voulez-vous remplacer le fichier "
+"existant ?"
 
 msgid "Cancelled"
 msgstr "Annulé"
@@ -102,8 +109,12 @@ msgstr "Annulé"
 msgid "Your upload has been cancelled."
 msgstr "Votre téléversement a été annulé."
 
-msgid "A file with this name has been uploaded but has not yet been processed by the MRI pipeline. Would you like to overwrite the existing file?"
-msgstr "Un fichier portant ce nom a été téléversé, mais n'a pas encore été traité par le pipeline IRM. Souhaitez-vous remplacer le fichier existant ?"
+msgid ""
+"A file with this name has been uploaded but has not yet been processed by "
+"the MRI pipeline. Would you like to overwrite the existing file?"
+msgstr ""
+"Un fichier portant ce nom a été téléversé, mais n'a pas encore été traité "
+"par le pipeline IRM. Souhaitez-vous remplacer le fichier existant ?"
 
 #, fuzzy
 msgid "Upload Successful!"
@@ -163,8 +174,8 @@ msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}} ({{inserted}} sur {{created}})"
 
 #, fuzzy
-msgid "{{numViolatedScans}} violated scans"
-msgstr "{{numViolatedScans}} scans non conformes"
+msgid "({{numViolatedScans}} violated scans)"
+msgstr "({{numViolatedScans}} scans non conformes)"
 
 #, fuzzy
 msgid "Tarchive Info"

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -131,7 +131,7 @@ msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}} ({{created}} में से {{inserted}})"
 
 msgid "({{numViolatedScans}} violated scans)"
-msgstr "{{numViolatedScans}} उल्लंघन स्कैन"
+msgstr "({{numViolatedScans}} उल्लंघन स्कैन)"
 
 msgid "Tarchive Info"
 msgstr "टीआर्काइव जानकारी"

--- a/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/hi/LC_MESSAGES/imaging_uploader.po
@@ -130,7 +130,7 @@ msgstr "डाली गई फ़ाइलों की संख्या"
 msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}} ({{created}} में से {{inserted}})"
 
-msgid "{{numViolatedScans}} violated scans"
+msgid "({{numViolatedScans}} violated scans)"
 msgstr "{{numViolatedScans}} उल्लंघन स्कैन"
 
 msgid "Tarchive Info"

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -39,7 +39,7 @@ msgstr ""
 msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr ""
 
-msgid "For files that are not Phantom Scans, file name must begin with"
+msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
 msgstr ""
 
 msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -39,7 +39,7 @@ msgstr ""
 msgid "File must be of type .tgz or tar.gz or .zip"
 msgstr ""
 
-msgid "For files that are not Phantom Scans, file name must begin with <0>{{prefix}}</0>"
+msgid "For files that are not Phantom Scans, file name must begin with"
 msgstr ""
 
 msgid "For example, for DCCID {{dccid}}, PSCID {{pscid}}, and Visit Label {{visitLabel}} the file name should be prefixed by: {{prefix}}"
@@ -130,7 +130,7 @@ msgstr ""
 msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr ""
 
-msgid "{{numViolatedScans}} violated scans"
+msgid "({{numViolatedScans}} violated scans)"
 msgstr ""
 
 msgid "Tarchive Info"

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -131,7 +131,7 @@ msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}} ({{inserted}} / {{created}})"
 
 msgid "({{numViolatedScans}} violated scans)"
-msgstr "{{numViolatedScans}} 件の違反スキャン"
+msgstr "({{numViolatedScans}} 件の違反スキャン)"
 
 msgid "Tarchive Info"
 msgstr "アーカイブ情報"

--- a/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/ja/LC_MESSAGES/imaging_uploader.po
@@ -130,7 +130,7 @@ msgstr "挿入されたファイルの数"
 msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}} ({{inserted}} / {{created}})"
 
-msgid "{{numViolatedScans}} violated scans"
+msgid "({{numViolatedScans}} violated scans)"
 msgstr "{{numViolatedScans}} 件の違反スキャン"
 
 msgid "Tarchive Info"

--- a/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
@@ -130,7 +130,7 @@ msgstr "插入的文件数"
 msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}}（{{created}} 中的 {{inserted}}）"
 
-msgid "{{numViolatedScans}} violated scans"
+msgid "({{numViolatedScans}} violated scans)"
 msgstr "{{numViolatedScans}} 扫描违规"
 
 msgid "Tarchive Info"

--- a/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/zh/LC_MESSAGES/imaging_uploader.po
@@ -131,7 +131,7 @@ msgid "{{successText}} ({{inserted}} out of {{created}})"
 msgstr "{{successText}}（{{created}} 中的 {{inserted}}）"
 
 msgid "({{numViolatedScans}} violated scans)"
-msgstr "{{numViolatedScans}} 扫描违规"
+msgstr "({{numViolatedScans}} 扫描违规)"
 
 msgid "Tarchive Info"
 msgstr "档案信息"


### PR DESCRIPTION
This PR performs the following fixes in the imaging uploader module:

1. Columns `Session ID` and `Patient Name` are now hidden.
2. The number of files created and inserted is now properly displayed in column `Progress`.
3. The link to the MRI violations module is now displayed in column `Number of Files Created`.

Fixes #10791 
