### PR TITLE
[dataquery] Dedup recent queries by content so "No run time" eliminates duplicates

### DIFF
--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -20,12 +20,11 @@ import 'I18nSetup';
 declare const loris: any;
 
 /**
- * Build an order-independent signature for a query filter group. AND/OR
- * groups are commutative, so terms are sorted to ignore the order they
- * were added in.
+ * Order-independent signature for a query filter group. Reordering the terms
+ * in an and/or group doesn't change the query, so they're sorted.
  *
  * @param {QueryGroup} group - the filter group to serialize
- * @returns {string} a stable signature for the group's content
+ * @returns {string} a stable signature for the group
  */
 function criteriaSignature(group: QueryGroup): string {
   const terms = group.group.map((term) => {
@@ -46,15 +45,12 @@ function criteriaSignature(group: QueryGroup): string {
 }
 
 /**
- * Build a signature representing the semantic content of a query (its
- * columns and filters), independent of its QueryID and run time.
- *
- * Identical queries can be stored under different QueryIDs because the
- * server dedupes saved queries by an exact string match on the query
- * JSON, so any non-semantic difference (column order, an optional visits
- * key) produces a distinct QueryID. Comparing content instead lets the
- * "eliminate duplicates" filter collapse them. Columns and filter terms
- * are sorted so their order does not affect the signature.
+ * Signature of a query's content (columns + filters), independent of QueryID
+ * and run time. Recent Queries lists every run, and two runs of the same
+ * query can have different QueryIDs: definitions are matched by exact JSON
+ * string, so something like column order stores a new one. Keying on content
+ * lets "eliminate duplicates" collapse them; columns and filter terms are
+ * sorted so their order doesn't matter.
  *
  * @param {FlattenedQuery} query - the query to build a signature for
  * @returns {string} a stable signature for the query's content

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -18,6 +18,58 @@ import {useTranslation} from 'react-i18next';
 import 'I18nSetup';
 
 declare const loris: any;
+
+/**
+ * Build an order-independent signature for a query filter group. AND/OR
+ * groups are commutative, so terms are sorted to ignore the order they
+ * were added in.
+ *
+ * @param {QueryGroup} group - the filter group to serialize
+ * @returns {string} a stable signature for the group's content
+ */
+function criteriaSignature(group: QueryGroup): string {
+  const terms = group.group.map((term) => {
+    if (term instanceof QueryGroup) {
+      return criteriaSignature(term);
+    }
+    const t = term as QueryTerm;
+    return JSON.stringify({
+      module: t.module,
+      category: t.category,
+      fieldname: t.fieldname,
+      op: t.op,
+      value: t.value,
+      visits: (t.visits ?? []).slice().sort(),
+    });
+  }).sort();
+  return JSON.stringify({operator: group.operator, terms});
+}
+
+/**
+ * Build a signature representing the semantic content of a query (its
+ * columns and filters), independent of its QueryID and run time.
+ *
+ * Identical queries can be stored under different QueryIDs because the
+ * server dedupes saved queries by an exact string match on the query
+ * JSON, so any non-semantic difference (column order, an optional visits
+ * key) produces a distinct QueryID. Comparing content instead lets the
+ * "eliminate duplicates" filter collapse them. Columns and filter terms
+ * are sorted so their order does not affect the signature.
+ *
+ * @param {FlattenedQuery} query - the query to build a signature for
+ * @returns {string} a stable signature for the query's content
+ */
+function queryContentSignature(query: FlattenedQuery): string {
+  const fields = query.fields.map((field: FlattenedField) => JSON.stringify({
+    module: field.module,
+    category: field.category,
+    field: field.field,
+    visits: (field.visits ?? []).map((v: VisitOption) => v.value).sort(),
+  })).sort();
+  const criteria = query.criteria ? criteriaSignature(query.criteria) : '';
+  return JSON.stringify({fields, criteria});
+}
+
 /**
  * Return the welcome tab for the DQT
  *
@@ -404,13 +456,21 @@ function QueryList(props: {
     );
   }
   if (noDuplicates === true) {
-    const queryList: {[queryID: number]: FlattenedQuery} = {};
+    const seen: {[signature: string]: number} = {};
     const newDisplayedQueries: FlattenedQuery[] = [];
     displayedQueries.forEach((val) => {
-      if (queryList.hasOwnProperty(val.QueryID)) {
+      const signature = queryContentSignature(val);
+      if (seen.hasOwnProperty(signature)) {
+        // A named query is a better representative for the group than an
+        // otherwise identical unnamed run, so keep it if the one already
+        // kept is unnamed.
+        const index = seen[signature];
+        if (!newDisplayedQueries[index].Name && val.Name) {
+          newDisplayedQueries[index] = val;
+        }
         return;
       }
-      queryList[val.QueryID] = val;
+      seen[signature] = newDisplayedQueries.length;
       newDisplayedQueries.push(val);
     });
     displayedQueries = newDisplayedQueries;


### PR DESCRIPTION
## Description
The "No run times (eliminate duplicates)" filter in the Recent Queries list was deduping on QueryID, but that doesn't actually catch duplicates. Identical queries can get saved under different QueryIDs, since the server dedupes saved queries by an exact string match on the query JSON, so any non-semantic difference (columns added in a different order, an optional visits key) ends up as a distinct QueryID. Keying on QueryID just leaves the duplicates in the list.

## Changes
- Dedup the recent queries by a signature of their actual content (columns + filters) instead of QueryID. Columns and filter terms are sorted so their order doesn't matter.
- When two collapse, keep the named one as the representative if there is one, otherwise the most recent run.

## Testing Instructions
1. Run a query.
2. Name it in the Recent Queries section.
3. Run the same query again from scratch.
4. Go to Recent Queries and tick "No run times (eliminate duplicates)".
5. The two runs now collapse into a single row (showing the named query).

## Related Issues
Resolves #10600
