### PR TITLE
[acknowledgements] Remove logic preventing end_date field to save

### DIFF
--- a/modules/acknowledgements/php/acknowledgementsprocess.class.inc
+++ b/modules/acknowledgements/php/acknowledgementsprocess.class.inc
@@ -66,9 +66,6 @@ class Acknowledgementsprocess extends \NDB_Page
         $roles        = "";
         $values       = json_decode($req->getBody()->getContents(), true);
         if (isset($values) && !is_null($values)) {
-            if (isset($values['addPresent']) && $values['addPresent'] === 'Yes') {
-                $values['addEndDate'] = null;
-            }
             if (isset($values['addAffiliations'])
                 && !is_null($values['addAffiliations'])
             ) {


### PR DESCRIPTION
Related to #10790

Testing:
1. Go to the `Acknowledgements` module
2. Add a new acknowledgement and make sure to fill in `End date` &  `Present` = 'Yes'
3. See if the `End date` displays in the table for the newly created acknowledgements