### PR TITLE
[imaging_uploader] No logs displayed in the log window

### DIFF
--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -18,6 +18,8 @@
  * @link     https://www.github.com/Jkat/Loris-Trunk/
  */
 
+$user = \NDB_Factory::singleton()->user();
+
 // Base access check - user must have either of these permissions
 // more access validation after request validation
 if (!$user->hasAnyPermission(
@@ -32,7 +34,6 @@ if (!$user->hasAnyPermission(
 }
 $config        = \NDB_Factory::singleton()->config();
 $advancedperms = $config->getSetting('useAdvancedPermissions');
-$user          = \NDB_Factory::singleton()->user();
 $centerString  = implode("','", $user->getCenterIDs());
 $projectString = implode("','", $user->getProjectIDs());
 $username      = $user->getUsername();
@@ -92,12 +93,10 @@ $accessData = $DB->pselectRow(
     ['uploadId' => $uploadId]
 );
 
-
 if (empty($accessData)) {
     http_response_code(403);
     return;
 }
-
 
 /* Fetch columns Inserting and InsertionComplete from table mri_upload
  * create Database object
@@ -124,10 +123,14 @@ if ($summary) {
     $query .= " AND Verbose = 'N'";
 }
 
-$notifications = $DB->pselect(
+$notifications = [];
+$rows = $DB->pselect(
     $query,
     ['processId' => $uploadId]
 );
+foreach($rows as $row) {
+    $notifications[] = $row;
+}
 
 // Return JSON object encapsulating the response
 echo json_encode(

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -124,11 +124,11 @@ if ($summary) {
 }
 
 $notifications = [];
-$rows = $DB->pselect(
+$rows          = $DB->pselect(
     $query,
     ['processId' => $uploadId]
 );
-foreach($rows as $row) {
+foreach ($rows as $row) {
     $notifications[] = $row;
 }
 


### PR DESCRIPTION
This PR fixes a bug that prevented the MRI scan processing logs to be displayed in the log viewer window of the imaging uploader module.


Fixes #10795 