### PR TITLE
[Core] Replace "Biological Sex" with "Sex Assigned At Birth"

### DIFF
--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -96,7 +96,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 ),
                 new DictionaryItem(
                     "Sex",
-                    "Candidate's biological sex",
+                    "Sex assigned at birth",
                     $candscope,
                     $t,
                     new Cardinality(Cardinality::SINGLE),

--- a/modules/dicom_archive/locale/dicom_archive.pot
+++ b/modules/dicom_archive/locale/dicom_archive.pot
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Patient Birthdate"
 msgstr ""
 
-msgid "Patient Biological Sex"
+msgid "Patient Sex Assigned at Birth"
 msgstr ""
 
 msgid "Date acquired"

--- a/modules/dicom_archive/templates/form_viewDetails.tpl
+++ b/modules/dicom_archive/templates/form_viewDetails.tpl
@@ -21,7 +21,7 @@
     <td>{$archive.PatientDoB}</td>
   </tr>
   <tr>
-    <th>{dgettext("dicom_archive", "Patient Biological Sex")}</th>
+    <th>{dgettext("dicom_archive", "Patient Sex Assigned at Birth")}</th>
     <td>{$archive.PatientSex}</td>
   </tr>
   <tr>

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -11,7 +11,7 @@
       {dgettext("timepoint_list", "EDC Age")}
     </th>
     <th>
-      {dgettext("timepoint_list", "Biological Sex")}
+      {dgettext("timepoint_list", "Sex Assigned At Birth")}
     </th>
     {if $display.ProjectTitle == $display.ProjectName && $display.ProjectName != ""}
       <th>

--- a/modules/statistics/jsx/widgets/recruitment.js
+++ b/modules/statistics/jsx/widgets/recruitment.js
@@ -59,7 +59,7 @@ const Recruitment = (props) => {
           chartObject: null,
         },
         'siterecruitment_bysex': {
-          title: t('Biological sex breakdown by site', {ns: 'statistics'}),
+          title: t('Sex breakdown by site', {ns: 'statistics'}),
           filters: '',
           chartType: 'bar',
           dataType: 'bar',
@@ -104,7 +104,7 @@ const Recruitment = (props) => {
       = t('Participants', {ns: 'statistics'});
 
     newdetails['siteBreakdown']['siterecruitment_bysex']['title']
-      = t('Biological sex breakdown by site', {ns: 'statistics'});
+      = t('Sex breakdown by site', {ns: 'statistics'});
 
     newdetails['projectBreakdown']['agedistribution_line']['title']
       = t('Candidate Age at Registration', {ns: 'statistics'});

--- a/modules/timepoint_list/locale/timepoint_list.pot
+++ b/modules/timepoint_list/locale/timepoint_list.pot
@@ -63,7 +63,7 @@ msgstr ""
 msgid "EDC Age"
 msgstr ""
 
-msgid "Biological Sex"
+msgid "Sex Assigned At Birth"
 msgstr ""
 
 msgid "You do not have access to any timepoints registered for this candidate."

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -10,7 +10,7 @@
       {dgettext("timepoint_list", "EDC Age")}
     </th>
     <th>
-      {dgettext("timepoint_list", "Biological Sex")}
+      {dgettext("timepoint_list", "Sex Assigned At Birth")}
     </th>
     <th>
       {dgettext("loris", "Project")}

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -23,7 +23,7 @@
       {dgettext("timepoint_list", "EDC Age")}
     </th>
     <th>
-      {dgettext("timepoint_list", "Biological Sex")}
+      {dgettext("timepoint_list", "Sex Assigned At Birth")}
     </th>
     {if $candidate.ProjectTitle == $candidate.ProjectName && $candidate.ProjectName != ""}
       <th>


### PR DESCRIPTION
This updates the "Biological Sex" wording which was mostly to avoid places where the word "sex" might be ambiguous when the "gender" column was changed to "sex" years ago, to a less ambiguous and more scientifically useful "Sex Assigned At Birth" wording.

There is still a reference to "biological sex" in the hed_schema_nodes table of raisinbread, but I'm not sure if the hed schema is a third party ontology or something we maintain ourselves, so I left it as-is.

TODO:
- [ ] Update translations

Maybe TODO:
- [ ] Update options in default schema ("Intersex", "Unknown", etc)