### PR TITLE
[data_release] Fixed delete files issue if language selected is not English

### DIFF
--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -133,9 +133,9 @@ class DataReleaseIndex extends Component {
                     });
                     this.show('manageFileForm');
                   }}
-                  >
-                    <span className='glyphicon glyphicon-pencil' />
-                  </a>
+                >
+                  <span className='glyphicon glyphicon-pencil' />
+                </a>
             }
           </td>
         );

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -80,32 +80,32 @@ class DataReleaseIndex extends Component {
 
   formatColumn(column, cell, row) {
     const {t} = this.props;
-    // Set class to 'bg-danger' if file is hidden.
-    let hidden = row['hiddenById']
+    
+    let hidden = row[t('Hidden By ID', { ns: 'data_release' })]
       && this.props.hasPermission('data_release_hide');
-    let result = <td
-      className={hidden ? 'bg-danger' : ''}
-    >{cell}</td>;
+      
+    let result = <td className={hidden ? 'bg-danger' : ''}>{cell}</td>;
+    
     switch (column) {
     case t('File Name', {ns: 'data_release'}):
       if (this.props.hasPermission('superuser')
             || this.props.hasPermission('data_release_view')
             || this.props.hasPermission('data_release_upload')
-            || this.props.hasPermission('data_release_edit_file_access')) {
+            || this.props.hasPermission('data_release_edit_file_access')) {           
         const downloadURL = loris.BaseURL
-             + '/data_release/files/'
-             + encodeURIComponent(row['dataReleaseID']);
+            + '/data_release/files/'
+            + encodeURIComponent(row[t('Data Release ID', { ns: 'data_release' })]);
+            
         result = (
           <td
             className={hidden ? 'bg-danger' : ''}
-            style={{display: 'flex',
-              justifyContent: 'space-between',
-            }}
+            style={{display: 'flex', justifyContent: 'space-between'}}
           >
             <a
-              href = {downloadURL}
-              target = "_blank"
-              download = {row['fileName']} >
+              href={downloadURL}
+              target="_blank"
+              download={row[t('File Name', { ns: 'data_release' })]}
+            >
               {cell}
             </a>
             {
@@ -118,25 +118,25 @@ class DataReleaseIndex extends Component {
                   onClick={() => {
                     this.setState({
                       managingFile: {
-                        fileName: row['fileName'],
-                        version: row['version'],
-                        hiddenById: row['hiddenById'],
-                        dataReleaseID: row['dataReleaseID'],
-                      },
+                        fileName: row[t('File Name', { ns: 'data_release' })],
+                        version: row[t('Version', { ns: 'data_release' })],
+                        hiddenById: row[t('Hidden By ID', { ns: 'data_release' })],
+                        dataReleaseID: row[t('Data Release ID', { ns: 'data_release' })]
+                      }
                     });
                     this.show('manageFileForm');
                   }}
                 >
-                  <span className='glyphicon glyphicon-pencil' />
+                  <span className="glyphicon glyphicon-pencil" />
                 </a>
             }
           </td>
         );
       }
       break;
-    case 'Version':
-      result = <td
-        className={hidden ? 'bg-danger' : ''}>
+      
+    case t('Version', {ns: 'data_release'}):
+      result = <td className={hidden ? 'bg-danger' : ''}>
         {cell}
       </td>;
       break;

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -117,13 +117,19 @@ class DataReleaseIndex extends Component {
                 <a
                   style={{marginLeft: 'auto'}}
                   onClick={() => {
+                    const fileName = t('File Name', {ns: 'data_release'});
+                    const version = t('Version', {ns: 'data_release'});
+                    const hiddenById = t('Hidden By ID',
+                      {ns: 'data_release'});
+                    const dataReleaseID = t('Data Release ID',
+                      {ns: 'data_release'});
                     this.setState({
                       managingFile: {
-                        fileName: row[t('File Name', {ns: 'data_release'})],
-                        version: row[t('Version', {ns: 'data_release'})],
-                        hiddenById: row[t('Hidden By ID', {ns: 'data_release'})],
-                        dataReleaseID: row[t('Data Release ID', {ns: 'data_release'})],
-                      }
+                        fileName: row[fileName],
+                        version: row[version],
+                        hiddenById: row[hiddenById],
+                        dataReleaseID: row[dataReleaseID],
+                      },
                     });
                     this.show('manageFileForm');
                   }}

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -80,12 +80,12 @@ class DataReleaseIndex extends Component {
 
   formatColumn(column, cell, row) {
     const {t} = this.props;
-
+    // Set class to 'bg-danger' if file is hidden.
     let hidden = row[t('Hidden By ID', {ns: 'data_release'})]
       && this.props.hasPermission('data_release_hide');
-
-    let result = <td className={hidden ? 'bg-danger' : ''}>{cell}</td>;
-
+    let result = <td
+      className={hidden ? 'bg-danger' : ''}
+    >{cell}</td>;
     switch (column) {
     case t('File Name', {ns: 'data_release'}):
       if (this.props.hasPermission('superuser')
@@ -93,21 +93,20 @@ class DataReleaseIndex extends Component {
             || this.props.hasPermission('data_release_upload')
             || this.props.hasPermission('data_release_edit_file_access')) {
         const downloadURL = loris.BaseURL
-            + '/data_release/files/'
-            + encodeURIComponent(
-              row[t('Data Release ID', {ns: 'data_release'})]
-            );
-
+             + '/data_release/files/'
+             + encodeURIComponent(row[t('Data Release ID',
+               {ns: 'data_release'})]);
         result = (
           <td
             className={hidden ? 'bg-danger' : ''}
-            style={{display: 'flex', justifyContent: 'space-between'}}
+            style={{display: 'flex',
+              justifyContent: 'space-between',
+            }}
           >
             <a
-              href={downloadURL}
-              target="_blank"
-              download={row[t('File Name', {ns: 'data_release'})]}
-            >
+              href = {downloadURL}
+              target = "_blank"
+              download = {row[t('File Name', {ns: 'data_release'})]} >
               {cell}
             </a>
             {
@@ -122,25 +121,23 @@ class DataReleaseIndex extends Component {
                       managingFile: {
                         fileName: row[t('File Name', {ns: 'data_release'})],
                         version: row[t('Version', {ns: 'data_release'})],
-                        hiddenById: row[t('Hidden By ID',
-                          {ns: 'data_release'})],
-                        dataReleaseID: row[t('Data Release ID',
-                          {ns: 'data_release'})],
-                      },
+                        hiddenById: row[t('Hidden By ID', {ns: 'data_release'})],
+                        dataReleaseID: row[t('Data Release ID', {ns: 'data_release'})],
+                      }
                     });
                     this.show('manageFileForm');
                   }}
-                >
-                  <span className="glyphicon glyphicon-pencil" />
-                </a>
+                  >
+                    <span className='glyphicon glyphicon-pencil' />
+                  </a>
             }
           </td>
         );
       }
       break;
-
     case t('Version', {ns: 'data_release'}):
-      result = <td className={hidden ? 'bg-danger' : ''}>
+      result = <td
+        className={hidden ? 'bg-danger' : ''}>
         {cell}
       </td>;
       break;
@@ -335,4 +332,3 @@ window.addEventListener('load', () => {
     />
   );
 });
-

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -80,22 +80,24 @@ class DataReleaseIndex extends Component {
 
   formatColumn(column, cell, row) {
     const {t} = this.props;
-    
-    let hidden = row[t('Hidden By ID', { ns: 'data_release' })]
+
+    let hidden = row[t('Hidden By ID', {ns: 'data_release'})]
       && this.props.hasPermission('data_release_hide');
-      
+
     let result = <td className={hidden ? 'bg-danger' : ''}>{cell}</td>;
-    
+
     switch (column) {
     case t('File Name', {ns: 'data_release'}):
       if (this.props.hasPermission('superuser')
             || this.props.hasPermission('data_release_view')
             || this.props.hasPermission('data_release_upload')
-            || this.props.hasPermission('data_release_edit_file_access')) {           
+            || this.props.hasPermission('data_release_edit_file_access')) {
         const downloadURL = loris.BaseURL
             + '/data_release/files/'
-            + encodeURIComponent(row[t('Data Release ID', { ns: 'data_release' })]);
-            
+            + encodeURIComponent(
+              row[t('Data Release ID', {ns: 'data_release'})]
+            );
+
         result = (
           <td
             className={hidden ? 'bg-danger' : ''}
@@ -104,7 +106,7 @@ class DataReleaseIndex extends Component {
             <a
               href={downloadURL}
               target="_blank"
-              download={row[t('File Name', { ns: 'data_release' })]}
+              download={row[t('File Name', {ns: 'data_release'})]}
             >
               {cell}
             </a>
@@ -118,11 +120,13 @@ class DataReleaseIndex extends Component {
                   onClick={() => {
                     this.setState({
                       managingFile: {
-                        fileName: row[t('File Name', { ns: 'data_release' })],
-                        version: row[t('Version', { ns: 'data_release' })],
-                        hiddenById: row[t('Hidden By ID', { ns: 'data_release' })],
-                        dataReleaseID: row[t('Data Release ID', { ns: 'data_release' })]
-                      }
+                        fileName: row[t('File Name', {ns: 'data_release'})],
+                        version: row[t('Version', {ns: 'data_release'})],
+                        hiddenById: row[t('Hidden By ID',
+                          {ns: 'data_release'})],
+                        dataReleaseID: row[t('Data Release ID',
+                          {ns: 'data_release'})],
+                      },
                     });
                     this.show('manageFileForm');
                   }}
@@ -134,7 +138,7 @@ class DataReleaseIndex extends Component {
         );
       }
       break;
-      
+
     case t('Version', {ns: 'data_release'}):
       result = <td className={hidden ? 'bg-danger' : ''}>
         {cell}

--- a/modules/data_release/jsx/dataReleaseIndex.js
+++ b/modules/data_release/jsx/dataReleaseIndex.js
@@ -81,7 +81,7 @@ class DataReleaseIndex extends Component {
   formatColumn(column, cell, row) {
     const {t} = this.props;
     // Set class to 'bg-danger' if file is hidden.
-    let hidden = row['Hidden By ID']
+    let hidden = row['hiddenById']
       && this.props.hasPermission('data_release_hide');
     let result = <td
       className={hidden ? 'bg-danger' : ''}
@@ -93,9 +93,8 @@ class DataReleaseIndex extends Component {
             || this.props.hasPermission('data_release_upload')
             || this.props.hasPermission('data_release_edit_file_access')) {
         const downloadURL = loris.BaseURL
-            + '/data_release/files/'
-            + encodeURIComponent(row[t('Data Release ID',
-              {ns: 'data_release'})]);
+             + '/data_release/files/'
+             + encodeURIComponent(row['dataReleaseID']);
         result = (
           <td
             className={hidden ? 'bg-danger' : ''}
@@ -106,7 +105,7 @@ class DataReleaseIndex extends Component {
             <a
               href = {downloadURL}
               target = "_blank"
-              download = {row[t('File Name', {ns: 'data_release'})]} >
+              download = {row['fileName']} >
               {cell}
             </a>
             {
@@ -119,10 +118,10 @@ class DataReleaseIndex extends Component {
                   onClick={() => {
                     this.setState({
                       managingFile: {
-                        fileName: row['File Name'],
-                        version: row['Version'],
-                        hiddenById: row['Hidden By ID'],
-                        dataReleaseID: row['Data Release ID'],
+                        fileName: row['fileName'],
+                        version: row['version'],
+                        hiddenById: row['hiddenById'],
+                        dataReleaseID: row['dataReleaseID'],
                       },
                     });
                     this.show('manageFileForm');


### PR DESCRIPTION
## Brief summary of changes
Now the files should be able to be deleted when the language is not set to English

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to data_release module
2. Try deleting a file in English as well as other languages
3. Make sure it works fine as intended

#### Link(s) to related issue(s)

* Resolves #10904   (Reference the issue this fixes, if any.)
