### PR TITLE
[dictionary] Fix "Visit" and "Cohort" filters in non-English

### DIFF
--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -329,7 +329,7 @@ class DataDictIndex extends Component {
         filter: {
           name: 'Visits',
           type: 'multiselect',
-	  sortByValue: false,
+          sortByValue: false,
           options: options.visits,
         },
       },

--- a/modules/dictionary/jsx/dataDictIndex.js
+++ b/modules/dictionary/jsx/dataDictIndex.js
@@ -329,6 +329,7 @@ class DataDictIndex extends Component {
         filter: {
           name: 'Visits',
           type: 'multiselect',
+	  sortByValue: false,
           options: options.visits,
         },
       },

--- a/modules/dictionary/php/datadictrow.class.inc
+++ b/modules/dictionary/php/datadictrow.class.inc
@@ -48,8 +48,14 @@ class DataDictRow implements \LORIS\Data\DataInstance,
         $this->item         = $item;
         $this->desc         = $desc;
         $this->status       = $descstatus;
-        $this->visits       = $visits;
-        $this->cohorts      = $cohorts;
+        $this->visits       = $visits != null ? array_map(
+            fn($visit) => dgettext("visit", $visit),
+            $visits,
+        ) : null;
+        $this->cohorts      = $cohorts != null ? array_map(
+            fn($cohort) => dgettext("cohort", $cohort),
+            $cohorts,
+        ) : null;
     }
 
     /**


### PR DESCRIPTION
This fixes the "Visit" and "Cohort" filters in the non-English user languages.

The filters were being translated but the data was not, so this translates the table values.

Also do not sort "Visit" in the filter so that they show up in the correct order in Japanese.