### PR TITLE
[dictionary] Fix Data Cardinality French translations

### DIFF
--- a/modules/dictionary/locale/fr/LC_MESSAGES/dictionary.po
+++ b/modules/dictionary/locale/fr/LC_MESSAGES/dictionary.po
@@ -74,7 +74,7 @@ msgid "Optional"
 msgstr "Optionnel"
 
 msgid "Many"
-msgstr "Beaucoup"
+msgstr "Plusieurs"
 
 msgid "Description"
 msgstr "Description"

--- a/modules/dictionary/locale/fr/LC_MESSAGES/dictionary.po
+++ b/modules/dictionary/locale/fr/LC_MESSAGES/dictionary.po
@@ -68,7 +68,7 @@ msgid "Unique"
 msgstr "Unique"
 
 msgid "Single"
-msgstr "Unique"
+msgstr "Une seule valeur"
 
 msgid "Optional"
 msgstr "Optionnel"


### PR DESCRIPTION
## Brief summary of changes
- Fixed bug where Unique and Single were both translated as Unique in French which was causing one to know appear in the dropdown.
- Corrected the `Many` translation to `Plusieurs` instead of `Beaucoup`

<img width="967" height="550" alt="image" src="https://github.com/user-attachments/assets/74cd5a00-f54f-4c84-85ad-85ae79c2903f" />

#### Testing instructions (if applicable)

1. Run `make dev`
2. Go to the `dictionary` module
3. Check that all 4 options appear in the `Data Cardinality` dropdown
4. Make sure the translations are correct (correct ones in screenshot)

#### Link(s) to related issue(s)

* Resolves [#10947](https://github.com/aces/Loris/issues/10947) and [#10946](https://github.com/aces/Loris/issues/10946)  (Reference the issue this fixes, if any.)
