### PR TITLE
[RB] Translate Visit Labels in French

### DIFF
--- a/raisinbread/locale/fr/LC_MESSAGES/visit.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/visit.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "V1"
-msgstr "1ᵉ Visite"
+msgstr "1ʳᵉ Visite"
 
 msgid "V2"
 msgstr "2ᵉ Visite"

--- a/raisinbread/locale/fr/LC_MESSAGES/visit.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/visit.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "V1"
+msgstr "1ᵉ Visite"
+
+msgid "V2"
+msgstr "2ᵉ Visite"
+
+msgid "V3"
+msgstr "3ᵉ Visite"
+
+msgid "V4"
+msgstr "4ᵉ Visite"
+
+msgid "V5"
+msgstr "5ᵉ Visite"
+
+msgid "V6"
+msgstr "6ᵉ Visite"
+


### PR DESCRIPTION
This translates Visit Labels in French in Raisinbread.

While the V1/V2/etc codes used in RB make sense, translating them will make inconsistencies more obvious as there are more people testing French than Japanese (which is currently the only language that translates them.)
