### PR TITLE
[statistics] Retrieve sex list with getSexList instead of hardcoded strings

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -267,21 +267,6 @@ msgstr "Date de décès"
 msgid "Sex"
 msgstr "Sexe"
 
-msgid "Female"
-msgid_plural "Females"
-msgstr[0] "Femme"
-msgstr[1] "Femmes"
-
-msgid "Male"
-msgid_plural "Males"
-msgstr[0] "Homme"
-msgstr[1] "Hommes"
-
-msgid "Other"
-msgid_plural "Others"
-msgstr[0] "Autre"
-msgstr[1] "Autres"
-
 msgid "Feedback"
 msgstr "Commentaires"
 

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -256,18 +256,6 @@ msgstr ""
 msgid "Sex"
 msgstr ""
 
-msgid "Female"
-msgid_plural "Females"
-msgstr[0] ""
-
-msgid "Male"
-msgid_plural "Males"
-msgstr[0] ""
-
-msgid "Other"
-msgid_plural "Others"
-msgstr[0] ""
-
 msgid "Feedback"
 msgstr ""
 

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -616,10 +616,7 @@ class Stats_Demographic extends \NDB_Form
                 $demographicProject
             );
         } else {
-            $subcategories = [
-                dngettext('loris', 'Male', 'Males', 1),
-                dngettext('loris', 'Female', 'Females', 1)
-            ];
+            $subcategories = array_values(\Utility::getSexList());
             $result        = iterator_to_array(
                 $db->pselect(
                     "SELECT s.CenterID as CenterID,

--- a/modules/statistics/templates/form_stats_demographic.tpl
+++ b/modules/statistics/templates/form_stats_demographic.tpl
@@ -116,7 +116,7 @@
         </tr>
         <tr>
             <td rowspan="2" align="left" style="vertical-align:middle">{dgettext('loris', 'Sex')}</td>
-            <td align="left" >{dngettext('statistics', 'Male', 'Males', 1)}</td>
+            <td align="left" >{dgettext('sex', 'Male')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]|default}>0}
                     {if {$sex_male[$NULL]|default}>0}
@@ -151,7 +151,7 @@
 
         </tr>
         <tr>
-            <td align="left">{dngettext('loris', 'Female', 'Females', 1)}</td>
+            <td align="left">{dgettext('sex', 'Female')}</td>
             {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]|default}>0}
                     {if {$sex_female[$NULL]|default}>0}

--- a/raisinbread/locale/fr/LC_MESSAGES/sex.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/sex.po
@@ -14,17 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Female"
-msgid_plural "Females"
-msgstr[0] "Femme"
-msgstr[1] "Femmes"
+msgstr "Femme"
 
 msgid "Male"
-msgid_plural "Males"
-msgstr[0] "Homme"
-msgstr[1] "Hommes"
+msgstr "Homme"
 
 msgid "Other"
-msgid_plural "Others"
-msgstr[0] "Autre"
-msgstr[1] "Autres"
-
+msgstr "Autre"

--- a/raisinbread/locale/hi/LC_MESSAGES/sex.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/sex.po
@@ -14,17 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Female"
-msgid_plural "Females"
-msgstr[0] "स्त्री"
-msgstr[1] "महिलाएँ"
+msgstr "स्त्री"
 
 msgid "Male"
-msgid_plural "Males"
-msgstr[0] "पुरुष"
-msgstr[1] "नर"
+msgstr "पुरुष"
 
 msgid "Other"
-msgid_plural "Others"
-msgstr[0] "अन्य"
-msgstr[1] "अन्य"
-
+msgstr "अन्य"

--- a/raisinbread/locale/ja/LC_MESSAGES/sex.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/sex.po
@@ -21,4 +21,3 @@ msgstr "男の人"
 
 msgid "Other"
 msgstr "不明"
-


### PR DESCRIPTION
## Brief summary of changes

This PR replaces the hardcoded sex labels in the Statistics module with values retrieved from `\Utility::getSexList()`. The retrieved values are translated using `dgettext` within the utility function, eliminating the need for the corresponding hardcoded entries in the loris translation files.

#### Testing instructions (if applicable)

1. git checkout HachemJ/RetrieveSexListFromDbInStatistics
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Reports' -> 'Statistics'
6. Switch the language to 'French'
7. Go to the 'Statistiques démographiques' tab
8. Confirm that the translated sex labels are displayed correctly throughout the Statistics module.

#### Link(s) to related issue(s)

* Resolves #10990 (Reference the issue this fixes, if any.)
