### PR TITLE
[media] Fix broken visit link related to multilingual code

### DIFF
--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -136,9 +136,9 @@ class MediaIndex extends Component {
       }
       break;
     case t('Visit Label', {ns: 'loris'}):
-      if (row['CandID'] !== null && row['SessionID']) {
+      if (row[t('CandID')] !== null && row[t('SessionID', {ns: 'loris'})]) {
         const sessionURL = loris.BaseURL + '/instrument_list/?candID=' +
-          row['CandID'] + '&sessionID=' + row['SessionID'];
+          row[t('CandID')] + '&sessionID=' + t(row[t('SessionID', {ns: 'loris'})]);
         result = <td className={style}><a href={sessionURL}>{cell}</a></td>;
       }
       break;

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -138,7 +138,8 @@ class MediaIndex extends Component {
     case t('Visit Label', {ns: 'loris'}):
       if (row[t('CandID')] !== null && row[t('SessionID', {ns: 'loris'})]) {
         const sessionURL = loris.BaseURL + '/instrument_list/?candID=' +
-          row[t('CandID')] + '&sessionID=' + t(row[t('SessionID', {ns: 'loris'})]);
+          row[t('CandID')] + '&sessionID='
+          + t(row[t('SessionID', {ns: 'loris'})]);
         result = <td className={style}><a href={sessionURL}>{cell}</a></td>;
       }
       break;


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bug where row['SessionID'] was undefined when using a language other than English because the row keys were localized (e.g. row['Identifiant de session'] in French).

#### Testing instructions (if applicable)

1. git checkout HachemJ/FixWrongLinksInMediaModuleIfLanguageNotDefault
2. Go to 'Clinical' -> 'Media'
3. Verify that the entries in the Visit Label column are displayed as clickable links.
4. Switch the language to 'French'
5. Verify that the visit labels are translated, remain clickable, and navigate to the same session as in English (i.e., the sessionID in the URL is unchanged)
6. Make sure the links are clickable in any language.

#### Link(s) to related issue(s)

* Resolves #11002 (Reference the issue this fixes, if any.)
