### PR TITLE
[dataquery] Clear filters btn

### DIFF
--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -101,6 +101,15 @@ function DefineFilters(props: {
     });
   };
 
+  const removeFiltersButton = (
+    <ButtonElement
+      label={t('Remove all filters', {ns: 'dataquery'})}
+      columnSize="col-sm-12"
+      buttonClass='btn btn-danger btn-remove'
+      onUserInput={clearAllFilters}
+    />
+  );
+
   useEffect(() => {
     setQueryMatches(null);
     if (!props.fields || props.fields.length === 0) {
@@ -371,13 +380,9 @@ function DefineFilters(props: {
                   props.query.operator = 'or';
                 }} />
             </div>
-            <ButtonElement
-              label={t('Remove all filters', {ns: 'dataquery'})}
-              columnSize="col-sm-12"
-              style={{marginTop: '1ex'}}
-              buttonClass='btn btn-danger btn-remove'
-              onUserInput={clearAllFilters}
-            />
+            <div style={{marginTop: '1ex'}}>
+              {removeFiltersButton}
+            </div>
           </div>
           {toggleAdvancedButton}
           {advancedButtons}
@@ -408,13 +413,7 @@ function DefineFilters(props: {
             newGroup={props.addNewQueryGroup}
             fulldictionary={props.fulldictionary}
             setDeleteItemIndex={setDeleteItemIndex}
-          />
-          <ButtonElement
-            label={t('Remove all filters', {ns: 'dataquery'})}
-            columnSize="col-sm-12"
-            style={{marginLeft: '5px'}}
-            buttonClass='btn btn-danger btn-remove'
-            onUserInput={clearAllFilters}
+            extraButton={removeFiltersButton}
           />
         </fieldset>
       </form>

--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -12,6 +12,7 @@ import {calcPayload} from './calcpayload';
 import {CategoriesAPIReturn} from './hooks/usedatadictionary';
 import React from 'react';
 import {Trans, useTranslation} from 'react-i18next';
+import swal from 'sweetalert2';
 
 /**
  * The define filters tab of the DQT
@@ -73,6 +74,33 @@ function DefineFilters(props: {
   const [modalQueryGroup, setModalGroup] = useState(props.query);
   const [deleteItemIndex, setDeleteItemIndex] = useState<number|null>(null);
   const [queryMatches, setQueryMatches] = useState(null);
+
+  /**
+   * Clear all the filters currently added
+   *
+   * @param e - React Mouse Event
+   */
+  const clearAllFilters = (e: React.MouseEvent) => {
+    e.preventDefault();
+    swal.fire({
+      title: t('Are you sure?', {ns: 'loris'}),
+      text: t(
+        'Are you sure you want to clear all filters?',
+        {ns: 'dataquery'},
+      ),
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: t('Yes', {ns: 'loris'}),
+      cancelButtonText: t('Cancel', {ns: 'loris'}),
+    }).then((result) => {
+      if (result.value) {
+        const emptyQuery = new QueryGroup('and');
+        props.setQuery(emptyQuery);
+        setModalGroup(emptyQuery);
+      }
+    });
+  };
+
   useEffect(() => {
     setQueryMatches(null);
     if (!props.fields || props.fields.length === 0) {
@@ -320,7 +348,11 @@ function DefineFilters(props: {
               style={{cursor: 'pointer'}} />
             </div>
           </div>
-          <div>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}>
             <div style={bGroupStyle}>
               <ButtonElement
                 label={t('Add "and" condition', {ns: 'dataquery'})}
@@ -339,6 +371,13 @@ function DefineFilters(props: {
                   props.query.operator = 'or';
                 }} />
             </div>
+            <ButtonElement
+              label={t('Remove all filters', {ns: 'dataquery'})}
+              columnSize="col-sm-12"
+              style={{marginTop: '1ex'}}
+              buttonClass='btn btn-danger btn-remove'
+              onUserInput={clearAllFilters}
+            />
           </div>
           {toggleAdvancedButton}
           {advancedButtons}
@@ -369,6 +408,13 @@ function DefineFilters(props: {
             newGroup={props.addNewQueryGroup}
             fulldictionary={props.fulldictionary}
             setDeleteItemIndex={setDeleteItemIndex}
+          />
+          <ButtonElement
+            label={t('Remove all filters', {ns: 'dataquery'})}
+            columnSize="col-sm-12"
+            style={{marginLeft: '5px'}}
+            buttonClass='btn btn-danger btn-remove'
+            onUserInput={clearAllFilters}
           />
         </fieldset>
       </form>

--- a/modules/dataquery/jsx/definefilters.tsx
+++ b/modules/dataquery/jsx/definefilters.tsx
@@ -85,7 +85,7 @@ function DefineFilters(props: {
     swal.fire({
       title: t('Are you sure?', {ns: 'loris'}),
       text: t(
-        'Are you sure you want to clear all filters?',
+        'This will remove all currently selected filters',
         {ns: 'dataquery'},
       ),
       type: 'warning',

--- a/modules/dataquery/jsx/querytree.tsx
+++ b/modules/dataquery/jsx/querytree.tsx
@@ -41,7 +41,7 @@ function alternateColour(c: string): string {
  * @param {object} props.mapCategoryName - Function to map the backend category name to a user friendly name
  * @param {object} props.fulldictionary - The dictionary of all modules that have been loaded
  * @param {function} props.setDeleteItemIndex - Callback to set or clear the index of the item marked for deletion
- * @param props.extraButton - Adds a button the far right on the row as the other two buttons
+ * @param {React.ReactElement} props.extraButton - Adds a button the far right on the row as the other two buttons
  * @returns {React.ReactElement} - the react element
  */
 function QueryTree(props: {

--- a/modules/dataquery/jsx/querytree.tsx
+++ b/modules/dataquery/jsx/querytree.tsx
@@ -41,6 +41,7 @@ function alternateColour(c: string): string {
  * @param {object} props.mapCategoryName - Function to map the backend category name to a user friendly name
  * @param {object} props.fulldictionary - The dictionary of all modules that have been loaded
  * @param {function} props.setDeleteItemIndex - Callback to set or clear the index of the item marked for deletion
+ * @param props.extraButton - Adds a button the far right on the row as the other two buttons
  * @returns {React.ReactElement} - the react element
  */
 function QueryTree(props: {
@@ -61,6 +62,7 @@ function QueryTree(props: {
     fulldictionary: FullDictionary,
     mapModuleName: (module: string) => string,
     mapCategoryName: (module: string, category: string) => string,
+    extraButton?: React.ReactNode,
 }) {
   const [deleteItemIndex, setDeleteItemIndex] = useState<number|null>(null);
   const {t} = useTranslation('dataquery');
@@ -185,7 +187,7 @@ function QueryTree(props: {
   switch (props.items.group.length) {
   case 0:
     warning = <div className="alert alert-warning"
-      style={{display: 'flex'}}>
+      style={{display: 'flex', marginBottom: 0}}>
       <i className="fas fa-exclamation-triangle"
         style={{
           fontSize: '1.5em',
@@ -199,7 +201,7 @@ function QueryTree(props: {
     break;
   case 1:
     warning = <div className="alert alert-warning"
-      style={{display: 'flex'}}>
+      style={{display: 'flex', marginBottom: 0}}>
       <i className="fas fa-exclamation-triangle"
         style={{
           fontSize: '1.5em',
@@ -263,6 +265,14 @@ function QueryTree(props: {
     margin: 0,
     padding: 0,
   };
+
+  const emptyGroupStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'center',
+    gap: '4px',
+    marginBottom: '20px',
+  };
+
   return (
     <div style={style}>
       <ul style={marginStyle}>
@@ -288,9 +298,17 @@ function QueryTree(props: {
                 columnSize='col-sm-12'
               />
             </div>
-            {warning}
-            {deleteGroupHTML}
-          </div></li>
+            <div style={emptyGroupStyle}>
+              {warning}
+              {deleteGroupHTML}
+            </div>
+            {props.extraButton ? (
+              <div style={{margin: '5px 0 0 auto'}}>
+                {props.extraButton}
+              </div>
+            ) : null}
+          </div>
+        </li>
       </ul>
     </div>
   );

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -190,6 +190,12 @@ msgstr ""
 msgid "Add \"or\" condition"
 msgstr ""
 
+msgid "Are you sure you want to clear all filters?"
+msgstr ""
+
+msgid "Remove all filters"
+msgstr ""
+
 msgid "Delete Item"
 msgstr ""
 

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Add \"or\" condition"
 msgstr ""
 
-msgid "Are you sure you want to clear all filters?"
+msgid "This will remove all currently selected filters"
 msgstr ""
 
 msgid "Remove all filters"

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -233,8 +233,8 @@ msgstr "Ajouter la condition « et »"
 msgid "Add \"or\" condition"
 msgstr "Ajouter la condition « ou »"
 
-msgid "Are you sure you want to clear all filters?"
-msgstr "Êtes-vous sûr de vouloir effacer tous les filtres ?"
+msgid "This will remove all currently selected filters"
+msgstr "Ceci supprimera tous les filtres actuellement sélectionnés."
 
 msgid "Remove all filters"
 msgstr "Supprimer tous les filtres"

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -233,6 +233,12 @@ msgstr "Ajouter la condition « et »"
 msgid "Add \"or\" condition"
 msgstr "Ajouter la condition « ou »"
 
+msgid "Are you sure you want to clear all filters?"
+msgstr "Êtes-vous sûr de vouloir effacer tous les filtres ?"
+
+msgid "Remove all filters"
+msgstr "Supprimer tous les filtres"
+
 msgid "Delete Item"
 msgstr "Supprimer l'élément"
 

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -191,8 +191,8 @@ msgstr "\"and\" शर्त जोड़ें"
 msgid "Add \"or\" condition"
 msgstr "\"or\" शर्त जोड़ें"
 
-msgid "Are you sure you want to clear all filters?"
-msgstr "क्या आप वाकई सभी फ़िल्टर साफ़ करना चाहते हैं?"
+msgid "This will remove all currently selected filters"
+msgstr "यह वर्तमान में चयनित सभी फ़िल्टर हटा देगा।"
 
 msgid "Remove all filters"
 msgstr "सभी फ़िल्टर हटाएँ"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -191,6 +191,12 @@ msgstr "\"and\" शर्त जोड़ें"
 msgid "Add \"or\" condition"
 msgstr "\"or\" शर्त जोड़ें"
 
+msgid "Are you sure you want to clear all filters?"
+msgstr "क्या आप वाकई सभी फ़िल्टर साफ़ करना चाहते हैं?"
+
+msgid "Remove all filters"
+msgstr "सभी फ़िल्टर हटाएँ"
+
 msgid "Delete Item"
 msgstr "आइटम हटाएँ"
 

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -199,8 +199,8 @@ msgstr "「and」条件を追加する"
 msgid "Add \"or\" condition"
 msgstr "「または」条件を追加する"
 
-msgid "Are you sure you want to clear all filters?"
-msgstr "すべてのフィルターを消去してもよろしいですか？"
+msgid "This will remove all currently selected filters"
+msgstr "これにより、現在選択されているすべてのフィルターが削除されます。"
 
 msgid "Remove all filters"
 msgstr "すべてのフィルターを削除"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -199,6 +199,12 @@ msgstr "「and」条件を追加する"
 msgid "Add \"or\" condition"
 msgstr "「または」条件を追加する"
 
+msgid "Are you sure you want to clear all filters?"
+msgstr "すべてのフィルターを消去してもよろしいですか？"
+
+msgid "Remove all filters"
+msgstr "すべてのフィルターを削除"
+
 msgid "Delete Item"
 msgstr "アイテムを削除"
 

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -199,6 +199,12 @@ msgstr "添加“与”条件"
 msgid "Add \"or\" condition"
 msgstr "添加“或”条件"
 
+msgid "Are you sure you want to clear all filters?"
+msgstr "您确定要清除所有筛选条件吗？"
+
+msgid "Remove all filters"
+msgstr "删除所有筛选条件"
+
 msgid "Delete Item"
 msgstr "删除项目"
 

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -199,8 +199,8 @@ msgstr "添加“与”条件"
 msgid "Add \"or\" condition"
 msgstr "添加“或”条件"
 
-msgid "Are you sure you want to clear all filters?"
-msgstr "您确定要清除所有筛选条件吗？"
+msgid "This will remove all currently selected filters"
+msgstr "这将删除当前选中的所有筛选条件。"
 
 msgid "Remove all filters"
 msgstr "删除所有筛选条件"


### PR DESCRIPTION
## Brief summary of changes

Adds a "Remove all filters" button to the DQT filter step, allowing users to remove all chosen filters with a single action instead of deleting each filter individually. The users are prompted to confirm action to avoid issues with accidental clicks of the button.

### Change preview
<img width="1577" height="1003" alt="Screenshot 2026-07-23 at 11 45 52 AM" src="https://github.com/user-attachments/assets/7a569e60-6785-4559-8693-70655439fe50" />

<img width="1577" height="1003" alt="Screenshot 2026-07-23 at 11 49 42 AM" src="https://github.com/user-attachments/assets/afb212ba-f6f5-4fd0-b117-4546b7910632" />

## Testing instructions

- Open the Data Query module and navigate to the filter editor.
- Add multiple filters.
- Click the Clear Filters button.
- Verify that all filters are removed.
- Confirm that other unsaved selections (e.g. fields and visits) remain unchanged.
- Verify that new filters can be added normally after clearing.

### Link(s) to related issue(s)
Resolves #10634