### PR TITLE
[instrument_builder] Fix missing labels translations in instrument builder

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -792,7 +792,7 @@ class ListElements extends Component {
               <span id="search_concept">
                 {this.props.value === 'Select One' ?
                   t('Select One', {ns: 'instrument_builder'}) :
-                  this.props.value}{' '}
+                  t(this.props.value, {ns: 'instrument_builder'})}
               </span>
               <span className="caret"></span>
             </button>

--- a/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
@@ -121,7 +121,7 @@ msgid "Data entry"
 msgstr "Entrée de données"
 
 msgid "Textbox"
-msgstr "Zone de texte"
+msgstr "Champ de texte"
 
 msgid "Textarea"
 msgstr "Zone de texte"


### PR DESCRIPTION
## Brief summary of changes
- Added translations for questions type labels.
- Updated the French translations to avoid 2 identical translations

<img width="1432" height="577" alt="image" src="https://github.com/user-attachments/assets/8e9badac-a1fd-4770-96c4-f9914e7dca4e" />
#### Testing instructions (if applicable)

1. Load an instrument
2. In the Build tab, click Modify on an existing field
3. See that the dropdown for the field type is in the correct language

#### Link(s) to related issue(s)

* Resolves [#10968](https://github.com/aces/Loris/issues/10968)
