### PR TITLE
[behavioural_qc] Fix broken links in multilingual LORIS

### DIFF
--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -253,6 +253,7 @@ class BehaviouralFeedback extends Component {
         filter: {
           name: 'Visit',
           type: 'select',
+          sortByValue: false,
           options: options.visits,
         },
       },

--- a/modules/behavioural_qc/jsx/tabs_content/dataConflicts.js
+++ b/modules/behavioural_qc/jsx/tabs_content/dataConflicts.js
@@ -81,60 +81,61 @@ class DataConflicts extends Component {
    * @return {*} a formatted table cell for a given column
    */
   formatColumn(column, cell, rowData, rowHeaders) {
+    const {t} = this.props;
     let reactElement = null;
     switch (column) {
-    case 'Visit':
+    case t('Visit', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/instrument_list/?candID=' +
-            rowData['DCCID'] +
+            rowData[t('DCCID', {ns: 'loris'})] +
             '&sessionID=' +
             rowData['sessionID']
           }>
-            {rowData['Visit']}
+            {rowData[t('Visit', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'PSCID':
+    case t('PSCID', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/' +
-            rowData['DCCID']
+            rowData[t('DCCID', {ns: 'loris'})]
           }>
-            {rowData['PSCID']}
+            {rowData[t('PSCID', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'DCCID':
+    case t('DCCID', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/' +
-            rowData['DCCID']
+            rowData[t('DCCID', {ns: 'loris'})]
           }>
-            {rowData['DCCID']}
+            {rowData[t('DCCID', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'Instrument':
+    case t('Instrument', {ns: 'loris', count: 1}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/instruments/' +
             rowData['testName'] +
             '/?candID=' +
-            rowData['DCCID'] +
+            rowData[t('DCCID', {ns: 'loris'})] +
             '&sessionID=' +
             rowData['sessionID'] +
             '&commentID=' +
             rowData['commentID']
           }>
-            {rowData['Instrument']}
+            {rowData[t('Instrument', {ns: 'loris', count: 1})]}
           </a>
         </td>
       );
@@ -196,6 +197,7 @@ class DataConflicts extends Component {
         filter: {
           name: 'Visit',
           type: 'select',
+          sortByValue: false,
           options: options.visits,
         },
       },

--- a/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
+++ b/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
@@ -81,60 +81,61 @@ class IncompleteForms extends Component {
    * @return {*} a formatted table cell for a given column
    */
   formatColumn(column, cell, rowData, rowHeaders) {
+    const {t} = this.props;
     let reactElement;
     switch (column) {
-    case 'Visit':
+    case t('Visit', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
               '/instrument_list/?candID=' +
-              rowData['DCCID'] +
+              rowData[t('DCCID', {ns: 'loris'})] +
               '&sessionID=' +
               rowData['sessionID']
           }>
-            {rowData['Visit']}
+            {rowData[t('Visit', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'PSCID':
+    case t('PSCID', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/' +
-            rowData['DCCID']
+            rowData[t('DCCID', {ns: 'loris'})]
           }>
-            {rowData['PSCID']}
+            {rowData[t('PSCID', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'DCCID':
+    case t('DCCID', {ns: 'loris'}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/' +
-            rowData['DCCID']
+            rowData[t('DCCID', {ns: 'loris'})]
           }>
-            {rowData['DCCID']}
+            {rowData[t('DCCID', {ns: 'loris'})]}
           </a>
         </td>
       );
       break;
-    case 'Instrument':
+    case t('Instrument', {ns: 'loris', count: 1}):
       reactElement = (
         <td>
           <a href={this.props.baseURL +
             '/instruments/' +
             rowData['test_name'] +
             '/?candID=' +
-            rowData['DCCID'] +
+            rowData[t('DCCID', {ns: 'loris'})] +
             '&sessionID=' +
             rowData['sessionID'] +
             '&commentID=' +
             rowData['commentID']
           }>
-            {rowData['Instrument']}
+            {rowData[t('Instrument', {ns: 'loris', count: 1})]}
           </a>
         </td>
       );
@@ -208,6 +209,7 @@ class IncompleteForms extends Component {
         filter: {
           name: 'Visit',
           type: 'select',
+          sortByValue: false,
           options: options.visits,
         },
       },


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bug where rowData[...] was undefined when using a language other than English because the row keys were localized (e.g. row['Visit] -> 'undefined' but row['Visite'] -> V1 in French).

Additionally, I added `sortByValue: false` to the Visit filter in each tab to preserve the correct visit order in the Japanese dropdown, consistent with the change done in the following Media module PR: https://github.com/aces/Loris/pull/10548/changes

#### Testing instructions (if applicable)

1. git checkout HachemJ/FixBrokenLinksInBehaviouralQc
2. Go to 'Clinical' -> 'Behavioural Quality Control'

For tabs 'Incomplete Forms' and 'Data Conflicts', verify that:

3. The entries in the four following columns (Instrument, DCCID, PSCID and Visit) are displayed as clickable links.
4. The links remain clickable and navigate to the same URL regardless of the selected language.

For tab 'Behavioural Feedback', verify that:

5. The entries in the three following columns (DCCID, PSCID, Feedback Level) are displayed as clickable links.
6. The links remain clickable and navigate to the same URL regardless of the selected language.

#### Link(s) to related issue(s)

* Resolves #10584 (Reference the issue this fixes, if any.)
