### PR TITLE
[schedule_module] Fix Japanese and Spanish typo/mistake and adding Spanish translations

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -218,6 +218,12 @@ msgstr "Retroalimentación"
 msgid "Scans"
 msgstr ""
 
+msgid "Date"
+msgstr "Fecha"
+
+msgid "Time"
+msgstr "Hora"
+
 msgid "Stage"
 msgstr "Etapa"
 

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -181,13 +181,13 @@ msgid "Module"
 msgstr ""
 
 msgid "Project"
-msgstr "Projecto"
+msgstr "Proyecto"
 
 msgid "Candidate Registration Project"
-msgstr "Projecto donde se registró al Candidato"
+msgstr "Proyecto donde se registró al Candidato"
 
 msgid "Timepoint Project"
-msgstr "Punto en el tiempo del Projecto"
+msgstr "Punto en el tiempo del Proyecto"
 
 msgid "Cohort"
 msgid_plural "Cohorts"

--- a/modules/schedule_module/jsx/scheduleIndex.js
+++ b/modules/schedule_module/jsx/scheduleIndex.js
@@ -22,6 +22,7 @@ import hiStrings from '../locale/hi/LC_MESSAGES/schedule_module.json';
 import jaStrings from '../locale/ja/LC_MESSAGES/schedule_module.json';
 import frStrings from '../locale/fr/LC_MESSAGES/schedule_module.json';
 import zhStrings from '../locale/zh/LC_MESSAGES/schedule_module.json';
+import esStrings from '../locale/es/LC_MESSAGES/schedule_module.json';
 
 /**
  * Schedule Module
@@ -630,6 +631,7 @@ window.addEventListener('load', () => {
   i18n.addResourceBundle('fr', 'schedule_module', frStrings);
   i18n.addResourceBundle('ja', 'schedule_module', jaStrings);
   i18n.addResourceBundle('zh', 'schedule_module', zhStrings);
+  i18n.addResourceBundle('es', 'schedule_module', esStrings);
   const Index = withTranslation(
     ['schedule_module', 'loris']
   )(ScheduleIndex);

--- a/modules/schedule_module/locale/es/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/es/LC_MESSAGES/schedule_module.po
@@ -1,0 +1,111 @@
+# Default LORIS strings to be translated (English).
+# Copy this to a language specific file and add translations to the
+# new file.
+# Copyright (C) 2025
+# This file is distributed under the same license as the LORIS package.
+# Dave MacFarlane <dave.macfarlane@mcin.ca>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: LORIS 27\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: 2025-12-09 10:55-0500\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.8\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Schedule Appointment"
+msgstr "Programar una cita"
+
+msgid "Appointment Date"
+msgstr "Fecha de la cita"
+
+msgid "Appointment Time"
+msgstr "Hora de la cita"
+
+msgid "Appointment Type"
+msgstr "Tipo de cita"
+
+msgid "AppointmentTypeName"
+msgstr "Nombre del tipo de cita"
+
+msgid "Edit"
+msgstr "Editar"
+
+msgid "Delete"
+msgstr "Eliminar"
+
+msgid "Data Entry Status"
+msgstr "Estado de la entrada de datos"
+
+msgid "Complete"
+msgstr "Completo"
+
+msgid "No Data Found"
+msgstr "No se encontraron datos"
+
+msgid "Not Started"
+msgstr "No iniciado"
+
+msgid "Edit Appointment"
+msgstr "Editar cita"
+
+msgid "Create Appointment"
+msgstr "Crear una cita"
+
+msgid "Add Appointment"
+msgstr "Agregar una cita"
+
+msgid "All"
+msgstr "Todos"
+
+msgid "Past"
+msgstr "Pasadas"
+
+msgid "Next 30 Days"
+msgstr "Próximos 30 días"
+
+msgid "Today"
+msgstr "Hoy"
+
+msgid "Appointment modified."
+msgstr "La cita ha sido modificada."
+
+msgid "Appointment added."
+msgstr "La cita ha sido agregada."
+
+msgid "Success!"
+msgstr "¡Éxito!"
+
+msgid "No changes were made!"
+msgstr "¡No se realizaron cambios!"
+
+msgid "You won't be able to revert this!"
+msgstr "¡No podrás revertir esta acción!"
+
+msgid "Yes, delete it!"
+msgstr "¡Sí, eliminar!"
+
+msgid "Deleted!"
+msgstr "¡Eliminado!"
+
+msgid "Your appointment has been deleted."
+msgstr "Tu cita ha sido eliminada."
+
+msgid "Starts At"
+msgstr "Hora de inicio"
+
+msgid "Date"
+msgstr "Fecha"
+
+msgid "Time"
+msgstr "Hora"
+
+msgid "Appointment Type Name"
+msgstr "Nombre del tipo de cita"

--- a/modules/schedule_module/locale/es/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/es/LC_MESSAGES/schedule_module.po
@@ -32,9 +32,6 @@ msgstr "Hora de la cita"
 msgid "Appointment Type"
 msgstr "Tipo de cita"
 
-msgid "AppointmentTypeName"
-msgstr "Nombre del tipo de cita"
-
 msgid "Edit"
 msgstr "Editar"
 

--- a/modules/schedule_module/locale/fr/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/fr/LC_MESSAGES/schedule_module.po
@@ -32,10 +32,6 @@ msgstr "Temps de rendez-vous"
 msgid "Appointment Type"
 msgstr "Type de rendez vous"
 
-#, fuzzy
-msgid "AppointmentTypeName"
-msgstr "Nom du type de rendez-vous"
-
 msgid "Edit"
 msgstr "Modifier"
 

--- a/modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/hi/LC_MESSAGES/schedule_module.po
@@ -31,9 +31,6 @@ msgstr "अपॉइंटमेंट समय"
 msgid "Appointment Type"
 msgstr "अपॉइंटमेंट प्रकार"
 
-msgid "AppointmentTypeName"
-msgstr "अपॉइंटमेंट प्रकार नाम"
-
 msgid "Edit"
 msgstr "संपादित करें"
 

--- a/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
@@ -31,10 +31,6 @@ msgstr "予約時間"
 msgid "Appointment Type"
 msgstr "予約の種類"
 
-# ???
-msgid "AppointmentTypeName"
-msgstr "予約タイプ名"
-
 msgid "Edit"
 msgstr "編集"
 

--- a/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/ja/LC_MESSAGES/schedule_module.po
@@ -33,7 +33,7 @@ msgstr "予約の種類"
 
 # ???
 msgid "AppointmentTypeName"
-msgstr ""
+msgstr "予約タイプ名"
 
 msgid "Edit"
 msgstr "編集"
@@ -99,7 +99,7 @@ msgid "Your appointment has been deleted."
 msgstr "予約は削除されました。"
 
 msgid "Starts At"
-msgstr "開始価格"
+msgstr "開始時刻"
 
 msgid "Date"
 msgstr "日付"

--- a/modules/schedule_module/locale/schedule_module.pot
+++ b/modules/schedule_module/locale/schedule_module.pot
@@ -30,9 +30,6 @@ msgstr ""
 msgid "Appointment Type"
 msgstr ""
 
-msgid "AppointmentTypeName"
-msgstr ""
-
 msgid "Edit"
 msgstr ""
 

--- a/modules/schedule_module/locale/zh/LC_MESSAGES/schedule_module.po
+++ b/modules/schedule_module/locale/zh/LC_MESSAGES/schedule_module.po
@@ -31,10 +31,6 @@ msgstr "预约时间"
 msgid "Appointment Type"
 msgstr "预约类型"
 
-# ???
-msgid "AppointmentTypeName"
-msgstr "预约类型名称"
-
 msgid "Edit"
 msgstr "编辑"
 


### PR DESCRIPTION
## Brief summary of changes
Some issues were reported in Japanese translations. 

After some research, it seems that the translation we used for "appointment" is translated as "reservation" by google translate but is in fact the closest thing to "appointment" in Japanese. We could translate "appointment" literally using the Japanese "foreign" alphabet but I think "reservation" is close enough. Please let me know if there are any thoughts about this in the review.

A Spanish typo was also reported so I took the opportunity to correct it and include the Spanish translations for the module even though it is not a requirement for the 29 release.

- Fixed the Japanese error for "Starts At" translation which was translated as "Starting price"
- Fixed typo/mistake in Spanish translation for "Project"
- Added Spanish translations

#### Testing instructions (if applicable)

1. Go to `schedule_module`
2. Test Japanese/Spanish translations
3. Ensure the translations mentioned in the issue are fixed and report incorrect/missing ones (that are not db related)

#### Link(s) to related issue(s)

* Resolves [#10892](https://github.com/aces/Loris/issues/10892)  (Reference the issue this fixes, if any.)
