### PR TITLE
[configuration] Fix Diagnosis Evolution project reset

### DIFF
--- a/modules/configuration/jsx/DiagnosisEvolution.js
+++ b/modules/configuration/jsx/DiagnosisEvolution.js
@@ -191,7 +191,8 @@ class DiagnosisEvolution extends Component {
                 label={t('Project', {ns: 'loris', count: 1})}
                 options={this.state.formData.projects}
                 onUserInput={this.setFormData}
-                value={JSON.stringify(trajectoryData.ProjectID)}
+                value={trajectoryData.ProjectID === null ?
+                  null : JSON.stringify(trajectoryData.ProjectID)}
                 required={true}
                 errorMessage={errorMessage.ProjectID}
               />


### PR DESCRIPTION
## Brief summary of changes

- Fixes the Diagnosis Evolution Reset button so the Project field is cleared when creating a new trajectory.
- Preserves the existing reset behavior for saved trajectories by restoring their original Project value.

#### Testing instructions

- Open `http://localhost:8080/configuration/diagnosis_evolution/`.
- Open the New Diagnosis Trajectory tab.
- Populate the trajectory fields, including Project.
- Click Reset and confirm all populated fields, including Project, are cleared.
- Open an existing trajectory and change its Project.
- Click Reset and confirm the original Project is restored.
- Run `target=configuration npm run compile`.

#### Link(s) to related issue(s)

- Resolves #10646