### PR TITLE
[Form] Pin clear selection above sorted visit options

### DIFF
--- a/jsx/Form.d.ts
+++ b/jsx/Form.d.ts
@@ -113,6 +113,7 @@ type selectElementProps = {
     noMargins?: boolean
     placeholder?: string
     sortByValue: boolean
+    pinnedOption?: string
 }
 
 /**

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -551,7 +551,17 @@ export class SelectElement extends Component {
           newOptions[options[key]] = key;
         }
       }
-      optionList = Object.keys(newOptions).sort().map(function(option) {
+      let sortedOptions = Object.keys(newOptions).sort();
+      if (this.props.pinnedOption
+          && options.hasOwnProperty(this.props.pinnedOption)
+      ) {
+        const pinnedValue = options[this.props.pinnedOption];
+        sortedOptions = sortedOptions.filter(
+          (option) => option !== pinnedValue
+        );
+        sortedOptions.unshift(pinnedValue);
+      }
+      optionList = sortedOptions.map(function(option) {
         let isDisabled = (newOptions[option] in disabledOptions);
         return (
           <option
@@ -655,6 +665,7 @@ SelectElement.propTypes = {
   noMargins: PropTypes.bool,
   placeholder: PropTypes.string,
   sortByValue: PropTypes.bool,
+  pinnedOption: PropTypes.string,
   labelPlacementTop: PropTypes.bool,
 };
 
@@ -676,6 +687,7 @@ SelectElement.defaultProps = {
   },
   noMargins: false,
   placeholder: '',
+  pinnedOption: null,
   labelPlacementTop: false,
 };
 

--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -173,6 +173,7 @@ const QueryChartForm = (props) => {
                 ...options.visits}}
               multiple ={true}
               emptyOption ={false}
+              pinnedOption ='__clear__'
               value ={formDataObj['selectedVisits'] || []}
               onUserInput ={(name, value) => {
                 setFormData(name, value);


### PR DESCRIPTION
## Brief summary of changes

- Adds an optional `pinnedOption` property to `SelectElement` when option sorting is enabled.
- Adds the property to the `SelectElement` TypeScript declaration.
- Pins the Clear Selection option above the sorted dashboard visit options.
- Uses the stable `__clear__` option key so translated labels do not affect the pinned option.
- Keeps the remaining visit options alphabetically sorted.

#### Testing instructions

- Configure a visit with a label beginning with a special character, such as `(Screening)`.
- Run `target=statistics npm run compile`.
- Open `http://localhost:8080/`.
- Open the filters for a dashboard chart.
- Confirm `-- Clear Selection --` appears above the special-character visit.
- Confirm the remaining visits remain alphabetically sorted.
- Select the special-character visit and confirm it can be cleared using `-- Clear Selection --`.

#### Link(s) to related issue(s)

- Resolves #10987