### PR TITLE
[behavioural_qc] Add missing db translations

### DIFF
--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -161,7 +161,10 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
             'feedback_level'  => $this->_feedback_level,
             'test_name'       => $this->_test_name,
             'field_name'      => $this->_field_name,
-            'feedback_status' => $this->_feedback_status,
+            'feedback_status' => dgettext(
+                'feedback_bvl_thread',
+                $this->_feedback_status
+            ),
         ];
     }
 }

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -148,7 +148,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'      => $this->_instrument,
+            'instrument'      => dgettext('test_names', $this->_instrument),
             'candID'          => $this->_candID,
             'pscID'           => $this->_pscID,
             'visit'           => $this->_visit,

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -148,7 +148,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'      => dgettext('test_names', $this->_instrument),
+            'instrument'      => $this->_instrument,
             'candID'          => $this->_candID,
             'pscID'           => $this->_pscID,
             'visit'           => $this->_visit,

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -134,7 +134,7 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'        => dgettext('test_names', $this->_instrument),
+            'instrument'        => $this->_instrument,
             'candID'            => $this->_candID,
             'pscID'             => $this->_pscID,
             'visit'             => dgettext('visit', $this->_visit),

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -134,10 +134,10 @@ class ConflictsDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'        => $this->_instrument,
+            'instrument'        => dgettext('test_names', $this->_instrument),
             'candID'            => $this->_candID,
             'pscID'             => $this->_pscID,
-            'visit'             => $this->_visit,
+            'visit'             => dgettext('visit', $this->_visit),
             'project'           => $this->_project,
             'cohort'            => $this->_cohort,
             'site'              => $this->_site,

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -141,7 +141,7 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'      => dgettext('test_names', $this->_instrument),
+            'instrument'      => $this->_instrument,
             'data_entry_type' => $this->_data_entry_type,
             'candID'          => $this->_candID,
             'pscID'           => $this->_pscID,

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -141,11 +141,11 @@ class IncompleteDTO implements \LORIS\Data\DataInstance,
     public function jsonSerialize() : array
     {
         return [
-            'instrument'      => $this->_instrument,
+            'instrument'      => dgettext('test_names', $this->_instrument),
             'data_entry_type' => $this->_data_entry_type,
             'candID'          => $this->_candID,
             'pscID'           => $this->_pscID,
-            'visit'           => $this->_visit,
+            'visit'           => dgettext('visit', $this->_visit),
             'project'         => $this->_project,
             'cohort'          => $this->_cohort,
             'site'            => $this->_site,

--- a/raisinbread/RB_files/RB_feedback_bvl_entry.sql
+++ b/raisinbread/RB_files/RB_feedback_bvl_entry.sql
@@ -1,7 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `feedback_bvl_entry`;
 LOCK TABLES `feedback_bvl_entry` WRITE;
-INSERT INTO `feedback_bvl_entry` (`ID`, `FeedbackID`, `Comment`, `UserID`, `Testdate`) VALUES (1,1,'Instrument (bmi) has been added to the battery. You may now complete data entry for this instrument. Please respond to this feedback to acknowledge the changes.','','2016-06-18 00:39:02');
 INSERT INTO `feedback_bvl_entry` (`ID`, `FeedbackID`, `Comment`, `UserID`, `Testdate`) VALUES (2,2,'Feedback','admin','2016-07-14 18:34:42');
 INSERT INTO `feedback_bvl_entry` (`ID`, `FeedbackID`, `Comment`, `UserID`, `Testdate`) VALUES (4,4,'Score doesn\'t match','admin','2016-07-14 18:37:33');
 INSERT INTO `feedback_bvl_entry` (`ID`, `FeedbackID`, `Comment`, `UserID`, `Testdate`) VALUES (5,5,'Some feedback','admin','2016-07-14 18:38:29');

--- a/raisinbread/RB_files/RB_feedback_bvl_thread.sql
+++ b/raisinbread/RB_files/RB_feedback_bvl_thread.sql
@@ -1,7 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `feedback_bvl_thread`;
 LOCK TABLES `feedback_bvl_thread` WRITE;
-INSERT INTO `feedback_bvl_thread` (`FeedbackID`, `CandidateID`, `SessionID`, `CommentID`, `Feedback_level`, `Feedback_type`, `Public`, `Status`, `Active`, `Date_taken`, `UserID`, `Testdate`, `FieldName`) VALUES (1,1004,0,'','instrument',3,'Y','opened','Y','2016-06-17','','2016-07-14 23:00:52','');
 INSERT INTO `feedback_bvl_thread` (`FeedbackID`, `CandidateID`, `SessionID`, `CommentID`, `Feedback_level`, `Feedback_type`, `Public`, `Status`, `Active`, `Date_taken`, `UserID`, `Testdate`, `FieldName`) VALUES (2,163,NULL,NULL,'profile',1,'Y','closed','Y','2016-07-14','admin','2016-07-14 22:58:15',NULL);
 INSERT INTO `feedback_bvl_thread` (`FeedbackID`, `CandidateID`, `SessionID`, `CommentID`, `Feedback_level`, `Feedback_type`, `Public`, `Status`, `Active`, `Date_taken`, `UserID`, `Testdate`, `FieldName`) VALUES (4,163,2,'300002MTL0022221465351036','instrument',2,'Y','closed','Y','2016-07-14','admin','2016-07-14 22:59:43','Across All Fields');
 INSERT INTO `feedback_bvl_thread` (`FeedbackID`, `CandidateID`, `SessionID`, `CommentID`, `Feedback_level`, `Feedback_type`, `Public`, `Status`, `Active`, `Date_taken`, `UserID`, `Testdate`, `FieldName`) VALUES (5,168,7,'300007MTL0077221465351036','instrument',1,'Y','closed','Y','2016-07-14','admin','2016-07-14 22:58:15','Administration');

--- a/raisinbread/locale/feedback_bvl_thread.pot
+++ b/raisinbread/locale/feedback_bvl_thread.pot
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "opened"
+msgstr ""

--- a/raisinbread/locale/fr/LC_MESSAGES/feedback_bvl_thread.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/feedback_bvl_thread.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "opened"
+msgstr "ouvert"

--- a/raisinbread/locale/hi/LC_MESSAGES/feedback_bvl_thread.po
+++ b/raisinbread/locale/hi/LC_MESSAGES/feedback_bvl_thread.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "opened"
+msgstr "खुला"

--- a/raisinbread/locale/ja/LC_MESSAGES/feedback_bvl_thread.po
+++ b/raisinbread/locale/ja/LC_MESSAGES/feedback_bvl_thread.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "opened"
+msgstr "オープン"


### PR DESCRIPTION
## Brief summary of changes

This PR adds the missing database translations for table entries in the Behavioural QC module.

I also removed a row with feedback_level = instrument that had no associated instrument entry. It appears to be invalid data and was causing a multilingual bug, so it seemed reasonable to remove it, assuming no tests depend on it.

#### Testing instructions (if applicable)

1. git checkout HachemJ/AddMissingDbTranslationsBehaviouralQc
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Clinical' -> 'Behavioural Quality Control'
6. Switch the language to French

For each of the three tabs (Incomplete Forms, Data Conflicts and Behavioural Feedback):
7. Verify that the table entries are translated in each of the three tabs

#### Link(s) to related issue(s)

* Resolves #10955 (Reference the issue this fixes, if any.)
* Resolves #11045 (Reference the issue this fixes, if any.)

