### PR TITLE
[tools] Fix DP_dump_table_data.php script bug (option ColumnStatistics)

### DIFF
--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -87,19 +87,14 @@ if (empty($adminUser) || empty($adminPassword) || empty($dbHost)) {
  */
 
 
-// Check MySQL version
-$mysqlVersionOutput = shell_exec(
-    'mysql -u '.escapeshellarg($adminUser).' -p'.escapeshellarg($adminPassword).
-    ' -h '.escapeshellarg($dbHost).' -e "SELECT VERSION();" 2>/dev/null'
-);
+// Determine whether the installed mysqldump executable supports
+// the --column-statistics option.
+$mysqldumpHelp = shell_exec('mysqldump --help 2>/dev/null') ?? '';
 
-preg_match('/\d+\.\d+\.\d+/', $mysqlVersionOutput, $matches);
-$mysqlVersion = $matches[0] ?? '0.0.0';
-
-// Determine whether --column-statistics=0 is needed
-$columnStatisticsFlag = version_compare($mysqlVersion, '8.0.0', '>=') ?
-    '--column-statistics=0 ' :
-    '';
+$columnStatisticsFlag = str_contains(
+    $mysqldumpHelp,
+    'column-statistics'
+) ? '--column-statistics=0 ' : '';
 
 // Loop through all tables to generate insert statements for each.
 foreach ($tableNames as $tableName) {


### PR DESCRIPTION
## Brief summary of changes

This PR updates how support for the --column-statistics option is detected when exporting data.

Previously, support for this option was determined based on the MySQL server version. However, the availability of --column-statistics depends on the installed mysqldump executable, not the server version. As a result, the export script was failing in my environment because support for this option was being determined from the MySQL server version rather than the installed mysqldump version.

<img width="412" height="270" alt="Untitled 25" src="https://github.com/user-attachments/assets/c6c95b34-d8a7-46a3-8e35-b02ce598eec8" />


The exporter now checks whether the installed mysqldump supports --column-statistics and only includes --column-statistics=0 when the option is available.
