### PR TITLE
[statistics] Fix incorrectly marked up statistics header

### DIFF
--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -23,8 +23,8 @@
         <table id="scandata" class="table table-primary table-bordered dynamictable">
             <thead>
             <tr class="info">
-                <th id="scantype">dgettext('Scan Type', 'loris')</th>
-                <th colspan="2">dgettext('QC Status', 'loris')</th>
+                <th id="scantype">{dgettext('loris', 'Scan Type')}</th>
+                <th colspan="2">{dgettext('loris', 'QC Status')}</th>
                 {foreach from=$Cohorts item=name key=proj}
                     <th>{$name}</th>
                 {/foreach}


### PR DESCRIPTION
Fix header on imaging tab that was not rendering correctly in the statistics imaging tab.

There were 2 problems:
1. The dgettext in the smarty template was not surrounded by {} and therefore being interpreted as a literal string instead of a translation
2. The parameter order for dgettext was incorrect.
