### PR TITLE
[modules | document_repository] Fix special characters in category name displayed as encoded characters to user

### DIFF
--- a/modules/document_repository/php/editcategory.class.inc
+++ b/modules/document_repository/php/editcategory.class.inc
@@ -82,7 +82,7 @@ class EditCategory extends \NDB_Page
             $req['categoryNameChange'] : null;
         $new_parent  = isset($req['newParentID']) ? $req['newParentID'] : null;
         if ($new_parent != null) {
-            $DB->update(
+            $DB->unsafeupdate(
                 "document_repository_categories",
                 [
                     "category_name" => $new_name,
@@ -93,7 +93,7 @@ class EditCategory extends \NDB_Page
                 ]
             );
         } else {
-            $DB->update(
+            $DB->unsafeupdate(
                 "document_repository_categories",
                 [
                     "category_name" => $new_name,

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -100,7 +100,7 @@ class UploadCategory extends \NDB_Page
         if ($this->existCategoryName($category_name, intval($parent_id))) {
             return false;
         }
-        $DB->insert(
+        $DB->unsafeinsert(
             "document_repository_categories",
             [
                 "category_name" => $category_name,


### PR DESCRIPTION
**Situation:**
The issue reported that category names containing special characters (such as `<`, `>`, `"`, `&`) were displaying as HTML-encoded text (e.g., `&lt;` or `&amp;`) on the Browse page. Upon investigation, this occurred because the backend automatically does encoding of values into HTML entities before saving them to the database. This was affecting the main Browse page but also breaking related components that share the same category database records, including the category trees and the dropdown menus in the Upload, Edit, and Delete tabs.

**Task:**
Bypass the core database wrapper's automatic HTML-entity encoding mechanism (`_HTMLEscapeArray`) when saving or updating category names in the document repository module, so raw strings are saved to the database. This fixes the issue at the source for both the Browse page and all related components without needing manual frontend decoding workarounds.

**Action:**
- Modified `uploadcategory.class.inc` to use `$DB->unsafeinsert` instead of `$DB->insert` when adding a category.
- Modified `editcategory.class.inc` to use `$DB->unsafeupdate` instead of `$DB->update` when modifying category details.
- Verified that these "unsafe" calls bypass `_HTMLEscapeArray`, allowing the raw string to be stored directly in MySQL and retrieved by the frontend API.

**Result:**
Category names containing special characters are now saved to the database in their raw, human-readable format, ensuring special characters display correctly on the Browse table, as well as the upload/edit/delete forms and category trees. Hence, this PR resolves #10866.

<img width="1841" height="897" alt="image" src="https://github.com/user-attachments/assets/2e8b2c6f-0d20-42bc-a53f-96ec50ffe816" />

<img width="1283" height="848" alt="image" src="https://github.com/user-attachments/assets/5c2a2d12-fcec-4e0c-9352-d4cc0221055f" />

<img width="1264" height="525" alt="image" src="https://github.com/user-attachments/assets/e8ba5e7a-defc-4d44-aebe-73c5a75f2f7b" />


<img width="1175" height="500" alt="image" src="https://github.com/user-attachments/assets/2b21e5e5-c2b7-4edc-bc1b-3508a88ee317" />


## Testing Instructions

1. Go to the Tools Dropdown menu -> Document Repository.
2. Select the **Add Category** tab.
3. Add a complicated category containing special characters, such as `R&D <Test> {Special Characters} [!@#$%^&*()_+=-`~;:'.,/] >`.
4. Verify that:
   - The category shows up correctly in the **Browse** table.
   - The category is listed correctly in the **Upload** category dropdown.
   - The category appears correctly in the category navigation trees.