### PR TITLE
[login] Add missing French translations

### DIFF
--- a/modules/login/jsx/loginIndex.js
+++ b/modules/login/jsx/loginIndex.js
@@ -427,7 +427,7 @@ class Login extends Component {
         return <div>
           <a href={'/oidc/login?loginWith=' + val}>
             {this.props.t('Login with {{provider}}', {
-              ns: 'openid_connect', provider: val,
+              ns: 'login', provider: val,
             })}
           </a>
         </div>;


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the multilingual bug related to 'Login with (provider)' mentioned in the corresponding issue. 

On my VM, “Terms of Use” is correctly translated as “Conditions d’utilisation”. After investigating, I found the translation in RB_policiesI18n.sql. I’m not sure yet why it isn’t being picked up on the test VM.

<img width="695" height="59" alt="image" src="https://github.com/user-attachments/assets/ba4938b5-30ef-43fe-bc93-b372a16139e2" />


<img width="853" height="473" alt="image" src="https://github.com/user-attachments/assets/a48d41f8-973b-4fc6-8a49-d732bee1a257" />

#### Testing instructions (if applicable)

1. `make testdata`

Populate the openid_connect_providers table. Without this, the “Login with …” option will not be displayed.

2. mysql
```sql
INSERT INTO `openid_connect_providers` (Name, BaseURI, ClientID, ClientSecret, RedirectURI) VALUES ('auth0', 'https://dev-p8q62jkwrvtaznao.us.auth0.com', '$mypublicid', '$mysecretid', 'https://mylorisserver.example.com/oidc/callback');
```
3. Login into your account

4. Go to 'Admin' -> 'Module Manager'

5. Go to the third page and enable the following module
<img width="1581" height="203" alt="image" src="https://github.com/user-attachments/assets/21a3af2d-d5c0-46c7-a2ce-08d6db3106c1" />

6. Log out

7. Switch the language to French

8. Verify that 'Login with (provider)' and 'Terms of Use' are translated in French

#### Link(s) to related issue(s)

* Resolves #11022 (Reference the issue this fixes, if any.)
