### PR TITLE
[user_accounts] Add missing Japanese translations and fix template

### DIFF
--- a/modules/user_accounts/locale/fr/LC_MESSAGES/user_accounts.po
+++ b/modules/user_accounts/locale/fr/LC_MESSAGES/user_accounts.po
@@ -208,13 +208,13 @@ msgstr "Les nouveaux et anciens mots de passe sont identiques."
 msgid "This email address is already in use"
 msgstr "Cette adresse email est déjà utilisée"
 
-msgid "You cannot edit your own account settings"
-msgstr "Vous ne pouvez pas modifier les paramètres de votre propre compte"
+msgid "You cannot edit your own account settings."
+msgstr "Vous ne pouvez pas modifier les paramètres de votre propre compte."
 
-msgid "To change your email or password, go to \"My Preferences\""
-msgstr "Pour modifier votre adresse courriel ou votre mot de passe, rendez-vous dans « Mes préférences »"
+msgid "To change your email or password, go to \"My Preferences\"."
+msgstr "Pour modifier votre adresse courriel ou votre mot de passe, rendez-vous dans « Mes préférences »."
 
-msgid "For any other changes, contact an administrator"
+msgid "For any other changes, contact an administrator."
 msgstr "Pour toute autre modification, veuillez contacter un administrateur."
 
 msgid "Do you really want to reject this user?"

--- a/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
+++ b/modules/user_accounts/locale/ja/LC_MESSAGES/user_accounts.po
@@ -199,6 +199,15 @@ msgstr "新しいパスワードと古いパスワードは同一です。"
 msgid "This email address is already in use"
 msgstr "このメールアドレスはすでに使用されています。"
 
+msgid "You cannot edit your own account settings."
+msgstr "アカウント設定はご自身で編集することはできません。"
+
+msgid "To change your email or password, go to \"My Preferences\"."
+msgstr "メールアドレスまたはパスワードを変更するには、「マイ設定」にアクセスしてください。"
+
+msgid "For any other changes, contact an administrator."
+msgstr "その他の変更については、管理者にお問い合わせください。"
+
 msgid "Do you really want to reject this user?"
 msgstr "本当にこのユーザーを拒否しますか？"
 

--- a/modules/user_accounts/locale/user_accounts.pot
+++ b/modules/user_accounts/locale/user_accounts.pot
@@ -198,13 +198,13 @@ msgstr ""
 msgid "This email address is already in use"
 msgstr ""
 
-msgid "You cannot edit your own account settings"
+msgid "You cannot edit your own account settings."
 msgstr ""
 
-msgid "To change your email or password, go to \"My Preferences\""
+msgid "To change your email or password, go to \"My Preferences\"."
 msgstr ""
 
-msgid "For any other changes, contact an administrator"
+msgid "For any other changes, contact an administrator."
 msgstr ""
 
 msgid "Do you really want to reject this user?"


### PR DESCRIPTION
The template for user accounts did not match the code (was missing a period at the end of the sentences) for some strings, causing the French translation to not be picked up.

This was noticed while adding Japanese translations, so they are both fixed in the same PR.
