### PR TITLE
[timepoint_list] Fix incorrect French translation

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -174,7 +174,7 @@ msgstr "Masquer les filtres avancés"
 
 #, fuzzy
 msgid "Pass"
-msgstr "Approuver"
+msgstr "Approuvé"
 
 msgid "Fail"
 msgstr "Echec"

--- a/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
@@ -28,7 +28,7 @@ msgstr "Cliquez pour ouvrir"
 
 #, fuzzy
 msgid "Stage Status"
-msgstr "Statue du stade"
+msgstr "Statut du stade"
 
 #, fuzzy
 msgid "Date of Stage"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the following incorrect French translations :

 string 'Stage Status' from 'Statue du Stade' to 'Statut du Stade'
 string 'Pass' from 'Approuver' to 'Approuvé'

#### Link(s) to related issue(s)

* Resolves #11034 (Reference the issue this fixes, if any.)
