### PR TITLE
[issue_tracker] Fix incorrect French translation

### DIFF
--- a/modules/issue_tracker/locale/fr/LC_MESSAGES/issue_tracker.po
+++ b/modules/issue_tracker/locale/fr/LC_MESSAGES/issue_tracker.po
@@ -86,7 +86,7 @@ msgid "Active Issues"
 msgstr "Incidents actifs"
 
 msgid "Closed Issues"
-msgstr "Incidents fermées"
+msgstr "Incidents fermés"
 
 msgid "My Issues"
 msgstr "Mes incidents"


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a typo in French.
'Closed Issues' should translate to 'Incidents fermés' instead of 'Incidents fermées'.

#### Link(s) to related issue(s)

* Resolves #10949 (Reference the issue this fixes, if any.)
