### PR TITLE
[genomic_browser] fixed missing rsID hyperlink in Genomic Browser

### DIFF
--- a/modules/genomic_browser/jsx/tabs_content/snp.js
+++ b/modules/genomic_browser/jsx/tabs_content/snp.js
@@ -87,13 +87,22 @@ class SNP extends Component {
       const url = `${this.props.baseURL}/${rowData.DCCID}/`;
       reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
       break;
+    case 'rsID':
+      const rsIdUrl = `https://www.ncbi.nlm.nih.gov/snp/${cell}`;
+      reactElement = (
+        <td>
+          <a href={rsIdUrl} target="_blank" rel="noopener noreferrer">
+            {cell}
+          </a>
+        </td>
+      );
+      break;
     default:
       reactElement = <td>{cell}</td>;
       break;
     }
     return reactElement;
   }
-
   /**
    * @return {DOMRect}
    */
@@ -218,7 +227,7 @@ class SNP extends Component {
       },
       {
         label: t('rsID', {ns: 'genomic_browser'}),
-        show: false,
+        show: true,
         filter: {
           name: 'rsID',
           type: 'text',

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -263,6 +263,7 @@ class SnpDTO implements DataInstance, SiteHaver
             'PSCID'               => $this->_PSCID,
             'Sex'                 => $this->_Sex,
             'Cohort'              => $this->_Cohort,
+            'Date_of_Birth'       => "",
             'externalID'          => $this->_externalID,
             'Chromosome'          => $this->_Chromosome,
             'Strand'              => $this->_Strand,
@@ -287,6 +288,7 @@ class SnpDTO implements DataInstance, SiteHaver
             'Damaging'            => $this->_Damaging,
             'Genotype_Quality'    => $this->_Genotype_Quality,
             'Exonic_Function'     => $this->_Exonic_Function,
+            'Genomic_Range'       => "",
         ];
     }
 


### PR DESCRIPTION
## Brief summary of changes
The rsID hyperlink now appears Genomic Browser

- [ ] Have you updated related documentation?
<img width="1185" height="440" alt="Screenshot 2026-07-27 at 2 38 33 PM" src="https://github.com/user-attachments/assets/af422a28-c01a-425f-9bea-0422e628299f" />

#### Testing instructions (if applicable)

1. Go to Genomics --> Genomic Browser --> SNP
2. Verify that the hyperlinks for rsID are now visible

#### Link(s) to related issue(s)

* Resolves #10922   (Reference the issue this fixes, if any.)
