### PR TITLE
[survey_accounts] Fix Add survey breadcrumb

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -379,5 +379,25 @@ class AddSurvey extends \NDB_Form
             ]
         );
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    #[\Override]
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb(
+                dgettext("survey_accounts", "Survey Accounts"),
+                "/survey_accounts/"
+            ),
+            new \LORIS\Breadcrumb(
+                dgettext("survey_accounts", "Add Survey"),
+                ""
+            )
+        );
+    }
 }
 


### PR DESCRIPTION
Fix the breadcrumb for "Add Survey" on the survey_accounts page. This also fixes the translation for languages where it is already translated.

Fixes #11038