### PR TITLE
[survey_accounts] Translate "Status" column in survey_accounts

### DIFF
--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -77,10 +77,10 @@ class Survey_Accounts extends \DataFrameworkMenu
     public function getFieldOptions() : array
     {
         $statusOptions = [
-            'Created'     => dgettext("loris", "Created"),
-            'Sent'        => dgettext("loris", "Sent"),
-            'In Progress' => dgettext("loris", "In Progress"),
-            'Complete'    => dgettext("loris", "Complete"),
+            dgettext("loris", "Created")     => dgettext("loris", "Created"),
+            dgettext("loris", "Sent")        => dgettext("loris", "Sent"),
+            dgettext("loris", "In Progress") => dgettext("loris", "In Progress"),
+            dgettext("loris", "Complete")    => dgettext("loris", "Complete"),
         ];
 
         $instruments

--- a/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
@@ -74,6 +74,9 @@ class SurveyAccountsProvisioner
     {
         $cid = \CenterID::singleton(intval($row['CenterID']));
         $pid = \ProjectID::singleton((intval($row['ProjectID'])));
+
+        // All status options already exist in the loris namespace.
+        $row['Status'] = dgettext('loris', $row['Status']);
         return new SurveyAccountsRow($row, $cid, $pid);
     }
 }


### PR DESCRIPTION
Use the same translations for the data table as for the filter.

Fixes #11037
