### PR TITLE
[login] Fix reset password bug in French (non-ASCII characters)

### DIFF
--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -161,10 +161,11 @@ class Email
             $body     = $message;
         }
 
+        $subject = mb_encode_mimeheader($match[1], 'UTF-8');
         // send the email
         return mail(
             $to,
-            $match[1],
+            $subject,
             preg_replace("/(?<!\r)\n/s", "\n", $body),
             $headers
         );


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the multilingual password reset bug described in the issue, where users could not receive password reset emails when their language preference was set to French. The problem was caused by the email subject containing non-ASCII characters without being properly encoded. Since the subject is an email header, it must be encoded before being passed to the mail() function (at the end of `Email.class.inc`). This PR fixes the issue by encoding the subject using `mb_encode_mimeheader()` before sending the email.

#### Testing instructions (if applicable)

1. Please follow the instructions described in the corresponding issue.

**Prerequisite:** Ensure the user account being tested has a valid email address configured. If necessary, update the user's email in the database:

```sql
UPDATE users
SET Email = 'user@example.com'
WHERE UserID = 'username';
```

#### Link(s) to related issue(s)

* Resolves #11023 (Reference the issue this fixes, if any.)
