### PR TITLE
[electrophysiology_browser] Fix French translations + typo (non-db only)

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -349,7 +349,7 @@ msgstr "Précédent"
 
 #, fuzzy
 msgid "Next"
-msgstr "La prochaine étape a commencé."
+msgstr "Suivant"
 
 msgid "Save"
 msgstr "Sauvegarder"

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
@@ -1063,7 +1063,7 @@ const AnnotationForm = ({
                 ? ' form-edit'
                 : ''
             )}
-            label={t('trial_type', {ns: 'electrophysiology_browser'})}
+            label="trial_type"
             value={currentAnnotation ? currentAnnotation.label : (label ?? '')}
             onUserInput={(_, value) => setLabel(value)}
             required={false/*currentAnnotation === null*/}

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/AnnotationForm.tsx
@@ -639,7 +639,7 @@ const AnnotationForm = ({
         showCancelButton: true,
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#d33',
-        confirmButtonText: 'Yes, delete it!',
+        confirmButtonText: t('Yes, delete it!', {ns: 'electrophysiology_browser'}),
       }).then((result) => {
         // if isConfirmed
         if (result.value) {
@@ -1063,7 +1063,7 @@ const AnnotationForm = ({
                 ? ' form-edit'
                 : ''
             )}
-            label="trial_type"
+            label={t('trial_type', {ns: 'electrophysiology_browser'})}
             value={currentAnnotation ? currentAnnotation.label : (label ?? '')}
             onUserInput={(_, value) => setLabel(value)}
             required={false/*currentAnnotation === null*/}
@@ -1088,7 +1088,7 @@ const AnnotationForm = ({
                 id="start-time"
                 min={domain[0]}
                 max={domain[1]}
-                label="onset"
+                label={t('onset', {ns: 'electrophysiology_browser'})}
                 noMargins={true}
                 elementClass={'form-element-row numeric-element-row'}
                 inputClass={"form-control input-sm" + (
@@ -1109,7 +1109,7 @@ const AnnotationForm = ({
                 id="duration"
                 min={domain[0]}
                 max={domain[1]}
-                label="duration"
+                label={t('duration', {ns: 'electrophysiology_browser'})}
                 noMargins={true}
                 elementClass={'form-element-row numeric-element-row'}
                 inputClass={"form-control input-sm" + (
@@ -1136,7 +1136,7 @@ const AnnotationForm = ({
                 id="end-time"
                 min={domain[0]}
                 max={domain[1]}
-                label="end time"
+                label={t('end time', {ns: 'electrophysiology_browser'})}
                 noMargins={true}
                 elementClass={'form-element-row numeric-element-row'}
                 inputClass={"form-control input-sm" + (
@@ -1575,8 +1575,8 @@ const AnnotationForm = ({
                     ),
                     type: 'warning',
                     showCancelButton: true,
-                    confirmButtonText: 'Proceed',
-                    cancelButtonText: 'Cancel',
+                    confirmButtonText: t('Proceed', {ns: 'loris'}),
+                    cancelButtonText: t('Cancel', {ns: 'loris'}),
                   }).then((result) => {
                     if (result.value) {
                       closePanel();

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/ChannelTypesSelector.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/ChannelTypesSelector.tsx
@@ -29,7 +29,7 @@ const ChannelTypesSelector = ({channelTypes, setChannelTypes}: {
   return (
     <div style={{position: 'relative'}}>
       <button className="btn btn-primary dropdown" data-toggle="dropdown">
-        {t('Channel Types')}
+        {t('Channel Types', {ns : 'electrophysiology_browser'})}
       </button>
       <ul className="dropdown-menu">
         {Object.entries(channelTypes).map(([name, {visible, channelsCount}]) => (

--- a/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
+++ b/modules/electrophysiology_browser/jsx/react-series-data-viewer/src/series/components/EventManager.tsx
@@ -329,7 +329,7 @@ const EventManager = ({
         <div>
           <span style={{fontSize: '0.75em',}}>
             {t(
-              'Total events in recording {{total}}', {
+              'Total events in recording: {{total}}', {
                 ns: 'electrophysiology_browser',
                 total: epochs.length
               }
@@ -710,7 +710,7 @@ const EventManager = ({
                         </span>
                       </div>
                       {epoch.properties.length > 0 &&
-                        <div><strong>Additional Columns </strong>
+                        <div><strong>{t('Additional Columns', {ns: 'electrophysiology_browser'})} </strong>
                           {
                             epoch.properties.map((property) => {
                               return <div>
@@ -727,7 +727,7 @@ const EventManager = ({
                         </div>
                       }
                       {
-                        <div><strong>HED </strong>
+                        <div><strong>{t('HED', {ns: 'electrophysiology_browser'})} </strong>
                           {
                             [
                               ...epoch.hed,

--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -619,9 +619,6 @@ msgstr ""
 msgid "end time"
 msgstr ""
 
-msgid "trial_type"
-msgstr ""
-
 msgid "onset"
 msgstr ""
 

--- a/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
+++ b/modules/electrophysiology_browser/locale/electrophysiology_browser.pot
@@ -242,7 +242,7 @@ msgid "Updated!"
 msgstr ""
 
 # EventManager
-msgid "Total events in recording {{total}}"
+msgid "Total events in recording: {{total}}"
 msgstr ""
 
 msgid "Display by:"
@@ -614,4 +614,22 @@ msgid "View Session"
 msgstr ""
 
 msgid "Channel Types"
+msgstr ""
+
+msgid "end time"
+msgstr ""
+
+msgid "trial_type"
+msgstr ""
+
+msgid "onset"
+msgstr ""
+
+msgid "duration"
+msgstr ""
+
+msgid "Yes, delete it!"
+msgstr ""
+
+msgid "HED"
 msgstr ""

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -293,8 +293,8 @@ msgstr "Mis à jour !"
 
 # EventManager
 #, fuzzy
-msgid "Total events in recording {{total}}"
-msgstr "Nombre total d'événements enregistrés {{total}}"
+msgid "Total events in recording: {{total}}"
+msgstr "Nombre total d'événements enregistrés: {{total}}"
 
 #, fuzzy
 msgid "Display by:"
@@ -388,7 +388,7 @@ msgstr "Cliquez pour afficher le schéma HED"
 
 #, fuzzy
 msgid "Open Dataset Tag Manager"
-msgstr "Gestionnaire de balises pour ensembles de données ouverts"
+msgstr "Gestionnaire de balises de jeux de données"
 
 #, fuzzy
 msgid "View/Edit Tags"
@@ -755,3 +755,21 @@ msgstr "Voir la session"
 
 msgid "Channel Types"
 msgstr "Types de chaînes"
+
+msgid "end time"
+msgstr "heure de fin"
+
+msgid "trial_type"
+msgstr "type d'essai"
+
+msgid "onset"
+msgstr "début"
+
+msgid "duration"
+msgstr "durée"
+
+msgid "Yes, delete it!"
+msgstr "Oui, supprimez-le !"
+
+msgid "HED"
+msgstr "HED"

--- a/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/fr/LC_MESSAGES/electrophysiology_browser.po
@@ -759,9 +759,6 @@ msgstr "Types de chaînes"
 msgid "end time"
 msgstr "heure de fin"
 
-msgid "trial_type"
-msgstr "type d'essai"
-
 msgid "onset"
 msgstr "début"
 

--- a/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/ja/LC_MESSAGES/electrophysiology_browser.po
@@ -242,8 +242,8 @@ msgid "Updated!"
 msgstr "更新しました！"
 
 # EventManager
-msgid "Total events in recording {{total}}"
-msgstr "記録中のイベントの合計数 {{total}}"
+msgid "Total events in recording: {{total}}"
+msgstr "記録中のイベントの合計数: {{total}}"
 
 msgid "Display by:"
 msgstr "表示順:"

--- a/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
+++ b/modules/electrophysiology_browser/locale/zh/LC_MESSAGES/electrophysiology_browser.po
@@ -242,8 +242,8 @@ msgid "Updated!"
 msgstr "更新了！"
 
 # EventManager
-msgid "Total events in recording {{total}}"
-msgstr "记录中的事件总数 {{total}}"
+msgid "Total events in recording: {{total}}"
+msgstr "记录中的事件总数: {{total}}"
 
 msgid "Display by:"
 msgstr "显示方式："


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the issue described in the corresponding issue report and corrects a minor UI typo by adding the missing trailing colon : to the 'Total events in recording' label.

#### Testing instructions (if applicable)

1. Testing is recommended for someone who already has the visualization component set up, ideally @lapadulamichael who reported the issue. The setup to access the visualization component of the module which contains most of the fixes is documented in the module's README.md, so anyone else assigned to the PR should be able to set it up without difficulty.

#### Link(s) to related issue(s)

* Resolves #10661 (Reference the issue this fixes, if any.)
