### PR TITLE
[instrument_list] Fix minor multilingual bugs

### DIFF
--- a/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
@@ -107,7 +107,7 @@ msgid "Across All Fields"
 msgstr "Dans tous les domaines"
 
 msgid "QC Class"
-msgstr "Classe CQ"
+msgstr "Classe de contrôle qualité"
 
 msgid "# Threads"
 msgstr "# Fils de discussion"

--- a/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
+++ b/modules/instrument_list/locale/fr/LC_MESSAGES/instrument_list.po
@@ -53,3 +53,9 @@ msgstr "Étape: %s"
 
 msgid "Start the \"%s\" Stage"
 msgstr "Débuter l'étape de la « %s »"
+
+msgid "BVL QC Type"
+msgstr "Type de contrôle qualité comportemental"
+
+msgid "BVL QC Status"
+msgstr "Statut du contrôle qualité comportemental"

--- a/modules/instrument_list/locale/instrument_list.pot
+++ b/modules/instrument_list/locale/instrument_list.pot
@@ -50,3 +50,9 @@ msgstr ""
 
 msgid "Start the \"%s\" Stage"
 msgstr ""
+
+msgid "BVL QC Type"
+msgstr ""
+
+msgid "BVL QC Status"
+msgstr ""

--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -58,7 +58,7 @@
 	</ul>
 
 
-	<h3 class="controlPanelSection">{dgettext("timepoint_list", "BVL QC")}</h3>
+	<h3 class="controlPanelSection">{dgettext("instrument_list", "BVL QC Type")}</h3>
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_type_none.icon|default:'far fa-square'}"></i></span>
@@ -87,7 +87,7 @@
 		</li>
 	</ul>
 
-	<h3 class="controlPanelSection">{dgettext("timepoint_list", "BVL QC")}</h3>
+	<h3 class="controlPanelSection">{dgettext("instrument_list", "BVL QC Status")}</h3>
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_status_none.icon|default:'far fa-square'}"></i></span>

--- a/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
+++ b/modules/timepoint_list/locale/fr/LC_MESSAGES/timepoint_list.po
@@ -38,7 +38,7 @@ msgid "Imaging Scan Done"
 msgstr "Scan d'imagerie complété"
 
 msgid "BVL QC"
-msgstr "CQ comportemental"
+msgstr "Contrôle qualité comportemental"
 
 msgid "BVL Exclusion"
 msgstr "Exclusion comportementale"
@@ -83,4 +83,4 @@ msgid "Hardcopy"
 msgstr "Copie papier"
 
 msgid "Complete"
-msgstr "Compléter"
+msgstr "Complété"


### PR DESCRIPTION
## Brief summary of changes

This PR expands the abbreviation CQ in the French translations, as it is not a widely recognized acronym. It also fixes the previously overwritten translations for BVL QC Status and BVL QC Type, which occurred during the initial localization of the module, and corrects a minor typo in the French translation.

#### Testing instructions (if applicable)

After logging in, navigate to the following URL /instrument_list/?candID=587630&sessionID=1053&lang=en-CA and switch the interface language to French.

1. Please refer to the images present in the corresponding issue.

#### Link(s) to related issue(s)

* Resolves #11062 (Reference the issue this fixes, if any.)
