### PR TITLE
[instrument_builder] Fix duplicate french translation

### DIFF
--- a/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
@@ -121,10 +121,10 @@ msgid "Data entry"
 msgstr "Entrée de données"
 
 msgid "Textbox"
-msgstr "Zone de texte"
+msgstr "Champ de texte"
 
 msgid "Textarea"
-msgstr "Zone de texte"
+msgstr "Champ de texte multiligne"
 
 msgid "Dropdown"
 msgstr "Liste déroulante"


### PR DESCRIPTION
## Brief summary of changes

This PR makes the French translations for Textbox and Textarea more specific, allowing users to easily distinguish between the single-line and multi-line input fields.

#### Testing instructions (if applicable)

1. Go to 'Tools' -> 'Instrument Builder'
2. Switch the language to French
3. Go to the 'Build' ('Construire' in French) tab
4. Click on 'Select One' ('Sélectionnez un seul choix' in French)
5. Verify that there is no more duplicate

<img width="1709" height="868" alt="Untitled 33" src="https://github.com/user-attachments/assets/700343b6-1349-4164-b2df-43c4b108eca4" />

#### Link(s) to related issue(s)

* Resolves #10942 (Reference the issue this fixes, if any.)
