### PR TITLE
[imaging_uploader] Add missing translations for pop up and error messages

### DIFF
--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -170,3 +170,12 @@ msgstr "Emplacement de téléversement"
 
 msgid "Upload Date"
 msgstr "Date d'importation"
+
+msgid "Invalid PSCID %s for CandID %s. Check that you entered the correct PSCID and CandID."
+msgstr "Le PSCID %s est invalide pour le CandID %s. Vérifiez que vous avez saisi le bon PSCID et le bon CandID."
+
+msgid "Invalid Visit Label %s for CandID %s. Check that you entered the correct Visit Label and CandID."
+msgstr "L'étiquette de visite %s est invalide pour le CandID %s. Vérifiez que vous avez saisi la bonne étiquette de visite et le bon CandID."
+
+msgid "The session associated with CandID %s and Visit Label %s is not active in the database."
+msgstr "La session associée au CandID %s et à l'étiquette de visite %s n'est pas active dans la base de données."

--- a/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
+++ b/modules/imaging_uploader/locale/fr/LC_MESSAGES/imaging_uploader.po
@@ -179,3 +179,27 @@ msgstr "L'étiquette de visite %s est invalide pour le CandID %s. Vérifiez que 
 
 msgid "The session associated with CandID %s and Visit Label %s is not active in the database."
 msgstr "La session associée au CandID %s et à l'étiquette de visite %s n'est pas active dans la base de données."
+
+msgid "Please make sure files are not larger than %s"
+msgstr "Veuillez vous assurer que les fichiers ne dépassent pas %s."
+
+msgid "The file %s is not of type .tgz, .tar.gz or .zip."
+msgstr "Le fichier %s n'est pas de type .tgz, .tar.gz ou .zip."
+
+msgid "The CandID %s does not exist in the database."
+msgstr "Le CandID %s n'existe pas dans la base de données."
+
+msgid "This user does not have permission to upload files for this session."
+msgstr "Cet utilisateur n'est pas autorisé à téléverser des fichiers pour cette session."
+
+msgid "The candidate associated with CandID %s and PSCID %s is not active in the database."
+msgstr "Le candidat associé au CandID %s et au PSCID %s n'est pas actif dans la base de données."
+
+msgid "File name and fields entered in CandID, PSCID, Visit Label must match. Verify that the information entered in all the fields above is correct or rename the file so that the file name matches %s or begins with \"%s\" and has the extension .tgz, tar.gz or .zip"
+msgstr "Le nom du fichier et les champs CandID, PSCID et Libellé de visite doivent correspondre. Vérifiez que les informations saisies dans les champs ci-dessus sont correctes ou renommez le fichier afin que son nom corresponde à %s ou commence par \"%s\" et qu'il ait l'extension .tgz, .tar.gz ou .zip."
+
+msgid "This file has already been uploaded."
+msgstr "Ce fichier a déjà été téléversé."
+
+msgid "An internal server error prevented this file from being uploaded. Please contact the system administrator: failed to copy %s to %s"
+msgstr "Une erreur interne du serveur a empêché le téléversement de ce fichier. Veuillez communiquer avec l'administrateur du système : impossible de copier %s vers %s."

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -138,3 +138,12 @@ msgstr ""
 
 msgid "Upload Date"
 msgstr ""
+
+msgid "Invalid PSCID %s for CandID %s. Check that you entered the correct PSCID and CandID."
+msgstr ""
+
+msgid "Invalid Visit Label %s for CandID %s. Check that you entered the correct Visit Label and CandID."
+msgstr ""
+
+msgid "The session associated with CandID %s and Visit Label %s is not active in the database."
+msgstr ""

--- a/modules/imaging_uploader/locale/imaging_uploader.pot
+++ b/modules/imaging_uploader/locale/imaging_uploader.pot
@@ -147,3 +147,27 @@ msgstr ""
 
 msgid "The session associated with CandID %s and Visit Label %s is not active in the database."
 msgstr ""
+
+msgid "Please make sure files are not larger than %s"
+msgstr ""
+
+msgid "The file %s is not of type .tgz, .tar.gz or .zip."
+msgstr ""
+
+msgid "The CandID %s does not exist in the database."
+msgstr ""
+
+msgid "This user does not have permission to upload files for this session."
+msgstr ""
+
+msgid "The candidate associated with CandID %s and PSCID %s is not active in the database."
+msgstr ""
+
+msgid "File name and fields entered in CandID, PSCID, Visit Label must match. Verify that the information entered in all the fields above is correct or rename the file so that the file name matches %s or begins with \"%s\" and has the extension .tgz, tar.gz or .zip"
+msgstr ""
+
+msgid "This file has already been uploaded."
+msgstr ""
+
+msgid "An internal server error prevented this file from being uploaded. Please contact the system administrator: failed to copy %s to %s"
+msgstr ""

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -176,8 +176,14 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             && ($_SERVER['REQUEST_METHOD']=='POST')
         ) { //catch file overload error...
             $upload_max_size = \Utility::getMaxUploadSize();
-            $error_message   = "Please make sure files are not larger than " .
-                                $upload_max_size;
+            $error_message   = sprintf(
+                dgettext(
+                    "imaging_uploader",
+                    "Please make sure files are not larger"
+                        . " than %s"
+                ),
+                $upload_max_size
+            );
             http_response_code(413);
             $errors = [
                 'IsPhantom'  => [],
@@ -358,8 +364,13 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         if (!$this->isCompressed($temp_file)) {
             array_push(
                 $errors["mriFile"],
-                "The file $file_name is not of type".
-                " .tgz, .tar.gz or .zip."
+                sprintf(
+                    dgettext(
+                        "imaging_uploader",
+                        "The file %s is not of type .tgz, .tar.gz or .zip."
+                    ),
+                    $file_name
+                )
             );
         }
 
@@ -401,8 +412,13 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 if (is_null($candidate) || $candidate["candid"] !== $candid) {
                     array_push(
                         $errors["candID"],
-                        "The CandID " . $candid .
-                        " does not exist in the database."
+                        sprintf(
+                            dgettext(
+                                "imaging_uploader",
+                                "The CandID %s does not exist in the database."
+                            ),
+                            $candid
+                        )
                     );
                 } else {
                     if (!$candidate['candid_with_pscid']) {
@@ -442,8 +458,11 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                             new \SessionID(strval($candidate['SessionID']))
                         );
                         if (!$session->isAccessibleBy($user)) {
-                            $errors["user"] = "This user does not have permission ".
-                            "to upload files for this session.";
+                            $errors["user"] = dgettext(
+                                "imaging_uploader",
+                                "This user does not have permission to upload"
+                                    . " files for this session."
+                            );
                             http_response_code(403);
                             header('Content-Type: application/json; charset=UTF-8');
                             exit(json_encode(['errors' => $errors]));
@@ -453,9 +472,15 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     if ($candidate['candidate_active'] == 'N') {
                         array_push(
                             $errors["pSCID"],
-                            "The candidate associated with CandID " .
-                            $candid . " and PSCID " .
-                            $pscid . " is not active in the database."
+                            sprintf(
+                                dgettext(
+                                    "imaging_uploader",
+                                    "The candidate associated with CandID %s and"
+                                    . "PSCID %s is not active in the database."
+                                ),
+                                $candid,
+                                $pscid
+                            )
                         );
                     }
                     if ($candidate['session_active'] == 'N') {
@@ -487,13 +512,20 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             if ((!preg_match("/^{$pcv}\.(zip|tgz|tar.gz)/", $file_name))
                 && (!preg_match("/^{$pcvu}.*(\.(zip|tgz|tar.gz))/", $file_name))
             ) {
-                     $file_name_error
-                         = "File name and fields entered in CandID, PSCID," .
-                     " Visit Label must match. Verify that the information" .
-                     " entered in all the fields above is correct or rename" .
-                     " the file so that the file name matches " . $pcv .
-                     " or begins with " . "\"". $pcvu . "\"" .
-                     ", and has the extension .tgz, tar.gz or .zip";
+                $file_name_error
+                    = sprintf(
+                        dgettext(
+                            "imaging_uploader",
+                            "File name and fields entered in CandID, PSCID, Visit"
+                            . " Label must match. Verify that the information"
+                            . " entered in all the fields above is correct or rename"
+                            . " the file so that the file name matches %s"
+                            . " or begins with \"%s\" and has the extension .tgz,"
+                            . " tar.gz or .zip"
+                        ),
+                        $pcv,
+                        $pcvu
+                    );
             }
         }
 
@@ -516,7 +548,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         if (!$updateFile && !empty($id) && file_exists($uploadPath)) {
             array_push(
                 $errors['mriFile'],
-                "This file has already been uploaded."
+                dgettext("imaging_uploader", "This file has already been uploaded.")
             );
         }
         // Loops through associative array of error messages
@@ -547,9 +579,16 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $temp_dir      = $this->tempdir();
         $new_temp_file = $temp_dir. "/". $file->fileInfo['name'];
         if (!copy($temp_file, $new_temp_file)) {
-            $msg = "An internal server error prevented this file from being "
-                 . "uploaded. Please contact the system administrator: "
-                 . "failed to copy $temp_file to $new_temp_file";
+            $msg = sprintf(
+                dgettext(
+                    "imaging_uploader",
+                    "An internal server error prevented"
+                        . " this file from being uploaded. Please contact the system"
+                        . "administrator: " . "failed to copy %s to %s"
+                ),
+                $temp_file,
+                $new_temp_file
+            );
             array_push($errors["mriFile"], $msg);
             http_response_code(400);
             header('Content-Type: application/json; charset=UTF-8');

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -423,17 +423,17 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     if (!$candidate['visit_label']) {
                             array_push(
                                 $errors["visitLabel"],
-                            sprintf(
-                                dgettext(
-                                    "imaging_uploader",
-                                    "Invalid Visit Label %s for CandID %s."
+                                sprintf(
+                                    dgettext(
+                                        "imaging_uploader",
+                                        "Invalid Visit Label %s for CandID %s."
                                         . " Check that you entered the correct"
                                         . " Visit Label and CandID."
-                                ),
-                                $visit_label,
-                                $candid
-                            )
-                        );
+                                    ),
+                                    $visit_label,
+                                    $candid
+                                )
+                            );
                     }
                     if ($advancedperms === 'true') {
                         // Basic fields have been validated, check user permisions

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -584,7 +584,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     "imaging_uploader",
                     "An internal server error prevented"
                         . " this file from being uploaded. Please contact the system"
-                        . "administrator: " . "failed to copy %s to %s"
+                        . " administrator: " . "failed to copy %s to %s"
                 ),
                 $temp_file,
                 $new_temp_file

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -408,20 +408,32 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     if (!$candidate['candid_with_pscid']) {
                         array_push(
                             $errors["pSCID"],
-                            "Invalid PSCID " . $pscid .
-                             " for CandID " . $candid .
-                             ". Check that you entered the correct" .
-                             " PSCID and CandID."
+                            sprintf(
+                                dgettext(
+                                    "imaging_uploader",
+                                    "Invalid PSCID %s for CandID %s. Check"
+                                        . " that you entered the correct PSCID"
+                                        . " and CandID."
+                                ),
+                                $pscid,
+                                $candid
+                            )
                         );
                     }
                     if (!$candidate['visit_label']) {
                             array_push(
                                 $errors["visitLabel"],
-                                "Invalid Visit Label " . $visit_label .
-                                " for CandID " . $candid .
-                                ". Check that you entered the correct" .
-                                " Visit Label and CandID."
-                            );
+                            sprintf(
+                                dgettext(
+                                    "imaging_uploader",
+                                    "Invalid Visit Label %s for CandID %s."
+                                        . " Check that you entered the correct"
+                                        . " Visit Label and CandID."
+                                ),
+                                $visit_label,
+                                $candid
+                            )
+                        );
                     }
                     if ($advancedperms === 'true') {
                         // Basic fields have been validated, check user permisions
@@ -449,10 +461,16 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     if ($candidate['session_active'] == 'N') {
                         array_push(
                             $errors["visitLabel"],
-                            "The session associated with CandID " .
-                            $candid . " and Visit Label " .
-                            $visit_label . " is not active in".
-                            " the database."
+                            sprintf(
+                                dgettext(
+                                    "imaging_uploader",
+                                    "The session associated with CandID %s and"
+                                        . " Visit Label %s is not active in the"
+                                        . " database."
+                                ),
+                                $candid,
+                                $visit_label
+                            )
                         );
                     }
                 }

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -476,7 +476,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                                 dgettext(
                                     "imaging_uploader",
                                     "The candidate associated with CandID %s and"
-                                    . "PSCID %s is not active in the database."
+                                    . " PSCID %s is not active in the database."
                                 ),
                                 $candid,
                                 $pscid


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing pop up and error messages translations in French in the imaging_uploader module.

Note: This PR also includes the translation of another error message in the same file.

#### Testing instructions (if applicable)

1. Go to 'Imaging' -> 'Imaging Uploader'
2. Go to the 'Upload' tab
3. Switch the language to French
4. Fill the Upload form (an example is shown below)

<img width="853" height="385" alt="image" src="https://github.com/user-attachments/assets/e121a725-270c-4769-a700-7a3f8d8daa60" />

5. Click on 'Soumettre'
6. Observe the translated pop up and error messages in French

<img width="853" height="475" alt="Telliverser un scan d&#39;age" src="https://github.com/user-attachments/assets/ad7216e5-1d96-4568-a23d-ae96e41e29fb" />

Note: run `sudo systemctl restart apache2` if the translation doesn't show up. 
Reason: https://github.com/aces/Loris/pull/10933#issuecomment-5035596645

#### Link(s) to related issue(s)

* Resolves #10813 (Reference the issue this fixes, if any.)
