### PR TITLE
[genomic_browser] PSCID links contain 4 leading zeros (using CandID padding instead of DCCID standard length)  #11054  -fix

### DIFF
--- a/modules/genomic_browser/php/provisioners/cnvprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/cnvprovisioner.class.inc
@@ -25,7 +25,7 @@ class CnvProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             "
             SELECT
                 psc.Name AS _PSC,
-                LPAD(candidate.CandID, 10, '0') AS _DCCID,
+                candidate.CandID AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
                 cohort.CohortID AS _Cohort,

--- a/modules/genomic_browser/php/provisioners/methylationprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/methylationprovisioner.class.inc
@@ -25,7 +25,7 @@ class MethylationProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisione
             "
             SELECT
                 psc.Name AS _PSC,
-                LPAD(candidate.CandID, 10, '0') AS _DCCID,
+                candidate.CandID AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
                 candidate.RegistrationCenterID as _centerID,

--- a/modules/genomic_browser/php/provisioners/profileprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/profileprovisioner.class.inc
@@ -25,7 +25,7 @@ class ProfileProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             "
             SELECT
                 psc.Name AS _PSC,
-                LPAD(candidate.CandID, 10, '0') AS _DCCID,
+                candidate.CandID AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
                 subproj.title AS _Cohort,

--- a/modules/genomic_browser/php/provisioners/snpprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/snpprovisioner.class.inc
@@ -25,7 +25,7 @@ class SnpProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             "
             SELECT
                 psc.Name AS _PSC,
-                LPAD(candidate.CandID, 10, '0') AS _DCCID,
+                candidate.CandID AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
                 co.title AS _Cohort,


### PR DESCRIPTION
[genomic_browser] PSCID links contain 4 leading zeros (using CandID padding instead of DCCID standard length)
 #11054
fix links from  "https://test-dev-270.loris.ca/0000300007/" to "https://test-dev-270.loris.ca/300007/"

