### PR TITLE
[genonic_browser] added missing CPG name hyperlink in Methylation tab of Genomic Browser

### DIFF
--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -87,13 +87,36 @@ class Methylation extends Component {
       const url = `${this.props.baseURL}/${rowData.DCCID}/`;
       reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
       break;
+    
+    // Corrected: Must match the label exactly as defined in the fields array
+    case 'CPG Name': 
+    case 'Gene':
+    case 'Accession number':
+    case 'Island Loc':
+      reactElement = (
+        <td>
+          {String(cell || '')
+            .split(',')
+            .map(v => v.trim())
+            .filter(Boolean) 
+            .map((val, i, arr) => (
+            <span key={i}>
+              <a href={`https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=${val}`} target="_blank" rel="noopener noreferrer">
+                {val}
+              </a>
+              {i < arr.length - 1 ? ', ' : ''}
+            </span>
+          ))}
+        </td>
+      );
+      break;
+
     default:
       reactElement = <td>{cell}</td>;
       break;
     }
     return reactElement;
   }
-
   /**
    * @return {DOMRect}
    */
@@ -162,7 +185,7 @@ class Methylation extends Component {
       },
       {
         label: t('CPG Name', {ns: 'genomic_browser'}),
-        show: false,
+        show: true,
         filter: {
           name: 'File',
           type: 'text',

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -87,9 +87,9 @@ class Methylation extends Component {
       const url = `${this.props.baseURL}/${rowData.DCCID}/`;
       reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
       break;
-    
+
     // Corrected: Must match the label exactly as defined in the fields array
-    case 'CPG Name': 
+    case 'CPG Name':
     case 'Gene':
     case 'Accession number':
     case 'Island Loc':
@@ -97,16 +97,22 @@ class Methylation extends Component {
         <td>
           {String(cell || '')
             .split(',')
-            .map(v => v.trim())
-            .filter(Boolean) 
+            .map((v) => v.trim())
+            .filter(Boolean)
             .map((val, i, arr) => (
-            <span key={i}>
-              <a href={`https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=${val}`} target="_blank" rel="noopener noreferrer">
-                {val}
-              </a>
-              {i < arr.length - 1 ? ', ' : ''}
-            </span>
-          ))}
+              <span key={i}>
+                <a
+                  href={
+                    `https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=${val}`
+                  }
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {val}
+                </a>
+                {i < arr.length - 1 ? ', ' : ''}
+              </span>
+            ))}
         </td>
       );
       break;

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -88,7 +88,6 @@ class Methylation extends Component {
       reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
       break;
 
-    // Corrected: Must match the label exactly as defined in the fields array
     case 'CPG Name':
     case 'Gene':
     case 'Accession number':

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -102,7 +102,8 @@ class Methylation extends Component {
               <span key={i}>
                 <a
                   href={
-                    `https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=${val}`
+                    'https://genome.ucsc.edu/cgi-bin/' +
+                    `hgTracks?db=hg19&position=${val}`
                   }
                   target="_blank"
                   rel="noopener noreferrer"

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -273,6 +273,7 @@ class MethylationDTO implements DataInstance, SiteHaver
             'PSCID'            => $this->_PSCID,
             'Sex'              => $this->_Sex,
             'Cohort'           => $this->_Cohort,
+            'Date_of_Birth'    => "", // Added to fix alignment
             'Sample'           => $this->_Sample,
             'cpg_name'         => $this->_cpg_name,
             'Beta_value'       => $this->_Beta_value,


### PR DESCRIPTION
## Brief summary of changes
Added missing CPG name hyperlink which was a regular text earlier

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Go to Genomic Browser
2. Select Methylation tab
3. Confirm whether the CPG name has a hyperlink

#### Link(s) to related issue(s)

* Resolves #10923   (Reference the issue this fixes, if any.)
