### PR TITLE
[survey_accounts] Fix visit label validation failing in non-English languages

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -117,7 +117,7 @@ class AddSurvey extends \NDB_Form
               ['CandID' => $error];
         }
 
-        if (! in_array($values['VL'], \Utility::getVisitList(), true)) {
+        if (! array_key_exists($values['VL'], \Utility::getVisitList())) {
             return ['VL' => dgettext(
                 'survey_accounts',
                 'You must specify a valid Visit Label.'

--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -158,6 +158,7 @@ class Email
             $body .= "--$boundary--";
         } else {
             $headers .= "Content-type: $type; charset=UTF-8\r\n";
+            $headers .= "Content-Transfer-Encoding: 8bit\r\n";
             $body     = $message;
         }
 

--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -158,7 +158,6 @@ class Email
             $body .= "--$boundary--";
         } else {
             $headers .= "Content-type: $type; charset=UTF-8\r\n";
-            $headers .= "Content-Transfer-Encoding: 8bit\r\n";
             $body     = $message;
         }
 


### PR DESCRIPTION
[survey_accounts] Fix visit label validation failing in non-English languages
survey account can't send email failing in non-English
 #11088

_validateAddSurvey() is checking against the translated labels using in_array(). Because "V1" is the stored value (not the translated label), the lookup always fails, causing the validation to fail every time.