### PR TITLE
[dataquery] fixes oversized table head element

### DIFF
--- a/jsx/DataTable.d.ts
+++ b/jsx/DataTable.d.ts
@@ -5,7 +5,7 @@ type TableRow = (string|null)[]
 
 type Field = {
     show: boolean
-    label: string
+    label: string | ReactNode
 }
 
 type hideOptions = {

--- a/modules/dataquery/css/viewdata.css
+++ b/modules/dataquery/css/viewdata.css
@@ -1,0 +1,13 @@
+.dataquery-view-container .header-text {
+  max-height: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 12;
+  display: -webkit-box;
+}
+
+.dataquery-view-container table th,
+.dataquery-view-container table td {
+  min-width: 150px;
+}

--- a/modules/dataquery/css/viewdata.css
+++ b/modules/dataquery/css/viewdata.css
@@ -6,8 +6,3 @@
   -webkit-line-clamp: 12;
   display: -webkit-box;
 }
-
-.dataquery-view-container table th,
-.dataquery-view-container table td {
-  min-width: 150px;
-}

--- a/modules/dataquery/jsx/getdictionarydescription.tsx
+++ b/modules/dataquery/jsx/getdictionarydescription.tsx
@@ -1,6 +1,18 @@
 import {FullDictionary} from './types';
 
 /**
+ * Parses string to remove HTML tags and return raw text
+ *
+ * @param {string} html - input string
+ * @returns {string} - parsed string
+ */
+function stripHTML(html: string): string {
+  if (!html) return '';
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return doc.body.textContent || html.replace(/<\/?[a-zA-Z][^>]*>?/gm, '');
+}
+
+/**
  * Get the dictionary for a given term
  *
  * @param {string} module - the module
@@ -23,7 +35,8 @@ function getDictionaryDescription(
     return fieldname;
   }
 
-  return dict[module][category][fieldname].description;
+  const desc = dict[module][category][fieldname].description;
+  return stripHTML(desc);
 }
 
 export default getDictionaryDescription;

--- a/modules/dataquery/jsx/getdictionarydescription.tsx
+++ b/modules/dataquery/jsx/getdictionarydescription.tsx
@@ -8,6 +8,11 @@ import {FullDictionary} from './types';
  */
 function stripHTML(html: string): string {
   if (!html) return '';
+
+  if (!/<[^>]+>/.test(html)) {
+    return html;
+  }
+
   const doc = new DOMParser().parseFromString(html, 'text/html');
   return doc.body.textContent || html.replace(/<\/?[a-zA-Z][^>]*>?/gm, '');
 }

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -11,6 +11,7 @@ import {QueryGroup} from './querydef';
 import {FullDictionary, FieldDictionary} from './types';
 import {calcPayload} from './calcpayload';
 import getDictionaryDescription from './getdictionarydescription';
+import '../css/viewdata.css';
 
 type TableRow = (string|null)[];
 
@@ -440,20 +441,6 @@ function ViewData(props: {
     />
     : <div />);
   return <div className='dataquery-view-container'>
-    <style>{`
-      .dataquery-view-container .header-text {
-        max-height: 250px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 12;
-        display: -webkit-box;
-      }
-      .dataquery-view-container table th,
-      .dataquery-view-container table td {
-        min-width: 150px;
-      }
-    `}</style>
     <SelectElement
       name='headerdisplay'
       options={{

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -384,7 +384,10 @@ function ViewData(props: {
           rowNumLabel={t('Row Number')}
           fields={organizedData.headers.map(
             (val: string) => {
-              return {show: true, label: val};
+              return {
+                show: true,
+                label: <div className="header-text">{val}</div>,
+              };
             })
           }
           data={organizedData.data}
@@ -436,7 +439,21 @@ function ViewData(props: {
       }
     />
     : <div />);
-  return <div>
+  return <div className='dataquery-view-container'>
+    <style>{`
+      .dataquery-view-container .header-text {
+        max-height: 250px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 12;
+        display: -webkit-box;
+      }
+      .dataquery-view-container table th,
+      .dataquery-view-container table td {
+        min-width: 150px;
+      }
+    `}</style>
     <SelectElement
       name='headerdisplay'
       options={{


### PR DESCRIPTION
## Brief summary of changes
- Fixes issue where field descriptions could render raw HTML inside <th>.
- Adds min-width to td/th and max-height to headers in the table rendering to prevent excessively tall table heads when displaying long text.

## Testing instructions

1. Create a query with fields that have raw HTML in their descriptions and very long text strings.
2. Render the dataquery table.
3. Verify the HTML tags are safely escaped and not rendered as active HTML.
4. Verify the table header layout remains constrained (doesn't stretch vertically).

## Link to related issue
* Resolves #10389
