### PR TITLE
[brainbrowser] Fix French translations mistake

### DIFF
--- a/modules/brainbrowser/locale/fr/LC_MESSAGES/brainbrowser.po
+++ b/modules/brainbrowser/locale/fr/LC_MESSAGES/brainbrowser.po
@@ -93,11 +93,11 @@ msgstr "Afficher les tranches"
 
 #, fuzzy
 msgid "Sagittal"
-msgstr "Sagittal"
+msgstr "Sagittales"
 
 msgid "Coronal"
-msgstr "Coronaire"
+msgstr "Coronaires"
 
 #, fuzzy
 msgid "Transverse"
-msgstr "Transversal"
+msgstr "Transversales"


### PR DESCRIPTION
## Brief summary of changes
Corrected some French translations to be in their feminine and plural forms

#### Testing instructions (if applicable)

1. Go to the `image_browser`
2. Click on one of the links to view session
3. Click on "Longitudinal View" to open `brainbrowser`
4. Change the language to French
5. Click expand the page and see translations

<img width="323" height="722" alt="image" src="https://github.com/user-attachments/assets/cf59329a-76cf-41f3-a105-cbc5a1917c7a" />

#### Link(s) to related issue(s)

* Resolves [#11050](https://github.com/aces/Loris/issues/11050)  (Reference the issue this fixes, if any.)
