### PR TITLE
[FilesUploadHandler] Adding missing translations

### DIFF
--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -424,3 +424,24 @@ msgstr "ID de archivo"
 
 msgid "Type"
 msgstr "Tipo"
+
+msgid "Upload directory is not a directory"
+msgstr "El directorio de carga no es un directorio válido"
+
+msgid "Upload directory is not writable"
+msgstr "No se puede escribir en el directorio de carga"
+
+msgid "Path traversal not allowed"
+msgstr "No se permite la navegación por rutas"
+
+msgid "This file has already been uploaded."
+msgstr "Este archivo ya ha sido cargado."
+
+msgid "File type not allowed"
+msgstr "Tipo de archivo no permitido"
+
+msgid "Could not upload file"
+msgstr "No se pudo cargar el archivo"
+
+msgid "Could not upload file: "
+msgstr "No se pudo cargar el archivo: "

--- a/locale/es/LC_MESSAGES/loris.po
+++ b/locale/es/LC_MESSAGES/loris.po
@@ -442,6 +442,3 @@ msgstr "Tipo de archivo no permitido"
 
 msgid "Could not upload file"
 msgstr "No se pudo cargar el archivo"
-
-msgid "Could not upload file: "
-msgstr "No se pudo cargar el archivo: "

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -643,3 +643,24 @@ msgstr "inconnu"
 
 msgid "Type"
 msgstr "Type"
+
+msgid "Upload directory is not a directory"
+msgstr "Le répertoire de téléversement n'est pas un répertoire valide"
+
+msgid "Upload directory is not writable"
+msgstr "Le répertoire de téléversement n'est pas modifiable"
+
+msgid "Path traversal not allowed"
+msgstr "La traversée de répertoires n'est pas autorisée"
+
+msgid "This file has already been uploaded."
+msgstr "Ce fichier a déjà été téléversé."
+
+msgid "File type not allowed"
+msgstr "Type de fichier non autorisé"
+
+msgid "Could not upload file"
+msgstr "Impossible de téléverser le fichier"
+
+msgid "Could not upload file: "
+msgstr "Impossible de téléverser le fichier : "

--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -662,5 +662,3 @@ msgstr "Type de fichier non autorisé"
 msgid "Could not upload file"
 msgstr "Impossible de téléverser le fichier"
 
-msgid "Could not upload file: "
-msgstr "Impossible de téléverser le fichier : "

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -594,5 +594,23 @@ msgstr "अज्ञात"
 msgid "Type"
 msgstr "प्रकार"
 
+msgid "Upload directory is not a directory"
+msgstr "अपलोड निर्देशिका एक मान्य निर्देशिका नहीं है"
+
+msgid "Upload directory is not writable"
+msgstr "अपलोड निर्देशिका में लिखा नहीं जा सकता"
+
+msgid "Path traversal not allowed"
+msgstr "पाथ ट्रैवर्सल की अनुमति नहीं है"
+
+msgid "This file has already been uploaded."
+msgstr "यह फ़ाइल पहले ही अपलोड की जा चुकी है।"
+
+msgid "File type not allowed"
+msgstr "इस फ़ाइल प्रकार की अनुमति नहीं है"
+
 msgid "Could not upload file"
 msgstr "फ़ाइल अपलोड नहीं हो सकी"
+
+msgid "Could not upload file: "
+msgstr "फ़ाइल अपलोड नहीं हो सकी: "

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -611,6 +611,3 @@ msgstr "इस फ़ाइल प्रकार की अनुमति न�
 
 msgid "Could not upload file"
 msgstr "फ़ाइल अपलोड नहीं हो सकी"
-
-msgid "Could not upload file: "
-msgstr "फ़ाइल अपलोड नहीं हो सकी: "

--- a/locale/hi/LC_MESSAGES/loris.po
+++ b/locale/hi/LC_MESSAGES/loris.po
@@ -593,3 +593,6 @@ msgstr "अज्ञात"
 
 msgid "Type"
 msgstr "प्रकार"
+
+msgid "Could not upload file"
+msgstr "फ़ाइल अपलोड नहीं हो सकी"

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -618,5 +618,23 @@ msgstr "不明"
 msgid "Type"
 msgstr "タイプ"
 
+msgid "Upload directory is not a directory"
+msgstr "アップロードディレクトリが有効なディレクトリではありません"
+
+msgid "Upload directory is not writable"
+msgstr "アップロードディレクトリに書き込めません"
+
+msgid "Path traversal not allowed"
+msgstr "パストラバーサルは許可されていません"
+
+msgid "This file has already been uploaded."
+msgstr "このファイルはすでにアップロードされています。"
+
+msgid "File type not allowed"
+msgstr "許可されていないファイル形式です"
+
 msgid "Could not upload file"
 msgstr "ファイルをアップロードできませんでした"
+
+msgid "Could not upload file: "
+msgstr "ファイルをアップロードできませんでした: "

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -635,6 +635,3 @@ msgstr "許可されていないファイル形式です"
 
 msgid "Could not upload file"
 msgstr "ファイルをアップロードできませんでした"
-
-msgid "Could not upload file: "
-msgstr "ファイルをアップロードできませんでした: "

--- a/locale/ja/LC_MESSAGES/loris.po
+++ b/locale/ja/LC_MESSAGES/loris.po
@@ -617,3 +617,6 @@ msgstr "不明"
 
 msgid "Type"
 msgstr "タイプ"
+
+msgid "Could not upload file"
+msgstr "ファイルをアップロードできませんでした"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -615,3 +615,27 @@ msgstr ""
 
 msgid "Type"
 msgstr ""
+
+msgid "Upload directory is not a directory"
+msgstr ""
+
+msgid "Upload directory is not writable"
+msgstr ""
+
+msgid "Upload directory is not writable"
+msgstr ""
+
+msgid "Path traversal not allowed"
+msgstr ""
+
+msgid "This file has already been uploaded."
+msgstr ""
+
+msgid "File type not allowed"
+msgstr ""
+
+msgid "Could not upload file"
+msgstr ""
+
+msgid "Could not upload file: "
+msgstr ""

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -636,6 +636,3 @@ msgstr ""
 
 msgid "Could not upload file"
 msgstr ""
-
-msgid "Could not upload file: "
-msgstr ""

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -617,5 +617,23 @@ msgstr "未知"
 msgid "Type"
 msgstr "类型"
 
+msgid "Upload directory is not a directory"
+msgstr "上传目录不是有效的目录"
+
+msgid "Upload directory is not writable"
+msgstr "上传目录不可写"
+
+msgid "Path traversal not allowed"
+msgstr "不允许路径遍历"
+
+msgid "This file has already been uploaded."
+msgstr "此文件已上传。"
+
+msgid "File type not allowed"
+msgstr "不允许的文件类型"
+
 msgid "Could not upload file"
 msgstr "无法上传文件"
+
+msgid "Could not upload file: "
+msgstr "无法上传文件："

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -634,6 +634,3 @@ msgstr "不允许的文件类型"
 
 msgid "Could not upload file"
 msgstr "无法上传文件"
-
-msgid "Could not upload file: "
-msgstr "无法上传文件："

--- a/locale/zh/LC_MESSAGES/loris.po
+++ b/locale/zh/LC_MESSAGES/loris.po
@@ -616,3 +616,6 @@ msgstr "未知"
 
 msgid "Type"
 msgstr "类型"
+
+msgid "Could not upload file"
+msgstr "无法上传文件"

--- a/modules/document_repository/jsx/uploadForm.js
+++ b/modules/document_repository/jsx/uploadForm.js
@@ -269,7 +269,7 @@ class DocUploadForm extends Component {
               swal.fire(
                 this.props.t('File too large', {ns: 'document_repository'}),
                 this.props.t('Could not upload file',
-                  {ns: 'document_repository'}),
+                  {ns: 'loris'}),
                 'error'
               );
             }
@@ -277,7 +277,7 @@ class DocUploadForm extends Component {
               swal.fire(
                 this.props.t('Permission denied', {ns: 'loris'}),
                 this.props.t('Could not upload file',
-                  {ns: 'document_repository'}),
+                  {ns: 'loris'}),
                 'error'
               );
             }

--- a/modules/document_repository/locale/document_repository.pot
+++ b/modules/document_repository/locale/document_repository.pot
@@ -63,9 +63,6 @@ msgstr ""
 msgid "File too large"
 msgstr ""
 
-msgid "Could not upload file"
-msgstr ""
-
 msgid "Something went wrong"
 msgstr ""
 

--- a/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/fr/LC_MESSAGES/document_repository.po
@@ -68,9 +68,6 @@ msgstr "Veuillez signaler le problème ou contacter votre administrateur."
 msgid "File too large"
 msgstr "Fichier trop volumineux"
 
-msgid "Could not upload file"
-msgstr "Impossible de téléverser le fichier"
-
 msgid "Something went wrong"
 msgstr "Un problème est survenu"
 

--- a/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/hi/LC_MESSAGES/document_repository.po
@@ -63,9 +63,6 @@ msgstr "कृपया समस्या की रिपोर्ट कर�
 msgid "File too large"
 msgstr "फ़ाइल बहुत बड़ी है"
 
-msgid "Could not upload file"
-msgstr "फ़ाइल अपलोड नहीं हो सकी"
-
 msgid "Something went wrong"
 msgstr "कुछ गलत हो गया"
 

--- a/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/ja/LC_MESSAGES/document_repository.po
@@ -64,9 +64,6 @@ msgstr "問題を報告するか、管理者に連絡してください"
 msgid "File too large"
 msgstr "ファイルが大きすぎます"
 
-msgid "Could not upload file"
-msgstr "ファイルをアップロードできませんでした"
-
 msgid "Something went wrong"
 msgstr "問題が発生しました"
 

--- a/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
+++ b/modules/document_repository/locale/zh/LC_MESSAGES/document_repository.po
@@ -64,9 +64,6 @@ msgstr "请报告问题或联系管理员"
 msgid "File too large"
 msgstr "文件太大"
 
-msgid "Could not upload file"
-msgstr "无法上传文件"
-
 msgid "Something went wrong"
 msgstr "出了点问题"
 

--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -73,13 +73,13 @@ class FilesUploadHandler implements RequestHandlerInterface
 
         if (! $this->uploadDirectory->isDir()) {
             throw new \ConfigurationException(
-                'Upload directory is not a directory'
+                dgettext('loris', 'Upload directory is not a directory')
             );
         }
 
         if (! $this->uploadDirectory->isWritable()) {
             throw new \ConfigurationException(
-                'Upload directory is not writable'
+                dgettext('loris', 'Upload directory is not writable')
             );
         }
     }
@@ -163,7 +163,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                 || str_contains($filename, "..") === true
             ) {
                 return new \LORIS\Http\Response\JSON\Forbidden(
-                    'Path traversal not allowed'
+                    dgettext('loris', 'Path traversal not allowed')
                 );
             }
 
@@ -179,7 +179,7 @@ class FilesUploadHandler implements RequestHandlerInterface
              */
             if (file_exists($targetPath) && $this->overwrite !== true) {
                 return new \LORIS\Http\Response\JSON\Conflict(
-                    'This file has already been uploaded.'
+                    dgettext('loris', 'This file has already been uploaded.')
                 );
             }
 
@@ -192,7 +192,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                 )
                 ) {
                     return new \LORIS\Http\Response\JSON\Forbidden(
-                        'File type not allowed'
+                        dgettext('loris', 'File type not allowed')
                     );
                 }
             }
@@ -202,10 +202,10 @@ class FilesUploadHandler implements RequestHandlerInterface
                 $file->moveTo($targetPath);
             } catch (\Exception $e) {
                 error_log(
-                    'Could not upload file: ' . $e->getMessage()
+                    dgettext('loris', 'Could not upload file: ') . $e->getMessage()
                 );
                 return new \LORIS\Http\Response\JSON\InternalServerError(
-                    'Could not upload file'
+                    dgettext('loris', 'Could not upload file')
                 );
             }
             chmod($targetPath, $this->permissions);

--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -202,7 +202,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                 $file->moveTo($targetPath);
             } catch (\Exception $e) {
                 error_log(
-                    dgettext('loris', 'Could not upload file: ') . $e->getMessage()
+                    'Could not upload file: ' . $e->getMessage()
                 );
                 return new \LORIS\Http\Response\JSON\InternalServerError(
                     dgettext('loris', 'Could not upload file')


### PR DESCRIPTION
## Brief summary of changes
- Added missing translations for `FilesUploadHandler.class.inc`.
- Relocated to the `loris` namespace some translations from `document_repository`

#### Testing instructions (if applicable)

1. run `make dev && sudo systemctl restart apache2`
2. Go to `electrophysiology_uploader`
3. Ensure that the translations are valid and working
4. Go to `document_repository`
5. Ensure that the relocated translations are working

#### Link(s) to related issue(s)

* Resolves [#10986](https://github.com/aces/Loris/issues/10986)  (Reference the issue this fixes, if any.)
