### PR TITLE
[survey_accounts] Translate to Japanese and clean up translation code

### DIFF
--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -69,9 +69,10 @@ $numSessions = $db->pselectOne(
 if ($numSessions != 1) {
     echo json_encode(
         [
-            'error_msg' => dgettext('loris', 'Visit').' '.
-                  $_REQUEST['VL'].' '.
-                  dgettext('survey_accounts', 'does not exist for given candidate'),
+		'error_msg' => sprintf(
+                 dgettext('survey_accounts', '%s does not exist for given candidate'),
+		 dgettext('loris', 'Visit')
+		)
         ]
     );
     exit(0);
@@ -101,16 +102,12 @@ foreach ($instrument_list as $instrument) {
     if ($_REQUEST['TN'] == $instrument['Test_name']) {
         echo json_encode(
             [
-                'error_msg' => dcngettext(
-                    'loris',
-                    'Instrument',
-                    'Instruments',
-                    1,
-                    LC_MESSAGES
-                ).' '. $_REQUEST['TN'].' ' .dgettext(
-                    'survey_accounts',
-                    'already exists for given candidate for visit'
-                ).' '. $_REQUEST['VL'],
+                'error_msg' => 
+		    sprintf(
+			    dgettext('survey_accounts', 'Instrument %s already exists for given candidate for visit %s',
+			    $_REQUEST['TN'],
+			    $_REQUEST['VL'],
+			    )
             ]
         );
         exit(0);

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -69,10 +69,10 @@ $numSessions = $db->pselectOne(
 if ($numSessions != 1) {
     echo json_encode(
         [
-		'error_msg' => sprintf(
-                 dgettext('survey_accounts', '%s does not exist for given candidate'),
-		 dgettext('loris', 'Visit')
-		)
+            'error_msg' => sprintf(
+                dgettext('survey_accounts', '%s does not exist for given candidate'),
+                dgettext('loris', 'Visit')
+            )
         ]
     );
     exit(0);
@@ -98,16 +98,22 @@ $instrument_list = $db->pselect(
         'v_VL'     => $_REQUEST['VL'],
     ]
 );
+
+// This line is too long inside the loop
+$msg = dgettext(
+    'survey_accounts',
+    'Instrument %s already exists for given candidate for visit %s'
+);
 foreach ($instrument_list as $instrument) {
     if ($_REQUEST['TN'] == $instrument['Test_name']) {
         echo json_encode(
             [
-                'error_msg' => 
-		    sprintf(
-			    dgettext('survey_accounts', 'Instrument %s already exists for given candidate for visit %s',
-			    $_REQUEST['TN'],
-			    $_REQUEST['VL'],
-			    )
+                'error_msg' =>
+            sprintf(
+                $msg,
+                $_REQUEST['TN'],
+                $_REQUEST['VL'],
+            )
             ]
         );
         exit(0);

--- a/modules/survey_accounts/jsx/surveyAccountsIndex.js
+++ b/modules/survey_accounts/jsx/surveyAccountsIndex.js
@@ -136,7 +136,7 @@ class SurveyAccountsIndex extends Component {
       },
       {label: t('URL', {ns: 'survey_accounts'}), show: true},
       {
-        label: t('Status', {ns: 'survey_accounts'}), show: true, filter: {
+        label: t('Status', {ns: 'loris'}), show: true, filter: {
           name: 'Status',
           type: 'select',
           options: options.statusOptions,

--- a/modules/survey_accounts/locale/fr/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/fr/LC_MESSAGES/survey_accounts.po
@@ -25,7 +25,7 @@ msgstr "Comptes de sondage"
 msgid "Survey was added successfully."
 msgstr "Le sondage a été ajouté avec succès."
 
-msgid "Click here to go back to view the list of survey's created"
+msgid "Click here to go back to view the list of surveys created"
 msgstr "Cliquez ici pour revenir à la liste des sondages créés"
 
 msgid "Survey List"
@@ -46,9 +46,6 @@ msgstr "Créer un sondage"
 msgid "Email survey"
 msgstr "Envoyer le sondage par courriel"
 
-msgid "Close"
-msgstr "Fermer"
-
 msgid "Email to Study Participant"
 msgstr "Courriel au participant à l'étude"
 
@@ -58,26 +55,20 @@ msgstr "Saisissez éventuellement un message personnalisé ici. Un courriel par 
 msgid "This is where your message goes."
 msgstr "Votre message s'inscrit ici."
 
-msgid "Email"
-msgstr "Adresse courriel"
-
 msgid "URL"
 msgstr "URL"
-
-msgid "Status"
-msgstr "Statut"
 
 msgid "PSCID and DCCID do not match or candidate does not exist."
 msgstr "Le PSCID et le DCCID ne correspondent pas ou le candidat n'existe pas."
 
-msgid "does not exist for given candidate"
-msgstr "n'existe pas pour le candidat donné"
+msgid "Visit does not exist for given candidate"
+msgstr "La visite n'existe pas pour le candidat spécifié"
 
 msgid "Please choose an instrument."
 msgstr "Veuillez choisir un instrument."
 
-msgid "already exists for given candidate for visit"
-msgstr "existe déjà pour le candidat donné pour la visite"
+msgid "Instrument %s already exists for given candidate for visit %s"
+msgstr "L'instrument %s existe déjà pour le candidat spécifié pour la visite %s"
 
 msgid "Email is not valid."
 msgstr "L'adresse courriel n'est pas valide."

--- a/modules/survey_accounts/locale/hi/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/hi/LC_MESSAGES/survey_accounts.po
@@ -25,7 +25,7 @@ msgstr "सर्वे खाते"
 msgid "Survey was added successfully."
 msgstr "सर्वे सफलतापूर्वक जोड़ा गया।"
 
-msgid "Click here to go back to view the list of survey's created"
+msgid "Click here to go back to view the list of surveys created"
 msgstr "बनाए गए सर्वे की सूची देखने के लिए यहाँ क्लिक करें"
 
 msgid "Survey List"
@@ -46,9 +46,6 @@ msgstr "सर्वे बनाएँ"
 msgid "Email survey"
 msgstr "सर्वे ईमेल करें"
 
-msgid "Close"
-msgstr "बंद करें"
-
 msgid "Email to Study Participant"
 msgstr "अध्ययन प्रतिभागी को ईमेल"
 
@@ -58,26 +55,21 @@ msgstr "वैकल्पिक रूप से यहाँ एक कस्�
 msgid "This is where your message goes."
 msgstr "यहाँ आपका संदेश जाएगा।"
 
-msgid "Email"
-msgstr "ईमेल"
-
 msgid "URL"
 msgstr "यूआरएल"
-
-msgid "Status"
-msgstr "स्थिति"
 
 msgid "PSCID and DCCID do not match or candidate does not exist."
 msgstr "पीएससीआईडी ​​और डीसीसीआईडी ​​मेल नहीं खाते या उम्मीदवार मौजूद नहीं है।"
 
-msgid "does not exist for given candidate"
-msgstr "दिए गए उम्मीदवार के लिए मौजूद नहीं है"
+msgid "Visit does not exist for given candidate"
+msgstr "दिए गए कैंडिडेट के लिए विज़िट मौजूद नहीं है"
+
 
 msgid "Please choose an instrument."
 msgstr "कृपया एक उपकरण चुनें."
 
-msgid "already exists for given candidate for visit"
-msgstr "दिए गए उम्मीदवार के लिए यात्रा हेतु पहले से ही मौजूद है"
+msgid "Instrument %s already exists for given candidate for visit %s"
+msgstr "विज़िट %s के लिए दिए गए कैंडिडेट के लिए इंस्ट्रूमेंट %s पहले से मौजूद है"
 
 msgid "Please confirm the email address."
 msgstr "कृपया ईमेल पता की पुष्टि करें."

--- a/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
@@ -36,7 +36,7 @@ msgid "Usage"
 msgstr "使用法"
 
 msgid "Use this form to create a link for a study participant to use in order to directly enter a form/data into Loris."
-msgstr ""
+msgstr "このフォームを使用して、研究参加者がロリスに直接フォーム/データを入力するためのリンクを作成します。"
 
 msgid "Add Survey"
 msgstr "アンケートを追加する"

--- a/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
+++ b/modules/survey_accounts/locale/ja/LC_MESSAGES/survey_accounts.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: LORIS 27\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -22,3 +22,70 @@ msgstr ""
 # I am not sure if this is the right kanji for "survey" 
 msgid "Survey Accounts"
 msgstr "視察アカウント"
+
+msgid "Survey was added successfully."
+msgstr "アンケートが正常に追加されました。"
+
+msgid "Click here to go back to view the list of surveys created"
+msgstr "作成したアンケートの一覧を表示するには、ここをクリックしてください。"
+
+msgid "Survey List"
+msgstr "調査リスト"
+
+msgid "Usage"
+msgstr "使用法"
+
+msgid "Use this form to create a link for a study participant to use in order to directly enter a form/data into Loris."
+msgstr ""
+
+msgid "Add Survey"
+msgstr "アンケートを追加する"
+
+msgid "Create survey"
+msgstr "アンケートを作成する"
+
+msgid "Email survey"
+msgstr "メールアンケート"
+
+msgid "Email to Study Participant"
+msgstr "研究参加者へのメール"
+
+msgid "Optionally enter a customized message here. A default email will be sent if left blank."
+msgstr "必要に応じて、ここにカスタムメッセージを入力してください。空欄の場合は、デフォルトのメールが送信されます。"
+
+msgid "This is where your message goes."
+msgstr "あなたのメッセージはここに送信されます。"
+
+msgid "URL"
+msgstr "URL"
+
+msgid "PSCID and DCCID do not match or candidate does not exist."
+msgstr "プロジェクト識別子と候補者識別子が一致しないか、該当する候補者が存在しません。"
+
+msgid "Visit does not exist for given candidate"
+msgstr "指定された候補者の訪問は存在しません"
+
+msgid "Please choose an instrument."
+msgstr "楽器を選択してください。"
+
+msgid "Instrument %s already exists for given candidate for visit %s"
+msgstr "指定された訪問先%2$sに対して、機器%1$sは既に存在します。"
+
+msgid "Email is not valid."
+msgstr "メールアドレスが無効です。"
+
+msgid "Please confirm the email address."
+msgstr "メールアドレスをご確認ください。"
+
+msgid "The email addresses do not match."
+msgstr "メールアドレスが一致しません。"
+
+msgid "You must specify a valid Visit Label."
+msgstr "有効な訪問ラベルを指定する必要があります。"
+
+msgid "You are not affiliated with this session's project"
+msgstr "あなたは今回のセッションのプロジェクトとは関係ありません"
+
+msgid "Confirm Email address"
+msgstr "メールアドレスを確認"
+

--- a/modules/survey_accounts/locale/survey_accounts.pot
+++ b/modules/survey_accounts/locale/survey_accounts.pot
@@ -24,7 +24,7 @@ msgstr ""
 msgid "Survey was added successfully."
 msgstr ""
 
-msgid "Click here to go back to view the list of survey's created"
+msgid "Click here to go back to view the list of surveys created"
 msgstr ""
 
 msgid "Survey List"
@@ -45,9 +45,6 @@ msgstr ""
 msgid "Email survey"
 msgstr ""
 
-msgid "Close"
-msgstr ""
-
 msgid "Email to Study Participant"
 msgstr ""
 
@@ -57,25 +54,19 @@ msgstr ""
 msgid "This is where your message goes."
 msgstr ""
 
-msgid "Email"
-msgstr ""
-
 msgid "URL"
-msgstr ""
-
-msgid "Status"
 msgstr ""
 
 msgid "PSCID and DCCID do not match or candidate does not exist."
 msgstr ""
 
-msgid "does not exist for given candidate"
+msgid "Visit does not exist for given candidate"
 msgstr ""
 
 msgid "Please choose an instrument."
 msgstr ""
 
-msgid "already exists for given candidate for visit"
+msgid "Instrument %s already exists for given candidate for visit %s"
 msgstr ""
 
 msgid "Email is not valid."

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -182,10 +182,13 @@ class AddSurvey extends \NDB_Form
                 'v_VL'     => $values['VL'],
             ]
         );
-        $reminder        = dgettext(
+
+        // This is mostly here because the line is too long inside the loop
+        $reminder = dgettext(
             'survey_accounts',
-            'already exists for given candidate for visit'
+            'Instrument %s already exists for given candidate for visit %s',
         );
+
         foreach ($instrument_list as $instrument) {
             if ($values['Test_name'] == $instrument['Test_name']) {
                 $instrument_instance = \NDB_BVL_Instrument::factory(
@@ -193,15 +196,12 @@ class AddSurvey extends \NDB_Form
                     $instrument['Test_name']
                 );
                 return [
-                    'Test_name' => dcngettext(
-                        'loris',
-                        'Instrument',
-                        'Instruments',
-                        1,
-                        LC_MESSAGES
-                    )." ".
-                        $instrument_instance->getFullName().
-                        " ". $reminder. " ". $values['VL'],
+                    'Test_name' => sprintf(
+                        $reminder,
+                        $instrument_instance->getFullName(),
+                        $values['VL'],
+                    )
+
                 ];
             }
         }

--- a/modules/survey_accounts/templates/form_addSurvey.tpl
+++ b/modules/survey_accounts/templates/form_addSurvey.tpl
@@ -73,7 +73,7 @@
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal">
                         <span aria-hidden="true">&times;</span>
-                        <span class="sr-only">{dgettext("survey_accounts", "Close")}</span>
+                        <span class="sr-only">{dgettext("loris", "Close")}</span>
                     </button>
                     <h3 class="modal-title">{dgettext("survey_accounts", "Email to Study Participant")}</h3>
                 </div>

--- a/modules/survey_accounts/templates/form_addSurvey.tpl
+++ b/modules/survey_accounts/templates/form_addSurvey.tpl
@@ -1,7 +1,7 @@
 {if $success}
 <p>
   {dgettext("survey_accounts", "Survey was added successfully.")}<br/>
-  {dgettext("survey_accounts", "Click here to go back to view the list of survey's created")} :
+  {dgettext("survey_accounts", "Click here to go back to view the list of surveys created")} :
   <a href="{$baseurl}/survey_accounts/">{dgettext("survey_accounts", "Survey List")}</a><br />
 </p>
 <br />


### PR DESCRIPTION
This translates the survey_accounts module into Japanese, and in doing so cleans up some portions of the translation code.

1. Close, Email, and Status all exist in the loris namespace, so use those instead of duplicating the translations in the module
2. There was an extra apostrophe in one of the English strings.
3. "already exists for given candidate for visit" was a partial string using string concatenation to add variables, so use an interpolated sprintf string
4. "does not exist for given candidate" was a string concatenation, but the only variable being concatenated was the translation of "Visit" from the loris namespace. So just include "Visit" in the whole string to make it easier to translate the sentence as a whole.
5. While updating the French to match the new template strings, I found "le candidat donné" for "the given candidate" to be an awkward literal translation, so I changed it to "le candidat spécifié". (I can revert this if French speakers disagree.)