### PR TITLE
[bvl_feedback] Add missing French translations

### DIFF
--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -189,7 +189,7 @@ class FeedbackPanelContent extends Component {
 
     return (
       <div className='panel-body'>{t(
-        'There are no threads for this user!'
+        'There are no threads for this user!', {ns: 'bvl_feedback'}
       )}</div>
     );
   }
@@ -359,10 +359,11 @@ class FeedbackPanelRow extends Component {
    * @return {JSX} - React markup for the component
    */
   render() {
+    const {t} = this.props;
     let arrow = 'glyphicon glyphicon-chevron-right glyphs';
     let threadEntries = [];
 
-    let buttonText = 'closed';
+    let buttonText = t('closed', {ns: 'bvl_feedback'});
     let buttonClass = 'btn btn-success dropdown-toggle btn-sm';
     let dropdown = (<li><a onClick={this.props.onClickOpen}>{this.props.t(
       'Open',
@@ -425,7 +426,7 @@ class FeedbackPanelRow extends Component {
     }
 
     if (this.props.status === 'opened') {
-      buttonText = 'opened';
+      buttonText = t('opened', {ns: 'bvl_feedback'});
       buttonClass = 'btn btn-danger dropdown-toggle btn-sm';
       dropdown = (<li><a onClick={this.props.onClickClose}>{this.props.t(
         'Close',
@@ -445,7 +446,17 @@ class FeedbackPanelRow extends Component {
           {this.props.fieldname ?
             <td>{this.props.fieldname}<br/>{this.props.type}</td> :
             <td>{this.props.type}</td>}
-          <td>{this.props.author} on:<br/>{this.props.date}</td>
+          <td>
+            <Trans
+              ns="bvl_feedback"
+              defaults="{{author}} on:<0/>{{date}}"
+              components={[<br />]}
+              values={{
+                author: this.props.author,
+                date: this.props.date,
+              }}
+            />
+          </td>
           <td>
             <div className='btn-group'>
               <button name='thread_button' type='button' className={buttonClass}
@@ -986,7 +997,7 @@ class FeedbackSummaryPanel extends Component {
             <tr className='info' key='info'>
               <th>{this.props.t('QC Class', {ns: 'bvl_feedback'})}</th>
               <th>{this.props.t('Instrument', {ns: 'loris', count: 1})}</th>
-              <th>{this.props.t('Visit', {ns: 'loris', count: 1})}</th>
+              <th>{this.props.t('Visit Label', {ns: 'loris'})}</th>
               <th>{this.props.t('# Threads', {ns: 'bvl_feedback'})}</th>
             </tr>
           </thead>

--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -4,7 +4,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import swal from 'sweetalert2';
 
-import {withTranslation} from 'react-i18next';
+import {withTranslation, Trans} from 'react-i18next';
 import i18n from 'I18nSetup';
 
 import jaStrings from '../locale/ja/LC_MESSAGES/bvl_feedback.json';

--- a/modules/bvl_feedback/locale/bvl_feedback.pot
+++ b/modules/bvl_feedback/locale/bvl_feedback.pot
@@ -29,25 +29,8 @@ msgstr ""
 # Comments from dashboard widget on raisinbread.
 # These are dynamically entered user data, but having
 # the test set value on demo translated looks better
-msgid "Input"
-msgstr ""
-
-msgid "Input Errors"
-msgstr ""
-
-msgid "Scoring"
-msgstr ""
-
-msgid "Scoring Errors"
-msgstr ""
-
-msgid "Other"
-msgstr ""
 
 msgid "Feedback Type"
-msgstr ""
-
-msgid "Feedback description"
 msgstr ""
 
 msgid "Feedback for PSCID: {{PSCID}}"
@@ -111,4 +94,13 @@ msgid "Feedback Threads"
 msgstr ""
 
 msgid "Field Name"
+msgstr ""
+
+msgid "opened"
+msgstr ""
+
+msgid "closed"
+msgstr ""
+
+msgid "{{author}} on:<0/>{{date}}"
 msgstr ""

--- a/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/fr/LC_MESSAGES/bvl_feedback.po
@@ -32,29 +32,10 @@ msgstr "Notifications de rétroaction comportementale"
 # Comments from dashboard widget on raisinbread.
 # These are dynamically entered user data, but having
 # the test set value on demo translated looks better
-msgid "Input"
-msgstr "Entrée"
-
-#, fuzzy
-msgid "Input Errors"
-msgstr "Erreurs de saisie"
-
-msgid "Scoring"
-msgstr "Score"
-
-#, fuzzy
-msgid "Scoring Errors"
-msgstr "Erreurs de notation"
-
-msgid "Other"
-msgstr "Autre"
 
 #, fuzzy
 msgid "Feedback Type"
 msgstr "Type de commentaire"
-
-msgid "Feedback description"
-msgstr "Description de la rétroaction"
 
 #, fuzzy
 msgid "Feedback for PSCID: {{PSCID}}"
@@ -71,7 +52,7 @@ msgid "There are no threads for this user!"
 msgstr "Il n'y a pas de fils de discussion pour cet utilisateur !"
 
 msgid "Open"
-msgstr "Ouvert"
+msgstr "Ouvrir"
 
 #, fuzzy
 msgid "Comment added!"
@@ -107,7 +88,7 @@ msgid "Across All Fields"
 msgstr "Dans tous les domaines"
 
 msgid "QC Class"
-msgstr "Classe CQ"
+msgstr "Classe de contrôle qualité"
 
 msgid "# Threads"
 msgstr "# Fils de discussion"
@@ -118,7 +99,7 @@ msgstr "Ce candidat n'a reçu aucun commentaire sur son comportement."
 
 #, fuzzy
 msgid "New {{feedbacklevel}} level feedback"
-msgstr "Nouveau {{feedbacklevel}} niveau de rétroaction"
+msgstr "Nouvelle rétroaction au niveau de l’{{feedbacklevel}}"
 
 #, fuzzy
 msgid "Open Thread Summary"
@@ -130,3 +111,12 @@ msgstr "Fils de discussion"
 
 msgid "Field Name"
 msgstr "Nom du champ"
+
+msgid "opened"
+msgstr "Ouvert"
+
+msgid "closed"
+msgstr "Fermé"
+
+msgid "{{author}} on:<0/>{{date}}"
+msgstr "{{author}} le :<0/>{{date}}"

--- a/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/ja/LC_MESSAGES/bvl_feedback.po
@@ -30,26 +30,9 @@ msgstr "行動フィードバック通知"
 # Comments from dashboard widget on raisinbread.
 # These are dynamically entered user data, but having
 # the test set value on demo translated looks better
-msgid "Input"
-msgstr "インプット"
-
-msgid "Input Errors"
-msgstr "入力エラー"
-
-msgid "Scoring"
-msgstr "得点"
-
-msgid "Scoring Errors"
-msgstr "得点エラー"
-
-msgid "Other"
-msgstr "他の"
 
 msgid "Feedback Type"
 msgstr "フィードバックタイプ"
-
-msgid "Feedback description"
-msgstr "フィードバックの説明"
 
 msgid "Feedback for PSCID: {{PSCID}}"
 msgstr "プロジェクト識別子へのフィードバック: {{PSCID}}"

--- a/modules/bvl_feedback/locale/zh/LC_MESSAGES/bvl_feedback.po
+++ b/modules/bvl_feedback/locale/zh/LC_MESSAGES/bvl_feedback.po
@@ -29,26 +29,9 @@ msgstr "行为数据反馈通知"
 # Comments from dashboard widget on raisinbread.
 # These are dynamically entered user data, but having
 # the test set value on demo translated looks better
-msgid "Input"
-msgstr "数据录入"
-
-msgid "Input Errors"
-msgstr "录入错误"
-
-msgid "Scoring"
-msgstr "评分"
-
-msgid "Scoring Errors"
-msgstr "评分错误"
-
-msgid "Other"
-msgstr "其他"
 
 msgid "Feedback Type"
 msgstr "反馈类型"
-
-msgid "Feedback description"
-msgstr "反馈说明"
 
 msgid "Feedback for PSCID: {{PSCID}}"
 msgstr "PSCID {{PSCID}} 的反馈"

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -112,7 +112,7 @@ class BVL_Feedback_Panel
         // Get field names
         $field_names = Utility::getSourcefields($test_name);
         $fields      = [];
-        $fields['Across All Fields'] = 'Across All Fields';
+        $fields['Across All Fields'] = dgettext('bvl_feedback', 'Across All Fields');
         foreach ($field_names as $field_name) {
             $fields[$field_name['SourceField']] = $field_name['SourceField'];
         }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -250,7 +250,7 @@ class NDB_BVL_Feedback
             $list[$record['Type']] = [
                 'Type'  => $record['Type'],
                 'Name'  => $record['Name'],
-                'Label' => $record['Description'],
+                'Label' => dgettext('feedback_bvl_type', $record['Description']),
             ];
         }
         return $list;

--- a/raisinbread/locale/feedback_bvl_type.pot
+++ b/raisinbread/locale/feedback_bvl_type.pot
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Input Errors"
+msgstr ""
+
+msgid "Scoring Errors"
+msgstr ""
+
+msgid "Other"
+msgstr ""

--- a/raisinbread/locale/fr/LC_MESSAGES/feedback_bvl_type.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/feedback_bvl_type.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Input Errors"
+msgstr "Erreurs de saisie"
+
+msgid "Scoring Errors"
+msgstr "Erreurs de cotation"
+
+msgid "Other"
+msgstr "Autre"


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing French translations to the Behavioural Feedback module, fixes typos, removes unused translation strings (e.g. “Input”, “Scoring Errors”) that are not referenced in the code, likely because they are database strings and require database translations instead.

#### Testing instructions (if applicable)

1. git checkout HachemJ/AddMissingTranslationsBvlFeedback
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Please refer to the instructions in the corresponding issue if you’re unsure how to access this page
6. Verify that the missing French translations have been added
7. Verify that the typos were fixed

#### Link(s) to related issue(s)

* Resolves #11080 (Reference the issue this fixes, if any.)
