### PR TITLE
[media] Translate file visibility options and translation files cleanup

### DIFF
--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -268,6 +268,7 @@ class MediaUploadForm extends Component {
    * @param {object} e - Form submission event
    */
   handleSubmit(e) {
+    const {t} = this.props;
     e.preventDefault();
 
     let formData = this.state.formData;

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -288,7 +288,7 @@ class MediaUploadForm extends Component {
     );
     if (!this.isValidFileName(requiredFileName, fileName)) {
       swal.fire(
-        'Invalid file name!',
+        t('Invalid file name!', {ns: 'media'}),
         'Your file\'s base name should be: <code>'
         + requiredFileName + '</code>'
         + '<br>followed by the file extension.',

--- a/modules/media/locale/es/LC_MESSAGES/media.po
+++ b/modules/media/locale/es/LC_MESSAGES/media.po
@@ -25,9 +25,6 @@ msgstr "Medios de comunicación"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-msgid "Instrument"
-msgstr "Instrumento"
-
 msgid "Date Taken"
 msgstr "Fecha de toma"
 
@@ -60,12 +57,6 @@ msgstr "Navegar"
 
 msgid "Upload"
 msgstr "Subir"
-
-msgid "An error occured while loading the page."
-msgstr "Se ha producido un error al cargar la página."
-
-msgid "Language"
-msgstr "Idioma"
 
 # New strings from uploadForm.js
 
@@ -122,15 +113,6 @@ msgstr "Ocultar archivo"
 
 msgid "Invalid file name!"
 msgstr "¡Nombre de archivo no válido!"
-
-msgid "File name should begin with:"
-msgstr "El nombre del archivo debe comenzar con:"
-
-msgid "A file with this name already exists!\n Would you like to override existing file?"
-msgstr "¡Ya existe un archivo con este nombre! ¿Desea sobrescribir el archivo existente?"
-
-msgid "Cancelled"
-msgstr "Cancelado"
 
 msgid "Success!"
 msgstr "¡Éxito!"

--- a/modules/media/locale/fr/LC_MESSAGES/media.po
+++ b/modules/media/locale/fr/LC_MESSAGES/media.po
@@ -26,9 +26,6 @@ msgstr "Média"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-msgid "Instrument"
-msgstr "Instrument"
-
 msgid "Date Taken"
 msgstr "Date de passage"
 
@@ -64,12 +61,6 @@ msgstr "Parcourir"
 
 msgid "Upload"
 msgstr "Téléverser"
-
-msgid "An error occured while loading the page."
-msgstr "Une erreur s'est produite lors du chargement de la page."
-
-msgid "Language"
-msgstr "Langage"
 
 # New strings from uploadForm.js
 msgid "An error occurred when loading the form!"
@@ -134,17 +125,6 @@ msgstr "Masquer le fichier"
 msgid "Invalid file name!"
 msgstr "Le nom de fichier spécifié n'est pas valide.  "
 
-#, fuzzy
-msgid "File name should begin with:"
-msgstr "Le nom du fichier doit commencer par :"
-
-#, fuzzy
-msgid "A file with this name already exists!\n Would you like to override existing file?"
-msgstr "Un fichier portant ce nom existe déjà ! Voulez-vous remplacer le fichier existant ?"
-
-msgid "Cancelled"
-msgstr "Annulée"
-
 msgid "Success!"
 msgstr "Réussi !"
 
@@ -168,3 +148,9 @@ msgstr "Ce champ est requis."
 #, fuzzy
 msgid "Candidate Media"
 msgstr "Médias candidats"
+
+msgid "Visible only"
+msgstr "Visibles uniquement"
+
+msgid "Hidden only"
+msgstr "Masqués uniquement"

--- a/modules/media/locale/hi/LC_MESSAGES/media.po
+++ b/modules/media/locale/hi/LC_MESSAGES/media.po
@@ -25,9 +25,6 @@ msgstr "मीडिया"
 msgid "File Name"
 msgstr "फ़ाइल नाम"
 
-msgid "Instrument"
-msgstr "इंस्ट्रूमेंट"
-
 msgid "Date Taken"
 msgstr "तारीख ली गई"
 
@@ -60,12 +57,6 @@ msgstr "ब्राउज़ करें"
 
 msgid "Upload"
 msgstr "अपलोड करें"
-
-msgid "An error occured while loading the page."
-msgstr "पृष्ठ लोड करते समय एक त्रुटि हुई।"
-
-msgid "Language"
-msgstr "भाषा"
 
 # New strings from uploadForm.js
 
@@ -122,15 +113,6 @@ msgstr "फ़ाइल छिपाएँ"
 
 msgid "Invalid file name!"
 msgstr "अमान्य फ़ाइल नाम!"
-
-msgid "File name should begin with:"
-msgstr "फ़ाइल नाम इससे शुरू होना चाहिए:"
-
-msgid "A file with this name already exists!\n Would you like to override existing file?"
-msgstr "इस नाम की एक फ़ाइल पहले से मौजूद है!\n क्या आप मौजूदा फ़ाइल को अधिलेखित करना चाहेंगे?"
-
-msgid "Cancelled"
-msgstr "रद्द कर दिया गया"
 
 msgid "Success!"
 msgstr "सफलता!"

--- a/modules/media/locale/ja/LC_MESSAGES/media.po
+++ b/modules/media/locale/ja/LC_MESSAGES/media.po
@@ -28,9 +28,6 @@ msgstr "候補者メディア"
 msgid "File Name"
 msgstr "ファイル名"
 
-msgid "Instrument"
-msgstr "楽器"
-
 msgid "Date Taken"
 msgstr "撮影日"
 
@@ -63,12 +60,6 @@ msgstr "ブラウズ"
 
 msgid "Upload"
 msgstr "アップロード"
-
-msgid "An error occured while loading the page."
-msgstr "ページの読み込み中にエラーが発生しました。"
-
-msgid "Language"
-msgstr "言語"
 
 # New strings from uploadForm.js
 
@@ -125,15 +116,6 @@ msgstr "ファイルを隠す"
 
 msgid "Invalid file name!"
 msgstr "ファイル名が無効です。"
-
-msgid "File name should begin with:"
-msgstr "ファイル名は次の文字で始まる必要があります:"
-
-msgid "A file with this name already exists!\n Would you like to override existing file?"
-msgstr "この名前のファイルは既に存在します!\n既存のファイルを上書きしますか?"
-
-msgid "Cancelled"
-msgstr "キャンセル"
 
 msgid "Success!"
 msgstr "成功！"

--- a/modules/media/locale/media.pot
+++ b/modules/media/locale/media.pot
@@ -24,9 +24,6 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-msgid "Instrument"
-msgstr ""
-
 msgid "Date Taken"
 msgstr ""
 
@@ -58,12 +55,6 @@ msgid "Browse"
 msgstr ""
 
 msgid "Upload"
-msgstr ""
-
-msgid "An error occured while loading the page."
-msgstr ""
-
-msgid "Language"
 msgstr ""
 
 # New strings from uploadForm.js
@@ -122,15 +113,6 @@ msgstr ""
 msgid "Invalid file name!"
 msgstr ""
 
-msgid "File name should begin with:"
-msgstr ""
-
-msgid "A file with this name already exists!\n Would you like to override existing file?"
-msgstr ""
-
-msgid "Cancelled"
-msgstr ""
-
 msgid "Success!"
 msgstr ""
 
@@ -150,4 +132,10 @@ msgid "This field is required."
 msgstr ""
 
 msgid "Candidate Media"
+msgstr ""
+
+msgid "Visible only"
+msgstr ""
+
+msgid "Hidden only"
 msgstr ""

--- a/modules/media/locale/zh/LC_MESSAGES/media.po
+++ b/modules/media/locale/zh/LC_MESSAGES/media.po
@@ -28,9 +28,6 @@ msgstr "候选媒体"
 msgid "File Name"
 msgstr "文件名"
 
-msgid "Instrument"
-msgstr "量表/评估工具"
-
 msgid "Date Taken"
 msgstr "拍摄日期"
 
@@ -63,12 +60,6 @@ msgstr "浏览"
 
 msgid "Upload"
 msgstr "上传"
-
-msgid "An error occured while loading the page."
-msgstr "加载页面时发生错误。"
-
-msgid "Language"
-msgstr "语言"
 
 # New strings from uploadForm.js
 msgid "An error occurred when loading the form!"
@@ -124,19 +115,6 @@ msgstr "隐藏文件"
 
 msgid "Invalid file name!"
 msgstr "文件名无效！"
-
-msgid "File name should begin with:"
-msgstr "文件名应以以下内容开头："
-
-msgid ""
-"A file with this name already exists!\n"
-" Would you like to override existing file?"
-msgstr ""
-"同名的文件已存在！ \n"
-" 您想覆盖现有文件吗？"
-
-msgid "Cancelled"
-msgstr "取消"
 
 msgid "Success!"
 msgstr "成功！"

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -120,8 +120,8 @@ class Media extends \DataFrameworkMenu
         $hiddenOptions = [];
         if (\User::singleton()->hasPermission('superuser')) {
             $hiddenOptions = [
-                'visible' => 'Visible only',
-                'hidden'  => 'Hidden only',
+                'visible' => dgettext('media', 'Visible only'),
+                'hidden'  => dgettext('media', 'Hidden only'),
             ];
         }
 


### PR DESCRIPTION
## Brief summary of changes

This PR translate the file visibility dropdown options 'Hidden only' and 'Visible only' in French.

It also includes a cleanup of the Media translation files by removing unused strings that are no longer referenced in the code.

Finally, it fixes a multilingual bug where the namespace for 'Invalid file name!' was missing.

#### Testing instructions (if applicable)

1. Go to 'Clinical' -> 'Media'
2. Switch the language to French
3. Verify that the dropdown options are translated
<img width="1708" height="869" alt="image" src="https://github.com/user-attachments/assets/b6650293-632e-4d4e-8170-0fa57e0b2afd" />


Note: run `sudo systemctl restart apache2` if the French translations do not appear.
Reason: https://github.com/aces/Loris/pull/10933#issuecomment-5035596645

#### Link(s) to related issue(s)

* Resolves #11105 (Reference the issue this fixes, if any.)
