### PR TITLE
[dasboard] Add missing French translation

### DIFF
--- a/modules/dashboard/locale/dashboard.pot
+++ b/modules/dashboard/locale/dashboard.pot
@@ -38,3 +38,6 @@ msgstr ""
 
 msgid "Last login:"
 msgstr ""
+
+msgid "No open tasks for you."
+msgstr ""

--- a/modules/dashboard/locale/fr/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/fr/LC_MESSAGES/dashboard.po
@@ -43,3 +43,6 @@ msgstr "Bienvenue, %s!"
 
 msgid "Last login:"
 msgstr "Dernière connexion:"
+
+msgid "No open tasks for you."
+msgstr "Aucune tâche ouverte ne vous est attribuée."

--- a/modules/dashboard/templates/mytasks.tpl
+++ b/modules/dashboard/templates/mytasks.tpl
@@ -16,5 +16,5 @@
 {/if}
 {/foreach}
 {else}
-No open tasks for you.
+{dgettext('dashboard', 'No open tasks for you.')}
 {/if}


### PR DESCRIPTION
## Brief summary of changes

This PR adds the French translation for the string 'No open tasks for you.'.

#### Testing instructions (if applicable)

1. Go to 'Admin' -> 'User accounts'
2. Click on 'Add User'
3. Create a new user (no assigned tasks) so that this message is displayed.
4. If you can’t log in, set Pending approval to No.
5. Log in to the new account.
6. Verify that the translated message appears in the top right corner.

<img width="1708" height="869" alt="image" src="https://github.com/user-attachments/assets/ed5202e4-b4f2-43bd-89be-bb604d4f507a" />

#### Link(s) to related issue(s)

* Resolves #11079 (Reference the issue this fixes, if any.)
