### PR TITLE
[dataquery] Fix multilingual date formatting bug

### DIFF
--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -15,9 +15,8 @@ import {FlattenedField, FlattenedQuery, VisitOption} from './types';
 import ReplayIcon from './ReplayIcon';
 import ShareIconA from './ShareIconA';
 import {useTranslation} from 'react-i18next';
-import 'I18nSetup';
+import i18n from 'I18nSetup';
 
-declare const loris: any;
 /**
  * Return the welcome tab for the DQT
  *
@@ -832,7 +831,7 @@ function SingleQueryDisplay(props: {
   let msg: React.ReactNode = null;
   if (query.RunTime) {
     const dateFormatter = new Intl.DateTimeFormat(
-      loris.user.langpref.replace('_', '-'),
+      i18n.language.replace('_', '-'),
       {
         dateStyle: 'long',
         timeStyle: 'medium',


### PR DESCRIPTION
## Brief summary of changes

This PR replaces `loris.user.langpref` by `i18n.language` to determine the language when formatting the recent query timestamp. This ensures the date/time format updates immediately after an in-module language change, rather than requiring a page refresh.

#### Testing instructions (if applicable)

1. Go to 'Reports' -> 'Data Query Tool (Beta)'
2. Accept the Terms of Use if prompted

<img width="855" height="432" alt="Image" src="https://github.com/user-attachments/assets/6a80c64f-c166-4aba-921b-89d4cf357f81" />

3. Please refer to the instructions in the corresponding issue.
4. After switching the language within the module, the date/time format is now displayed in the selected language without requiring a hard refresh.


https://github.com/user-attachments/assets/7194450d-aba4-49c0-b880-c24fb5da8f58



#### Link(s) to related issue(s)

* Resolves #10897 (Reference the issue this fixes, if any.)
