### PR TITLE
[genomic_browser] Fix several issues including misaligned table columns, broken filters, and multilingual code

### DIFF
--- a/modules/genomic_browser/jsx/tabs_content/cnv.js
+++ b/modules/genomic_browser/jsx/tabs_content/cnv.js
@@ -152,10 +152,6 @@ class CNV extends Component {
         },
       },
       {
-        label: t('Date of Birth', {ns: 'loris'}),
-        show: false,
-      },
-      {
         label: t('External ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
@@ -179,8 +175,8 @@ class CNV extends Component {
           name: 'Strand',
           type: 'select',
           options: {
-            F: 'Forward',
-            R: 'Reverse',
+            '+': t('Forward', {ns: 'genomic_browser'}),
+            '-': t('Reverse', {ns: 'genomic_browser'}),
           },
         },
       },

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -153,10 +153,6 @@ class Methylation extends Component {
         },
       },
       {
-        label: t('Date of Birth', {ns: 'loris'}),
-        show: false,
-      },
-      {
         label: t('Sample', {ns: 'genomic_browser'}),
         show: true,
       },
@@ -183,8 +179,8 @@ class Methylation extends Component {
           name: 'Strand',
           type: 'select',
           options: {
-            F: 'Forward',
-            R: 'Reverse',
+            '+': t('Forward', {ns: 'genomic_browser'}),
+            '-': t('Reverse', {ns: 'genomic_browser'}),
           },
         },
       },

--- a/modules/genomic_browser/jsx/tabs_content/snp.js
+++ b/modules/genomic_browser/jsx/tabs_content/snp.js
@@ -153,10 +153,6 @@ class SNP extends Component {
         },
       },
       {
-        label: t('Date of Birth', {ns: 'loris'}),
-        show: false,
-      },
-      {
         label: t('External ID', {ns: 'genomic_browser'}),
         show: false,
         filter: {
@@ -182,8 +178,8 @@ class SNP extends Component {
           name: 'Strand',
           type: 'select',
           options: {
-            F: 'Forward',
-            R: 'Reverse',
+            '+': t('Forward', {ns: 'genomic_browser'}),
+            '-': t('Reverse', {ns: 'genomic_browser'}),
           },
         },
       },

--- a/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
+++ b/modules/genomic_browser/locale/fr/LC_MESSAGES/genomic_browser.po
@@ -314,3 +314,9 @@ msgstr "non classé"
 
 msgid "Upload error!"
 msgstr "Erreur de téléversement !"
+
+msgid "Forward"
+msgstr "Sens"
+
+msgid "Reverse"
+msgstr "Antisens"

--- a/modules/genomic_browser/locale/genomic_browser.pot
+++ b/modules/genomic_browser/locale/genomic_browser.pot
@@ -315,3 +315,9 @@ msgstr ""
 
 msgid "Upload error!"
 msgstr ""
+
+msgid "Forward"
+msgstr ""
+
+msgid "Reverse"
+msgstr ""

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -212,10 +212,10 @@ class CnvDTO implements DataInstance, SiteHaver
     public function jsonSerialize() : array
     {
         return [
-            'PSC'               => $this->_PSC,
+            'PSC'               => dgettext("psc", $this->_PSC),
             'DCCID'             => $this->_DCCID,
             'PSCID'             => $this->_PSCID,
-            'Sex'               => $this->_Sex,
+            'Sex'               => dgettext("sex", $this->_Sex),
             'Cohort'            => $this->_Cohort,
             'ExternalID'        => $this->_ExternalID,
             'Chromosome'        => $this->_Chromosome,
@@ -226,11 +226,11 @@ class CnvDTO implements DataInstance, SiteHaver
             'Gene_Symbol'       => $this->_Gene_Symbol,
             'Gene_Name'         => $this->_Gene_Name,
             'CNV_Description'   => $this->_CNV_Description,
-            'CNV_Type'          => $this->_CNV_Type,
+            'CNV_Type'          => dgettext("genomic_browser", $this->_CNV_Type),
             'Copy_Num_Change'   => $this->_Copy_Num_Change,
             'Event_Name'        => $this->_Event_Name,
             'Common_CNV'        => $this->_Common_CNV,
-            'Characteristics'   => $this->_Characteristics,
+            'Characteristics'   => dgettext("genomic_browser", $this->_Characteristics),
             'Inheritance'       => $this->_Inheritance,
             'Array_Report'      => $this->_Array_Report,
             'Markers'           => $this->_Markers,

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -230,7 +230,10 @@ class CnvDTO implements DataInstance, SiteHaver
             'Copy_Num_Change'   => $this->_Copy_Num_Change,
             'Event_Name'        => $this->_Event_Name,
             'Common_CNV'        => $this->_Common_CNV,
-            'Characteristics'   => dgettext("genomic_browser", $this->_Characteristics),
+            'Characteristics'   => dgettext(
+                "genomic_browser",
+                $this->_Characteristics
+            ),
             'Inheritance'       => $this->_Inheritance,
             'Array_Report'      => $this->_Array_Report,
             'Markers'           => $this->_Markers,

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -226,15 +226,14 @@ class CnvDTO implements DataInstance, SiteHaver
             'Gene_Symbol'       => $this->_Gene_Symbol,
             'Gene_Name'         => $this->_Gene_Name,
             'CNV_Description'   => $this->_CNV_Description,
-            'CNV_Type'          => dgettext("genomic_browser", $this->_CNV_Type),
+            'CNV_Type'          => $this->_CNV_Type === "unknown"
+                ? dgettext("loris", $this->_CNV_Type)
+                : dgettext("genomic_browser", $this->_CNV_Type),
             'Copy_Num_Change'   => $this->_Copy_Num_Change,
             'Event_Name'        => $this->_Event_Name,
             'Common_CNV'        => $this->_Common_CNV,
-            'Characteristics'   => dgettext(
-                "genomic_browser",
-                $this->_Characteristics
-            ),
-            'Inheritance'       => $this->_Inheritance,
+            'Characteristics'   => $this->_Characteristics,
+            'Inheritance'       => dgettext("loris", $this->_Inheritance),
             'Array_Report'      => $this->_Array_Report,
             'Markers'           => $this->_Markers,
             'Validation_Method' => $this->_Validation_Method,

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -271,7 +271,7 @@ class MethylationDTO implements DataInstance, SiteHaver
             'PSC'              => $this->_PSC,
             'DCCID'            => $this->_DCCID,
             'PSCID'            => $this->_PSCID,
-            'Sex'              => $this->_Sex,
+            'Sex'              => dgettext("sex", $this->_Sex),
             'Cohort'           => $this->_Cohort,
             'Sample'           => $this->_Sample,
             'cpg_name'         => $this->_cpg_name,
@@ -284,7 +284,7 @@ class MethylationDTO implements DataInstance, SiteHaver
             'Probe_Loc_B'      => $this->_Probe_Loc_B,
             'Probe_Seq_B'      => $this->_Probe_Seq_B,
             'Design'           => $this->_Design,
-            'Color'            => $this->_Color,
+            'Color'            => dgettext("genomics_browser", $this->_Color),
             'Assembly'         => $this->_Assembly,
             'SNP_10'           => $this->_SNP_10,
             'Gene'             => $this->_Gene,
@@ -299,7 +299,7 @@ class MethylationDTO implements DataInstance, SiteHaver
             'Reg_Feature_Loc'  => $this->_Reg_Feature_Loc,
             'Reg_Feature_Grp'  => $this->_Reg_Feature_Grp,
             'DHS'              => $this->_DHS,
-            'Platform'         => $this->_Platform,
+            'Platform'         => dgettext("genotyping_platform", $this->_Platform),
         ];
     }
 

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -126,11 +126,12 @@ class ProfileDTO implements DataInstance, SiteHaver
     public function jsonSerialize(): array
     {
         return [
-            'centerID'   => $this->_PSC,
+            'centerID'   => dgettext("psc", $this->_PSC),
             'DCCID'      => $this->_DCCID,
             'PSCID'      => $this->_PSCID,
-            'Sex'        => $this->_Sex,
-            'Cohort'     => $this->_Cohort,
+            'Sex'        => dgettext("sex", $this->_Sex),
+            'Cohort'     => $this->_Cohort ? dgettext("cohort", $this->_Cohort)
+                : $this->_Cohort,
             'externalID' => $this->_externalID,
             'File'       => $this->_File,
             'SNP'        => $this->_SNP,

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -257,12 +257,14 @@ class SnpDTO implements DataInstance, SiteHaver
      */
     public function jsonSerialize(): array
     {
+        $cohort = $this->_Cohort;
         return [
-            'PSC'                 => $this->_PSC,
+            'PSC'                 => dgettext("psc", $this->_PSC),
             'DCCID'               => $this->_DCCID,
             'PSCID'               => $this->_PSCID,
-            'Sex'                 => $this->_Sex,
-            'Cohort'              => $this->_Cohort,
+            'Sex'                 => dgettext("sex", $this->_Sex),
+            'Cohort'              => $cohort ?
+                dgettext("cohort", $cohort) : $cohort,
             'externalID'          => $this->_externalID,
             'Chromosome'          => $this->_Chromosome,
             'Strand'              => $this->_Strand,

--- a/modules/genomic_browser/php/snpbrowser.class.inc
+++ b/modules/genomic_browser/php/snpbrowser.class.inc
@@ -89,7 +89,7 @@ class SnpBrowser extends \DataFrameworkMenu implements ETagCalculator
             );
         $platform_options = [];
         foreach ($platform_results as $row) {
-            $name = $row['Name'];
+            $name = dgettext('genotyping_platform', $row['Name']);
             $platform_options[$name] = $name;
         }
         return (new \LORIS\genomic_browser\Views\SNP(

--- a/modules/genomic_browser/php/views/cnv.class.inc
+++ b/modules/genomic_browser/php/views/cnv.class.inc
@@ -40,11 +40,13 @@ class CNV
      */
     public function __construct($platform_options, $sites, $cohorts)
     {
+        $sexes = \Utility::getSexList();
+        $sexes = array_combine($sexes, $sexes);
         $this->_formElement = [
             'Sites'    => $sites,
             'Cohorts'  => $cohorts,
             'Platform' => $platform_options,
-            'Sex'      => \Utility::getSexList(),
+            'Sex'      => $sexes,
         ];
     }
 

--- a/modules/genomic_browser/php/views/methylation.class.inc
+++ b/modules/genomic_browser/php/views/methylation.class.inc
@@ -39,6 +39,8 @@ class Methylation
      */
     public function __construct($sites, $cohorts)
     {
+        $sexes = \Utility::getSexList();
+        $sexes = array_combine($sexes, $sexes);
         $this->_formElement = [
             'Sites'           => $sites,
             'Cohorts'         => $cohorts,
@@ -58,7 +60,7 @@ class Methylation
                 'genotyping_platform',
                 'Name'
             ),
-            'Sex'             => \Utility::getSexList(),
+            'Sex'             => $sexes,
         ];
     }
 

--- a/modules/genomic_browser/php/views/profiles.class.inc
+++ b/modules/genomic_browser/php/views/profiles.class.inc
@@ -39,10 +39,12 @@ class Profiles
      */
     public function __construct($sites, $cohorts)
     {
+        $sexes = \Utility::getSexList();
+        $sexes = array_combine($sexes, $sexes);
         $this->_formElement = [
             'Sites'   => $sites,
             'Cohorts' => $cohorts,
-            'Sex'     => \Utility::getSexList(),
+            'Sex'     => $sexes,
         ];
     }
 

--- a/modules/genomic_browser/php/views/snp.class.inc
+++ b/modules/genomic_browser/php/views/snp.class.inc
@@ -40,11 +40,13 @@ class SNP
      */
     public function __construct($sites, $cohorts, $platform_options)
     {
+        $sexes = \Utility::getSexList();
+        $sexes = array_combine($sexes, $sexes);
         $this->_formElement = [
             'Sites'    => $sites,
             'Cohorts'  => $cohorts,
             'Platform' => $platform_options,
-            'Sex'      => \Utility::getSexList(),
+            'Sex'      => $sexes,
         ];
     }
 

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -269,6 +269,13 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
             []
         );
 
+        $cohortOptions = array_map(
+            function ($name) {
+                return dgettext("cohort", $name);
+            },
+            $cohortOptions
+        );
+
         if (!$numericKeys) {
             $cohortNames = array_values($cohortOptions);
             return array_combine($cohortNames, $cohortNames);

--- a/raisinbread/locale/fr/LC_MESSAGES/genotyping_platform.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/genotyping_platform.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Custom CNV array"
+msgstr "Puce CNV personnalisée"
+
+msgid "Custom SNP array"
+msgstr "Puce SNP personnalisée"

--- a/raisinbread/locale/genotyping_platform.pot
+++ b/raisinbread/locale/genotyping_platform.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 29\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Custom CNV array"
+msgstr ""
+
+msgid "Custom SNP array"
+msgstr ""


### PR DESCRIPTION
## Brief summary of changes

This PR fixes several issues in the genomic_browser module related to filtering, translations, and data presentation. It corrects column alignment issues that caused values to appear under incorrect headers, ensuring that the displayed data corresponds to the appropriate columns. It also fixes filtering for translated fields such as Sex, Cohorts and Strand by keeping filter values consistent with the underlying data while displaying translated labels to users. In addition, the PR adds missing translations for several genomic specific values and adds the remaining translations of option lists throughout the module.

It also removes an unused Date of Birth column from the frontend. The column does not appear in the backend JSON response at all, so it was effectively unused. Since the table data is constructed using `json.data.map((e) => Object.values(e))`, having an extra frontend only column shifted the column ordering and contributed to the alignment issues.

#### Testing instructions (if applicable)

1. git checkout HachemJ/FixDataEntriesAndFiltersTranslationsGenomicBrowser
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Genomics' -> 'Genomic Browser'
6.

#### Link(s) to related issue(s)

* Resolves #10924
* Resolves #11108
* Resolves #11123
* Resolves #11124