### PR TITLE
[media] Fix multilingual visits filter

### DIFF
--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -70,7 +70,8 @@ class Media extends \DataFrameworkMenu
         $db   = $this->loris->getDatabaseConnection();
 
         $siteList  = [];
-        $visitList = \Utility::getVisitList();
+        $visits = \Utility::getVisitList();
+        $visitList = array_combine($visits, $visits);
 
         // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) {

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -70,7 +70,7 @@ class Media extends \DataFrameworkMenu
         $db   = $this->loris->getDatabaseConnection();
 
         $siteList  = [];
-        $visits = \Utility::getVisitList();
+        $visits    = \Utility::getVisitList();
         $visitList = array_combine($visits, $visits);
 
         // allow to view all sites data through filter


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the filtering of visits when the language is set to something other than English.

#### Testing instructions (if applicable)

1. Go to 'Clinical' -> 'Media'
2. Switch the language to 'French'
3. Test the Visit Label filter
4. Verify that each option returns the corresponding rows instead of always returning zero results

#### Link(s) to related issue(s)

* Resolves #11117 (Reference the issue this fixes, if any.)
