### PR TITLE
Update version number to 29 before release

### DIFF
--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -19,7 +19,7 @@ In addition to the above, the following packages should be installed with `yum` 
  
  * [Composer](https://getcomposer.org)  
  
- * NodeJS 16.10.0 (or higher)
+ * NodeJS 20.20.0 (or higher)
  
  * NPM 8.19.2 (or higher)
  

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -10,9 +10,9 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 # System Requirements - Install dependencies
 
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
-* MariaDB 10.3 is supported for LORIS 28.
+* MariaDB 10.3 is supported for LORIS 29.
 
-* PHP 8.3 (or higher) is supported for LORIS 28.
+* PHP 8.4 (or higher) is supported for LORIS 29.
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher  
@@ -43,7 +43,7 @@ sudo yum update
 # By default, the repository for PHP 5.4 is enabled
 # Make sure to have only one repository for PHP enabled
 sudo yum-config-manager --disable remi-php54
-sudo yum-config-manager --enable remi-php82
+sudo yum-config-manager --enable remi-php84
 sudo yum install php php-pdo php-pdo_mysql php-fpm php-gd php-json php-mbstring php-mysqlnd php-xml php-xmlrpc php-opcache
 ```
 ## MariaDB

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -18,7 +18,7 @@ LORIS requires a LAMP stack in order to run, specifically:
 
 * MySQL 5.7 (or MariaDB 10.3) (or higher)
 
-* PHP 8.3 (or higher)
+* PHP 8.4 (or higher)
 
 Additionally, the following package manager are required to build LORIS:  
 
@@ -46,21 +46,21 @@ The following Ubuntu packages are required and should be installed using
 
 * software-properties-common
 
-* php8.3-mysql
+* php8.4-mysql
 
-* php8.3-xml
+* php8.4-xml
 
-* php8.3-mbstring
+* php8.4-mbstring
 
-* php8.3-gd
+* php8.4-gd
 
-* php8.3-zip
+* php8.4-zip
 
-* php8.3-curl
+* php8.4-curl
 
-* php8.3-intl
+* php8.4-intl
 
-* libapache2-mod-php8.3
+* libapache2-mod-php8.4
 
 * gettext
 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -22,7 +22,7 @@ LORIS requires a LAMP stack in order to run, specifically:
 
 Additionally, the following package manager are required to build LORIS:  
 
-* NodeJS 16.10.0 (or higher)
+* NodeJS 20.20.0 (or higher)
 
 * NPM 8.19.2 (or higher)
 

--- a/tools/generate_table_po.php
+++ b/tools/generate_table_po.php
@@ -93,7 +93,7 @@ fwrite(
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\\n"
+"Project-Id-Version: LORIS 29\\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"


### PR DESCRIPTION
This updates the version number to "LORIS 29" for the LORIS 29 release. It is based on the references in #9868 and one more that was found by `git grep`.