### PR TITLE
[Dashboard/Statistics] Fix scans date filter

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -578,7 +578,7 @@ class Charts extends \NDB_Page
         );
 
         $recruitmentdata = [];
-        $labels = [];
+        $labels          = [];
         foreach ($recruitment_summary as $row) {
             $siteId = $row['SiteID'];
             $year   = $row['Year'];
@@ -739,7 +739,7 @@ class Charts extends \NDB_Page
         }
 
         if (($queryParams['dateRegisteredStart'] ?? "undefined") != 'undefined') {
-            $paramName          = 'dateStart' . (++$paramCounter);
+            $paramName = 'dateStart' . (++$paramCounter);
             if ($scansbymonth === true) {
                 $projectQuery .= " AND DATE(pf.Value) >= :$paramName";
             } else {
@@ -749,7 +749,7 @@ class Charts extends \NDB_Page
             $params[$paramName] = $queryParams['dateRegisteredStart'];
         }
         if (($queryParams['dateRegisteredEnd'] ?? "undefined") != 'undefined') {
-            $paramName          = 'dateEnd' . (++$paramCounter);
+            $paramName = 'dateEnd' . (++$paramCounter);
             if ($scansbymonth === true) {
                 $projectQuery .= " AND DATE(pf.Value) <= :$paramName";
             } else {

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -554,25 +554,6 @@ class Charts extends \NDB_Page
 
         $conditions = $this->_buildQueryConditions($request, false);
 
-        $recruitmentData      = [];
-        $recruitmentStartDate = $DB->pselectOne(
-            "SELECT MIN(Date_registered) FROM candidate",
-            []
-        );
-        $recruitmentEndDate   = $DB->pselectOne(
-            "SELECT MAX(Date_registered) FROM candidate",
-            []
-        );
-
-        if ($recruitmentStartDate !== null
-            && $recruitmentEndDate !== null
-        ) {
-            $recruitmentData['labels'] = $this->_createSiteLineChartLabels(
-                new \DateTimeImmutable($recruitmentStartDate),
-                new \DateTimeImmutable($recruitmentEndDate)
-            );
-        }
-
         $user          = \NDB_Factory::singleton()->user();
         $list_of_sites = $user->getStudySites();
 
@@ -597,10 +578,12 @@ class Charts extends \NDB_Page
         );
 
         $recruitmentdata = [];
+        $labels = [];
         foreach ($recruitment_summary as $row) {
             $siteId = $row['SiteID'];
             $year   = $row['Year'];
             $month  = $row['Month'];
+            $labels["{$month}-{$year}"] = true;
             if (!isset($recruitmentdata[$siteId])) {
                 $recruitmentdata[$siteId] = [
                     $year => [$month => $row['Count']]
@@ -613,6 +596,7 @@ class Charts extends \NDB_Page
             }
 
         }
+        $recruitmentData['labels'] = array_keys($labels);
         foreach ($list_of_sites as $siteID => $siteName) {
             if (!isset($recruitmentData['labels'])) {
                 continue;
@@ -755,15 +739,23 @@ class Charts extends \NDB_Page
         }
 
         if (($queryParams['dateRegisteredStart'] ?? "undefined") != 'undefined') {
-            $candJoin           = "JOIN candidate c ON c.ID=s.CandidateID";
             $paramName          = 'dateStart' . (++$paramCounter);
-            $projectQuery      .= " AND c.Date_registered >= :$paramName";
+            if ($scansbymonth === true) {
+                $projectQuery .= " AND DATE(pf.Value) >= :$paramName";
+            } else {
+                $candJoin      = "JOIN candidate c ON c.ID=s.CandidateID";
+                $projectQuery .= " AND c.Date_registered >= :$paramName";
+            }
             $params[$paramName] = $queryParams['dateRegisteredStart'];
         }
         if (($queryParams['dateRegisteredEnd'] ?? "undefined") != 'undefined') {
-            $candJoin           = "JOIN candidate c ON c.ID=s.CandidateID";
             $paramName          = 'dateEnd' . (++$paramCounter);
-            $projectQuery      .= " AND c.Date_registered <= :$paramName";
+            if ($scansbymonth === true) {
+                $projectQuery .= " AND DATE(pf.Value) <= :$paramName";
+            } else {
+                $candJoin      = "JOIN candidate c ON c.ID=s.CandidateID";
+                $projectQuery .= " AND c.Date_registered <= :$paramName";
+            }
             $params[$paramName] = $queryParams['dateRegisteredEnd'];
         }
         if (is_numeric($queryParams['candidateAgeMin'] ?? null)) {
@@ -798,34 +790,6 @@ class Charts extends \NDB_Page
             'candJoin'               => $candJoin,
             'params'                 => $params,
         ];
-    }
-
-    /**
-     * Helper to generate labels for every month between startDate and endDate.
-     *
-     * @param \DateTimeImmutable $startDate The start date for the labels.
-     * @param \DateTimeImmutable $endDate   The end date for the labels.
-     *
-     * @return array
-     */
-    private function _createSiteLineChartLabels(
-        \DateTimeImmutable $startDate,
-        \DateTimeImmutable $endDate
-    ) : array {
-        $month = date_interval_create_from_date_string('1 month');
-
-        // Since we're only concerned with months, act as if $startDate
-        // is always the first of the month so that the last month doesn't
-        // get truncated.
-        $betweenDate = new \DateTimeImmutable($startDate->format('Y-m-01'));
-
-        $labels = [];
-
-        while ($betweenDate <= $endDate) {
-            $labels[]    = $betweenDate->format('n-Y');
-            $betweenDate = $betweenDate->add($month);
-        }
-        return $labels;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
- In Study Progression - Scans, the chart would show for each month, but the date registered would only filter for year. So if you do 2017-01-01 to 2017-11-01, a scan at 2017-10 would not show. This has been fixed
<img width="595" height="672" alt="image" src="https://github.com/user-attachments/assets/1a659c55-07c7-4189-bff3-a76c374396cf" />


#### Testing instructions (if applicable)

1. Scroll down to Study Progression and switch to Scans in the dashboard
2. Open filters and filter to a specific month and see that it works now