### PR TITLE
[statistics] Update Visit label and French translation

### DIFF
--- a/modules/statistics/jsx/widgets/helpers/queryChartForm.js
+++ b/modules/statistics/jsx/widgets/helpers/queryChartForm.js
@@ -166,7 +166,7 @@ const QueryChartForm = (props) => {
           <div>
             <label style ={{fontWeight: 'bold',
               marginBottom: '5px',
-              display: 'block'}}>{t('Visit', {ns: 'loris'})}</label>
+              display: 'block'}}>{t('Visit Label', {ns: 'loris'})}</label>
             <SelectElement
               name ='selectedVisits'
               options ={{__clear__: clearSelection,

--- a/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
+++ b/modules/statistics/locale/fr/LC_MESSAGES/statistics.po
@@ -58,7 +58,7 @@ msgid "Range Start"
 msgstr "Début de la plage"
 
 msgid "Range End"
-msgstr "Fin de la Plage"
+msgstr "Fin de la plage"
 
 msgid "Total recruitment by Age"
 msgstr "Recrutement total par âge"


### PR DESCRIPTION
## Brief summary of changes

This PR updates the dropdown label from 'Visit' to 'Visit Label' and corrects the French translation typo by changing 'Fin de la Plage' to 'Fin de la plage'.

#### Testing instructions (if applicable)

1. Log into your account
2. Switch the language to French
3. Click on 'Afficher les filtres'

<img width="1701" height="865" alt="Untitled 50" src="https://github.com/user-attachments/assets/a258845d-77c1-4e3c-a8a1-fdd3753e5664" />

#### Link(s) to related issue(s)

* Resolves #11119 (Reference the issue this fixes, if any.)
