### PR TITLE
[help_editor] Fix Duplicate help editor checkmark

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -51,7 +51,7 @@
                 return carry.concat(' - ', item.text);
               }, ''));
             {/if}
-            {if !$breadcrumbs|strstr:'"Edit Help Content"'}
+            if (loris.Subtest !== 'edit_help_content') {
               const helpContainers = document.getElementsByClassName('help-container');
               for (let i = 0; i < helpContainers.length; i++) {
                 ReactDOM.createRoot(
@@ -64,7 +64,7 @@
                   })
                 );
               }
-            {/if}
+            }
 
             // Make Navigation bar toggle change glyphicon up/down
             let navBtn = document.querySelector('.nav-button');


### PR DESCRIPTION
## Brief summary of changes
Updated `main.tpl` to have the exclude `edit_help_content` instead of the string. The translations were causing it to not be excluded when it was not in English.

<img width="1503" height="662" alt="image" src="https://github.com/user-attachments/assets/a4aaa35d-a880-4aca-94d0-ace83f6d5dfe" />

#### Testing instructions (if applicable)

1. Go to `help_editor`
2. Try to create or modify an existing help content
3. Verify that the question mark does not appear twice (view issue for reference)

#### Link(s) to related issue(s)

* Resolves [#10870](https://github.com/aces/Loris/issues/10870)  (Reference the issue this fixes, if any.)
