### PR TITLE
[instrument_builder] Translate 'Browse' button in French

### DIFF
--- a/htdocs/js/jquery.fileupload.js
+++ b/htdocs/js/jquery.fileupload.js
@@ -9,9 +9,12 @@
     '</div>';
   let inputButtonGroup = '<div class="input-group-btn"></div>';
   let inputButton = '<div class="btn btn-primary btn-file"></div>';
-  let buttonText = '<i class="glyphicon glyphicon-folder-open"></i>'
-                   + '&nbsp;Browse …';
   let wrapper = function(element) {
+    const browseLabel = $(element).data('browseLabel');
+
+    const buttonText =
+    '<i class="glyphicon glyphicon-folder-open"></i>'
+    + '&nbsp;' + browseLabel;
     $(element).wrap(inputGroup);
     $(element).before(fileNameDisplay);
     $(element).parent().find('.file-caption-name').attr('id', element.name);

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -194,7 +194,9 @@ class LoadPane extends Component {
           </div>
           <input
             className='fileUpload'
-            type='file' id='instfile'
+            type='file'
+            id='instfile'
+            data-browse-label={t('Browse', {ns: 'loris'})}
             onChange={this.chooseFile}
           />
           <input

--- a/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/fr/LC_MESSAGES/instrument_builder.po
@@ -249,8 +249,5 @@ msgstr "Nom de question en double"
 msgid "Top"
 msgstr "Haut"
 
-msgid "Browse"
-msgstr "Parcourir"
-
 msgid "Delete"
 msgstr "Supprimer"

--- a/modules/instrument_builder/locale/hi/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/hi/LC_MESSAGES/instrument_builder.po
@@ -214,9 +214,6 @@ msgstr "डुप्लिकेट प्रश्न नाम"
 msgid "Top"
 msgstr "शीर्ष"
 
-msgid "Browse"
-msgstr "ब्राउज़ करें"
-
 msgid "Delete"
 msgstr "हटाएं"
 

--- a/modules/instrument_builder/locale/instrument_builder.pot
+++ b/modules/instrument_builder/locale/instrument_builder.pot
@@ -213,8 +213,5 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-msgid "Browse"
-msgstr ""
-
 msgid "Delete"
 msgstr ""

--- a/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/ja/LC_MESSAGES/instrument_builder.po
@@ -214,8 +214,5 @@ msgstr "質問名が重複しています"
 msgid "Top"
 msgstr "トップ"
 
-msgid "Browse"
-msgstr "ブラウズ"
-
 msgid "Delete"
 msgstr "消去"

--- a/modules/instrument_builder/locale/zh/LC_MESSAGES/instrument_builder.po
+++ b/modules/instrument_builder/locale/zh/LC_MESSAGES/instrument_builder.po
@@ -214,8 +214,5 @@ msgstr "问题名称重复"
 msgid "Top"
 msgstr "顶部"
 
-msgid "Browse"
-msgstr "浏览"
-
 msgid "Delete"
 msgstr "删除"


### PR DESCRIPTION
## Brief summary of changes

This PR updates the custom file upload component to use the localized “Browse” label instead of hardcoded string 'Browse ...', allowing the button text to be translated based on the current language.

#### Testing instructions (if applicable)

1. Go to 'Tools' -> 'Instrument Builder'
2. Navigate to the 'Load' tab
3. Switch the language to French
4. The button label should now be translated
5. Rename a file on your computer with the .linst extension and verify that it can be uploaded using the translated Browse button.

#### Link(s) to related issue(s)

* Resolves #10281 (Reference the issue this fixes, if any.)
