### PR TITLE
[ExternalLinks] Add missing French translations

### DIFF
--- a/locale/fr/LC_MESSAGES/loris.po
+++ b/locale/fr/LC_MESSAGES/loris.po
@@ -48,6 +48,25 @@ msgstr "Se déconnecter"
 msgid "My Preferences"
 msgstr "Mes préférences"
 
+msgid "by"
+msgstr "par"
+
+msgid "Powered by"
+msgstr "Développé par"
+
+msgid "Created by"
+msgstr "Créé par"
+
+msgid "Developed at"
+msgstr "Développé par"
+
+msgid "The Neuro (Montreal Neurological Institute-Hospital)"
+msgstr "Le Neuro (L'Institut-Hôpital neurologique de Montréal)"
+
+msgid "All rights reserved."
+msgstr "Tous droits réservés."
+
+
 # Auto extracted strings from PHP
 # Menu categories
 #: modules/configuration/php/module.class.inc:50

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -49,7 +49,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-msgid "Powered by LORIS"
+msgid "Powered by"
 msgstr ""
 
 msgid "Created by"

--- a/locale/loris.pot
+++ b/locale/loris.pot
@@ -46,6 +46,24 @@ msgstr ""
 msgid "My Preferences"
 msgstr ""
 
+msgid "by"
+msgstr ""
+
+msgid "Powered by LORIS"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Developed at"
+msgstr ""
+
+msgid "The Neuro (Montreal Neurological Institute-Hospital)"
+msgstr ""
+
+msgid "All rights reserved."
+msgstr ""
+
 # Auto extracted strings from PHP
 # Menu categories
 #: modules/configuration/php/module.class.inc:50

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -86,7 +86,7 @@ class Module extends \Module
         foreach ($dashboard_links as $text => $url) {
             $links[] = [
                 'url'        => $url,
-                'label'      => $text,
+                'label'      => dgettext("ExternalLinks", $text),
                 'WindowName' => md5($url),
             ];
         }

--- a/raisinbread/locale/ExternalLinks.pot
+++ b/raisinbread/locale/ExternalLinks.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/raisinbread/locale/ExternalLinks.pot
+++ b/raisinbread/locale/ExternalLinks.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Loris Website"
+msgstr ""
+
+msgid "GitHub"
+msgstr ""

--- a/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 
-"Project-Id-Version: LORIS 28\n"
+"Project-Id-Version: LORIS 29\n"
 "Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
 "POT-Creation-Date: 2025-04-08 14:37-0400\n"
 "PO-Revision-Date: 2026-06-11 14:37-0400\n"

--- a/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Loris Website"
-msgstr "Site web LORIS"
+msgstr "Site web Loris"
 
 msgid "GitHub"
 msgstr "GitHub"

--- a/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
+++ b/raisinbread/locale/fr/LC_MESSAGES/ExternalLinks.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+
+"Project-Id-Version: LORIS 28\n"
+"Report-Msgid-Bugs-To: https://github.com/aces/Loris/issues\n"
+"POT-Creation-Date: 2025-04-08 14:37-0400\n"
+"PO-Revision-Date: 2026-06-11 14:37-0400\n"
+"Last-Translator: Saagar Arya <saagar.arya@mcin.ca>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "Loris Website"
+msgstr "Site web LORIS"
+
+msgid "GitHub"
+msgstr "GitHub"

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -349,10 +349,10 @@
                     </ul>
                 </center>
                 <div align="center" colspan="1">
-                    Powered by LORIS &copy; {$currentyear}. All rights reserved.
+                    {dgettext("loris", "Powered by")} LORIS&copy; {$currentyear}. {dgettext("loris", "All rights reserved.")}
                 </div>
       		<div align="center" colspan="1">
-                    Created by <a href="http://mcin-cnim.ca/" target="_blank">
+                    {dgettext("loris", "Created by")} <a href="http://mcin-cnim.ca/" target="_blank">
                          MCIN
                     </a>
                 </div>

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -79,13 +79,13 @@
   </section>
 
   <footer class="footer">
-    Powered by <a href="https://loris.ca/" target="_blank">LORIS</a>
+    {dgettext("loris", "Powered by")} <a href="https://loris.ca/" target="_blank">LORIS</a>
     | GPL-3.0 &copy; {$currentyear} <br/>
-    Developed at
+    {dgettext("loris", "Developed at")}
     <a href="https://mcgill.ca/neuro/" target="_blank">
-      The Neuro (Montreal Neurological Institute-Hospital)
+      {dgettext("loris", "The Neuro (Montreal Neurological Institute-Hospital)")}
     </a>
-    by <a href="https://mcin.ca/" target="_blank">MCIN</a>
+    {dgettext("loris", "by")} <a href="https://mcin.ca/" target="_blank">MCIN</a>
   </footer>
   <script src="{$baseurl}/js/modernizr/modernizr.min.js"/>
   <script>

--- a/src/Middleware/AnonymousPageDecorationMiddleware.php
+++ b/src/Middleware/AnonymousPageDecorationMiddleware.php
@@ -59,7 +59,7 @@ class AnonymousPageDecorationMiddleware implements MiddlewareInterface
 
             $tpl_data['links'][] = array(
                                     'url'        => $url,
-                                    'label'      => $label,
+                                    'label'      => dgettext("ExternalLinks", $label),
                                     'windowName' => $WindowName,
                                    );
         }

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -247,7 +247,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
             $tpl_data['links'][] = array(
                                     'url'        => $url,
-                                    'label'      => $label,
+                                    'label'      => dgettext("ExternalLinks", $label),
                                     'windowName' => $WindowName,
                                    );
         }


### PR DESCRIPTION
## Brief summary of changes
Adding ExternalLinks French translations
<img width="967" height="226" alt="image" src="https://github.com/user-attachments/assets/32ce0e5c-cc7d-447a-b454-a614bd89db23" />
<img width="383" height="107" alt="image" src="https://github.com/user-attachments/assets/78c6f73d-ce87-4ec7-9ec5-096aa88f4a13" />

#### Testing instructions (if applicable)

1. delete `project/locale`
2. copy `raisinbread/locale into project/locale`
3. run `make dev` (make sure it ran the `msgfmt --use-fuzzy -o table.mo table.po` commands)
4. Go to dashboard
5. See translation
6. Go to any module
7. See footer translation

#### Link(s) to related issue(s)

* Resolves [#11145](https://github.com/aces/Loris/issues/11145) and [#10264](https://github.com/aces/Loris/issues/10264) (Reference the issue this fixes, if any.)
