### PR TITLE
[dictionary] Translate filter categories except for instruments

### DIFF
--- a/modules/biobank/locale/biobank.pot
+++ b/modules/biobank/locale/biobank.pot
@@ -507,3 +507,6 @@ msgstr ""
 
 msgid "Containers"
 msgstr ""
+
+msgid "Specimen Collection and Availability"
+msgstr ""

--- a/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
@@ -520,3 +520,6 @@ msgstr "Nouvelle entrée"
 
 msgid "Containers"
 msgstr "Conteneurs"
+
+msgid "Specimen Collection and Availability"
+msgstr "Collecte et disponibilité des échantillons"

--- a/modules/biobank/php/queryengine.class.inc
+++ b/modules/biobank/php/queryengine.class.inc
@@ -83,7 +83,7 @@ class QueryEngine extends SQLQueryEngine
         $scope    = new Scope(Scope::SESSION);
         $specimen = new Category(
             "Specimen",
-            "Specimen Collection and Availability",
+            dgettext("biobank", "Specimen Collection and Availability"),
         );
 
         $specimenTypes     = $this->_getSpecimenTypes();

--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -234,3 +234,12 @@ msgstr ""
 
 msgid "Consent Type"
 msgstr ""
+
+msgid "Candidate Demographics"
+msgstr ""
+
+msgid "Candidate Identifiers"
+msgstr ""
+
+msgid "Other parameters"
+msgstr ""

--- a/modules/candidate_parameters/locale/fr/LC_MESSAGES/candidate_parameters.po
+++ b/modules/candidate_parameters/locale/fr/LC_MESSAGES/candidate_parameters.po
@@ -229,6 +229,15 @@ msgstr "Détails: "
 msgid "Comments: "
 msgstr "Commentaires: "
 
+msgid "Candidate Demographics"
+msgstr "Données démographiques du participant"
+
+msgid "Candidate Identifiers"
+msgstr "Identifiants du participant"
+
+msgid "Other parameters"
+msgstr "Autres paramètres"
+
 # Widgets
 msgid "Consent Summary"
 msgstr "Résumé du consentement"

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -29,7 +29,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $ids = new \LORIS\Data\Dictionary\Category(
             "Identifiers",
-            "Candidate Identifiers"
+            dgettext("candidate_parameters", "Candidate Identifiers")
         );
 
         $ids = $ids->withItems(
@@ -74,7 +74,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $demographics = new \LORIS\Data\Dictionary\Category(
             "Demographics",
-            "Candidate Demographics",
+            dgettext("candidate_parameters", "Candidate Demographics"),
         );
         $sexList      = array_keys(\Utility::getSexList());
         $t            = new Enumeration(...$sexList);
@@ -111,7 +111,13 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             ]
         );
 
-        $meta = new \LORIS\Data\Dictionary\Category("Meta", "Other parameters");
+        $meta = new \LORIS\Data\Dictionary\Category(
+            "Meta",
+            dgettext(
+                "candidate_parameters",
+                "Other parameters"
+            )
+        );
 
         $db = $this->loris->getDatabaseConnection();
         $participantstatus_options = $db->pselectCol(

--- a/modules/imaging_browser/locale/fr/LC_MESSAGES/imaging_browser.po
+++ b/modules/imaging_browser/locale/fr/LC_MESSAGES/imaging_browser.po
@@ -203,3 +203,6 @@ msgstr "Sujet"
 #, fuzzy
 msgid "Download DICOM"
 msgstr "Télécharger les DICOMs"
+
+msgid "Image Acquisitions"
+msgstr "Acquisitions d'images"

--- a/modules/imaging_browser/locale/imaging_browser.pot
+++ b/modules/imaging_browser/locale/imaging_browser.pot
@@ -208,3 +208,6 @@ msgstr ""
 
 msgid "Download DICOM"
 msgstr ""
+
+msgid "Image Acquisitions"
+msgstr ""

--- a/modules/imaging_browser/php/queryengine.class.inc
+++ b/modules/imaging_browser/php/queryengine.class.inc
@@ -192,7 +192,7 @@ class QueryEngine extends \LORIS\Data\Query\SQLQueryEngine
         $scope  = new Scope(Scope::SESSION);
         $images = new \LORIS\Data\Dictionary\Category(
             "Images",
-            "Image Acquisitions",
+            dgettext("imaging_browser", "Image Acquisitions"),
         );
         $items  = [
             new DictionaryItem(


### PR DESCRIPTION
## Brief summary of changes

This PR translates the derived filter categories in the Data Dictionary module into French.

#### Testing instructions (if applicable)

1. Go to 'Tools' -> 'Data Dictionary'
2. Switch the language to French
3. Select every module expect instruments from the Modules dropdown
4. Verify that its derived categories are translated

I excluded 'Instruments' module from the PR because the 'categories' or test full names are not available through a Query Engine file like the other modules. I had previously implemented database translations for Instruments in another PR, but since the list of instruments was not exhaustive, that change was requested to be reverted. See the referenced review comment for details.

https://github.com/aces/Loris/pull/11018#issuecomment-5096298601

#### Link(s) to related issue(s)

* Resolves #10614 (Reference the issue this fixes, if any.)
