### PR TITLE
[timepoint_list] Translate 'Unknown' entry in Language column

### DIFF
--- a/modules/timepoint_list/test/TimepointListIntegrationTest.php
+++ b/modules/timepoint_list/test/TimepointListIntegrationTest.php
@@ -41,7 +41,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
         '',
         '',
         '',
-        'unknown',
+        'Unknown',
     ];
 
     /**

--- a/modules/timepoint_list/test/TimepointListIntegrationTest.php
+++ b/modules/timepoint_list/test/TimepointListIntegrationTest.php
@@ -41,7 +41,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
         '',
         '',
         '',
-        'Unknown',
+        'unknown',
     ];
 
     /**

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1447,7 +1447,13 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     {
         $lang = $this->getData('Language');
         if ($lang === null) {
-            return new \Language(dgettext("loris", "unknown"), "en_CA");
+            return new \Language(
+                mb_convert_case(
+                    dgettext("loris", "unknown"),
+                    MB_CASE_TITLE
+                ),
+                "en_CA"
+            );
         }
         return $lang;
     }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -1447,7 +1447,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     {
         $lang = $this->getData('Language');
         if ($lang === null) {
-            return new \Language("Unknown", "en_CA");
+            return new \Language(dgettext("loris", "unknown"), "en_CA");
         }
         return $lang;
     }


### PR DESCRIPTION
## Brief summary of changes

This PR updates the 'Unknown' value in the Language column to be translatable.

#### Testing instructions (if applicable)

1. Go to 'Candidate' -> 'Access Profile'
2. Click on any candidate’s PSCID.
3. If the candidate has no visits/time points, go back to Step 2.
4. Switch the language to French.
4. Verify that the 'Unknown' value in the Language column is translated to 'Inconnu'.

<img width="1707" height="866" alt="Untitled 52" src="https://github.com/user-attachments/assets/33b292b9-2491-42c7-bcc2-0c539730eb3f" />


#### Link(s) to related issue(s)

* Resolves #10627 (Reference the issue this fixes, if any.)
