### PR TITLE
[examiner] Missing certification status options translations

### DIFF
--- a/modules/examiner/locale/examiner.pot
+++ b/modules/examiner/locale/examiner.pot
@@ -89,3 +89,12 @@ msgstr ""
 
 msgid "This examiner already exists."
 msgstr ""
+
+msgid "Not Certified"
+msgstr ""
+
+msgid "In Training"
+msgstr ""
+
+msgid "Certified"
+msgstr ""

--- a/modules/examiner/locale/fr/LC_MESSAGES/examiner.po
+++ b/modules/examiner/locale/fr/LC_MESSAGES/examiner.po
@@ -98,3 +98,12 @@ msgstr "Permission refusée : vous ne pouvez pas assigner un examinateur à ce s
 
 msgid "This examiner already exists."
 msgstr "Cet examinateur existe déjà."
+
+msgid "Not Certified"
+msgstr "Non certifié"
+
+msgid "In Training"
+msgstr "En formation"
+
+msgid "Certified"
+msgstr "Certifié"

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -309,10 +309,10 @@ class EditExaminer extends \NDB_Form
             'maxYear'        => $config->getSetting('endYear'),
         ];
         $statusOptions = [
-            ''              => 'N/A',
-            'not_certified' => 'Not Certified',
-            'in_training'   => 'In Training',
-            'certified'     => 'Certified',
+            ''              => dgettext("loris", "N/A"),
+            'not_certified' => dgettext("loris", "Not Certified"),
+            'in_training'   => dgettext("loris", "In Training"),
+            'certified'     => dgettext("loris", "Certified"),
         ];
 
         // Get the list of certification instruments

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -310,9 +310,9 @@ class EditExaminer extends \NDB_Form
         ];
         $statusOptions = [
             ''              => dgettext("loris", "N/A"),
-            'not_certified' => dgettext("loris", "Not Certified"),
-            'in_training'   => dgettext("loris", "In Training"),
-            'certified'     => dgettext("loris", "Certified"),
+            'not_certified' => dgettext("examiner", "Not Certified"),
+            'in_training'   => dgettext("examiner", "In Training"),
+            'certified'     => dgettext("examiner", "Certified"),
         ];
 
         // Get the list of certification instruments

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -295,24 +295,43 @@ class EditExaminer extends \NDB_Form
             ['EID' => $this->identifier]
         );
 
-        $this->tpl_data['certification_history'] = \iterator_to_array(
-            $certification_history
-        );
-
-        $config = \NDB_Config::singleton();
-
-        $dateOptions   = [
-            'language'       => 'en',
-            'format'         => 'YMd',
-            'addEmptyOption' => true,
-            'minYear'        => $config->getSetting('startYear'),
-            'maxYear'        => $config->getSetting('endYear'),
-        ];
         $statusOptions = [
             ''              => dgettext("loris", "N/A"),
             'not_certified' => dgettext("examiner", "Not Certified"),
             'in_training'   => dgettext("examiner", "In Training"),
             'certified'     => dgettext("examiner", "Certified"),
+        ];
+
+        $certificationHistory = iterator_to_array($certification_history);
+
+        foreach ($certificationHistory as &$history) {
+            if (!empty($history['old'])) {
+                $history['old'] = $statusOptions[$history['old']]
+                    ?? mb_convert_case(
+                        str_replace('_', ' ', $history['old']),
+                        MB_CASE_TITLE
+                    );
+            }
+
+            if (!empty($history['new'])) {
+                $history['new'] = $statusOptions[$history['new']]
+                    ?? mb_convert_case(
+                        str_replace('_', ' ', $history['new']),
+                        MB_CASE_TITLE
+                    );
+            }
+        }
+        unset($history);
+        $this->tpl_data['certification_history'] = $certificationHistory;
+
+        $config = \NDB_Config::singleton();
+
+        $dateOptions = [
+            'language'       => 'en',
+            'format'         => 'YMd',
+            'addEmptyOption' => true,
+            'minYear'        => $config->getSetting('startYear'),
+            'maxYear'        => $config->getSetting('endYear'),
         ];
 
         // Get the list of certification instruments

--- a/modules/examiner/templates/form_editExaminer.tpl
+++ b/modules/examiner/templates/form_editExaminer.tpl
@@ -73,23 +73,9 @@
         <td>{$certification_history[history_row]['changeDate']}</td>
         <td>{$certification_history[history_row]['userID']}</td>
         <td>{$certification_history[history_row]['Measure']}</td>
-        <td>
-            {if $certification_history[history_row]['old'] != ""}
-                {dgettext(
-                    "examiner",
-                    $certification_history[history_row]['old']
-                )}
-            {/if}
-        </td>
+        <td>{$certification_history[history_row]['old']}</td>
         <td>{$certification_history[history_row]['old_date']}</td>
-        <td>
-            {if $certification_history[history_row]['new'] != ""}
-                {dgettext(
-                    "examiner",
-                    $certification_history[history_row]['new']
-                )}
-            {/if}
-        </td>
+        <td>{$certification_history[history_row]['new']}</td>
         <td>{$certification_history[history_row]['new_date']}</td>
     </tr>
     {sectionelse}

--- a/modules/examiner/templates/form_editExaminer.tpl
+++ b/modules/examiner/templates/form_editExaminer.tpl
@@ -73,9 +73,23 @@
         <td>{$certification_history[history_row]['changeDate']}</td>
         <td>{$certification_history[history_row]['userID']}</td>
         <td>{$certification_history[history_row]['Measure']}</td>
-        <td>{$certification_history[history_row]['old']}</td>
+        <td>
+            {if $certification_history[history_row]['old'] != ""}
+                {dgettext(
+                    "examiner",
+                    $certification_history[history_row]['old']
+                )}
+            {/if}
+        </td>
         <td>{$certification_history[history_row]['old_date']}</td>
-        <td>{$certification_history[history_row]['new']}</td>
+        <td>
+            {if $certification_history[history_row]['new'] != ""}
+                {dgettext(
+                    "examiner",
+                    $certification_history[history_row]['new']
+                )}
+            {/if}
+        </td>
         <td>{$certification_history[history_row]['new_date']}</td>
     </tr>
     {sectionelse}


### PR DESCRIPTION
## Brief summary of changes

This PR translates the certification status options in the Edit Examiner form to French and updates the change log to display user-facing labels instead of backend enum values.

#### Testing instructions (if applicable)

Prerequisite: In your config.xml, set EnableCertification to 1 and configure at least one valid certification instrument.

e.g. 

```xml
<EnableCertification>1</EnableCertification>
...
<CertificationInstruments>
                <test value="bmi">BMI</test>
                <test value="radiology_review">Radiology Review</test>
</CertificationInstruments>
```            

1. Go to 'Clinical' -> 'Examiner'
2. Click on an examiner’s name to open the Edit Examiner page
3. Switch the language to French
4. Verify that the certification status dropdowns are displayed in French
5. Verify that the Old Value and New Value columns in the Change Log (table) display the translated certification statuses
6. Confirm that the Old Value and New Value columns display user-facing labels (e.g., 'Not Certified' in English or 'Non certifié' in French) instead of the backend enum values (e.g., not_certified)

<img width="854" height="434" alt="image" src="https://github.com/user-attachments/assets/5b5245e2-6ef7-46db-b0ac-9012377202de" />

#### Link(s) to related issue(s)

* Resolves #10619 (Reference the issue this fixes, if any.)
