### PR TITLE
Convert ucwords to mb_convert_case

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -462,7 +462,7 @@ class EditExaminer extends \NDB_Form
      */
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
-        $label = dgettext('examiner', ucwords(str_replace('_', ' ', $this->name)));
+        $label = dgettext('examiner', 'Examiner');
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb($label, "/$this->name"),
             new \LORIS\Breadcrumb(

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -464,9 +464,6 @@ class Charts extends \NDB_Page
         // Convert into the desired format
         $recruitmentByEthnicityData = [];
         foreach ($ethnicities as $id => $count) {
-            $id = str_replace("_", " ", $id);
-            $id = strtolower($id);
-            $id = ucwords($id);
             if ($id == null) {
                 $id = dgettext("statistics", "Unknown");
             }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1032,7 +1032,7 @@ class Edit_User extends \NDB_Form
                     . "<h3 id=\"header_$lastRole\" "
                     . "class=\"perm_header button\" "
                     . "style=\"text-align: center; margin-top: 5px;\">"
-                    . ucwords(dgettext('permissions_category', $row['type']))
+                    . dgettext('permissions_category', $row['type'])
                     . '</h3>'
                     . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">"
                 );

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -586,7 +586,7 @@ class NDB_Menu_Filter extends NDB_Menu
             $this->tpl_data['headers'][$i]['name'] = $header;
             // format header
             $this->tpl_data['headers'][$i]['displayName']
-                = ucwords(str_replace('_', ' ', $header));
+                = mb_convert_case(str_replace('_', ' ', $header), MB_CASE_TITLE);
             // set field ordering
             if (isset($this->filter['order'])) {
                 $this->tpl_data['headers'][$i]['fieldOrder']
@@ -748,7 +748,10 @@ class NDB_Menu_Filter extends NDB_Menu
 
         $headers = array_map(
             function ($header) {
-                return ucwords(str_replace('_', ' ', $header));
+                return mb_convert_case(
+                    str_replace('_', ' ', $header),
+                    MB_CASE_TITLE
+                );
             },
             $this->headers
         );

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -995,8 +995,14 @@ class NDB_Page extends \LORIS\Http\Endpoint implements
     {
         // If the page name is the same as the module directory name,
         // there should only be 1 level of breadcrumb.
-        $pagename = ucwords(str_replace('_', ' ', $this->name));
-        $sublabel = ucwords(str_replace('_', ' ', $this->page));
+        $pagename = mb_convert_case(
+            str_replace('_', ' ', $this->name),
+            MB_CASE_TITLE
+        );
+        $sublabel = mb_convert_case(
+            str_replace('_', ' ', $this->page),
+            MB_CASE_TITLE
+        );
 
         if ($pagename == $sublabel) {
             return new \LORIS\BreadcrumbTrail(

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -762,7 +762,7 @@ class NDB_PageTest extends TestCase
     {
         $name     = $this->_page->name;
         $page     = $this->_page->page;
-        $sublabel = ucwords(str_replace('_', ' ', $page));
+        $sublabel = mb_convert_case(str_replace('_', ' ', $page), MB_CASE_TITLE);
         $this->assertEquals(
             new \LORIS\BreadcrumbTrail(
                 new \LORIS\Breadcrumb($this->_page->Module->getLongName(), "/$name"),


### PR DESCRIPTION
## Brief summary of changes

This PR replaces some calls to PHP’s ucwords() with mb_convert_case() and removes unnecessary ucwords() calls where the input values were already in the desired format.

#### Testing instructions (if applicable)

Prerequisite: Compare the results against 29.0-release (or test VM). The only expected differences are improved capitalization of non ASCII characters, where applicable.

1. Open the Edit Examiner page by clicking an examiner’s name and verify that the breadcrumb remains unchanged.
2. Open a module that uses NDB_Menu_Filter (e.g. Imaging QC) and verify that the table headers remain unchanged.
3. In User Accounts, click a user’s name to open the Edit User page and verify that the role names and permission category headings remain unchanged.
4. Open the Statistics module and verify that the ethnicity chart labels remain unchanged.

#### Link(s) to related issue(s)

* Resolves #10997 (Reference the issue this fixes, if any.)
