### PR TITLE
[dataquery] Query error message

### DIFF
--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -5,7 +5,7 @@ import {useTranslation} from 'react-i18next';
 import fetchDataStream from 'jslib/fetchDataStream';
 
 import DataTable from 'jsx/DataTable';
-import {SelectElement, CheckboxElement} from 'jsx/Form';
+import {SelectElement, CheckboxElement, ButtonElement} from 'jsx/Form';
 import {APIQueryField, APIQueryObject} from './types';
 import {QueryGroup} from './querydef';
 import {FullDictionary, FieldDictionary} from './types';
@@ -172,6 +172,8 @@ type RunQueryType = {
   loading: boolean,
   data: string[][],
   totalcount: number,
+  hasError: boolean,
+  retry: () => void,
 };
 /**
  * React hook to run a given query.
@@ -189,40 +191,47 @@ function useRunQuery(
   const [expectedResults, setExpectedResults] = useState<number>(0);
   const [resultData, setResultData] = useState<string[][]>([]);
   const [loading, setLoading] = useState<boolean>(false);
+  const [hasError, setHasError] = useState<boolean>(false);
+  const [retryCount, setRetryCount] = useState<number>(0);
+
+  /**
+   * Method used to trigger a new query fetch run
+   */
+  const retry = () => setRetryCount((c) => c + 1);
 
   useEffect(() => {
     setLoading(true);
+    setHasError(false);
+    setResultData([]);
     const payload: APIQueryObject = calcPayload(fields, filters);
-    fetch(
-      '/dataquery/queries',
-      {
-        method: 'post',
-        credentials: 'same-origin',
-        body: JSON.stringify(payload),
-      },
-    ).then(
-      (resp) => {
-        if (!resp.ok) {
-          throw new Error('Error creating query.');
-        }
+
+    fetch('/dataquery/queries', {
+      method: 'post',
+      credentials: 'same-origin',
+      body: JSON.stringify(payload),
+    })
+      .then((resp) => {
+        if (!resp.ok) throw new Error('Error creating query.');
         return resp.json();
-      }
-    ).then(
-      (data) => {
+      })
+      .then((data) => {
+        return fetch(`/dataquery/queries/${data.QueryID}/count`, {
+          method: 'GET',
+          credentials: 'same-origin',
+        })
+          .then((resp) => {
+            if (!resp.ok) throw new Error('Could not get query count.');
+            return resp.json();
+          })
+          .then((json) => {
+            setExpectedResults(json.count);
+            return data;
+          });
+      })
+      .then((data) => {
         const resultbuffer: any[] = [];
-        fetch(
-          '/dataquery/queries/'
-                            + data.QueryID + '/count',
-          {
-            method: 'GET',
-            credentials: 'same-origin',
-          }
-        ).then((resp) => resp.json()
-        ).then( (json) => {
-          setExpectedResults(json.count);
-        });
         fetchDataStream(
-          '/dataquery/queries/' + data.QueryID + '/run',
+          `/dataquery/queries/${data.QueryID}/run`,
           (row: any) => {
             resultbuffer.push(row);
           },
@@ -238,20 +247,22 @@ function useRunQuery(
           'post',
         );
         onRun(); // forces query list to be reloaded
-      }
-    ).catch(
-      (msg) => {
+      })
+      .catch((err) => {
+        setHasError(true);
+        setLoading(false);
         swal.fire({
           type: 'error',
-          text: msg,
+          text: err.message || 'An unexpected error occurred.',
         });
-      }
-    );
-  }, [fields, filters]);
+      });
+  }, [fields, filters, retryCount]);
   return {
     loading: loading,
     data: resultData,
     totalcount: expectedResults,
+    hasError: hasError,
+    retry: retry,
   };
 }
 
@@ -496,7 +507,29 @@ function ViewData(props: {
       sortByValue={false}
     />
     {emptyCheckbox}
-    {queryTable}
+    {queryData.hasError ? (
+      <div style={{
+        margin: '16px auto',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        textAlign: 'center',
+        backgroundColor: '#f7fbff',
+        padding: '32px',
+        maxWidth: '600px',
+        borderRadius: '8px',
+        border: '1px solid #dbeafe',
+      }}>
+        <h3 style={{margin: '15px 0 16px 0'}}>Something went wrong.</h3>
+        <ButtonElement
+          label={t('Run Query Again', {ns: 'dataquery'})}
+          onUserInput={queryData.retry}
+          buttonClass='btn btn-primary'
+          columnSize='col-sm-12'
+          type='button'
+        />
+      </div>
+    ) : <>{queryTable}</>}
   </div>;
 }
 

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -520,7 +520,9 @@ function ViewData(props: {
         borderRadius: '8px',
         border: '1px solid #dbeafe',
       }}>
-        <h3 style={{margin: '15px 0 16px 0'}}>Something went wrong.</h3>
+        <h3 style={{margin: '15px 0 16px 0'}}>
+          {t('Something went wrong.', {ns: 'dataquery'})}
+        </h3>
         <ButtonElement
           label={t('Run Query Again', {ns: 'dataquery'})}
           onUserInput={queryData.retry}

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -211,7 +211,9 @@ function useRunQuery(
       body: JSON.stringify(payload),
     })
       .then((resp) => {
-        if (!resp.ok) throw new Error('Error creating query.');
+        if (!resp.ok) {
+          throw new Error('Error creating query.');
+        }
         return resp.json();
       })
       .then((data) => {
@@ -220,7 +222,9 @@ function useRunQuery(
           credentials: 'same-origin',
         })
           .then((resp) => {
-            if (!resp.ok) throw new Error('Could not get query count.');
+            if (!resp.ok) {
+              throw new Error('Could not get query count.');
+            }
             return resp.json();
           })
           .then((json) => {

--- a/modules/dataquery/locale/dataquery.pot
+++ b/modules/dataquery/locale/dataquery.pot
@@ -538,3 +538,9 @@ msgstr ""
 
 msgid "or"
 msgstr ""
+
+msgid "Something went wrong."
+msgstr ""
+
+msgid "Run Query Again"
+msgstr ""

--- a/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/fr/LC_MESSAGES/dataquery.po
@@ -657,3 +657,9 @@ msgstr "Onglet invalide"
 
 msgid "or"
 msgstr "ou"
+
+msgid "Something went wrong."
+msgstr "Une erreur est survenue."
+
+msgid "Run Query Again"
+msgstr "Réexécuter la requête"

--- a/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/hi/LC_MESSAGES/dataquery.po
@@ -529,3 +529,9 @@ msgstr "अमान्य उत्तर"
 
 msgid "Invalid tab"
 msgstr "अमान्य टैब"
+
+msgid "Something went wrong."
+msgstr "कुछ गलत हो गया।"
+
+msgid "Run Query Again"
+msgstr "फिर से क्वेरी चलाएँ"

--- a/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/ja/LC_MESSAGES/dataquery.po
@@ -533,3 +533,9 @@ msgstr "無効なタブ"
 
 msgid "or"
 msgstr "または"
+
+msgid "Something went wrong."
+msgstr "問題が発生しました。"
+
+msgid "Run Query Again"
+msgstr "クエリを再実行"

--- a/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
+++ b/modules/dataquery/locale/zh/LC_MESSAGES/dataquery.po
@@ -533,3 +533,9 @@ msgstr "无效标签"
 
 msgid "or"
 msgstr "或者"
+
+msgid "Something went wrong."
+msgstr "出错了。"
+
+msgid "Run Query Again"
+msgstr "重新运行查询"


### PR DESCRIPTION
## Brief summary of changes

- Fixes an error in the .then chaining of the useEffect in the useRunQuery method that wasn't returning an error message properly when the error happened in the `/dataquery/queries/${data.QueryID}/count` endpoint
- Adds a button to re-run a query if it has had an error in the execution.

### Before
<img width="1369" height="962" alt="image" src="https://github.com/user-attachments/assets/80521408-7c68-463e-b9bc-80bec4c4793e" />

### After
<img width="1384" height="961" alt="image" src="https://github.com/user-attachments/assets/a94e4b1e-45d4-444c-97a7-bed90c4bd3df" />
<img width="1370" height="957" alt="image" src="https://github.com/user-attachments/assets/92820f43-292f-45c4-acef-3601404b0b6d" />

### Testing instructions
Note: Executed on a new instance with the Raisinbread dataset.

1. Go the the Data Query Tool (beta) module
2. Select a couple of fields
3. Run query

### Link(s) to related issue(s)
* Issue #9829
