### PR TITLE
[dashboard] Display last login timestamp in local timezone

### DIFF
--- a/modules/dashboard/jsx/welcome.js
+++ b/modules/dashboard/jsx/welcome.js
@@ -1,6 +1,21 @@
 import DOMPurify from 'dompurify';
+import i18n from 'I18nSetup';
 
 window.addEventListener('load', () => {
+  const lastLogin = document.getElementById('last-login');
+
+  if (lastLogin?.dataset.timestamp) {
+    const timestamp = new Date(lastLogin.dataset.timestamp);
+    if (!isNaN(timestamp.getTime())) {
+      lastLogin.textContent = new Intl.DateTimeFormat(
+        i18n.language.replace('_', '-'),
+        {
+          dateStyle: 'full',
+          timeStyle: 'short',
+        }
+      ).format(timestamp);
+    }
+  }
   fetch(loris.BaseURL + '/dashboard/projectdescription').then( (resp) => {
     if (!resp.ok) {
       throw new Error('Could not get project description');

--- a/modules/dashboard/locale/dashboard.pot
+++ b/modules/dashboard/locale/dashboard.pot
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Welcome, %s!"
 msgstr ""
 
-msgid "Last login:"
+msgid "Last login: "
 msgstr ""
 
 msgid "No open tasks for you."

--- a/modules/dashboard/locale/fr/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/fr/LC_MESSAGES/dashboard.po
@@ -41,8 +41,8 @@ msgstr "...jamais. Bienvenue!"
 msgid "Welcome, %s!"
 msgstr "Bienvenue, %s!"
 
-msgid "Last login:"
-msgstr "Dernière connexion:"
+msgid "Last login: "
+msgstr "Dernière connexion: "
 
 msgid "No open tasks for you."
 msgstr "Aucune tâche ouverte ne vous est attribuée."

--- a/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/ja/LC_MESSAGES/dashboard.po
@@ -37,6 +37,6 @@ msgstr "…絶対にない。初めまして！"
 msgid "Welcome, %s!"
 msgstr "ようこそ、%s ！"
 
-msgid "Last login:"
-msgstr "最終ログイン:"
+msgid "Last login: "
+msgstr "最終ログイン: "
 

--- a/modules/dashboard/locale/zh/LC_MESSAGES/dashboard.po
+++ b/modules/dashboard/locale/zh/LC_MESSAGES/dashboard.po
@@ -37,5 +37,5 @@ msgstr "...绝不。欢迎！"
 msgid "Welcome, %s!"
 msgstr "欢迎，%s！"
 
-msgid "Last login:"
+msgid "Last login: "
 msgstr "上次登录："

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -104,13 +104,7 @@ class Module extends \Module
         if ($last_login === null) {
             $logindatestring = dgettext("dashboard", "...never. Welcome!");
         } else {
-            $formatter = new \IntlDateFormatter(
-                '',
-                \IntlDateFormatter::TRADITIONAL,
-                \IntlDateFormatter::SHORT
-            );
-
-            $logindatestring = $formatter->format($last_login);
+            $logindatestring = $last_login->format(\DateTimeInterface::ATOM);
         }
 
         return new Widget(

--- a/modules/dashboard/templates/welcomebody.tpl
+++ b/modules/dashboard/templates/welcomebody.tpl
@@ -2,6 +2,6 @@
    that they can be translated in the .po files before the
    variable interpolation *}
 <h3 class="welcome">{sprintf(dgettext("dashboard", "Welcome, %s!"), $username)}</h3>
-<p class="pull-right small login-time">{dgettext("dashboard", "Last login:")} {$last_login}</p>
+<p class="pull-right small login-time">{dgettext("dashboard", "Last login: ")}<span id="last-login" data-timestamp="{$last_login}"</span></p>
 <p id="project-description" class="project-description"></p>
 <script src="/dashboard/js/welcome.js"></script>


### PR DESCRIPTION
## Brief summary of changes

This PR updates the Dashboard welcome widget to display the last login timestamp in the user’s local timezone.

The timestamp is now passed to the frontend and formatted in JavaScript, since PHP runs on the server and does not know the browser’s local timezone.

Since this change already involved the frontend date formatting, `loris.user.langpref` was also replaced with the active `i18n.language` at the same time, consistent with the date multilingual fix in other modules (e.g. brainbrowser).

#### Testing instructions (if applicable)

1. Log in into your account
2. Verify that the Last login timestamp is displayed in your local timezone

<img width="256" height="54" alt="image" src="https://github.com/user-attachments/assets/6d859757-99f8-44ad-a1d1-9d4a364f325a" />

<img width="853" height="497" alt="Untitled 57" src="https://github.com/user-attachments/assets/8fe51dba-9cdb-4725-be30-b02df4623983" />


#### Link(s) to related issue(s)

* Resolves #10652
* See #11121 for context
