### PR TITLE
[imaging_qc] Translate imaging_qc module (db translations only)

### DIFF
--- a/modules/imaging_qc/jsx/imagingQCIndex.js
+++ b/modules/imaging_qc/jsx/imagingQCIndex.js
@@ -26,6 +26,7 @@ class ImagingQCIndex extends Component {
       error: '',
     };
     this.fetchData = this.fetchData.bind(this);
+    this.formatColumn = this.formatColumn.bind(this);
   }
 
   /**
@@ -37,30 +38,31 @@ class ImagingQCIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
+    const {t} = this.props;
     let result = <td>{cell}</td>;
     switch (column) {
-    case 'Scan Done in MRI Parameter Form':
+    case t('Scan Done in MRI Parameter Form', {ns: 'imaging_qc'}):
       if (cell == 'Yes') {
         let mpfURL = loris.BaseURL
                        + '/instruments/mri_parameter_form/?commentID='
                        + row.CommentID
                        + '&sessionID='
-                       + row['Session ID']
+                       + row['SessionID']
                        + '&candID='
                        + row.DCCID;
         result = <td><a href={mpfURL}>{cell}</a></td>;
       }
       break;
-    case 'Scan Location':
-      if (cell == 'In Imaging Browser') {
+    case t('Scan Location', {ns: 'imaging_qc'}):
+      if (cell == t('In Imaging Browser', {ns: 'imaging_qc'})) {
         let imgURL = loris.BaseURL
                        + '/imaging_browser/viewSession/?sessionID='
-                       + row['Session ID'];
+                       + row['SessionID'];
         result = <td><a href={imgURL}>{cell}</a></td>;
       }
       break;
-    case 'Tarchive':
-      if (cell == 'In DICOM') {
+    case t('Tarchive', {ns: 'imaging_qc'}):
+      if (cell == t('In DICOM Archives', {ns: 'imaging_qc'})) {
         let tarchiveURL = loris.BaseURL +
               '/dicom_archive/viewDetails/?tarchiveID=' + row.TarchiveID;
         result = <td><a href = {tarchiveURL}>{cell}</a></td>;

--- a/modules/imaging_qc/locale/fr/LC_MESSAGES/imaging_qc.po
+++ b/modules/imaging_qc/locale/fr/LC_MESSAGES/imaging_qc.po
@@ -37,12 +37,6 @@ msgstr "Emplacement du scan"
 msgid "CommentID"
 msgstr "ID du commentaire"
 
-msgid "Found in Imaging Browser"
-msgstr "Trouvé dans le navigateur d'imagerie"
-
-msgid "Found in MRI Violated Scans"
-msgstr "Trouvé dans les scans IRM non conformes"
-
 msgid "Missing"
 msgstr "Manquant"
 
@@ -54,3 +48,9 @@ msgstr "Complet"
 
 msgid "In DICOM Archives"
 msgstr "Dans les archives DICOM"
+
+msgid "In Imaging Browser"
+msgstr "Dans le navigateur d’imagerie"
+
+msgid "In MRI Violated Scans"
+msgstr "Dans les scans IRM non conformes"

--- a/modules/imaging_qc/locale/imaging_qc.pot
+++ b/modules/imaging_qc/locale/imaging_qc.pot
@@ -36,12 +36,6 @@ msgstr ""
 msgid "CommentID"
 msgstr ""
 
-msgid "Found in Imaging Browser"
-msgstr ""
-
-msgid "Found in MRI Violated Scans"
-msgstr ""
-
 msgid "Missing"
 msgstr ""
 
@@ -52,4 +46,10 @@ msgid "Complete"
 msgstr ""
 
 msgid "In DICOM Archives"
+msgstr ""
+
+msgid "In Imaging Browser"
+msgstr ""
+
+msgid "In MRI Violated Scans"
 msgstr ""

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -123,7 +123,7 @@ class Imaging_QC extends \NDB_Menu_Filter
                       ts.TarchiveID = t.TarchiveID
                       AND (ts.EchoTime BETWEEN mp.TE_min AND mp.TE_max)
                       AND (ts.RepetitionTime BETWEEN mp.TR_min AND mp.TR_max)".
-               " ) THEN 'In DICOM'".
+               " ) THEN 'In DICOM Archives'".
               " ELSE 'Missing'
            END as tarchive_loc,
            (SELECT Name FROM Project WHERE ProjectID=s.ProjectID) as project,".
@@ -191,7 +191,8 @@ class Imaging_QC extends \NDB_Menu_Filter
         $user      = \User::singleton();
         $db        = $this->loris->getDatabaseConnection();
         $siteList  = [];
-        $visitList = \Utility::getVisitList();
+        $visits    = \Utility::getVisitList();
+        $visitList = array_combine($visits, $visits);
         // allow to view all sites data through filter
         if ($user->hasPermission('imaging_browser_qc')) {
             $siteList = \Utility::getSiteList();
@@ -233,18 +234,24 @@ class Imaging_QC extends \NDB_Menu_Filter
             $uploaderList[$up['UploadedBy']] = $up['UploadedBy'];
         }
 
-        $scan_location = [
-            "In Imaging Browser"    => dgettext(
-                "imaging_qc",
-                "Found in Imaging Browser"
-            ),
-            "In MRI Violated Scans" => dgettext(
-                "imaging_qc",
-                "Found in MRI Violated Scans"
-            ),
-            "Missing"               => dgettext("imaging_qc", "Missing"),
-        ];
+        $incomplete = dgettext("imaging_qc", "Incomplete");
+        $complete   = dgettext("imaging_qc", "Complete");
+        $yes        = dgettext("loris", "Yes");
+        $no         = dgettext("loris", "No");
+        $inDicomArchives    = dgettext("imaging_qc", "In DICOM Archives");
+        $inImagingBrowser   = dgettext("imaging_qc", "In Imaging Browser");
+        $inMRIViolatedScans = dgettext("imaging_qc", "In MRI Violated Scans");
+        $pass    = dgettext("loris", "Pass");
+        $fail    = dgettext("loris", "Fail");
+        $true    = dgettext("loris", "True");
+        $false   = dgettext("loris", "False");
+        $missing = dgettext("imaging_qc", "Missing");
 
+        $scan_location      = [
+            $inImagingBrowser   => $inImagingBrowser,
+            $inMRIViolatedScans => $inMRIViolatedScans,
+            $missing            => $missing,
+        ];
         $this->fieldOptions
             = [
                 'site'                       => $siteList,
@@ -252,26 +259,26 @@ class Imaging_QC extends \NDB_Menu_Filter
                 'cohort'                     => $cohortList2,
                 'scanType'                   => $scan_types,
                 'mRIParameterForm'           => [
-                    "Incomplete" => dgettext("imaging_qc", "Incomplete"),
-                    "Complete"   => dgettext("imaging_qc", "Complete"),
+                    $incomplete => $incomplete,
+                    $complete   => $complete,
                 ],
                 'scanDoneInMRIParameterForm' => [
-                    "Yes" => dgettext("loris", "Yes"),
-                    "No"  => dgettext("loris", "No"),
+                    $yes => $yes,
+                    $no  => $no,
                 ],
                 'tarchive'                   => [
-                    "In DICOM" => dgettext("imaging_qc", "In DICOM Archives"),
-                    "Missing"  => dgettext("imaging_qc", "Missing"),
+                    $inDicomArchives => $inDicomArchives,
+                    $missing         => $missing,
                 ],
                 'scanLocation'               => $scan_location,
                 'qCStatus'                   => [
-                    "Pass" => dgettext("loris", "Pass"),
-                    "Fail" => dgettext("loris", "Fail"),
+                    $pass => $pass,
+                    $fail => $fail,
                 ],
                 'uploadedBy'                 => $uploaderList,
                 'selected'                   => [
-                    "True"  => dgettext("loris", "True"),
-                    "False" => dgettext("loris", "False"),
+                    $true  => $true,
+                    $false => $false,
                 ],
                 'visitLabel'                 => $visitList,
             ];
@@ -366,6 +373,91 @@ class Imaging_QC extends \NDB_Menu_Filter
             TarchiveID ';
 
         $this->order_by = 'PSCID';
+    }
+
+    /**
+     * Returns the full list of imaging QC rows with translated display values.
+     *
+     * @return array
+     */
+    function _getFullList()
+    {
+        $data = parent::_getFullList();
+
+        foreach ($data as &$row) {
+            if (!empty($row['site'])) {
+                $row['site'] = dgettext(
+                    'psc',
+                    $row['site']
+                );
+            }
+
+            if (!empty($row['project'])) {
+                $row['project'] = dgettext(
+                    'project',
+                    $row['project']
+                );
+            }
+
+            if (!empty($row['cohort'])) {
+                $row['cohort'] = dgettext(
+                    'cohort',
+                    $row['cohort']
+                );
+            }
+
+            if (!empty($row['visit_label'])) {
+                $row['visit_label'] = dgettext(
+                    'visit',
+                    $row['visit_label']
+                );
+            }
+
+            if (!empty($row['mri_parameter_form'])) {
+                $row['mri_parameter_form'] = dgettext(
+                    'imaging_qc',
+                    $row['mri_parameter_form']
+                );
+            }
+
+            if (!empty($row['scan_done'])) {
+                $row['scan_done'] = dgettext(
+                    'loris',
+                    $row['scan_done']
+                );
+            }
+
+            if (!empty($row['qc_status'])) {
+                $row['qc_status'] = dgettext(
+                    'loris',
+                    $row['qc_status']
+                );
+            }
+
+            if (!empty($row['tarchive_loc'])) {
+                $row['tarchive_loc'] = dgettext(
+                    'imaging_qc',
+                    $row['tarchive_loc']
+                );
+            }
+
+            if (!empty($row['scan_location'])) {
+                $row['scan_location'] = dgettext(
+                    'imaging_qc',
+                    $row['scan_location']
+                );
+            }
+
+            if (!empty($row['selected'])) {
+                $row['selected'] = dgettext(
+                    'loris',
+                    $row['selected']
+                );
+            }
+        }
+
+        unset($row);
+        return $data;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This PR fixes several multilingual issues in the imaging_qc module, including broken filters, missing translations, db translation issues, inconsistent behavior between English and French, and some cleanup.

Since the DataTable translations were missing from this module and could not be applied directly as in other modules, I overrid `getFullList()` to handle them.

#### Testing instructions (if applicable)

1. git checkout HachemJ/TranslateImagingQcDb
2. delete `project/locale`
3. copy `raisinbread/locale` into `project/locale`
4. run `make dev` (make sure it ran the msgfmt --use-fuzzy -o table.mo table.po commands)
5. Go to 'Imaging' -> 'Imaging Quality Control'
6. Switch the language to 'French'
7. Verify that all filters work correctly and that the page and DataTable are fully translated

#### Link(s) to related issue(s)

* Resolves #11052 (Reference the issue this fixes, if any.)
