### PR TITLE
[dataquery] Fetch accessible instruments in a single query in the dictionary module

### DIFF
--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -89,17 +89,10 @@ class Module extends \Module
 
         $categoryitems = [];
 
-        // Get the instruments that the user has access to based on their Projects
-        $userVisits  = $user->getVisits();
-        $instruments = [];
-        foreach ($userVisits as $visitLabel => $_) {
-            $visitInstruments = \Utility::getVisitInstruments($visitLabel);
-            foreach ($visitInstruments as $testName => $fullName) {
-                if (!isset($instruments[$testName])) {
-                    $instruments[$testName] = $fullName;
-                }
-            }
-        }
+        // Get the instruments that the user has access to based on their visits.
+        $instruments = \Utility::getVisitsInstruments(
+            array_keys($user->getVisits())
+        );
         foreach ($modules as $module) {
             if ($formodule !== null && $module->getName() !== $formodule) {
                 continue;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -817,6 +817,49 @@ class Utility
     }
 
     /**
+     * Get all the instruments which currently exist for a set of visit labels
+     * in the database.
+     *
+     * @param string[] $visit_labels The visit labels for which you would like
+     *                               to know the existing instruments
+     *
+     * @return array Array of instruments which exist for the given visit labels
+     *               array is of the form [$Test_name => $Full_name]
+     */
+    static function getVisitsInstruments(array $visit_labels): array
+    {
+        if (empty($visit_labels)) {
+            return [];
+        }
+
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+
+        $params       = [];
+        $placeholders = [];
+        foreach (array_values($visit_labels) as $i => $visit_label) {
+            $params["vl$i"] = $visit_label;
+            $placeholders[] = ":vl$i";
+        }
+
+        $test_names = $DB->pselectColWithIndexKey(
+            "SELECT DISTINCT t.Test_name, t.Full_name
+            FROM session s
+            JOIN candidate c ON (c.ID=s.CandidateID)
+            JOIN flag f ON (f.sessionID=s.id)
+            JOIN test_names t ON (f.TestID=t.ID)
+            WHERE c.Active='Y' AND s.Active='Y'
+            AND s.Visit_label IN (" . join(',', $placeholders) . ")
+            AND s.CenterID != '1' AND c.Entity_type != 'Scanner'
+            ORDER BY t.Full_name",
+            $params,
+            'Test_name'
+        );
+
+        return $test_names;
+    }
+
+    /**
      * Effectively resolve '..' characters in a file path
      *
      * @param string $path A potentially-relative filepath to be resolved


### PR DESCRIPTION
## Description

`/dictionary/categories` (and `/dictionary/module/<name>`) scaled linearly with the number of distinct visit labels in the database. `getUserModuleCategories()` built the set of instruments the user can access by running one `Utility::getVisitInstruments()` query per visit label, and each of those queries joins `session`, `candidate`, `flag` and `test_names`.

This replaces the per-visit loop with a single query that fetches the distinct instruments across all of the user's visits.

## Changes

- Replaced the per-visit `foreach` loop in `LORIS\dictionary\Module::getUserModuleCategories()` with a single query over all of the user's visits

## Testing Instructions

1. Use a database with a large number of distinct `session.Visit_label` values.
2. Log in and open the Data Query Tool, or request `GET /dictionary/categories` directly.
3. Confirm the endpoint now returns quickly rather than blocking for tens of seconds.
4. Confirm the instrument categories shown in the tool are the same as before this change (the response body should be identical).

## Related Issues

Closes #11166. The slow loop was introduced in #9903.
