### PR TITLE
Candidate CandID Patch Fix

### DIFF
--- a/SQL/Archive/27.0/2025-02-05-Change-Candid-FK-To-ID.sql
+++ b/SQL/Archive/27.0/2025-02-05-Change-Candid-FK-To-ID.sql
@@ -99,3 +99,6 @@ ALTER TABLE family ADD CONSTRAINT FK_family_candidate_1 FOREIGN KEY (CandidateID
 
 -- Change candidate's PK to ID
 ALTER TABLE candidate DROP PRIMARY KEY, ADD PRIMARY KEY(ID);
+
+-- CandIDGenerator uses length of 10 unsigned int, this modifies table to avoid out of range generations
+ALTER TABLE candidate MODIFY CandID INT(10) unsigned NOT NULL;

--- a/SQL/Release_patches/26.0_To_27.0_upgrade.sql
+++ b/SQL/Release_patches/26.0_To_27.0_upgrade.sql
@@ -516,6 +516,10 @@ ALTER TABLE family ADD CONSTRAINT FK_family_candidate_1 FOREIGN KEY (CandidateID
 
 -- Change candidate's PK to ID
 ALTER TABLE candidate DROP PRIMARY KEY, ADD PRIMARY KEY(ID);
+
+-- CandIDGenerator uses length of 10 unsigned int, this modifies table to avoid out of range generations
+ALTER TABLE candidate MODIFY CandID INT(10) unsigned NOT NULL;
+
 ALTER TABLE permissions CHANGE `action` `action` enum (
       'Close',
       'Create',
@@ -573,7 +577,9 @@ VALUES ('view_instrument_data', 'Data',
 (SELECT ID FROM modules WHERE Name = 'instruments'), 'View', 2);
 INSERT IGNORE INTO user_perm_rel (userID, permID) 
 SELECT users.ID, permissions.permID FROM users 
-CROSS JOIN permissions WHERE users.userID='admin';CREATE TABLE `openid_connect_providers` (
+CROSS JOIN permissions WHERE users.userID='admin';
+
+CREATE TABLE `openid_connect_providers` (
     `OpenIDProviderID` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `Name` varchar(255) NOT NULL,
     `BaseURI` text NOT NULL, -- the provider's base uri that hosts .well-known/openid-configuration

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -46,7 +46,7 @@ class Timepoint_List extends \NDB_Menu
 
         // check user permissions
         return $user->hasPermission('access_all_profiles')
-            || ($user->hasPermission('data_entry') 
+            || ($user->hasPermission('data_entry')
                 && $candidate->isAccessibleBy($user));
     }
 


### PR DESCRIPTION
## Brief summary of changes
This PR fixes `candidate.CandID` still being a signed int after running the upgrade patch. This was causing newly generated CandIDs to sometimes be out of range.

This is because the change to candidate.CandID's type being `int(10) unsigned` was done only in the schema and not included in the `SQL/Archive/27.0/2025-02-05-Change-Candid-FK-To-ID.sql` patch.

I added this to the archived patch and the release patch :
```sql
-- CandIDGenerator uses length of 10 unsigned int, this modifies table to avoid out of range generations
ALTER TABLE candidate MODIFY CandID INT(10) unsigned NOT NULL;
```