### PR TITLE
[SQL] Add missing Biobank menu category to 27.0_to_28.0_upgrade.sql

### DIFF
--- a/SQL/Release_patches/27.0_to_28.0_upgrade.sql
+++ b/SQL/Release_patches/27.0_to_28.0_upgrade.sql
@@ -55,9 +55,10 @@ INSERT INTO menu_categories (name, orderby) VALUES
 ('Electrophysiology', 3),
 ('Genomics', 4),
 ('Imaging', 5),
-('Reports', 6),
-('Tools', 7),
-('Admin', 8);
+('Biobank', 6),
+('Reports', 7),
+('Tools', 8),
+('Admin', 9);
 CREATE TABLE policies (
     PolicyID INT AUTO_INCREMENT PRIMARY KEY,
     Name VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Brief summary of changes

This PR adds the Biobank menu category entry to the 27.0_to_28.0_upgrade.sql upgrade script.

This ensures that instances upgrading to LORIS 28 receive the same Biobank menu category configuration defined in 0000-00-03-ConfigTables.sql for new installations.

<img width="1676" height="839" alt="image" src="https://github.com/user-attachments/assets/7d63e121-33da-4477-b4ce-03f0ee38cc62" />