### PR TITLE
[dataquery] pin icon line break for non admin users

### DIFF
--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -827,7 +827,7 @@ function SingleQueryDisplay(props: {
       }>
       <i className="fas fa-thumbtack fa-stack-1x"> </i>
     </span>
-    : <div />;
+    : <></>;
 
   let msg: React.ReactNode = null;
   if (query.RunTime) {

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -891,7 +891,7 @@ function SingleQueryDisplay(props: {
         <i className="fas fa-slash fa-stack-1x"></i>
         <i className="fas fa-thumbtack fa-stack-1x"> </i>
       </span>
-      : <div />;
+      : <></>;
     msg = <div><b>{name}</b>&nbsp;{loadIcon}{unpinIcon}</div>;
   } else {
     console.error('Invalid query. Neither shared nor recent', query);

--- a/modules/dataquery/jsx/welcome.tsx
+++ b/modules/dataquery/jsx/welcome.tsx
@@ -827,7 +827,7 @@ function SingleQueryDisplay(props: {
       }>
       <i className="fas fa-thumbtack fa-stack-1x"> </i>
     </span>
-    : <></>;
+    : null;
 
   let msg: React.ReactNode = null;
   if (query.RunTime) {
@@ -891,7 +891,7 @@ function SingleQueryDisplay(props: {
         <i className="fas fa-slash fa-stack-1x"></i>
         <i className="fas fa-thumbtack fa-stack-1x"> </i>
       </span>
-      : <></>;
+      : null;
     msg = <div><b>{name}</b>&nbsp;{loadIcon}{unpinIcon}</div>;
   } else {
     console.error('Invalid query. Neither shared nor recent', query);


### PR DESCRIPTION
## Brief summary of changes
Fixes an unexpected line break in the icon row for the Recent Queries item header where the share icon would drop to a new line for non-admin users.

### Previously
<img width="510" height="101" alt="image" src="https://github.com/user-attachments/assets/86afb7f4-2518-4c78-ac62-cc03e81cfe56" />

### After
<img width="524" height="83" alt="image" src="https://github.com/user-attachments/assets/b9ebf76f-da2b-4311-8a7c-7285e551120e" />


## Testing instructions

  1. Log in with a user account that does not have admin (superuser) permissions.
  2. Navigate to the Data Query Tool (beta).
  3. View any recent query under the Recent Queries section.
  4. All icons should render horizontally inline on a single line.

## Link(s) to related issue(s)

* Resolves #10589
