### PR TITLE
[biobank] [dataquery] Add missing translations for query engine items descriptions

### DIFF
--- a/modules/biobank/locale/biobank.pot
+++ b/modules/biobank/locale/biobank.pot
@@ -507,3 +507,48 @@ msgstr ""
 
 msgid "Containers"
 msgstr ""
+
+msgid "Specimen Collection and Availability"
+msgstr ""
+
+msgid "Whether the session has any specimen collected"
+msgstr ""
+
+msgid "Whether the session has any specimen currently available"
+msgstr ""
+
+msgid "Type of specimen"
+msgstr ""
+
+msgid "Barcode for specimen"
+msgstr ""
+
+msgid "Current quantity of specimen"
+msgstr ""
+
+msgid "Unit of measurement for specimen quantity"
+msgstr ""
+
+msgid "Whether specimen is available or used/discarded"
+msgstr ""
+
+msgid "Number of freeze-thaw cycles for specimen"
+msgstr ""
+
+msgid "Date specimen was collected"
+msgstr ""
+
+msgid "Time specimen was collected"
+msgstr ""
+
+msgid "Collection protocol used for specimen"
+msgstr ""
+
+msgid "Center where specimen was collected"
+msgstr ""
+
+msgid "Type of container holding specimen"
+msgstr ""
+
+msgid "Storage temperature for specimen"
+msgstr ""

--- a/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
+++ b/modules/biobank/locale/fr/LC_MESSAGES/biobank.po
@@ -520,3 +520,48 @@ msgstr "Nouvelle entrée"
 
 msgid "Containers"
 msgstr "Conteneurs"
+
+msgid "Specimen Collection and Availability"
+msgstr "Prélèvement et disponibilité des échantillons"
+
+msgid "Whether the session has any specimen collected"
+msgstr "Indique si des échantillons ont été prélevés lors de la session"
+
+msgid "Whether the session has any specimen currently available"
+msgstr "Indique si des échantillons de la session sont actuellement disponibles"
+
+msgid "Type of specimen"
+msgstr "Type d'échantillon"
+
+msgid "Barcode for specimen"
+msgstr "Code-barres de l'échantillon"
+
+msgid "Current quantity of specimen"
+msgstr "Quantité actuelle de l'échantillon"
+
+msgid "Unit of measurement for specimen quantity"
+msgstr "Unité de mesure de la quantité de l'échantillon"
+
+msgid "Whether specimen is available or used/discarded"
+msgstr "Indique si l'échantillon est disponible, utilisé ou éliminé"
+
+msgid "Number of freeze-thaw cycles for specimen"
+msgstr "Nombre de cycles de congélation-décongélation de l'échantillon"
+
+msgid "Date specimen was collected"
+msgstr "Date de prélèvement de l'échantillon"
+
+msgid "Time specimen was collected"
+msgstr "Heure de prélèvement de l'échantillon"
+
+msgid "Collection protocol used for specimen"
+msgstr "Protocole de prélèvement utilisé pour l'échantillon"
+
+msgid "Center where specimen was collected"
+msgstr "Centre où l'échantillon a été prélevé"
+
+msgid "Type of container holding specimen"
+msgstr "Type de contenant de l'échantillon"
+
+msgid "Storage temperature for specimen"
+msgstr "Température de conservation de l'échantillon"

--- a/modules/biobank/php/queryengine.class.inc
+++ b/modules/biobank/php/queryengine.class.inc
@@ -83,7 +83,7 @@ class QueryEngine extends SQLQueryEngine
         $scope    = new Scope(Scope::SESSION);
         $specimen = new Category(
             "Specimen",
-            "Specimen Collection and Availability",
+            dgettext("biobank", "Specimen Collection and Availability"),
         );
 
         $specimenTypes     = $this->_getSpecimenTypes();
@@ -92,98 +92,140 @@ class QueryEngine extends SQLQueryEngine
         $items = [
             new DictionaryItem(
                 "SpecimenCollectionDone",
-                "Whether the session has any specimen collected",
+                dgettext(
+                    "biobank",
+                    "Whether the session has any specimen collected"
+                ),
                 $scope,
                 new BooleanType(),
                 new Cardinality(Cardinality::SINGLE),
             ),
             new DictionaryItem(
                 "SpecimenAvailable",
-                "Whether the session has any specimen currently available",
+                dgettext(
+                    "biobank",
+                    "Whether the session has any specimen currently available"
+                ),
                 $scope,
                 new BooleanType(),
                 new Cardinality(Cardinality::SINGLE),
             ),
             new DictionaryItem(
                 "SpecimenType",
-                "Type of specimen",
+                dgettext(
+                    "biobank",
+                    "Type of specimen"
+                ),
                 $scope,
                 new Enumeration(...$specimenTypes),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenBarcode",
-                "Barcode for specimen",
+                dgettext(
+                    "biobank",
+                    "Barcode for specimen"
+                ),
                 $scope,
                 new StringType(40),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenQuantity",
-                "Current quantity of specimen",
+                dgettext(
+                    "biobank",
+                    "Current quantity of specimen"
+                ),
                 $scope,
                 new DecimalType(),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenUnit",
-                "Unit of measurement for specimen quantity",
+                dgettext(
+                    "biobank",
+                    "Unit of measurement for specimen quantity"
+                ),
                 $scope,
                 new StringType(20),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenStatus",
-                "Whether specimen is available or used/discarded",
+                dgettext(
+                    "biobank",
+                    "Whether specimen is available or used/discarded"
+                ),
                 $scope,
                 new Enumeration(...$containerStatuses),
                 new Cardinality(Cardinality::MANY)
             ),
             new DictionaryItem(
                 "SpecimenFreezeThawCycle",
-                "Number of freeze-thaw cycles for specimen",
+                dgettext(
+                    "biobank",
+                    "Number of freeze-thaw cycles for specimen"
+                ),
                 $scope,
                 new IntegerType(),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenCollectionDate",
-                "Date specimen was collected",
+                dgettext(
+                    "biobank",
+                    "Date specimen was collected"
+                ),
                 $scope,
                 new DateType(),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenCollectionTime",
-                "Time specimen was collected",
+                dgettext(
+                    "biobank",
+                    "Time specimen was collected"
+                ),
                 $scope,
                 new StringType(8),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenCollectionProtocol",
-                "Collection protocol used for specimen",
+                dgettext(
+                    "biobank",
+                    "Collection protocol used for specimen"
+                ),
                 $scope,
                 new StringType(100),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenCollectionCenter",
-                "Center where specimen was collected",
+                dgettext(
+                    "biobank",
+                    "Center where specimen was collected"
+                ),
                 $scope,
                 new StringType(255),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenContainerType",
-                "Type of container holding specimen",
+                dgettext(
+                    "biobank",
+                    "Type of container holding specimen"
+                ),
                 $scope,
                 new StringType(40),
                 new Cardinality(Cardinality::MANY),
             ),
             new DictionaryItem(
                 "SpecimenTemperature",
-                "Storage temperature for specimen",
+                dgettext(
+                    "biobank",
+                    "Storage temperature for specimen"
+                ),
                 $scope,
                 new DecimalType(),
                 new Cardinality(Cardinality::MANY),


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing translations for Biobank Query Engine item descriptions under the Specimen Collection and Availability category in the new Data Query module.

#### Testing instructions (if applicable)

1. Go to 'Reports' -> 'Data Query Tool (Beta)'
2. Accept the Terms of Use if prompted
3. Switch the language to 'French'

<img width="855" height="432" alt="Image" src="https://github.com/user-attachments/assets/6a80c64f-c166-4aba-921b-89d4cf357f81" />

4. Click on 'Continuer à définir les champs'

5. Please follow the steps shown in the video

https://github.com/user-attachments/assets/95194732-37a8-45c7-89a4-05f4c8757606



#### Link(s) to related issue(s)

* See #11104 for context (Reference the issue this fixes, if any.)
