### PR TITLE
[candidate_parameters] [dataquery] Add missing translations for query engine items descriptions

### DIFF
--- a/modules/candidate_parameters/locale/candidate_parameters.pot
+++ b/modules/candidate_parameters/locale/candidate_parameters.pot
@@ -228,6 +228,87 @@ msgstr ""
 msgid "Comments: "
 msgstr ""
 
+msgid "Candidate Identifiers"
+msgstr ""
+
+msgid "LORIS Candidate Identifier"
+msgstr ""
+
+msgid "Project Candidate Identifier"
+msgstr ""
+
+msgid "Caveat Emptor Flag for Candidate"
+msgstr ""
+
+msgid "Reason for Caveat Emptor Flag Candidate"
+msgstr ""
+
+msgid "Other reason for Caveat Emptor Flag Candidate, please specify"
+msgstr ""
+
+msgid "Candidate Demographics"
+msgstr ""
+
+msgid "Date of Birth"
+msgstr ""
+
+msgid "Date of Death"
+msgstr ""
+
+msgid "Candidate's biological sex"
+msgstr ""
+
+msgid "Expected Date of Confinement"
+msgstr ""
+
+msgid "Other parameters"
+msgstr ""
+
+msgid "The study visit label"
+msgstr ""
+
+msgid "The date when the visit was registered"
+msgstr ""
+
+msgid "Visit's current stage"
+msgstr ""
+
+msgid "Behavioural feedback at the session level"
+msgstr ""
+
+msgid "Whether a session was failure or did the candidate withdrawal"
+msgstr ""
+
+msgid "The LORIS project to categorize this session"
+msgstr ""
+
+msgid "The LORIS cohort used for battery selection"
+msgstr ""
+
+msgid "The Site at which a visit occurred"
+msgstr ""
+
+msgid "The type of entity which this candidate represents"
+msgstr ""
+
+msgid "The status of the participant within the study"
+msgstr ""
+
+msgid "The reason of the status of the participant within the study"
+msgstr ""
+
+msgid "Comments about the status of the participant within the study"
+msgstr ""
+
+msgid "Candidate comments"
+msgstr ""
+
+msgid "The site at which this candidate was initially registered"
+msgstr ""
+
+msgid "The project for which this candidate was initially registered"
+msgstr ""
+
 # Widgets
 msgid "Consent Summary"
 msgstr ""

--- a/modules/candidate_parameters/locale/fr/LC_MESSAGES/candidate_parameters.po
+++ b/modules/candidate_parameters/locale/fr/LC_MESSAGES/candidate_parameters.po
@@ -229,6 +229,84 @@ msgstr "Détails: "
 msgid "Comments: "
 msgstr "Commentaires: "
 
+msgid "Candidate Identifiers"
+msgstr "Identifiants du candidat"
+
+msgid "LORIS Candidate Identifier"
+msgstr "Identifiant LORIS du candidat"
+
+msgid "Project Candidate Identifier"
+msgstr "Identifiant du candidat dans le projet"
+
+msgid "Reason for Caveat Emptor Flag Candidate"
+msgstr "Raison de l'indicateur Caveat Emptor du candidat"
+
+msgid "Other reason for Caveat Emptor Flag Candidate, please specify"
+msgstr "Autre raison de l'indicateur Caveat Emptor du candidat, veuillez préciser"
+
+msgid "Candidate Demographics"
+msgstr "Données démographiques du candidat"
+
+msgid "Date of Birth"
+msgstr "Date de naissance"
+
+msgid "Date of Death"
+msgstr "Date de décès"
+
+msgid "Candidate's biological sex"
+msgstr "Sexe biologique du candidat"
+
+msgid "Expected Date of Confinement"
+msgstr "Date prévue d'accouchement"
+
+msgid "Other parameters"
+msgstr "Autres paramètres"
+
+msgid "The study visit label"
+msgstr "Libellé de la visite de l'étude"
+
+msgid "The date when the visit was registered"
+msgstr "Date à laquelle la visite a été enregistrée"
+
+msgid "Visit's current stage"
+msgstr "Étape actuelle de la visite"
+
+msgid "Behavioural feedback at the session level"
+msgstr "Commentaires comportementaux au niveau de la session"
+
+msgid "Whether a session was failure or did the candidate withdrawal"
+msgstr "Indique si la session a échoué ou si le candidat s'est retiré"
+
+msgid "The LORIS project to categorize this session"
+msgstr "Projet LORIS utilisé pour catégoriser cette session"
+
+msgid "The LORIS cohort used for battery selection"
+msgstr "Cohorte LORIS utilisée pour la sélection de la batterie"
+
+msgid "The Site at which a visit occurred"
+msgstr "Site où la visite a eu lieu"
+
+msgid "The type of entity which this candidate represents"
+msgstr "Type d'entité que ce candidat représente"
+
+msgid "The status of the participant within the study"
+msgstr "Statut du participant au sein de l'étude"
+
+msgid "The reason of the status of the participant within the study"
+msgstr "Raison du statut du participant au sein de l'étude"
+
+msgid "Comments about the status of the participant within the study"
+msgstr "Commentaires sur le statut du participant au sein de l'étude"
+
+msgid "Candidate comments"
+msgstr "Commentaires sur le candidat"
+
+msgid "The site at which this candidate was initially registered"
+msgstr "Site où ce candidat a été initialement enregistré"
+
+msgid "The project for which this candidate was initially registered"
+msgstr "Projet pour lequel ce candidat a été initialement enregistré"
+
 # Widgets
 msgid "Consent Summary"
 msgstr "Résumé du consentement"

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -29,42 +29,55 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $ids = new \LORIS\Data\Dictionary\Category(
             "Identifiers",
-            "Candidate Identifiers"
+            dgettext("candidate_parameters", "Candidate Identifiers")
         );
 
         $ids = $ids->withItems(
             [
                 new DictionaryItem(
                     "CandID",
-                    "LORIS Candidate Identifier",
+                    dgettext("candidate_parameters", "LORIS Candidate Identifier"),
                     $candscope,
                     new \LORIS\Data\Types\IntegerType(999999),
                     new Cardinality(Cardinality::UNIQUE),
                 ),
                 new DictionaryItem(
                     "PSCID",
-                    "Project Candidate Identifier",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Project Candidate Identifier"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::UNIQUE),
                 ),
                 new DictionaryItem(
                     "flagged_caveatemptor",
-                    "Caveat Emptor Flag for Candidate",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Caveat Emptor Flag for Candidate"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\Enumeration("true", "false"),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "flagged_reason",
-                    "Reason for Caveat Emptor Flag Candidate",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Reason for Caveat Emptor Flag Candidate"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\StringType(255), // FIXME: Make an enum
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "flagged_other",
-                    "Other reason for Caveat Emptor Flag Candidate, please specify",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Other reason for Caveat Emptor Flag Candidate," 
+                        . " please specify"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::SINGLE),
@@ -74,7 +87,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
 
         $demographics = new \LORIS\Data\Dictionary\Category(
             "Demographics",
-            "Candidate Demographics",
+            dgettext("candidate_parameters", "Candidate Demographics"),
         );
         $sexList      = array_keys(\Utility::getSexList());
         $t            = new Enumeration(...$sexList);
@@ -82,28 +95,28 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             [
                 new DictionaryItem(
                     "DoB",
-                    "Date of Birth",
+                    dgettext("candidate_parameters", "Date of Birth"),
                     $candscope,
                     new \LORIS\Data\Types\DateType(),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "DoD",
-                    "Date of Death",
+                    dgettext("candidate_parameters", "Date of Death"),
                     $candscope,
                     new \LORIS\Data\Types\DateType(),
                     new Cardinality(Cardinality::OPTIONAL),
                 ),
                 new DictionaryItem(
                     "Sex",
-                    "Candidate's biological sex",
+                    dgettext("candidate_parameters", "Candidate's biological sex"),
                     $candscope,
                     $t,
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "EDC",
-                    "Expected Data of Confinement",
+                    dgettext("candidate_parameters", "Expected Date of Confinement"),
                     $candscope,
                     new \LORIS\Data\Types\DateType(),
                     new Cardinality(Cardinality::OPTIONAL),
@@ -111,7 +124,10 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             ]
         );
 
-        $meta = new \LORIS\Data\Dictionary\Category("Meta", "Other parameters");
+        $meta = new \LORIS\Data\Dictionary\Category(
+            "Meta",
+            dgettext("candidate_parameters", "Other parameters")
+        );
 
         $db = $this->loris->getDatabaseConnection();
         $participantstatus_options = $db->pselectCol(
@@ -122,35 +138,47 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
             [
                 new DictionaryItem(
                     "VisitLabel",
-                    "The study visit label",
+                    dgettext("candidate_parameters", "The study visit label"),
                     $sesscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::UNIQUE),
                 ),
                 new DictionaryItem(
                     "DateRegistered",
-                    "The date when the visit was registered",
+                    dgettext(
+                        "candidate_parameters", 
+                        "The date when the visit was registered"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\DateType(),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "CurrentStage",
-                    "Visit's current stage",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Visit's current stage"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\StringType(255), // FIXME: Make an enum
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "SessionFeedback",
-                    "Behavioural feedback at the session level",
+                    dgettext(
+                        "candidate_parameters", 
+                        "Behavioural feedback at the session level"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "SessionFailure",
-                    "Whether a session was failure or did the candidate withdrawal",
+                    dgettext(
+                        "candidate_parameters",
+                        "Whether a session was failure or did the candidate withdrawal"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\Enumeration(
                         'Failure',
@@ -161,70 +189,100 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 ),
                 new DictionaryItem(
                     "Project",
-                    "The LORIS project to categorize this session",
+                    dgettext(
+                        "candidate_parameters",
+                        "The LORIS project to categorize this session"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\StringType(255), // FIXME: Make an enum
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "Cohort",
-                    "The LORIS cohort used for battery selection",
+                    dgettext(
+                        "candidate_parameters",
+                        "The LORIS cohort used for battery selection"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "Site",
-                    "The Site at which a visit occurred",
+                    dgettext(
+                        "candidate_parameters",
+                        "The Site at which a visit occurred"
+                    ),
                     $sesscope,
                     new \LORIS\Data\Types\Enumeration(...\Utility::getSiteList()),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "EntityType",
-                    "The type of entity which this candidate represents",
+                    dgettext(
+                        "candidate_parameters",
+                        "The type of entity which this candidate represents"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\Enumeration('Human', 'Scanner'),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "ParticipantStatus",
-                    "The status of the participant within the study",
+                    dgettext(
+                        "candidate_parameters",
+                        "The status of the participant within the study"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\Enumeration(...$participantstatus_options),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "ParticipantStatusReason",
-                    "The reason of the status of the participant within the study",
+                    dgettext(
+                        "candidate_parameters",
+                        "The reason of the status of the participant within the"
+                        . " study"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\Enumeration(...$participantstatus_options),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "ParticipantStatusComments",
-                    "Comments about the status of the participant within the study",
+                    dgettext(
+                        "candidate_parameters",
+                        "Comments about the status of the participant within the"
+                        . " study"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\StringType(),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "CandidateComments",
-                    "Candidate comments",
+                    dgettext("candidate_parameters", "Candidate comments"),
                     $candscope,
                     new \LORIS\Data\Types\StringType(255),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "RegistrationSite",
-                    "The site at which this candidate was initially registered",
+                    dgettext(
+                        "candidate_parameters",
+                        "The site at which this candidate was initially registered"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\Enumeration(...\Utility::getSiteList()),
                     new Cardinality(Cardinality::SINGLE),
                 ),
                 new DictionaryItem(
                     "RegistrationProject",
-                    "The project for which this candidate was initially registered",
+                    dgettext(
+                        "candidate_parameters",
+                        "The project for which this candidate was initially"
+                        . " registered"
+                    ),
                     $candscope,
                     new \LORIS\Data\Types\StringType(255), // FIXME: Make an enum
                     new Cardinality(Cardinality::SINGLE),

--- a/modules/candidate_parameters/php/candidatequeryengine.class.inc
+++ b/modules/candidate_parameters/php/candidatequeryengine.class.inc
@@ -44,7 +44,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "PSCID",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "Project Candidate Identifier"
                     ),
                     $candscope,
@@ -54,7 +54,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "flagged_caveatemptor",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "Caveat Emptor Flag for Candidate"
                     ),
                     $candscope,
@@ -64,7 +64,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "flagged_reason",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "Reason for Caveat Emptor Flag Candidate"
                     ),
                     $candscope,
@@ -74,8 +74,8 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "flagged_other",
                     dgettext(
-                        "candidate_parameters", 
-                        "Other reason for Caveat Emptor Flag Candidate," 
+                        "candidate_parameters",
+                        "Other reason for Caveat Emptor Flag Candidate,"
                         . " please specify"
                     ),
                     $candscope,
@@ -146,7 +146,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "DateRegistered",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "The date when the visit was registered"
                     ),
                     $sesscope,
@@ -156,7 +156,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "CurrentStage",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "Visit's current stage"
                     ),
                     $sesscope,
@@ -166,7 +166,7 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                 new DictionaryItem(
                     "SessionFeedback",
                     dgettext(
-                        "candidate_parameters", 
+                        "candidate_parameters",
                         "Behavioural feedback at the session level"
                     ),
                     $sesscope,
@@ -177,7 +177,8 @@ class CandidateQueryEngine extends \LORIS\Data\Query\SQLQueryEngine
                     "SessionFailure",
                     dgettext(
                         "candidate_parameters",
-                        "Whether a session was failure or did the candidate withdrawal"
+                        "Whether a session was failure or did the candidate"
+                        . " withdrawal"
                     ),
                     $sesscope,
                     new \LORIS\Data\Types\Enumeration(


### PR DESCRIPTION
## Brief summary of changes

This PR adds missing translations for Candidate Parameters Query Engine item descriptions under the following three categories in the new Data Query module :

- Candidate Identifiers
- Candidate Demographics
- Other parameters

#### Testing instructions (if applicable)

1. Go to 'Reports' -> 'Data Query Tool (Beta)'
2. Accept the Terms of Use if prompted
3. Switch the language to 'French'

<img width="855" height="432" alt="Image" src="https://github.com/user-attachments/assets/6a80c64f-c166-4aba-921b-89d4cf357f81" />

4. Click on 'Continuer à définir les champs'

5. Please follow the steps shown in the video

https://github.com/user-attachments/assets/b5de6900-67a7-4b5c-afa3-82215ac60c98






#### Link(s) to related issue(s)

* See #11104 for context (Reference the issue this fixes, if any.)
