### PR TITLE
Dataquery visit separator

### DIFF
--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -439,9 +439,9 @@ function ViewData(props: {
   return <div>
     <style>{`
       .dataquery-session-row {
-        display: 'flex';
-        flex-direction: 'row';
-        justify-content: 'start';
+        display: flex;
+        flex-direction: row;
+        justify-content: start;
         flex-grow: 1;
         flex-shrink: 1;
         flex-basis: 0;

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -437,6 +437,20 @@ function ViewData(props: {
     />
     : <div />);
   return <div>
+    <style>{`
+      .dataquery-session-row {
+        display: 'flex';
+        flex-direction: 'row';
+        justify-content: 'start';
+        flex-grow: 1;
+        flex-shrink: 1;
+        flex-basis: 0;
+        border-bottom: thin dotted black;
+      }
+      .dataquery-session-row:last-child {
+        border-bottom: none;
+      }
+    `}</style>
     <SelectElement
       name='headerdisplay'
       options={{
@@ -982,22 +996,12 @@ function organizedFormatter(
             };
             let theval = visitval(visit, cell);
             if (!displayEmptyVisits && !hasdata) {
-              return <div key={visit} />;
+              return null;
             }
             if (theval === null) {
               theval = <i>{t('(No data)', {ns: 'dataquery'})}</i>;
             }
-            return (<div key={visit} style={
-              {
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'start',
-                flexGrow: 1,
-                flexShrink: 1,
-                flexBasis: 0,
-                borderBottom: 'thin dotted black',
-              }
-            }>
+            return (<div key={visit} className="dataquery-session-row">
               <div style={
                 {
                   fontWeight: 'bold',
@@ -1048,22 +1052,12 @@ function organizedFormatter(
             };
             let theval = visitval(visit, cell);
             if (!displayEmptyVisits && !hasdata) {
-              return <div key={visit} />;
+              return null;
             }
             if (theval === null) {
               theval = <i>{t('(No data)', {ns: 'dataquery'})}</i>;
             }
-            return (<div key={visit} style={
-              {
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'start',
-                flexGrow: 1,
-                flexShrink: 1,
-                flexBasis: 0,
-                borderBottom: 'thin dotted black',
-              }
-            }>
+            return (<div key={visit} className="dataquery-session-row">
               <div style={
                 {
                   fontWeight: 'bold',


### PR DESCRIPTION
# Brief summary of changes
 * Removes last dotted line in a listing of visits in the dataquery table view

## Previously
<img width="533" height="599" alt="image" src="https://github.com/user-attachments/assets/8e266df9-0b25-4242-9117-a43bf4a731d8" />
<img width="750" height="420" alt="image" src="https://github.com/user-attachments/assets/98f1212f-bb91-42df-b376-48dbcdffb19c" />

## After
<img width="524" height="597" alt="image" src="https://github.com/user-attachments/assets/34a6fe99-5fdc-459a-97c0-724996755080" />
<img width="742" height="415" alt="image" src="https://github.com/user-attachments/assets/3b44dfe2-d6d0-47eb-8379-17f2bb72ec80" />


# Testing instructions

1. Navigate to the dataquery module.
2. Create a selection that includes at least one field with multiple visits.
3. Verify that the dotted line for the last visit no longer appears in the table view.
4. Also test the result when the “Display Empty Visits?” checkbox is unchecked.

# Link(s) to related issue(s)

* Resolves #9831
