### PR TITLE
[imaging_uploader] Fix outdated SQL query in TestPlan after CandID to CandidateID refactor

### DIFF
--- a/modules/imaging_uploader/test/TestPlan.md
+++ b/modules/imaging_uploader/test/TestPlan.md
@@ -56,7 +56,7 @@
 
     _e.g. SQL command to set session associated with CandID X and Visit Label Y as inactive:_
 
-    `UPDATE session SET Active = 'N' WHERE CandID = X AND Visit_label = 'Y';`
+    `UPDATE session s JOIN candidate c ON c.ID = s.CandidateID SET s.Active = 'N' WHERE c.CandID = X AND s.Visit_label = 'Y';`
 
     [Manual Testing]
 


### PR DESCRIPTION
## Brief summary of changes

This PR fixes an outdated SQL query in the TestPlan.md of the imaging_uploader module that was missed during the CandID to CandidateID refactor and discovered while upgrading imaging_uploader to version 27 during the CBIGR upgrade.

#### Testing instructions (if applicable)

1. Run the original query using a valid CandID for X (e.g. 947103) and Visit_label for Y (e.g. 'V6'). It should return an Unknown column 'CandID' error.
2. Try the updated query using the same X and Y values and confirm that the corresponding session is successfully set to inactive (Active = 'N').

