### PR TITLE
[login] Allow multiple projects on account requests

### DIFF
--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -37,9 +37,7 @@ class RequestAccount extends Component {
           site: this.props.data.site
             ? Object.keys(this.props.data.site)['']
             : '',
-          project: this.props.data.project
-            ? Object.keys(this.props.data.project)['']
-            : '',
+          project: [],
           language_preference: this.props.data.language
             ? Object.keys(this.props.data.language)['']
             : '',
@@ -263,9 +261,11 @@ class RequestAccount extends Component {
             options={this.props.data.project}
             value={this.state.form.value.project}
             onUserInput={this.setForm}
+            multiple={true}
             emptyOption={false}
             required={true}
-            placeholder={this.props.t('Choose your project:', {ns: 'login'})}
+            label={this.props.t('Project', {ns: 'loris', count: 2})}
+            labelPlacementTop={true}
           />
           <SelectElement
             name={'language_preference'}

--- a/modules/login/jsx/requestAccount.js
+++ b/modules/login/jsx/requestAccount.js
@@ -264,7 +264,7 @@ class RequestAccount extends Component {
             multiple={true}
             emptyOption={false}
             required={true}
-            label={this.props.t('Project', {ns: 'loris', count: 2})}
+            label={this.props.t('Projects', {ns: 'login'})}
             labelPlacementTop={true}
           />
           <SelectElement

--- a/modules/login/locale/fr/LC_MESSAGES/login.po
+++ b/modules/login/locale/fr/LC_MESSAGES/login.po
@@ -102,9 +102,8 @@ msgstr "Retour à la page de connexion"
 msgid "Choose your site:"
 msgstr "Choisissez votre site :"
 
-#, fuzzy
-msgid "Choose your project:"
-msgstr "Choisissez votre projet :"
+msgid "Projects"
+msgstr "Projets"
 
 msgid "Preferred language:"
 msgstr "Langue préférée :"

--- a/modules/login/locale/ja/LC_MESSAGES/login.po
+++ b/modules/login/locale/ja/LC_MESSAGES/login.po
@@ -87,8 +87,8 @@ msgstr "ログインページに戻ります。"
 msgid "Choose your site:"
 msgstr "サイトを選択してください:"
 
-msgid "Choose your project:"
-msgstr "プロジェクトを選択してください:"
+msgid "Projects"
+msgstr "プロジェクト"
 
 msgid "Preferred language:"
 msgstr "優先言語:"

--- a/modules/login/locale/login.pot
+++ b/modules/login/locale/login.pot
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Choose your site:"
 msgstr ""
 
-msgid "Choose your project:"
+msgid "Projects"
 msgstr ""
 
 msgid "Preferred language:"

--- a/modules/login/locale/zh/LC_MESSAGES/login.po
+++ b/modules/login/locale/zh/LC_MESSAGES/login.po
@@ -85,8 +85,8 @@ msgstr "返回登录页面"
 msgid "Choose your site:"
 msgstr "选择您的网站："
 
-msgid "Choose your project:"
-msgstr "选择您的项目："
+msgid "Projects"
+msgstr "项目"
 
 msgid "Preferred language:"
 msgstr "首选语言："

--- a/modules/login/php/signup.class.inc
+++ b/modules/login/php/signup.class.inc
@@ -112,7 +112,20 @@ class Signup extends \NDB_Page implements ETagCalculator
             false
         );
         $site     = $values['site'];
-        $project  = $values['project'];
+        $projects = $values['project'] ?? [];
+        if (!is_array($projects)) {
+            $projects = [$projects];
+        }
+        $projectList         = \Utility::getProjectList();
+        $projects            = array_values(
+            array_unique(
+                array_filter(
+                    $projects,
+                    fn($project) => (is_string($project) || is_int($project))
+                        && array_key_exists($project, $projectList)
+                )
+            )
+        );
         $language_preference = $values['language_preference'] ?? null;
         $fullname            = $name . ' ' . $lastname;
 
@@ -178,8 +191,7 @@ class Signup extends \NDB_Page implements ETagCalculator
             }
 
             // verify project exists
-            $projectList = \Utility::getProjectList();
-            if (!is_null($project) && array_key_exists($project, $projectList)) {
+            foreach ($projects as $project) {
                 $DB->insert(
                     'user_project_rel',
                     [
@@ -227,10 +239,20 @@ class Signup extends \NDB_Page implements ETagCalculator
         }
 
         // Don't send out emails if this is a sandbox VM.
-        if (!$factory->config()->settingEnabled('sandbox')) {
+        if (!$factory->config()->settingEnabled('sandbox')
+            && !empty($projects)
+        ) {
+            $params = ['center' => $site];
+            $projectPlaceholders = [];
+            foreach ($projects as $index => $project) {
+                $key = 'project' . $index;
+                $projectPlaceholders[] = ':' . $key;
+                $params[$key]          = $project;
+            }
+
             // Send an email to all users meeting the following criteria:
             //     - Associated with the Site
-            //     - Associated with the Project
+            //     - Associated with at least one requested Project
             //     - Have the User Management permission
             $query  = "
                 SELECT DISTINCT
@@ -242,11 +264,10 @@ class Signup extends \NDB_Page implements ETagCalculator
                     JOIN user_project_rel uprojr ON u.ID = uprojr.UserID
                 WHERE
                     upr.CenterID = :center
-                    AND uprojr.ProjectID = :project";
-            $result = $DB->pselect(
-                $query,
-                ['center' => $site, 'project' => $project]
-            );
+                    AND uprojr.ProjectID IN ("
+                    . implode(',', $projectPlaceholders)
+                    . ")";
+            $result = $DB->pselect($query, $params);
             foreach ($result as $row) {
                 $hasPermission = \User::factory($row['userID'])
                     ->hasAnyPermission(

--- a/modules/login/test/Request_Account_test_plan.md
+++ b/modules/login/test/Request_Account_test_plan.md
@@ -7,15 +7,17 @@
 4. Verify that clicking "Submit" button with valid form data will load page acknowledging receipt (Thank you page)
 5. Verify "Return to Loris login page" link on Thank you page works
 6. Verify that if a policy is added to the project for module `login`, the policy is displayed on the Request Account form page, and it is required that the policy has been viewed to request an account.
+7. Verify that the Project field supports selecting one or more projects.
+8. Request an account with multiple projects selected and verify that every selected project is assigned to the pending user.
 	
 ### Approving new User Account Request:
-6. Log in as another user who has permission: `user_accounts` (User Management) and does not have permission: `user_accounts_multisite` (Across all sites create and edit users). Verify that new account request notification is counted in Dashboard (count has incremented).
-7. Verify that Dashboard "Accounts pending approval" link will load the User Accounts module filtered for all accounts where Pending(=1/Yes) and Site is not yet assigned
-8. Approve a new user account request (set Pending approval=No, set Site, check "Send email to user" and "Generate new password" boxes, set various permissions).  
-9. Verify that new user is notified by email when account is approved.
-10. Once account is approved, try logging in with new user credentials
+9. Log in as another user who has permission: `user_accounts` (User Management) and does not have permission: `user_accounts_multisite` (Across all sites create and edit users). Verify that new account request notification is counted in Dashboard (count has incremented).
+10. Verify that Dashboard "Accounts pending approval" link will load the User Accounts module filtered for all accounts where Pending(=1/Yes) and Site is not yet assigned
+11. Approve a new user account request (set Pending approval=No, set Site, check "Send email to user" and "Generate new password" boxes, set various permissions).
+12. Verify that new user is notified by email when account is approved.
+13. Once account is approved, try logging in with new user credentials
 
 ### Email functionality
-11. Disable the `sandbox` configuration setting in your configuration file.
-12. Create a new user account using an email address you can access. Give it either the `user_accounts` or `user_accounts_multisite` permission.
-13. Issue a new user account request specifying the same site and project as the user you created in the previous step. Verify that an email is sent to your email address.
+14. Disable the `sandbox` configuration setting in your configuration file.
+15. Create a new user account using an email address you can access. Give it either the `user_accounts` or `user_accounts_multisite` permission.
+16. Issue a new user account request specifying the same site and at least one of the same projects as the user you created in the previous step. Verify that an email is sent to your email address.

--- a/modules/login/test/Request_Account_test_plan.md
+++ b/modules/login/test/Request_Account_test_plan.md
@@ -7,17 +7,18 @@
 4. Verify that clicking "Submit" button with valid form data will load page acknowledging receipt (Thank you page)
 5. Verify "Return to Loris login page" link on Thank you page works
 6. Verify that if a policy is added to the project for module `login`, the policy is displayed on the Request Account form page, and it is required that the policy has been viewed to request an account.
-7. Verify that the Project field supports selecting one or more projects.
-8. Request an account with multiple projects selected and verify that every selected project is assigned to the pending user.
+7. Verify that the Projects field supports selecting one or more projects.
+8. Request an account with one project selected and verify that project is assigned to the pending user.
+9. Request an account with multiple projects selected and verify that every selected project is assigned to the pending user.
 	
 ### Approving new User Account Request:
-9. Log in as another user who has permission: `user_accounts` (User Management) and does not have permission: `user_accounts_multisite` (Across all sites create and edit users). Verify that new account request notification is counted in Dashboard (count has incremented).
-10. Verify that Dashboard "Accounts pending approval" link will load the User Accounts module filtered for all accounts where Pending(=1/Yes) and Site is not yet assigned
-11. Approve a new user account request (set Pending approval=No, set Site, check "Send email to user" and "Generate new password" boxes, set various permissions).
-12. Verify that new user is notified by email when account is approved.
-13. Once account is approved, try logging in with new user credentials
+10. Log in as another user who has permission: `user_accounts` (User Management) and does not have permission: `user_accounts_multisite` (Across all sites create and edit users). Verify that new account request notification is counted in Dashboard (count has incremented).
+11. Verify that Dashboard "Accounts pending approval" link will load the User Accounts module filtered for all accounts where Pending(=1/Yes) and Site is not yet assigned
+12. Approve a new user account request (set Pending approval=No, set Site, check "Send email to user" and "Generate new password" boxes, set various permissions).
+13. Verify that new user is notified by email when account is approved.
+14. Once account is approved, try logging in with new user credentials
 
 ### Email functionality
-14. Disable the `sandbox` configuration setting in your configuration file.
-15. Create a new user account using an email address you can access. Give it either the `user_accounts` or `user_accounts_multisite` permission.
-16. Issue a new user account request specifying the same site and at least one of the same projects as the user you created in the previous step. Verify that an email is sent to your email address.
+15. Disable the `sandbox` configuration setting in your configuration file.
+16. Create a new user account using an email address you can access. Give it either the `user_accounts` or `user_accounts_multisite` permission.
+17. Issue a new user account request specifying the same site and at least one of the same projects as the user you created in the previous step. Verify that an email is sent to your email address.


### PR DESCRIPTION
## Brief summary of changes

- Updates the Request Account form so users can select multiple projects.
- Saves every valid selected project to the requested account.
- Notifies relevant administrators for the selected projects at the chosen site.
- Preserves support for existing requests that submit a single project.
- Updates the Request Account test plan for multi-project registration.

<img width="500" height="440" alt="image" src="https://github.com/user-attachments/assets/de467912-7a65-4b23-865d-85c5e9d8cc6a" />

<!-- Add the Request Account multi-select screenshot here. -->

#### Testing instructions

- Open `http://localhost:8081/` and click **Request Account**.
- Confirm the **Project** field allows multiple selections and is required.
- Select two projects, complete the required fields, and submit the request.
- Confirm the success page appears.
- Confirm the requested account is associated with both selected projects in `user_project_rel`.
- Confirm relevant administrators for the selected projects and site receive only one notification.

#### Link(s) to related issue(s)

- Resolves #11138