### PR TITLE
Fix vulnerability in API call that fetches a project's candidate ID list

### DIFF
--- a/modules/api/php/views/project.class.inc
+++ b/modules/api/php/views/project.class.inc
@@ -52,9 +52,13 @@ class Project
     {
         $meta = ['Project' => $this->_project->getName()];
 
+        $centerIDs = \User::singleton()->hasPermission('access_all_profiles')
+            ? []
+            : \User::singleton()->getCenterIDs();
+
         $obj = [
             'Meta'        => $meta,
-            'Candidates'  => $this->_project->getCandidateIds(),
+            'Candidates'  => $this->_project->getCandidateIds($centerIDs),
             'Instruments' => array_keys(\Utility::getAllInstruments()),
             'Visits'      => $this->_getVisits(),
         ];
@@ -83,9 +87,13 @@ class Project
     {
         $meta = ['Project' => $this->_project->getName()];
 
+        $centerIDs = \User::singleton()->hasPermission('access_all_profiles')
+            ? []
+            : \User::singleton()->getCenterIDs();
+
         return [
             'Meta'       => $meta,
-            'Candidates' => $this->_project->getCandidateIds(),
+            'Candidates' => $this->_project->getCandidateIds($centerIDs),
         ];
     }
 

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -386,7 +386,7 @@ class Project implements \JsonSerializable
         return iterator_to_array($cohortData);
     }
 
-   /**
+    /**
      * Get that project's participants
      *
      * @param array $centerIDs A list of center IDs that the candidate's

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -386,16 +386,29 @@ class Project implements \JsonSerializable
         return iterator_to_array($cohortData);
     }
 
-    /**
+   /**
      * Get that project's participants
+     *
+     * @param array $centerIDs A list of center IDs that the candidate's
+     *                         registration center ID must be in.
      *
      * @return array A list of object representation of a basic candidates
      */
-    public function getCandidateIds(): array
+    public function getCandidateIds(array $centerIDs = []): array
     {
         $factory = \NDB_Factory::singleton();
 
-        $p = [$this->_projectId];
+        $args['v_project_id'] = implode(',', [$this->_projectId]);
+
+        // Compute clause restricting the candidate's center ID (if any)
+        // and its associated argument.
+        if (!empty($centerIDs)) {
+            $args['v_center_id'] = implode(',', $centerIDs);
+        }
+        $centerIDClause = empty($centerIDs)
+            ? ''
+            : "AND FIND_IN_SET(IFNULL(RegistrationCenterID, '-1'), :v_center_id)";
+
         $candidatesData = $factory->database()->pselect(
             "
             SELECT
@@ -405,8 +418,9 @@ class Project implements \JsonSerializable
             WHERE
               active = 'Y' AND
               FIND_IN_SET(IFNULL(RegistrationProjectID, '-1'), :v_project_id)
+              $centerIDClause
             ",
-            ['v_project_id' => implode(',', $p)]
+            $args
         );
         return array_map(
             function ($row) {


### PR DESCRIPTION
This PR modifies the behavior of the API call that gets the list of candidate IDs for a given project. The call now filters the list of candidate IDs based on the candidates the user is allowed to access.

