### PR TITLE
[publication] Add submitted publishing status

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2566,7 +2566,7 @@ CREATE TABLE `publication` (
     `doi` text DEFAULT NULL,
     `datePublication` date DEFAULT NULL,
     `link` varchar(255) DEFAULT NULL,
-    `publishingStatus` enum('In Progress','Published') DEFAULT NULL,
+    `publishingStatus` enum('In Progress','Submitted','Published') DEFAULT NULL,
     `project` int(10) unsigned DEFAULT NULL,
     `LeadInvestigator` VARCHAR(255) DEFAULT NULL,
     `LeadInvestigatorEmail` VARCHAR(255) DEFAULT NULL,

--- a/SQL/New_patches/2026-08-26-add-publication-submitted-status.sql
+++ b/SQL/New_patches/2026-08-26-add-publication-submitted-status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE publication
+MODIFY COLUMN publishingStatus enum('In Progress','Submitted','Published') DEFAULT NULL;

--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -423,8 +423,9 @@ class ProjectFormFields extends React.Component {
     };
 
     const publishingStatusOptions = {
-      'In Progress': 'In progress',
-      'Published': 'Published',
+      'In Progress': t('In Progress', {ns: 'publication'}),
+      'Submitted': t('Submitted', {ns: 'publication'}),
+      'Published': t('Published', {ns: 'publication'}),
     };
 
     const allVOIs = this.props.allVOIs;

--- a/modules/publication/locale/publication.pot
+++ b/modules/publication/locale/publication.pot
@@ -123,6 +123,12 @@ msgstr ""
 msgid "Project Proposal Creator"
 msgstr ""
 
+msgid "In Progress"
+msgstr ""
+
+msgid "Submitted"
+msgstr ""
+
 msgid "Published"
 msgstr ""
 

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -232,15 +232,17 @@ class Publication extends \NDB_Menu_Filter_Form
             "Link"
         );
 
-        $pubPublished  = "Published";
         $pubInProgress = "In Progress";
+        $pubSubmitted  = "Submitted";
+        $pubPublished  = "Published";
 
         $this->addSelect(
             'publishingStatus',
             "Publishing Status",
             [
-                $pubPublished  => $pubPublished,
                 $pubInProgress => $pubInProgress,
+                $pubSubmitted  => $pubSubmitted,
+                $pubPublished  => $pubPublished,
             ]
         );
     }

--- a/modules/publication/test/TestPlan.md
+++ b/modules/publication/test/TestPlan.md
@@ -43,4 +43,7 @@ report.
 11. Test file download and file deletion. Only users that are affiliated 
 with the proposal can delete. File download should only be allowed for
 users with proposal affiliation or view permission can download.
-12. Test that the title of a proposal is only editable if the status is still Pending. 
+12. Test that the title of a proposal is only editable if the status is still Pending.
+13. Confirm that Publishing Status offers In Progress, Submitted, and Published.
+Save a proposal with each status and verify that the selected value appears in the
+publication table and remains selected when the proposal is reopened.


### PR DESCRIPTION
## Brief summary of changes

- Adds `Submitted` as a publication publishing status alongside `In Progress` and `Published`.
- Updates the publication proposal form and publication list filter to expose all three statuses.
- Adds the database schema update and upgrade patch while preserving existing status values.
- Adds translation entries and manual testing instructions for the publishing statuses.

<img width="1678" height="996" alt="image" src="https://github.com/user-attachments/assets/29cff772-0d84-413c-9b7c-66f3ac8de4e9" />


#### Testing instructions 

- Apply `SQL/New_patches/2026-08-26-add-publication-submitted-status.sql`.
- Open `/publication/` as a user with publication proposal access.
- Open **Propose a Project** and confirm **Publishing Status** offers **In Progress**, **Submitted**, and **Published**.
- Save a proposal with each status and confirm the selected value appears in the publication table.
- Reopen the proposal and confirm the selected publishing status persists.
- Filter the publication table by **Submitted** and confirm only submitted proposals appear.

#### Link(s) to related issue(s)

- Resolves #11141