### PR TITLE
[biobank] Add the missing Biobank menu category to the upgrade path

### DIFF
--- a/SQL/New_patches/2026-09-03-biobank_menu_category.sql
+++ b/SQL/New_patches/2026-09-03-biobank_menu_category.sql
@@ -1,0 +1,17 @@
+-- The 27.0 to 28.0 upgrade activates the biobank module and installs its
+-- permissions, but the menu_categories table it creates in the same patch holds
+-- only the eight categories that predate biobank. The Biobank category itself
+-- was only ever added to the fresh install schema, so an upgraded instance runs
+-- an active module whose category does not exist, and every page raises
+-- "Menu category Biobank not found" before it renders.
+
+-- Guarded on the category being absent so that this changes nothing on a fresh
+-- install, or on a second run.
+UPDATE menu_categories
+   SET orderby = orderby + 1
+ WHERE orderby >= 6
+   AND (SELECT COUNT(*)
+          FROM (SELECT name FROM menu_categories) AS existing
+         WHERE existing.name = 'Biobank') = 0;
+
+INSERT IGNORE INTO menu_categories (name, orderby) VALUES ('Biobank', 6);


### PR DESCRIPTION
## Description

The 27.0 to 28.0 upgrade activates the biobank module and installs its permissions, but the `menu_categories` table it creates in that same patch only holds the eight categories that predate biobank. The Biobank category itself was only ever added to the fresh install schema in #9475, and no release patch inserts it.

So any instance that was upgraded rather than freshly installed ends up running an active biobank module whose menu category does not exist. `MenuCategory::singleton()` throws, and every page dies before it renders:

```
Uncaught LorisException: Menu category Biobank not found in src/GUI/MenuCategory.php:44
```

Fresh installs are fine, which is why this has gone unnoticed.

## Changes

- Added a patch that inserts the Biobank category and shifts Reports, Tools and Admin up one, so the ordering matches `SQL/0000-00-03-ConfigTables.sql`.
- The shift is guarded on the category being absent, so the patch does nothing on a fresh install or on a second run.

## Testing Instructions

1. On an instance that was upgraded rather than freshly installed, confirm that `SELECT * FROM menu_categories` returns eight rows with no Biobank, and that `SELECT Active FROM modules WHERE Name='biobank'` returns Y.
2. Load any page. It should fail with "Menu category Biobank not found".
3. Run `SQL/New_patches/2026-09-03-biobank_menu_category.sql`.
4. Load the page again. It should render, with Biobank sitting between Imaging and Reports in the menu.
5. Run the patch twice more and confirm `menu_categories` is unchanged.

## Related Issues

Introduced by #9475, which added the category to the fresh install schema only.
