### PR TITLE
[Core] Index candidate.CandID

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -181,6 +181,7 @@ CREATE TABLE `candidate` (
   `ProbandDoB` date DEFAULT NULL,
   UNIQUE KEY `ID` (`ID`),
   UNIQUE KEY `ExternalID` (`ExternalID`),
+  UNIQUE KEY `CandID` (`CandID`),
   KEY `FK_candidate_1` (`RegistrationCenterID`),
   KEY `CandidateActive` (`Active`),
   KEY `FK_candidate_2_idx` (`flagged_reason`),

--- a/SQL/New_patches/2026-09-03-candidate_candid_index.sql
+++ b/SQL/New_patches/2026-09-03-candidate_candid_index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CandID ON candidate (CandID);


### PR DESCRIPTION
## Description

`CandID` is the candidate identifier the application keys on, but the `candidate` table doesn't carry an index for it. It indexes `PSCID`, `ExternalID`, `Active`, `RegistrationCenterID`, `flagged_reason`, `Sex` and `ProbandSex`, but not `CandID`. So every lookup by CandID is a full table scan.

That stays invisible until something does a lot of them at once. The dataquery run endpoint resolves CandID to `candidate.ID` once per result row, batched 2000 rows at a time, so each batch does 2000 scans. On a 32,487 candidate instance that is 65 million row reads per batch.

Measured there, a batch went from 74.89 s to 0.32 s.

The index is unique, which is what `CandIDGenerator` already assumes. It picks a random ID, checks the table for a collision, and returns it for insertion. The check and the insert are separate statements, so what stopped two concurrent registrations landing on the same CandID was the primary key the table used to carry on that column. Since #9556 moved the primary key to `candidate.ID`, nothing has.

## Changes

- Added `UNIQUE KEY \`CandID\` (\`CandID\`)` to the `candidate` table in the install schema.
- Added the matching patch for existing instances.

## Testing Instructions

1. Run `EXPLAIN SELECT ID FROM candidate WHERE CandID = <some CandID>`. It should report a full table scan.
2. Apply the patch.
3. Run the same EXPLAIN. It should now use the `CandID` index.
4. In the Data Query Tool, select PSCID and run the query.
