### PR TITLE
[dataquery] Loading, empty and failed all look the same

### DIFF
--- a/jslib/fetchDataStream.js
+++ b/jslib/fetchDataStream.js
@@ -67,8 +67,12 @@ async function fetchDataStream(dataURL, rowcb, chunkcb, endstreamcb, method) {
 
   let remainder = [];
   let doneLoop = false;
+  let ended = false;
   while (!doneLoop) {
     await reader.read().then(({done, value}) => {
+      if (done) {
+        return {remainder: [], eos: true};
+      }
       let combined;
       if (remainder.length == 0) {
         combined = value;
@@ -83,7 +87,10 @@ async function fetchDataStream(dataURL, rowcb, chunkcb, endstreamcb, method) {
           combined[i+remainder.length] = value[i];
         }
       }
-      return processLines(combined, rowcb, endstreamcb);
+      return processLines(combined, rowcb, (row) => {
+        ended = true;
+        endstreamcb(row);
+      });
     }).then(({remainder: rem, eos}) => {
       chunkcb(eos);
       doneLoop = eos;
@@ -92,6 +99,13 @@ async function fetchDataStream(dataURL, rowcb, chunkcb, endstreamcb, method) {
       console.error(err);
       doneLoop = true;
     });
+  }
+
+  // The caller waits on the end of stream callback to know it can stop. A
+  // stream that errors, or that closes without its terminating byte, must
+  // still reach it or the caller waits forever.
+  if (!ended) {
+    endstreamcb([]);
   }
 }
 

--- a/modules/dataquery/jsx/hooks/usesharedqueries.tsx
+++ b/modules/dataquery/jsx/hooks/usesharedqueries.tsx
@@ -161,11 +161,8 @@ function useSharedQueries(): SharedQueriesType {
                 const queryObj: FlattenedQuery
                         = allQueries[queryRun.QueryID];
                 if (!queryObj) {
-                  console.error(
-                    'Could not get ',
-                    queryRun.QueryID,
-                    ' from ',
-                    allQueries);
+                  // The queries endpoint filters out queries the user cannot
+                  // access, so a run can reference one that is not in the list.
                   return;
                 }
                 convertedrecent.push({

--- a/modules/dataquery/jsx/viewdata.tsx
+++ b/modules/dataquery/jsx/viewdata.tsx
@@ -131,14 +131,12 @@ function ProgressBar(props: {type: string, value: number, max: number}) {
   const {t} = useTranslation('dataquery');
   switch (props.type) {
   case 'loading':
-    if (props.value == 0) {
-      return <h2>{t('Query not yet run', {ns: 'dataquery'})}</h2>;
-    }
     return (<div>
       <label htmlFor="loadingprogress">{t('Loading data:',
         {ns: 'dataquery'})}</label>
       <progress id="loadingprogress"
-        value={props.value} max={props.max}>
+        value={props.max > 0 ? props.value : undefined}
+        max={props.max > 0 ? props.max : undefined}>
         {t('{{value}} of {{max}} candidates',
           {ns: 'dataquery', value: props.value, max: props.max})}
       </progress>


### PR DESCRIPTION
## Description

A query that is running but has not returned a row yet renders "Query not yet run", because the loading bar treats a count of zero as nothing having happened. A query that legitimately returns no rows says the same thing.

A stream that errors, or that closes without its terminating byte, never reaches the end of stream callback. That callback is the only thing that clears the loading flag, so the page waits forever and shows nothing.

A run whose query the user cannot access is reported with `console.error`. The queries endpoint filters those out deliberately, so the condition is expected, and it fills the console on every page load.

## Changes

- The loading bar reports progress from the first render, and stays indeterminate until there is a total to measure against.
- `fetchDataStream` handles a reader that reports done, and reaches the end of stream callback on every exit path.
- A run referencing a query that is not in the accessible list is skipped without logging.

## Testing Instructions

1. Run a query in the Data Query Tool. From the first render it should read "Loading data:" and never "Query not yet run".
2. Open the browser console on the main page. There should be no "Could not get" entries.


## Related Issues

Covers half of #9829, the misleading state. The error message and the re-run button are in #11195.
