### PR TITLE
[Core] Add design tokens and a design system document

### DIFF
--- a/docs/DesignSystem.md
+++ b/docs/DesignSystem.md
@@ -1,0 +1,395 @@
+# Design system
+
+This document covers how LORIS looks and how to style something new. The values themselves live in
+[`htdocs/css/tokens.css`](../htdocs/css/tokens.css), which every page loads. See
+[CodingStandards.md](CodingStandards.md) for language conventions.
+
+## Principles
+
+**Serious, not severe.** People use LORIS to find data they will build papers on. Nothing should read
+as playful or provisional. That means restraint rather than greyness: one accent colour, generous
+spacing, and no decoration that is not carrying information.
+
+**Familiar before novel.** LORIS is deployed at institutions that trained their staff on it. A change
+that makes people relearn where things are has failed however good it looks. Improve the quality of a
+control, and keep its position and its meaning.
+
+**Density is a feature.** This is data software, and users want more on screen rather than less. Size
+controls to their content. Do not spend vertical space on decoration.
+
+**One component, used everywhere.** Every bespoke control becomes a future inconsistency. When a
+shared component cannot do what you need, extend it so the whole application gains the capability. A
+change that touches many screens because one component improved is a good change.
+
+## Never hardcode a value
+
+Colours, spacing, radii and shadows come from `tokens.css`. If you are typing a hex value or a pixel
+measurement into a component, stop and use a token. If no token fits, add one. That is a signal the
+system was missing something, not that your component is special.
+
+```css
+/* No */
+.thing { background: #eaf1f8; border-radius: 4px; padding: 8px; }
+
+/* Yes */
+.thing {
+    background: var(--loris-color-accent-fill);
+    border-radius: var(--loris-radius);
+    padding: var(--loris-space-md);
+}
+```
+
+### Two layers, and only one of them is for you
+
+`tokens.css` holds a **palette** naming colours for what they are (`--loris-blue-700`,
+`--loris-grey-300`) and **roles** naming them for the job they do (`--loris-color-accent`,
+`--loris-border`, `--loris-text-muted`).
+
+**Components reference roles, never the palette.** Repointing a role then restyles everything that
+plays that part, instead of requiring a search through components. Adding a palette entry is rare and
+deliberate. It means LORIS genuinely has a new colour.
+
+### Three strengths of a colour
+
+A hue is used at up to three strengths, and the role names say which job each one does.
+
+| Strength | What it is | Used for |
+|---|---|---|
+| **solid** | The colour itself | A border, an icon, a filled button, text |
+| **fill** | A tint you can see is coloured | The ground something sits on: a selected row, a tag |
+| **highlight** | Barely there | Hover, and nothing else |
+
+A hue gets a step because something needs it, not for symmetry. Only the blue has all three: it is
+the only one that draws a hover, and the highlight exists for nothing else.
+
+## Colour
+
+This is not starting from nothing. `htdocs/bootstrap/css/custom-css.css` has carried a header called
+"Loris color palette v.0.1" for years, declaring two blues and an orange. It stalled because it lived
+in a comment where no code could reference it, and because it handed everything else to Bootstrap.
+What follows makes it real.
+
+### Blue, the primary
+
+The two declared blues anchor the scale. The darkest is already the pressed state of every primary
+button, and the two lightest are the tints used for highlights and hovered rows.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/blue-900.svg) | `--loris-blue-900` | `#042d54` | Pressed |
+| ![](images/palette/blue-700.svg) | `--loris-blue-700` | `#064785` | Navigation, panel headings |
+| ![](images/palette/blue-500.svg) | `--loris-blue-500` | `#246eb6` | Lighter blue |
+| ![](images/palette/blue-100.svg) | `--loris-blue-100` | `#e4ebf2` | Fill, selected row |
+| ![](images/palette/blue-50.svg) | `--loris-blue-50` | `#f3f6f9` | Highlight, hovered row |
+
+### Sky, the information colour
+
+The same hue as the navy carried light and saturated instead of dark. This is not a new colour: the
+biobank has drawn its live layer in it for years, with `.node.available`, `.node.selected` and its
+hover borders all `#a6d3f5` against the navy for what is already filled. What is new is that it has
+a name and a second step.
+
+Two steps, and it should stay at two. A third would be a highlight, its highlight works out at
+`#edf6fd` against `#f3f6f9` for the accent's, and a difference of 6, 0, 4 is not a difference. It
+needs none in any case: a highlight only ever means hover, and hover belongs to the accent.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/sky.svg) | `--loris-sky` | `#a6d3f5` | Help, notices, a standing rule |
+| ![](images/palette/sky-100.svg) | `--loris-sky-100` | `#d6eafa` | Information ground |
+
+### Orange, the secondary
+
+The attention colour, and the scarce one. It marks a state the interface is only passing through, or
+one that is governing what other actions will do: the run a drag is sweeping over, a rule now
+standing, a switch that is on. Two steps, because it never draws a hover, and no darker one.
+Darkening an orange this saturated makes it look burnt rather than deep.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/orange.svg) | `--loris-orange` | `#e89a0c` | Active border, switch that is on |
+| ![](images/palette/orange-100.svg) | `--loris-orange-100` | `#fdf2dc` | Active ground |
+
+### Purple, the tertiary
+
+Present in electrophysiology as an event badge. It carries no fixed meaning, which makes it the one
+available for telling categories apart where blue and orange are already spoken for. Two steps, for
+the same reason as the orange. The middle tints of a purple this saturated turn fuchsia.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/purple.svg) | `--loris-purple` | `#690096` | Categorical |
+| ![](images/palette/purple-100.svg) | `--loris-purple-100` | `#f2e6f7` | Categorical ground |
+
+### Semantic colours
+
+These are named for the colour they are, because their meanings are already fixed. Red means
+something failed wherever it appears. What matters is that it is the same red everywhere.
+
+| | Token | Hex | Meaning |
+|---|---|---|---|
+| ![](images/palette/green.svg) | `--loris-green` | `#0f9d58` | Success |
+| ![](images/palette/red.svg) | `--loris-red` | `#c0402a` | Error |
+| ![](images/palette/amber.svg) | `--loris-amber` | `#d17a00` | Warning |
+| ![](images/palette/sky.svg) | `--loris-sky` | `#a6d3f5` | Information |
+
+Warning is deliberately not the same orange as the secondary. If a standing rule were the colour of
+a warning, neither would mean anything.
+
+### Grey
+
+| | Token | Hex |
+|---|---|---|
+| ![](images/palette/grey-1000.svg) | `--loris-grey-1000` | `#000000` |
+| ![](images/palette/grey-800.svg) | `--loris-grey-800` | `#333333` |
+| ![](images/palette/grey-600.svg) | `--loris-grey-600` | `#666666` |
+| ![](images/palette/grey-500.svg) | `--loris-grey-500` | `#999999` |
+| ![](images/palette/grey-300.svg) | `--loris-grey-300` | `#cccccc` |
+| ![](images/palette/grey-250.svg) | `--loris-grey-250` | `#dddddd` |
+| ![](images/palette/grey-150.svg) | `--loris-grey-150` | `#efefef` |
+| ![](images/palette/grey-50.svg) | `--loris-grey-50` | `#f8f8f8` |
+| ![](images/palette/white.svg) | `--loris-white` | `#ffffff` |
+
+### Colours being retired
+
+| Colour | Where it is | What happens to it |
+|---|---|---|
+| `#093782` | `modules/biobank`, `modules/dqt` | A second navy, a shade off `--loris-blue-700`. Use the token. |
+| `#ff9a24` | `modules/dqt` | Use `--loris-orange`. |
+| `#e98430` | `modules/biobank` | Use `--loris-orange`. |
+| `#d54a08` | `modules/electrophysiology_browser` | Use `--loris-orange`. |
+| `#fa5705` | `modules/brainbrowser` | Use `--loris-orange`. |
+
+Four oranges for one idea, in four modules, none of them the orange the palette declares.
+
+`#1c70b6` is a separate case and is not on this list. It is the blue bootstrap itself is compiled
+with, recorded in `htdocs/bootstrap/config.json`, so it is a deliberate choice rather than module
+drift. It sits a shade off `--loris-blue-500`, and the two should be reconciled the next time
+bootstrap is rebuilt rather than by editing the compiled stylesheet.
+
+## The three states
+
+A surface answers three questions, and it answers them the same way wherever it is. Use the state
+roles rather than reaching for a hue, so that no two screens drift apart.
+
+| State | Role | Says |
+|---|---|---|
+| **Hover** | `--loris-state-hover` | Where the pointer is. It follows the cursor, covers a lot of ground and goes as soon as the pointer moves, so it is the lightest step there is. |
+| **Selected** | `--loris-state-selected`, `--loris-state-selected-solid` | What is chosen. It is settled, nothing is happening to it, and it sits one step up from hover in the same blue. |
+| **Active** | `--loris-state-active`, `--loris-state-active-solid` | Something is being passed through rather than rested in, and is about to change on release. The only state drawn in the secondary, and deliberately rare. |
+
+The distinction that matters, and the one that is easy to get wrong, is between **selected** and
+**active**.
+
+A ticked row in a dropdown is selected. It is a settled choice, it sits there, and it changes nothing
+outside itself.
+
+Active is **intermediary**: a state the interface is passing through rather than resting in, such as
+the run a drag is sweeping over before the pointer comes up. Those rows are neither chosen nor idle,
+they are about to change, and the stroke has to show its consequence while it is still being made.
+
+A rule that is merely standing is not this, and the difference is worth holding onto. The switch that
+makes every field added from now on take the visits currently chosen changes nothing you can see when
+you throw it. What it changes is what the *next* action means, and that is **information**: it is
+`--loris-color-info`, the sky, alongside help text and notices. Nothing is in flight, so nothing is
+orange.
+
+The test to apply: **is this on its way somewhere?** If it resolves the moment the user lets go, it is
+active. If it will still be true tomorrow and governs what other actions do, it is information. If it
+is simply a choice at rest, it is selected.
+
+Spending the orange on ordinary selection is the failure mode. It is loud on purpose, and a screen
+where everything chosen is orange has nothing left to say when something really is in flight.
+
+Two more things follow:
+
+**A button has no selected state**, because it is an action rather than something that can be
+chosen. Its hover moves the outline and the label and leaves the ground where it is. Filling a
+button on hover puts its label on a colour the label was never chosen against, and the orange in
+particular carries neither white text nor its own.
+
+**The navigation bar is the exception.** It sits on the dark blue, where no wash of the accent would
+show at all, so it keeps the orange that `@accent-color-hover` declared for it. Nothing on a light
+ground should follow it.
+
+## Colour that carries meaning
+
+LORIS is used all day by people who did not choose their monitor, in rooms with the lights on, and by
+people who do not separate hues the way the person picking the colours does. Around one man in twelve
+has some form of colour vision deficiency. None of that is an edge case in software someone uses for
+their job.
+
+Three rules, in the order they get broken.
+
+### 1. Never let colour be the only difference
+
+This is the one that matters most, and the one this system relies on. The state grounds are
+deliberately close together: hover, selected and active sit within 1.1 of each other in contrast
+terms, because they are washes rather than signals. That is fine, and only fine, because none of them
+is carrying the meaning alone.
+
+| State | The ground | What carries it besides the ground |
+|---|---|---|
+| Hover | `--loris-state-hover` | The pointer is on it. It is not information, it is feedback. |
+| Selected | `--loris-state-selected` | A bar down the left edge, a heavier label, and a ticked control |
+| Active | `--loris-state-active` | A bar down the left edge, and the buttons that will consume it change with it |
+| Switch on | `--loris-color-info` | The thumb is at the other end of the track |
+
+If you remove the colour from any row above, the interface still says the same thing. Build to that
+test. A ground is an amplifier, never the message.
+
+### 2. Text on a fill reaches 4.5:1
+
+Every combination the system produces clears it with room to spare, because the fills are pale and
+the text is dark. Measured:
+
+| | Ratio |
+|---|---|
+| `--loris-text` on any state ground | 10.2 to 11.7 |
+| `--loris-text-muted` on the hover ground | 5.3 |
+| White on `--loris-color-accent` | 9.3 |
+| `--loris-color-accent` on white | 9.3 |
+
+The rule bites when someone reaches for a solid as a text colour. `--loris-orange` on white is
+**2.3**, and `--loris-sky` on white is **1.6**. Neither is a text colour. They are grounds and marks.
+
+### 3. A control's own shape reaches 3:1
+
+A button, a track, a checkbox or a focus ring has to be findable against what is behind it, which is
+a different requirement from the text inside it. This is where the pale colours fail, and it is not
+optional:
+
+| | Against white | |
+|---|---|---|
+| `--loris-sky` | 1.58 | fails |
+| `--loris-grey-300` | 1.6 | fails |
+| `--loris-orange` | 2.32 | fails |
+| `--loris-blue-500` | 5.28 | passes |
+| `--loris-grey-600` | 5.74 | passes |
+
+So a control drawn in a pale colour needs an edge drawn in something that passes. The switch is the
+worked example: its track is the sky when on and a grey when off, and both carry an inset ring
+(`--loris-color-info-edge`, `--loris-control-off-edge`) so the control is findable whatever it is
+doing. Draw the ring inside, with `inset`, so turning it on does not move anything.
+
+There is a second reason the switch is built that way. The sky and the light grey it originally
+replaced have relative luminances of 0.613 and 0.604 — near enough identical that on and off differed
+in hue and in nothing else, which is to say they did not differ at all for a reader who cannot
+separate the two. **Two states must never differ in hue alone.** Change the lightness too.
+
+### When a colour has to move
+
+If a value cannot meet these, change the value rather than the rule, and change it in `tokens.css` so
+everything moves together. Adapting a hue's saturation or lightness to make it work is a normal thing
+to do here, not a compromise.
+
+## Type
+
+LORIS inherited Bootstrap's Helvetica and Arial stack, which nobody chose and which shows a different
+typeface depending on the operating system. Two deliberate choices replace it. Neither downloads
+anything.
+
+| Token | Face | Used for |
+|---|---|---|
+| `--loris-font-family` | The operating system's own interface face | Labels, descriptions, buttons, headings |
+| `--loris-font-family-mono` | The system monospace | Identifiers |
+
+### When to use the monospace
+
+Monospace marks **a value someone might copy or transcribe**. It does not mark "a technical thing".
+Used sparingly it tells a reader something. Used everywhere it stops meaning anything, and the page
+gets louder for no benefit.
+
+Use it for:
+
+1. Identifiers a person reads character by character. PSCIDs, DCCIDs, visit labels, barcodes.
+2. Values that get copied into another system, a spreadsheet or an email.
+3. Raw stored values where the exact characters matter, such as a filename or a path.
+
+Do not use it for:
+
+1. Field and column names. Underscores and word shapes already make
+   `alcohol_use_disorders_identification_testconcise_a_auditc_q1` unambiguous, so the monospace adds
+   nothing and spends a signal that is then unavailable where it is needed.
+2. Counts and summaries. `All (354)` describes a selection, it is not one of the values in it.
+3. Anything a person reads as a sentence, including descriptions and help text.
+
+The test to apply: **would someone need to reproduce these exact characters somewhere else?** If yes,
+use the monospace. If they are only reading it, do not.
+
+## Where styles live
+
+| What | Where |
+|---|---|
+| Values shared by more than one component | `htdocs/css/tokens.css` |
+| A component's own appearance | A stylesheet beside it, imported by it, such as `jsx/Select.css` |
+| A module's own layout | `modules/<module>/css/`, imported by the JSX |
+| Anything with a `:hover`, `:focus` or `:disabled` state | A stylesheet, never an inline style |
+
+Inline styles cannot express states or media queries. Use them only for values computed at runtime.
+
+## Bootstrap
+
+LORIS is built on Bootstrap 3, which has had no security patches since 2019. It is not being removed,
+because that would touch every module. **Do not build on it in new components.** Give a new component
+its own appearance from tokens. Bootstrap continues to serve what it already serves, and its share
+shrinks as components are replaced.
+
+This is not only about the end of life date. Borrowing a Bootstrap class and then laying it out
+differently puts you in a specificity fight. `.form-control` sets `display: block`, `.input-group`
+sets `display: table`, and `.list-group-item.active` sets `z-index: 2`, all of which beat an equally
+specific rule of your own on source order. If you have to override one, qualify the selector with the
+element, as in `button.my-trigger`, rather than reaching for `!important`. If your component owns its
+layout outright, the conflict does not arise at all.
+
+## Components
+
+The shared controls live in `jsx/` and take no label, form row or offset of their own, so they can be
+placed anywhere.
+
+- **`Select`** is a selection shown as a dropdown over a searchable list. It holds many values, or one
+  with `multiple={false}`. Options can be grouped to order the most relevant first. Set `mono` when
+  the options are identifiers.
+- **`Textbox`** is a single line text input. With `search` it gains a magnifier and a control to clear
+  it.
+- **`Toggle`** is a boolean, drawn either as a switch or as a checkbox.
+- **`Button`** performs an action, in one of four displays: `primary`, `secondary`, `quiet` or
+  `danger`.
+
+`Form.js` wraps these for use inside a form, adding the label, row and error message. If you need a
+control outside a form, use the component directly rather than fighting the wrapper's layout.
+
+### A prop, not a new component
+
+Where two controls differ by one boolean, they are one component. A multiple selection is a select
+with `multiple`. A search box is a text input with `search`. A switch and a checkbox are one boolean
+with two displays. Splitting them is how a codebase ends up with several implementations of one idea.
+
+## Labels on controls
+
+`Select` and `Textbox` accept a `label` that sits inside the field while it is empty and rises onto
+its top edge once it is not. The border carries a real gap for it, so the label needs no backdrop and
+works on any colour behind it.
+
+Use this in toolbars and dense control strips, where a row of labels would cost vertical space and
+turn a toolbar back into a form. Do not use it in ordinary forms. A plain label above the field costs
+nothing there and stays full size, and shrinking it trades legibility for tidiness that is not
+scarce.
+
+## Still open
+
+These have not been decided. A change that touches them should say so rather than settle them
+quietly.
+
+1. Where `--loris-color-primary` applies. The navy is the brand colour but currently has no consumer,
+   because actions all use the accent blue.
+2. A density scale. Control heights are inherited at 34px rather than chosen.
+3. Whether the information colour is right for help text and notices as well as for standing rules.
+   The family was introduced for the second and is documented for all three, but only the standing
+   rules have a consumer so far. If help surfaces end up wanting something else, this splits again.
+4. Whether the purple takes any of this. It is currently only categorical, and no case has been
+   named for it.
+5. The hardcoded orange hover still in the navbar dropdowns at the top of `custom-css.css`. On the
+   dark navbar the orange is right, but those menus open on white, where it does not have the
+   contrast to be read. Fixing it means changing the most familiar surface in LORIS, so it is worth
+   deciding rather than doing.

--- a/docs/images/palette/amber.svg
+++ b/docs/images/palette/amber.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="amber #d17a00"><rect width="120" height="44" rx="4" fill="#d17a00" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-100.svg
+++ b/docs/images/palette/blue-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-100 #e4ebf2"><rect width="120" height="44" rx="4" fill="#e4ebf2" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-50.svg
+++ b/docs/images/palette/blue-50.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-50 #f3f6f9"><rect width="120" height="44" rx="4" fill="#f3f6f9" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-500.svg
+++ b/docs/images/palette/blue-500.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-500 #246eb6"><rect width="120" height="44" rx="4" fill="#246eb6" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-700.svg
+++ b/docs/images/palette/blue-700.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-700 #064785"><rect width="120" height="44" rx="4" fill="#064785" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-900.svg
+++ b/docs/images/palette/blue-900.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-900 #042d54"><rect width="120" height="44" rx="4" fill="#042d54" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/green.svg
+++ b/docs/images/palette/green.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="green #0f9d58"><rect width="120" height="44" rx="4" fill="#0f9d58" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-1000.svg
+++ b/docs/images/palette/grey-1000.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-1000 #000000"><rect width="120" height="44" rx="4" fill="#000000" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-150.svg
+++ b/docs/images/palette/grey-150.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-150 #efefef"><rect width="120" height="44" rx="4" fill="#efefef" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-250.svg
+++ b/docs/images/palette/grey-250.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-250 #dddddd"><rect width="120" height="44" rx="4" fill="#dddddd" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-300.svg
+++ b/docs/images/palette/grey-300.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-300 #cccccc"><rect width="120" height="44" rx="4" fill="#cccccc" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-50.svg
+++ b/docs/images/palette/grey-50.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-50 #f8f8f8"><rect width="120" height="44" rx="4" fill="#f8f8f8" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-500.svg
+++ b/docs/images/palette/grey-500.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-500 #999999"><rect width="120" height="44" rx="4" fill="#999999" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-600.svg
+++ b/docs/images/palette/grey-600.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-600 #666666"><rect width="120" height="44" rx="4" fill="#666666" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-800.svg
+++ b/docs/images/palette/grey-800.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-800 #333333"><rect width="120" height="44" rx="4" fill="#333333" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/orange-100.svg
+++ b/docs/images/palette/orange-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="orange-100 #fdf2dc"><rect width="120" height="44" rx="4" fill="#fdf2dc" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/orange.svg
+++ b/docs/images/palette/orange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="orange #e89a0c"><rect width="120" height="44" rx="4" fill="#e89a0c" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/purple-100.svg
+++ b/docs/images/palette/purple-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="purple-100 #f2e6f7"><rect width="120" height="44" rx="4" fill="#f2e6f7" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/purple.svg
+++ b/docs/images/palette/purple.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="purple #690096"><rect width="120" height="44" rx="4" fill="#690096" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/red.svg
+++ b/docs/images/palette/red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="red #c0402a"><rect width="120" height="44" rx="4" fill="#c0402a" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/sky-100.svg
+++ b/docs/images/palette/sky-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="sky-100 #d6eafa"><rect width="120" height="44" rx="4" fill="#d6eafa" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/sky.svg
+++ b/docs/images/palette/sky.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="sky #a6d3f5"><rect width="120" height="44" rx="4" fill="#a6d3f5" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/white.svg
+++ b/docs/images/palette/white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="white #ffffff"><rect width="120" height="44" rx="4" fill="#ffffff" stroke="#00000022" stroke-width="1"/></svg>

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -933,3 +933,118 @@ select[multiple].input-sm.resizable {
     height: 100px;
     resize: both;
 }
+
+
+/*******************************
+States, drawn from the palette
+
+Bootstrap draws the hover and selected states for every surface it still owns,
+in its own colours rather than ours, so a page mixes colours nobody chose with
+colours we did. The rules below map the states bootstrap draws most often onto
+the tokens in htdocs/css/tokens.css.
+
+Hover and selection are two different questions, so they get two different
+steps of the accent. Hover says where the pointer is and goes as soon as it
+moves, so it is the lightest step there is. Selection says what is chosen, and
+sits one step up.
+
+Neither is the secondary. The orange is kept for the one case that asks to be
+noticed: something in effect because of what the user did. Nothing bootstrap
+draws here qualifies, so nothing here is orange.
+
+The navigation bar is the exception. It sits on the dark blue, where no wash of
+the accent would show at all, so it keeps the orange declared for it at the top
+of this file.
+
+This section is deliberately narrow: hover, focus, and the selected row. Do not
+add to it to avoid writing a component properly. It shrinks as surfaces are
+converted and goes when bootstrap does.
+
+See docs/DesignSystem.md.
+****************************************/
+
+/* ---- Links --------------------------------------------------------- */
+
+a:hover,
+a:focus {
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Navigation and menus ------------------------------------------ */
+
+.nav > li > a:hover,
+.nav > li > a:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-color-accent-strong);
+}
+
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Rows and lists ------------------------------------------------ */
+
+.table-hover > tbody > tr:hover {
+    background-color: var(--loris-state-hover);
+}
+
+a.list-group-item:hover,
+a.list-group-item:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-text);
+}
+
+/* Marked the way a chosen row is marked in the select, so a list built from
+   bootstrap and a list built from a component say the same thing. */
+.list-group-item.active,
+.list-group-item.active:hover,
+.list-group-item.active:focus {
+    background-color: var(--loris-state-selected);
+    border-color: var(--loris-border-divider);
+    box-shadow: inset 3px 0 0 var(--loris-state-selected-solid);
+    color: var(--loris-text);
+}
+
+/* ---- Buttons ------------------------------------------------------- */
+
+/* Hover moves the outline and the label, and leaves the ground where it is. A
+   button is an action rather than something that can be chosen, so it has no
+   selected state to be told apart from, and filling it on hover would put the
+   label on a colour it was never chosen against. */
+.btn-default:hover,
+.btn-default:focus {
+    background-color: var(--loris-state-hover);
+    border-color: var(--loris-color-accent-strong);
+    color: var(--loris-color-accent-strong);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: var(--loris-color-accent-strong);
+    border-color: var(--loris-color-accent-strong);
+}
+
+.btn-link:hover,
+.btn-link:focus {
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Pagination ---------------------------------------------------- */
+
+.pagination > li > a:hover,
+.pagination > li > a:focus {
+    color: var(--loris-color-accent-strong);
+    background-color: var(--loris-state-hover);
+    border-color: var(--loris-border-divider);
+}
+
+/* The page you are on is not a choice you can change your mind about later, it
+   is where you are, so it takes the accent solid rather than a selected tint. */
+.pagination > .active > a,
+.pagination > .active > a:hover,
+.pagination > .active > a:focus {
+    background-color: var(--loris-color-accent);
+    border-color: var(--loris-color-accent);
+}

--- a/htdocs/css/tokens.css
+++ b/htdocs/css/tokens.css
@@ -1,0 +1,221 @@
+/**
+ * Design tokens.
+ *
+ * The single source of truth for the values components style themselves with.
+ * Nothing below should be repeated as a literal anywhere else.
+ *
+ * There are two layers, and the distinction matters:
+ *
+ *   Palette  - the raw colours LORIS is built from. Named for what they are.
+ *              Add to these rarely, and only for a colour the product really
+ *              has.
+ *   Roles    - what a colour is for. Named for the job, not the hue.
+ *              Components reference these, never the palette, so that
+ *              restyling means repointing a role rather than hunting through
+ *              components.
+ *
+ * A component with a value nothing else shares keeps it in its own stylesheet,
+ * built from these. Anything two components would both want belongs here.
+ *
+ * Loaded on every page from main.tpl and public_layout.tpl.
+ *
+ * docs/DesignSystem.md explains how to use these and when to add one.
+ */
+:root {
+    /* ---- Palette ------------------------------------------------- */
+
+    /* Blue, the primary. The middle pair is what "Loris color palette v.0.1"
+       at the head of custom-css.css has declared all along. */
+    --loris-blue-900: #042d54;
+    --loris-blue-700: #064785;
+    --loris-blue-500: #246eb6;
+    --loris-blue-100: #e4ebf2;
+    --loris-blue-50: #f3f6f9;
+
+    /* Sky, the information colour. The same hue as the navy, carried light and
+       saturated instead of dark, which is how the biobank has drawn its live
+       layer for years: an available slot, a hovered container and a lifecycle
+       line are all this, against the navy for what is already filled. Two
+       steps. A third would be a highlight, and a highlight only ever means
+       hover, which belongs to the accent. */
+    --loris-sky: #a6d3f5;
+    --loris-sky-100: #d6eafa;
+
+    /* Orange, the secondary. The colour the same palette declared. Two steps,
+       because it never draws a hover and so never needs a highlight. */
+    --loris-orange: #e89a0c;
+    --loris-orange-100: #fdf2dc;
+
+    /* Purple, the tertiary. Unclaimed, so it is what tells categories apart.
+       Two steps, because nothing it marks is hovered. */
+    --loris-purple: #690096;
+    --loris-purple-100: #f2e6f7;
+
+    /* Named for the colour they are, because the meanings are already fixed. */
+    --loris-green: #0f9d58;
+    --loris-red: #c0402a;
+    --loris-amber: #d17a00;
+
+    /* Grey, black to white */
+    --loris-grey-1000: #000;
+    --loris-grey-800: #333;
+    --loris-grey-600: #666;
+    --loris-grey-500: #999;
+    --loris-grey-300: #ccc;
+    --loris-grey-250: #ddd;
+    --loris-grey-150: #efefef;
+    --loris-grey-50: #f8f8f8;
+    --loris-white: #fff;
+
+    /* ---- Roles --------------------------------------------------- */
+
+    /* Actions. LORIS's bootstrap is already compiled with the navy, so this is
+       what every existing button is drawn in.
+
+       A hue is used at three strengths, and the names say which job each does:
+
+         solid      - the colour itself, for a border, an icon, a filled
+                      button or text.
+         fill       - a tint you can see is coloured, for a ground something
+                      sits on.
+         highlight  - barely there, and only ever for hover.
+
+       A hue gets a step because something needs it, not for symmetry. */
+    --loris-color-accent: var(--loris-blue-700);
+    --loris-color-accent-strong: var(--loris-blue-900);
+    --loris-color-accent-border: var(--loris-blue-500);
+    --loris-color-accent-fill: var(--loris-blue-100);
+    --loris-color-accent-highlight: var(--loris-blue-50);
+
+    --loris-color-secondary: var(--loris-orange);
+    --loris-color-secondary-fill: var(--loris-orange-100);
+
+    /* Information sits with the other meanings rather than with the states,
+       because that is what it is: it marks what is there to help, and what is
+       true right now and governs what the next action will do. Help and
+       notices, and the standing rules a screen is operating under. */
+    --loris-color-info: var(--loris-sky);
+    --loris-color-info-fill: var(--loris-sky-100);
+
+    /* The sky is too light to define a shape against a white page on its own:
+       it reaches 1.58 against white where a control needs 3. This is the edge
+       to draw round it when it has to be seen as a control rather than only
+       as a colour. It is the accent's lighter blue, the same hue carried
+       darker, rather than a new step that would sit a few percent from it. */
+    --loris-color-info-edge: var(--loris-blue-500);
+
+    --loris-color-warning: var(--loris-amber);
+    --loris-color-success: var(--loris-green);
+    --loris-danger: var(--loris-red);
+    --loris-danger-strong: var(--loris-red);
+
+    /* States. Three questions a surface answers, and it answers them the same
+       way wherever it is.
+
+       Hover says where the pointer is. It follows the cursor, covers a lot of
+       ground and goes as soon as the pointer moves, so it is the lightest step
+       there is.
+
+       Selected says what is chosen. It is settled, nothing is happening to it,
+       and nobody needs to look at it, so it stays in the accent one step up
+       from hover.
+
+       Active is a state being passed through rather than rested in: the run a
+       drag is sweeping over before the pointer comes up, work about to happen
+       on release. It is the only state drawn in the secondary, and it is
+       deliberately rare. A rule that is merely standing is not this. That is
+       information, and it is drawn in the sky. */
+    --loris-state-hover: var(--loris-color-accent-highlight);
+    --loris-state-selected: var(--loris-color-accent-fill);
+    --loris-state-selected-solid: var(--loris-color-accent);
+    --loris-state-active: var(--loris-color-secondary-fill);
+    --loris-state-active-solid: var(--loris-color-secondary);
+
+    /* Surfaces */
+    --loris-surface: var(--loris-white);
+    --loris-surface-sunken: var(--loris-grey-50);
+
+    /* Borders */
+    --loris-border: var(--loris-grey-300);
+    --loris-border-subtle: var(--loris-grey-150);
+    --loris-border-divider: var(--loris-grey-250);
+
+    /* Text */
+    --loris-text: var(--loris-grey-800);
+    --loris-text-muted: var(--loris-grey-600);
+    --loris-text-faint: var(--loris-grey-500);
+    --loris-text-disabled: var(--loris-grey-300);
+
+    /* Controls. The off track is darker than a border grey on purpose. A
+       switch turned on is the sky, whose relative luminance is 0.613 against
+       0.604 for the light grey this replaced, so on and off would have
+       differed in hue and in nothing else, and said nothing at all to a reader
+       who cannot separate the two. */
+    --loris-control-off: var(--loris-grey-500);
+    --loris-control-off-edge: var(--loris-grey-600);
+
+    /* Elevation */
+    --loris-shadow-overlay: 0 6px 18px rgba(0, 0, 0, .18);
+    --loris-shadow-raised: 0 1px 2px rgba(0, 0, 0, .3);
+
+    /* The look of a field. Owned here rather than inherited from bootstrap, so
+       that a control placed outside a form still matches one inside it. */
+    --loris-field-bg: var(--loris-white);
+    --loris-field-border: var(--loris-grey-300);
+    --loris-field-border-focus: var(--loris-blue-500);
+    --loris-field-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+
+    /* Kept apart from the shadow because a field whose border is drawn by
+       something else still wants the glow, and an inset shadow would draw a
+       line across whatever sits on the top edge. */
+    --loris-field-glow-focus: 0 0 8px rgba(36, 110, 182, .5);
+    --loris-field-shadow-focus: var(--loris-field-shadow),
+                                var(--loris-field-glow-focus);
+    --loris-field-padding: 6px 12px;
+
+    /* ---- Shape, spacing and type --------------------------------- */
+
+    /* Corners. Anything rounded uses one of these. */
+    --loris-radius: 4px;
+    --loris-radius-sm: 3px;
+
+    /* Spacing steps used for laying controls out against one another */
+    --loris-space-xs: 4px;
+    --loris-space-sm: 6px;
+    --loris-space-md: 8px;
+    --loris-space-lg: 10px;
+    --loris-space-xl: 16px;
+
+    /* Type. These record what LORIS already sets rather than proposing
+       anything: the family, size and line height come from bootstrap's base,
+       which every page inherits. Components should reference these instead of
+       relying on inheritance, so that changing type once changes it
+       everywhere. */
+    /* The interface uses the operating system's own face: native everywhere,
+       nothing to download, and quiet enough to disappear behind the work. */
+    --loris-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                         "Helvetica Neue", Arial, sans-serif;
+
+    /* Identifiers use a monospace instead. A PSCID, a visit label or a field
+       name is read character by character and often transcribed, so the
+       characters that a proportional face lets collide -- I, l and 1, O and 0
+       -- have to stay apart. */
+    --loris-font-family-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+                              Consolas, "Liberation Mono", monospace;
+    --loris-font-size: 14px;
+    --loris-font-size-sm: 12px;
+    --loris-font-size-xs: 11px;
+    --loris-line-height: 1.42857143;
+
+    /* Height of a control sitting in a row with a form-control */
+    --loris-control-height: 34px;
+    --loris-control-height-sm: 30px;
+}
+
+/* The application inherits its type from bootstrap, which nobody chose and
+   which renders differently per operating system. Setting it here means one
+   place decides. Qualified with html so it does not depend on this sheet
+   loading after bootstrap's. */
+html body {
+    font-family: var(--loris-font-family);
+}

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -4,6 +4,7 @@
     <head>
         <link rel="stylesheet" href="{$baseurl}/{$css}" type="text/css" />
         <link rel="stylesheet" href="{$baseurl}/fontawesome/css/all.css" type="text/css" />
+        <link rel="stylesheet" href="{$baseurl}/css/tokens.css" type="text/css" />
         <link rel="stylesheet" href="{$baseurl}/css/tooltip.css" type="text/css" />
         <link type="image/x-icon" rel="icon" href="/images/favicon.ico">
 

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -9,6 +9,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{$study_title}</title>
+  <link rel="stylesheet" href="{$baseurl}/css/tokens.css" type="text/css" />
   <link rel="stylesheet" href="{$baseurl}/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="{$baseurl}/css/public_layout.css">
   <link type="image/x-icon" rel="icon" href="{$baseurl}/images/favicon.ico">


### PR DESCRIPTION
## Description

LORIS has no shared source for its colours. `htdocs/bootstrap/css/custom-css.css` has carried a header called "Loris color palette v.0.1" for years, declaring `#064785`, `#246EB6` and `#E89A0C`, but it sits in a comment where no code can reference it. So modules pick their own. There are four different oranges in the tree, in biobank, dqt, electrophysiology_browser and brainbrowser, and none of them is the declared one.

This adds `htdocs/css/tokens.css`, loaded on every page, and a document explaining how to use it.

The tokens come in two layers. A palette names colours for what they are, `--loris-blue-700` and `--loris-sky`. Roles name them for the job, `--loris-color-accent` and `--loris-state-hover`. Components reference roles, so restyling means repointing a role rather than searching through modules.

`custom-css.css` gains a section drawing the states bootstrap still owns, hover and selection, from those roles. Bootstrap draws them in its own palette otherwise, so a page mixes colours nobody chose with colours we did.

## Changes

- Added `htdocs/css/tokens.css`, loaded from `main.tpl` and `public_layout.tpl`.
- Added `docs/DesignSystem.md` and the palette swatches it references.
- Added a states section to `custom-css.css` mapping bootstrap's hover and selected states onto the tokens.

## Testing Instructions

1. Load any page and confirm `css/tokens.css` is fetched.
2. Hover a row in a table. It should take a pale blue rather than bootstrap's grey.
3. Hover a `.btn-default`. Its border and label should change and its background should stay near white.
4. Open a page with a selected `.list-group-item` and confirm it is the accent blue with a bar down its left edge.
