### PR TITLE
[JSX] Add unwrapped Select, Textbox, Toggle and Button

### DIFF
--- a/docs/DesignSystem.md
+++ b/docs/DesignSystem.md
@@ -1,0 +1,395 @@
+# Design system
+
+This document covers how LORIS looks and how to style something new. The values themselves live in
+[`htdocs/css/tokens.css`](../htdocs/css/tokens.css), which every page loads. See
+[CodingStandards.md](CodingStandards.md) for language conventions.
+
+## Principles
+
+**Serious, not severe.** People use LORIS to find data they will build papers on. Nothing should read
+as playful or provisional. That means restraint rather than greyness: one accent colour, generous
+spacing, and no decoration that is not carrying information.
+
+**Familiar before novel.** LORIS is deployed at institutions that trained their staff on it. A change
+that makes people relearn where things are has failed however good it looks. Improve the quality of a
+control, and keep its position and its meaning.
+
+**Density is a feature.** This is data software, and users want more on screen rather than less. Size
+controls to their content. Do not spend vertical space on decoration.
+
+**One component, used everywhere.** Every bespoke control becomes a future inconsistency. When a
+shared component cannot do what you need, extend it so the whole application gains the capability. A
+change that touches many screens because one component improved is a good change.
+
+## Never hardcode a value
+
+Colours, spacing, radii and shadows come from `tokens.css`. If you are typing a hex value or a pixel
+measurement into a component, stop and use a token. If no token fits, add one. That is a signal the
+system was missing something, not that your component is special.
+
+```css
+/* No */
+.thing { background: #eaf1f8; border-radius: 4px; padding: 8px; }
+
+/* Yes */
+.thing {
+    background: var(--loris-color-accent-fill);
+    border-radius: var(--loris-radius);
+    padding: var(--loris-space-md);
+}
+```
+
+### Two layers, and only one of them is for you
+
+`tokens.css` holds a **palette** naming colours for what they are (`--loris-blue-700`,
+`--loris-grey-300`) and **roles** naming them for the job they do (`--loris-color-accent`,
+`--loris-border`, `--loris-text-muted`).
+
+**Components reference roles, never the palette.** Repointing a role then restyles everything that
+plays that part, instead of requiring a search through components. Adding a palette entry is rare and
+deliberate. It means LORIS genuinely has a new colour.
+
+### Three strengths of a colour
+
+A hue is used at up to three strengths, and the role names say which job each one does.
+
+| Strength | What it is | Used for |
+|---|---|---|
+| **solid** | The colour itself | A border, an icon, a filled button, text |
+| **fill** | A tint you can see is coloured | The ground something sits on: a selected row, a tag |
+| **highlight** | Barely there | Hover, and nothing else |
+
+A hue gets a step because something needs it, not for symmetry. Only the blue has all three: it is
+the only one that draws a hover, and the highlight exists for nothing else.
+
+## Colour
+
+This is not starting from nothing. `htdocs/bootstrap/css/custom-css.css` has carried a header called
+"Loris color palette v.0.1" for years, declaring two blues and an orange. It stalled because it lived
+in a comment where no code could reference it, and because it handed everything else to Bootstrap.
+What follows makes it real.
+
+### Blue, the primary
+
+The two declared blues anchor the scale. The darkest is already the pressed state of every primary
+button, and the two lightest are the tints used for highlights and hovered rows.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/blue-900.svg) | `--loris-blue-900` | `#042d54` | Pressed |
+| ![](images/palette/blue-700.svg) | `--loris-blue-700` | `#064785` | Navigation, panel headings |
+| ![](images/palette/blue-500.svg) | `--loris-blue-500` | `#246eb6` | Lighter blue |
+| ![](images/palette/blue-100.svg) | `--loris-blue-100` | `#e4ebf2` | Fill, selected row |
+| ![](images/palette/blue-50.svg) | `--loris-blue-50` | `#f3f6f9` | Highlight, hovered row |
+
+### Sky, the information colour
+
+The same hue as the navy carried light and saturated instead of dark. This is not a new colour: the
+biobank has drawn its live layer in it for years, with `.node.available`, `.node.selected` and its
+hover borders all `#a6d3f5` against the navy for what is already filled. What is new is that it has
+a name and a second step.
+
+Two steps, and it should stay at two. A third would be a highlight, its highlight works out at
+`#edf6fd` against `#f3f6f9` for the accent's, and a difference of 6, 0, 4 is not a difference. It
+needs none in any case: a highlight only ever means hover, and hover belongs to the accent.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/sky.svg) | `--loris-sky` | `#a6d3f5` | Help, notices, a standing rule |
+| ![](images/palette/sky-100.svg) | `--loris-sky-100` | `#d6eafa` | Information ground |
+
+### Orange, the secondary
+
+The attention colour, and the scarce one. It marks a state the interface is only passing through, or
+one that is governing what other actions will do: the run a drag is sweeping over, a rule now
+standing, a switch that is on. Two steps, because it never draws a hover, and no darker one.
+Darkening an orange this saturated makes it look burnt rather than deep.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/orange.svg) | `--loris-orange` | `#e89a0c` | Active border, switch that is on |
+| ![](images/palette/orange-100.svg) | `--loris-orange-100` | `#fdf2dc` | Active ground |
+
+### Purple, the tertiary
+
+Present in electrophysiology as an event badge. It carries no fixed meaning, which makes it the one
+available for telling categories apart where blue and orange are already spoken for. Two steps, for
+the same reason as the orange. The middle tints of a purple this saturated turn fuchsia.
+
+| | Token | Hex | Used for |
+|---|---|---|---|
+| ![](images/palette/purple.svg) | `--loris-purple` | `#690096` | Categorical |
+| ![](images/palette/purple-100.svg) | `--loris-purple-100` | `#f2e6f7` | Categorical ground |
+
+### Semantic colours
+
+These are named for the colour they are, because their meanings are already fixed. Red means
+something failed wherever it appears. What matters is that it is the same red everywhere.
+
+| | Token | Hex | Meaning |
+|---|---|---|---|
+| ![](images/palette/green.svg) | `--loris-green` | `#0f9d58` | Success |
+| ![](images/palette/red.svg) | `--loris-red` | `#c0402a` | Error |
+| ![](images/palette/amber.svg) | `--loris-amber` | `#d17a00` | Warning |
+| ![](images/palette/sky.svg) | `--loris-sky` | `#a6d3f5` | Information |
+
+Warning is deliberately not the same orange as the secondary. If a standing rule were the colour of
+a warning, neither would mean anything.
+
+### Grey
+
+| | Token | Hex |
+|---|---|---|
+| ![](images/palette/grey-1000.svg) | `--loris-grey-1000` | `#000000` |
+| ![](images/palette/grey-800.svg) | `--loris-grey-800` | `#333333` |
+| ![](images/palette/grey-600.svg) | `--loris-grey-600` | `#666666` |
+| ![](images/palette/grey-500.svg) | `--loris-grey-500` | `#999999` |
+| ![](images/palette/grey-300.svg) | `--loris-grey-300` | `#cccccc` |
+| ![](images/palette/grey-250.svg) | `--loris-grey-250` | `#dddddd` |
+| ![](images/palette/grey-150.svg) | `--loris-grey-150` | `#efefef` |
+| ![](images/palette/grey-50.svg) | `--loris-grey-50` | `#f8f8f8` |
+| ![](images/palette/white.svg) | `--loris-white` | `#ffffff` |
+
+### Colours being retired
+
+| Colour | Where it is | What happens to it |
+|---|---|---|
+| `#093782` | `modules/biobank`, `modules/dqt` | A second navy, a shade off `--loris-blue-700`. Use the token. |
+| `#ff9a24` | `modules/dqt` | Use `--loris-orange`. |
+| `#e98430` | `modules/biobank` | Use `--loris-orange`. |
+| `#d54a08` | `modules/electrophysiology_browser` | Use `--loris-orange`. |
+| `#fa5705` | `modules/brainbrowser` | Use `--loris-orange`. |
+
+Four oranges for one idea, in four modules, none of them the orange the palette declares.
+
+`#1c70b6` is a separate case and is not on this list. It is the blue bootstrap itself is compiled
+with, recorded in `htdocs/bootstrap/config.json`, so it is a deliberate choice rather than module
+drift. It sits a shade off `--loris-blue-500`, and the two should be reconciled the next time
+bootstrap is rebuilt rather than by editing the compiled stylesheet.
+
+## The three states
+
+A surface answers three questions, and it answers them the same way wherever it is. Use the state
+roles rather than reaching for a hue, so that no two screens drift apart.
+
+| State | Role | Says |
+|---|---|---|
+| **Hover** | `--loris-state-hover` | Where the pointer is. It follows the cursor, covers a lot of ground and goes as soon as the pointer moves, so it is the lightest step there is. |
+| **Selected** | `--loris-state-selected`, `--loris-state-selected-solid` | What is chosen. It is settled, nothing is happening to it, and it sits one step up from hover in the same blue. |
+| **Active** | `--loris-state-active`, `--loris-state-active-solid` | Something is being passed through rather than rested in, and is about to change on release. The only state drawn in the secondary, and deliberately rare. |
+
+The distinction that matters, and the one that is easy to get wrong, is between **selected** and
+**active**.
+
+A ticked row in a dropdown is selected. It is a settled choice, it sits there, and it changes nothing
+outside itself.
+
+Active is **intermediary**: a state the interface is passing through rather than resting in, such as
+the run a drag is sweeping over before the pointer comes up. Those rows are neither chosen nor idle,
+they are about to change, and the stroke has to show its consequence while it is still being made.
+
+A rule that is merely standing is not this, and the difference is worth holding onto. The switch that
+makes every field added from now on take the visits currently chosen changes nothing you can see when
+you throw it. What it changes is what the *next* action means, and that is **information**: it is
+`--loris-color-info`, the sky, alongside help text and notices. Nothing is in flight, so nothing is
+orange.
+
+The test to apply: **is this on its way somewhere?** If it resolves the moment the user lets go, it is
+active. If it will still be true tomorrow and governs what other actions do, it is information. If it
+is simply a choice at rest, it is selected.
+
+Spending the orange on ordinary selection is the failure mode. It is loud on purpose, and a screen
+where everything chosen is orange has nothing left to say when something really is in flight.
+
+Two more things follow:
+
+**A button has no selected state**, because it is an action rather than something that can be
+chosen. Its hover moves the outline and the label and leaves the ground where it is. Filling a
+button on hover puts its label on a colour the label was never chosen against, and the orange in
+particular carries neither white text nor its own.
+
+**The navigation bar is the exception.** It sits on the dark blue, where no wash of the accent would
+show at all, so it keeps the orange that `@accent-color-hover` declared for it. Nothing on a light
+ground should follow it.
+
+## Colour that carries meaning
+
+LORIS is used all day by people who did not choose their monitor, in rooms with the lights on, and by
+people who do not separate hues the way the person picking the colours does. Around one man in twelve
+has some form of colour vision deficiency. None of that is an edge case in software someone uses for
+their job.
+
+Three rules, in the order they get broken.
+
+### 1. Never let colour be the only difference
+
+This is the one that matters most, and the one this system relies on. The state grounds are
+deliberately close together: hover, selected and active sit within 1.1 of each other in contrast
+terms, because they are washes rather than signals. That is fine, and only fine, because none of them
+is carrying the meaning alone.
+
+| State | The ground | What carries it besides the ground |
+|---|---|---|
+| Hover | `--loris-state-hover` | The pointer is on it. It is not information, it is feedback. |
+| Selected | `--loris-state-selected` | A bar down the left edge, a heavier label, and a ticked control |
+| Active | `--loris-state-active` | A bar down the left edge, and the buttons that will consume it change with it |
+| Switch on | `--loris-color-info` | The thumb is at the other end of the track |
+
+If you remove the colour from any row above, the interface still says the same thing. Build to that
+test. A ground is an amplifier, never the message.
+
+### 2. Text on a fill reaches 4.5:1
+
+Every combination the system produces clears it with room to spare, because the fills are pale and
+the text is dark. Measured:
+
+| | Ratio |
+|---|---|
+| `--loris-text` on any state ground | 10.2 to 11.7 |
+| `--loris-text-muted` on the hover ground | 5.3 |
+| White on `--loris-color-accent` | 9.3 |
+| `--loris-color-accent` on white | 9.3 |
+
+The rule bites when someone reaches for a solid as a text colour. `--loris-orange` on white is
+**2.3**, and `--loris-sky` on white is **1.6**. Neither is a text colour. They are grounds and marks.
+
+### 3. A control's own shape reaches 3:1
+
+A button, a track, a checkbox or a focus ring has to be findable against what is behind it, which is
+a different requirement from the text inside it. This is where the pale colours fail, and it is not
+optional:
+
+| | Against white | |
+|---|---|---|
+| `--loris-sky` | 1.58 | fails |
+| `--loris-grey-300` | 1.6 | fails |
+| `--loris-orange` | 2.32 | fails |
+| `--loris-blue-500` | 5.28 | passes |
+| `--loris-grey-600` | 5.74 | passes |
+
+So a control drawn in a pale colour needs an edge drawn in something that passes. The switch is the
+worked example: its track is the sky when on and a grey when off, and both carry an inset ring
+(`--loris-color-info-edge`, `--loris-control-off-edge`) so the control is findable whatever it is
+doing. Draw the ring inside, with `inset`, so turning it on does not move anything.
+
+There is a second reason the switch is built that way. The sky and the light grey it originally
+replaced have relative luminances of 0.613 and 0.604 — near enough identical that on and off differed
+in hue and in nothing else, which is to say they did not differ at all for a reader who cannot
+separate the two. **Two states must never differ in hue alone.** Change the lightness too.
+
+### When a colour has to move
+
+If a value cannot meet these, change the value rather than the rule, and change it in `tokens.css` so
+everything moves together. Adapting a hue's saturation or lightness to make it work is a normal thing
+to do here, not a compromise.
+
+## Type
+
+LORIS inherited Bootstrap's Helvetica and Arial stack, which nobody chose and which shows a different
+typeface depending on the operating system. Two deliberate choices replace it. Neither downloads
+anything.
+
+| Token | Face | Used for |
+|---|---|---|
+| `--loris-font-family` | The operating system's own interface face | Labels, descriptions, buttons, headings |
+| `--loris-font-family-mono` | The system monospace | Identifiers |
+
+### When to use the monospace
+
+Monospace marks **a value someone might copy or transcribe**. It does not mark "a technical thing".
+Used sparingly it tells a reader something. Used everywhere it stops meaning anything, and the page
+gets louder for no benefit.
+
+Use it for:
+
+1. Identifiers a person reads character by character. PSCIDs, DCCIDs, visit labels, barcodes.
+2. Values that get copied into another system, a spreadsheet or an email.
+3. Raw stored values where the exact characters matter, such as a filename or a path.
+
+Do not use it for:
+
+1. Field and column names. Underscores and word shapes already make
+   `alcohol_use_disorders_identification_testconcise_a_auditc_q1` unambiguous, so the monospace adds
+   nothing and spends a signal that is then unavailable where it is needed.
+2. Counts and summaries. `All (354)` describes a selection, it is not one of the values in it.
+3. Anything a person reads as a sentence, including descriptions and help text.
+
+The test to apply: **would someone need to reproduce these exact characters somewhere else?** If yes,
+use the monospace. If they are only reading it, do not.
+
+## Where styles live
+
+| What | Where |
+|---|---|
+| Values shared by more than one component | `htdocs/css/tokens.css` |
+| A component's own appearance | A stylesheet beside it, imported by it, such as `jsx/Select.css` |
+| A module's own layout | `modules/<module>/css/`, imported by the JSX |
+| Anything with a `:hover`, `:focus` or `:disabled` state | A stylesheet, never an inline style |
+
+Inline styles cannot express states or media queries. Use them only for values computed at runtime.
+
+## Bootstrap
+
+LORIS is built on Bootstrap 3, which has had no security patches since 2019. It is not being removed,
+because that would touch every module. **Do not build on it in new components.** Give a new component
+its own appearance from tokens. Bootstrap continues to serve what it already serves, and its share
+shrinks as components are replaced.
+
+This is not only about the end of life date. Borrowing a Bootstrap class and then laying it out
+differently puts you in a specificity fight. `.form-control` sets `display: block`, `.input-group`
+sets `display: table`, and `.list-group-item.active` sets `z-index: 2`, all of which beat an equally
+specific rule of your own on source order. If you have to override one, qualify the selector with the
+element, as in `button.my-trigger`, rather than reaching for `!important`. If your component owns its
+layout outright, the conflict does not arise at all.
+
+## Components
+
+The shared controls live in `jsx/` and take no label, form row or offset of their own, so they can be
+placed anywhere.
+
+- **`Select`** is a selection shown as a dropdown over a searchable list. It holds many values, or one
+  with `multiple={false}`. Options can be grouped to order the most relevant first. Set `mono` when
+  the options are identifiers.
+- **`Textbox`** is a single line text input. With `search` it gains a magnifier and a control to clear
+  it.
+- **`Toggle`** is a boolean, drawn either as a switch or as a checkbox.
+- **`Button`** performs an action, in one of four displays: `primary`, `secondary`, `quiet` or
+  `danger`.
+
+`Form.js` wraps these for use inside a form, adding the label, row and error message. If you need a
+control outside a form, use the component directly rather than fighting the wrapper's layout.
+
+### A prop, not a new component
+
+Where two controls differ by one boolean, they are one component. A multiple selection is a select
+with `multiple`. A search box is a text input with `search`. A switch and a checkbox are one boolean
+with two displays. Splitting them is how a codebase ends up with several implementations of one idea.
+
+## Labels on controls
+
+`Select` and `Textbox` accept a `label` that sits inside the field while it is empty and rises onto
+its top edge once it is not. The border carries a real gap for it, so the label needs no backdrop and
+works on any colour behind it.
+
+Use this in toolbars and dense control strips, where a row of labels would cost vertical space and
+turn a toolbar back into a form. Do not use it in ordinary forms. A plain label above the field costs
+nothing there and stays full size, and shrinking it trades legibility for tidiness that is not
+scarce.
+
+## Still open
+
+These have not been decided. A change that touches them should say so rather than settle them
+quietly.
+
+1. Where `--loris-color-primary` applies. The navy is the brand colour but currently has no consumer,
+   because actions all use the accent blue.
+2. A density scale. Control heights are inherited at 34px rather than chosen.
+3. Whether the information colour is right for help text and notices as well as for standing rules.
+   The family was introduced for the second and is documented for all three, but only the standing
+   rules have a consumer so far. If help surfaces end up wanting something else, this splits again.
+4. Whether the purple takes any of this. It is currently only categorical, and no case has been
+   named for it.
+5. The hardcoded orange hover still in the navbar dropdowns at the top of `custom-css.css`. On the
+   dark navbar the orange is right, but those menus open on white, where it does not have the
+   contrast to be read. Fixing it means changing the most familiar surface in LORIS, so it is worth
+   deciding rather than doing.

--- a/docs/images/palette/amber.svg
+++ b/docs/images/palette/amber.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="amber #d17a00"><rect width="120" height="44" rx="4" fill="#d17a00" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-100.svg
+++ b/docs/images/palette/blue-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-100 #e4ebf2"><rect width="120" height="44" rx="4" fill="#e4ebf2" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-50.svg
+++ b/docs/images/palette/blue-50.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-50 #f3f6f9"><rect width="120" height="44" rx="4" fill="#f3f6f9" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-500.svg
+++ b/docs/images/palette/blue-500.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-500 #246eb6"><rect width="120" height="44" rx="4" fill="#246eb6" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-700.svg
+++ b/docs/images/palette/blue-700.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-700 #064785"><rect width="120" height="44" rx="4" fill="#064785" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/blue-900.svg
+++ b/docs/images/palette/blue-900.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="blue-900 #042d54"><rect width="120" height="44" rx="4" fill="#042d54" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/green.svg
+++ b/docs/images/palette/green.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="green #0f9d58"><rect width="120" height="44" rx="4" fill="#0f9d58" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-1000.svg
+++ b/docs/images/palette/grey-1000.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-1000 #000000"><rect width="120" height="44" rx="4" fill="#000000" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-150.svg
+++ b/docs/images/palette/grey-150.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-150 #efefef"><rect width="120" height="44" rx="4" fill="#efefef" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-250.svg
+++ b/docs/images/palette/grey-250.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-250 #dddddd"><rect width="120" height="44" rx="4" fill="#dddddd" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-300.svg
+++ b/docs/images/palette/grey-300.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-300 #cccccc"><rect width="120" height="44" rx="4" fill="#cccccc" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-50.svg
+++ b/docs/images/palette/grey-50.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-50 #f8f8f8"><rect width="120" height="44" rx="4" fill="#f8f8f8" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-500.svg
+++ b/docs/images/palette/grey-500.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-500 #999999"><rect width="120" height="44" rx="4" fill="#999999" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-600.svg
+++ b/docs/images/palette/grey-600.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-600 #666666"><rect width="120" height="44" rx="4" fill="#666666" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/grey-800.svg
+++ b/docs/images/palette/grey-800.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="grey-800 #333333"><rect width="120" height="44" rx="4" fill="#333333" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/orange-100.svg
+++ b/docs/images/palette/orange-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="orange-100 #fdf2dc"><rect width="120" height="44" rx="4" fill="#fdf2dc" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/orange.svg
+++ b/docs/images/palette/orange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="orange #e89a0c"><rect width="120" height="44" rx="4" fill="#e89a0c" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/purple-100.svg
+++ b/docs/images/palette/purple-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="purple-100 #f2e6f7"><rect width="120" height="44" rx="4" fill="#f2e6f7" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/purple.svg
+++ b/docs/images/palette/purple.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="purple #690096"><rect width="120" height="44" rx="4" fill="#690096" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/red.svg
+++ b/docs/images/palette/red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="red #c0402a"><rect width="120" height="44" rx="4" fill="#c0402a" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/sky-100.svg
+++ b/docs/images/palette/sky-100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="sky-100 #d6eafa"><rect width="120" height="44" rx="4" fill="#d6eafa" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/sky.svg
+++ b/docs/images/palette/sky.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="sky #a6d3f5"><rect width="120" height="44" rx="4" fill="#a6d3f5" stroke="#00000022" stroke-width="1"/></svg>

--- a/docs/images/palette/white.svg
+++ b/docs/images/palette/white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="44" viewBox="0 0 120 44" role="img" aria-label="white #ffffff"><rect width="120" height="44" rx="4" fill="#ffffff" stroke="#00000022" stroke-width="1"/></svg>

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -933,3 +933,118 @@ select[multiple].input-sm.resizable {
     height: 100px;
     resize: both;
 }
+
+
+/*******************************
+States, drawn from the palette
+
+Bootstrap draws the hover and selected states for every surface it still owns,
+in its own colours rather than ours, so a page mixes colours nobody chose with
+colours we did. The rules below map the states bootstrap draws most often onto
+the tokens in htdocs/css/tokens.css.
+
+Hover and selection are two different questions, so they get two different
+steps of the accent. Hover says where the pointer is and goes as soon as it
+moves, so it is the lightest step there is. Selection says what is chosen, and
+sits one step up.
+
+Neither is the secondary. The orange is kept for the one case that asks to be
+noticed: something in effect because of what the user did. Nothing bootstrap
+draws here qualifies, so nothing here is orange.
+
+The navigation bar is the exception. It sits on the dark blue, where no wash of
+the accent would show at all, so it keeps the orange declared for it at the top
+of this file.
+
+This section is deliberately narrow: hover, focus, and the selected row. Do not
+add to it to avoid writing a component properly. It shrinks as surfaces are
+converted and goes when bootstrap does.
+
+See docs/DesignSystem.md.
+****************************************/
+
+/* ---- Links --------------------------------------------------------- */
+
+a:hover,
+a:focus {
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Navigation and menus ------------------------------------------ */
+
+.nav > li > a:hover,
+.nav > li > a:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-color-accent-strong);
+}
+
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Rows and lists ------------------------------------------------ */
+
+.table-hover > tbody > tr:hover {
+    background-color: var(--loris-state-hover);
+}
+
+a.list-group-item:hover,
+a.list-group-item:focus {
+    background-color: var(--loris-state-hover);
+    color: var(--loris-text);
+}
+
+/* Marked the way a chosen row is marked in the select, so a list built from
+   bootstrap and a list built from a component say the same thing. */
+.list-group-item.active,
+.list-group-item.active:hover,
+.list-group-item.active:focus {
+    background-color: var(--loris-state-selected);
+    border-color: var(--loris-border-divider);
+    box-shadow: inset 3px 0 0 var(--loris-state-selected-solid);
+    color: var(--loris-text);
+}
+
+/* ---- Buttons ------------------------------------------------------- */
+
+/* Hover moves the outline and the label, and leaves the ground where it is. A
+   button is an action rather than something that can be chosen, so it has no
+   selected state to be told apart from, and filling it on hover would put the
+   label on a colour it was never chosen against. */
+.btn-default:hover,
+.btn-default:focus {
+    background-color: var(--loris-state-hover);
+    border-color: var(--loris-color-accent-strong);
+    color: var(--loris-color-accent-strong);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: var(--loris-color-accent-strong);
+    border-color: var(--loris-color-accent-strong);
+}
+
+.btn-link:hover,
+.btn-link:focus {
+    color: var(--loris-color-accent-strong);
+}
+
+/* ---- Pagination ---------------------------------------------------- */
+
+.pagination > li > a:hover,
+.pagination > li > a:focus {
+    color: var(--loris-color-accent-strong);
+    background-color: var(--loris-state-hover);
+    border-color: var(--loris-border-divider);
+}
+
+/* The page you are on is not a choice you can change your mind about later, it
+   is where you are, so it takes the accent solid rather than a selected tint. */
+.pagination > .active > a,
+.pagination > .active > a:hover,
+.pagination > .active > a:focus {
+    background-color: var(--loris-color-accent);
+    border-color: var(--loris-color-accent);
+}

--- a/htdocs/css/tokens.css
+++ b/htdocs/css/tokens.css
@@ -1,0 +1,221 @@
+/**
+ * Design tokens.
+ *
+ * The single source of truth for the values components style themselves with.
+ * Nothing below should be repeated as a literal anywhere else.
+ *
+ * There are two layers, and the distinction matters:
+ *
+ *   Palette  - the raw colours LORIS is built from. Named for what they are.
+ *              Add to these rarely, and only for a colour the product really
+ *              has.
+ *   Roles    - what a colour is for. Named for the job, not the hue.
+ *              Components reference these, never the palette, so that
+ *              restyling means repointing a role rather than hunting through
+ *              components.
+ *
+ * A component with a value nothing else shares keeps it in its own stylesheet,
+ * built from these. Anything two components would both want belongs here.
+ *
+ * Loaded on every page from main.tpl and public_layout.tpl.
+ *
+ * docs/DesignSystem.md explains how to use these and when to add one.
+ */
+:root {
+    /* ---- Palette ------------------------------------------------- */
+
+    /* Blue, the primary. The middle pair is what "Loris color palette v.0.1"
+       at the head of custom-css.css has declared all along. */
+    --loris-blue-900: #042d54;
+    --loris-blue-700: #064785;
+    --loris-blue-500: #246eb6;
+    --loris-blue-100: #e4ebf2;
+    --loris-blue-50: #f3f6f9;
+
+    /* Sky, the information colour. The same hue as the navy, carried light and
+       saturated instead of dark, which is how the biobank has drawn its live
+       layer for years: an available slot, a hovered container and a lifecycle
+       line are all this, against the navy for what is already filled. Two
+       steps. A third would be a highlight, and a highlight only ever means
+       hover, which belongs to the accent. */
+    --loris-sky: #a6d3f5;
+    --loris-sky-100: #d6eafa;
+
+    /* Orange, the secondary. The colour the same palette declared. Two steps,
+       because it never draws a hover and so never needs a highlight. */
+    --loris-orange: #e89a0c;
+    --loris-orange-100: #fdf2dc;
+
+    /* Purple, the tertiary. Unclaimed, so it is what tells categories apart.
+       Two steps, because nothing it marks is hovered. */
+    --loris-purple: #690096;
+    --loris-purple-100: #f2e6f7;
+
+    /* Named for the colour they are, because the meanings are already fixed. */
+    --loris-green: #0f9d58;
+    --loris-red: #c0402a;
+    --loris-amber: #d17a00;
+
+    /* Grey, black to white */
+    --loris-grey-1000: #000;
+    --loris-grey-800: #333;
+    --loris-grey-600: #666;
+    --loris-grey-500: #999;
+    --loris-grey-300: #ccc;
+    --loris-grey-250: #ddd;
+    --loris-grey-150: #efefef;
+    --loris-grey-50: #f8f8f8;
+    --loris-white: #fff;
+
+    /* ---- Roles --------------------------------------------------- */
+
+    /* Actions. LORIS's bootstrap is already compiled with the navy, so this is
+       what every existing button is drawn in.
+
+       A hue is used at three strengths, and the names say which job each does:
+
+         solid      - the colour itself, for a border, an icon, a filled
+                      button or text.
+         fill       - a tint you can see is coloured, for a ground something
+                      sits on.
+         highlight  - barely there, and only ever for hover.
+
+       A hue gets a step because something needs it, not for symmetry. */
+    --loris-color-accent: var(--loris-blue-700);
+    --loris-color-accent-strong: var(--loris-blue-900);
+    --loris-color-accent-border: var(--loris-blue-500);
+    --loris-color-accent-fill: var(--loris-blue-100);
+    --loris-color-accent-highlight: var(--loris-blue-50);
+
+    --loris-color-secondary: var(--loris-orange);
+    --loris-color-secondary-fill: var(--loris-orange-100);
+
+    /* Information sits with the other meanings rather than with the states,
+       because that is what it is: it marks what is there to help, and what is
+       true right now and governs what the next action will do. Help and
+       notices, and the standing rules a screen is operating under. */
+    --loris-color-info: var(--loris-sky);
+    --loris-color-info-fill: var(--loris-sky-100);
+
+    /* The sky is too light to define a shape against a white page on its own:
+       it reaches 1.58 against white where a control needs 3. This is the edge
+       to draw round it when it has to be seen as a control rather than only
+       as a colour. It is the accent's lighter blue, the same hue carried
+       darker, rather than a new step that would sit a few percent from it. */
+    --loris-color-info-edge: var(--loris-blue-500);
+
+    --loris-color-warning: var(--loris-amber);
+    --loris-color-success: var(--loris-green);
+    --loris-danger: var(--loris-red);
+    --loris-danger-strong: var(--loris-red);
+
+    /* States. Three questions a surface answers, and it answers them the same
+       way wherever it is.
+
+       Hover says where the pointer is. It follows the cursor, covers a lot of
+       ground and goes as soon as the pointer moves, so it is the lightest step
+       there is.
+
+       Selected says what is chosen. It is settled, nothing is happening to it,
+       and nobody needs to look at it, so it stays in the accent one step up
+       from hover.
+
+       Active is a state being passed through rather than rested in: the run a
+       drag is sweeping over before the pointer comes up, work about to happen
+       on release. It is the only state drawn in the secondary, and it is
+       deliberately rare. A rule that is merely standing is not this. That is
+       information, and it is drawn in the sky. */
+    --loris-state-hover: var(--loris-color-accent-highlight);
+    --loris-state-selected: var(--loris-color-accent-fill);
+    --loris-state-selected-solid: var(--loris-color-accent);
+    --loris-state-active: var(--loris-color-secondary-fill);
+    --loris-state-active-solid: var(--loris-color-secondary);
+
+    /* Surfaces */
+    --loris-surface: var(--loris-white);
+    --loris-surface-sunken: var(--loris-grey-50);
+
+    /* Borders */
+    --loris-border: var(--loris-grey-300);
+    --loris-border-subtle: var(--loris-grey-150);
+    --loris-border-divider: var(--loris-grey-250);
+
+    /* Text */
+    --loris-text: var(--loris-grey-800);
+    --loris-text-muted: var(--loris-grey-600);
+    --loris-text-faint: var(--loris-grey-500);
+    --loris-text-disabled: var(--loris-grey-300);
+
+    /* Controls. The off track is darker than a border grey on purpose. A
+       switch turned on is the sky, whose relative luminance is 0.613 against
+       0.604 for the light grey this replaced, so on and off would have
+       differed in hue and in nothing else, and said nothing at all to a reader
+       who cannot separate the two. */
+    --loris-control-off: var(--loris-grey-500);
+    --loris-control-off-edge: var(--loris-grey-600);
+
+    /* Elevation */
+    --loris-shadow-overlay: 0 6px 18px rgba(0, 0, 0, .18);
+    --loris-shadow-raised: 0 1px 2px rgba(0, 0, 0, .3);
+
+    /* The look of a field. Owned here rather than inherited from bootstrap, so
+       that a control placed outside a form still matches one inside it. */
+    --loris-field-bg: var(--loris-white);
+    --loris-field-border: var(--loris-grey-300);
+    --loris-field-border-focus: var(--loris-blue-500);
+    --loris-field-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+
+    /* Kept apart from the shadow because a field whose border is drawn by
+       something else still wants the glow, and an inset shadow would draw a
+       line across whatever sits on the top edge. */
+    --loris-field-glow-focus: 0 0 8px rgba(36, 110, 182, .5);
+    --loris-field-shadow-focus: var(--loris-field-shadow),
+                                var(--loris-field-glow-focus);
+    --loris-field-padding: 6px 12px;
+
+    /* ---- Shape, spacing and type --------------------------------- */
+
+    /* Corners. Anything rounded uses one of these. */
+    --loris-radius: 4px;
+    --loris-radius-sm: 3px;
+
+    /* Spacing steps used for laying controls out against one another */
+    --loris-space-xs: 4px;
+    --loris-space-sm: 6px;
+    --loris-space-md: 8px;
+    --loris-space-lg: 10px;
+    --loris-space-xl: 16px;
+
+    /* Type. These record what LORIS already sets rather than proposing
+       anything: the family, size and line height come from bootstrap's base,
+       which every page inherits. Components should reference these instead of
+       relying on inheritance, so that changing type once changes it
+       everywhere. */
+    /* The interface uses the operating system's own face: native everywhere,
+       nothing to download, and quiet enough to disappear behind the work. */
+    --loris-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                         "Helvetica Neue", Arial, sans-serif;
+
+    /* Identifiers use a monospace instead. A PSCID, a visit label or a field
+       name is read character by character and often transcribed, so the
+       characters that a proportional face lets collide -- I, l and 1, O and 0
+       -- have to stay apart. */
+    --loris-font-family-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+                              Consolas, "Liberation Mono", monospace;
+    --loris-font-size: 14px;
+    --loris-font-size-sm: 12px;
+    --loris-font-size-xs: 11px;
+    --loris-line-height: 1.42857143;
+
+    /* Height of a control sitting in a row with a form-control */
+    --loris-control-height: 34px;
+    --loris-control-height-sm: 30px;
+}
+
+/* The application inherits its type from bootstrap, which nobody chose and
+   which renders differently per operating system. Setting it here means one
+   place decides. Qualified with html so it does not depend on this sheet
+   loading after bootstrap's. */
+html body {
+    font-family: var(--loris-font-family);
+}

--- a/jsx/Button.css
+++ b/jsx/Button.css
@@ -1,0 +1,97 @@
+/**
+ * Styles for the Button component. Every value comes from a token in
+ * htdocs/css/tokens.css.
+ */
+
+.loris-button {
+    height: var(--loris-control-height);
+    padding: 0 var(--loris-space-lg);
+    font-family: var(--loris-font-family);
+    font-size: var(--loris-font-size);
+    line-height: var(--loris-line-height);
+    border-radius: var(--loris-radius);
+    border: 1px solid transparent;
+    background: none;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.loris-button:disabled {
+    opacity: .55;
+    cursor: not-allowed;
+}
+
+.loris-button.primary {
+    background: var(--loris-color-accent);
+    border-color: var(--loris-color-accent-strong);
+    color: var(--loris-surface);
+}
+
+/* Hover deepens the fill rather than changing its hue. A button is an action,
+   not something that can be chosen, so it has no selected state to be confused
+   with, and the label has to stay legible against whatever the ground
+   becomes. */
+.loris-button.primary:hover:not(:disabled),
+.loris-button.primary:focus-visible {
+    background: var(--loris-color-accent-strong);
+    border-color: var(--loris-color-accent-strong);
+}
+
+/* Outlined rather than filled, so it reads as available without claiming the
+   weight a primary does. */
+.loris-button.secondary {
+    background: var(--loris-field-bg);
+    border-color: var(--loris-color-accent);
+    color: var(--loris-color-accent);
+}
+
+/* The outline and the label carry the state. The ground barely moves, because
+   filling it would put the label on a colour it was not chosen against. */
+.loris-button.secondary:hover:not(:disabled),
+.loris-button.secondary:focus-visible {
+    background: var(--loris-state-hover);
+    border-color: var(--loris-color-accent-strong);
+    color: var(--loris-color-accent-strong);
+}
+
+/* Aimed at something: a run marked in a list nearby is what this will act on
+   when it is pressed. It takes that run's own colour, so the mark and the
+   control that consumes it read as one thing. The label stays the body colour,
+   because the secondary is a ground here and cannot be read against itself.
+
+   Hover cannot move the ground without breaking that link, so it draws a ring
+   instead. */
+.loris-button.secondary.targeted,
+.loris-button.secondary.targeted:hover:not(:disabled),
+.loris-button.secondary.targeted:focus-visible {
+    background: var(--loris-state-active);
+    border-color: var(--loris-state-active-solid);
+    color: var(--loris-text);
+}
+
+.loris-button.secondary.targeted:hover:not(:disabled),
+.loris-button.secondary.targeted:focus-visible {
+    box-shadow: 0 0 0 3px var(--loris-state-active);
+}
+
+/* Available without competing with the action beside it. */
+.loris-button.quiet {
+    color: var(--loris-color-accent);
+    padding: 0 var(--loris-space-sm);
+}
+
+.loris-button.quiet:hover:not(:disabled),
+.loris-button.quiet:focus-visible {
+    color: var(--loris-color-accent-strong);
+    text-decoration: underline;
+}
+
+.loris-button.danger {
+    color: var(--loris-danger);
+}
+
+.loris-button.danger:hover:not(:disabled),
+.loris-button.danger:focus-visible {
+    color: var(--loris-danger-strong);
+    text-decoration: underline;
+}

--- a/jsx/Button.tsx
+++ b/jsx/Button.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import './Button.css';
+
+/**
+ * A control that performs an action.
+ *
+ * Choose the display by how much weight the action deserves, so that a set of
+ * buttons reads as a hierarchy rather than as equals:
+ *
+ *   primary    the action being encouraged
+ *   secondary  an ordinary action, outlined rather than filled so it does not
+ *              compete with a primary beside it
+ *   quiet      an action that should be available without asking for
+ *              attention, drawn as text rather than as a control
+ *   danger     an action that destroys something
+ *
+ * It is the unwrapped control, with no form row around it, so it can be placed
+ * anywhere.
+ *
+ * @param {object} props - React props
+ * @param {React.ReactNode} props.children - The label
+ * @param {function} props.onClick - Callback when pressed
+ * @param {string|undefined} props.display - "primary" (the default),
+ *                                           "secondary", "quiet" or "danger"
+ * @param {boolean|undefined} props.disabled - Disables the button
+ * @param {string|undefined} props.type - Button type, defaults to "button"
+ * @param {string|undefined} props.title - Tooltip text
+ * @returns {React.ReactElement} - The button
+ */
+function Button(props: {
+    children: React.ReactNode,
+    onClick?: () => void,
+    display?: 'primary' | 'secondary' | 'quiet' | 'danger',
+    disabled?: boolean,
+    type?: 'button' | 'submit',
+    title?: string,
+}): React.ReactElement {
+  return (
+    <button type={props.type || 'button'}
+      className={'loris-button ' + (props.display || 'primary')}
+      disabled={props.disabled}
+      title={props.title}
+      onClick={props.onClick}>
+      {props.children}
+    </button>
+  );
+}
+
+export default Button;

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -8,6 +8,8 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import InputLabel from 'jsx/form/InputLabel';
+import Select from 'jsx/Select';
+import Textbox from 'jsx/Textbox';
 import {withTranslation} from 'react-i18next';
 
 /**
@@ -614,20 +616,41 @@ export class SelectElement extends Component {
           />
         )}
         <div className={inputClass}>
-          <select
-            name={this.props.name}
-            multiple={this.props.multiple}
-            className="form-control"
-            id={this.props.id}
-            value={value}
-            onChange={this.handleChange}
-            required={this.props.required}
-            disabled={this.props.disabled}
-            style={{overflow: 'auto'}}
-          >
-            {emptyOptionHTML}
-            {optionList}
-          </select>
+          {this.props.multiple ? (
+            <Select
+              name={this.props.name}
+              options={options}
+              value={Array.isArray(value) ? value : []}
+              disabledOptions={Object.keys(disabledOptions)}
+              placeholder={this.props.placeholder}
+              disabled={this.props.disabled}
+              groups={this.props.groups}
+              badge={this.props.badge}
+              footer={this.props.footer}
+              display={this.props.display}
+              searchPlaceholder={this.props.searchPlaceholder}
+              maxVisible={this.props.maxVisible}
+              selectLabel={this.props.selectLabel}
+              deselectLabel={this.props.deselectLabel}
+              onChange={(values) => this.props.onUserInput(
+                this.props.name, values
+              )}
+            />
+          ) : (
+            <select
+              name={this.props.name}
+              className="form-control"
+              id={this.props.id}
+              value={value}
+              onChange={this.handleChange}
+              required={this.props.required}
+              disabled={this.props.disabled}
+              style={{overflow: 'auto'}}
+            >
+              {emptyOptionHTML}
+              {optionList}
+            </select>
+          )}
           {errorMessage}
         </div>
       </div>
@@ -639,6 +662,14 @@ SelectElement.propTypes = {
   name: PropTypes.string.isRequired,
   options: PropTypes.object.isRequired,
   disabledOptions: PropTypes.object,
+  groups: PropTypes.array,
+  badge: PropTypes.node,
+  footer: PropTypes.node,
+  display: PropTypes.oneOf(['names', 'tags', 'count']),
+  searchPlaceholder: PropTypes.string,
+  maxVisible: PropTypes.number,
+  selectLabel: PropTypes.string,
+  deselectLabel: PropTypes.string,
   label: PropTypes.string,
   value: PropTypes.oneOfType([
     PropTypes.string,
@@ -1133,15 +1164,16 @@ export class TextboxElement extends Component {
           />
         )}
         <div className={inputClass}>
-          <input
-            type="text"
-            className="form-control"
+          <Textbox
             name={this.props.name}
             id={this.props.id}
             value={this.props.value || ''}
+            search={this.props.search}
             required={this.props.required}
             disabled={this.props.disabled}
-            onChange={this.handleChange}
+            onChange={(value) => this.props.onUserInput(
+              this.props.name, value
+            )}
             onBlur={this.handleBlur}
             autoComplete={this.props.autoComplete}
             placeholder={this.props.placeholder}
@@ -1154,6 +1186,7 @@ export class TextboxElement extends Component {
 }
 
 TextboxElement.propTypes = {
+  search: PropTypes.bool,
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   value: PropTypes.string,

--- a/jsx/Select.css
+++ b/jsx/Select.css
@@ -1,0 +1,410 @@
+/**
+ * Styles for the Select component.
+ *
+ * Every value here comes from a token in htdocs/css/tokens.css. Hover, focus
+ * and disabled states live in this stylesheet rather than in inline styles
+ * because those states cannot be expressed inline.
+ */
+
+.loris-select {
+    position: relative;
+    display: flex;
+}
+
+/* An open panel has to sit above whatever comes after it in the document, so
+   the control itself lifts rather than relying on the panel's z-index, which
+   only ranks it inside this element's own stacking context. */
+.loris-select.open {
+    z-index: 1001;
+}
+
+/* The trigger draws its own field rather than borrowing .form-control, so
+   there is nothing of bootstrap's to outrank. */
+.loris-select-trigger {
+    flex: 1 1 auto;
+    width: 100%;
+    height: var(--loris-control-height);
+    padding: var(--loris-field-padding);
+    font-family: var(--loris-font-family);
+    font-size: var(--loris-font-size);
+    line-height: var(--loris-line-height);
+    color: var(--loris-text);
+    background: var(--loris-field-bg);
+    border: 1px solid var(--loris-field-border);
+    border-radius: var(--loris-radius);
+    box-shadow: var(--loris-field-shadow);
+    display: flex;
+    align-items: center;
+    gap: var(--loris-space-sm);
+    text-align: left;
+    cursor: pointer;
+}
+
+/* Indicators sit hard right, as the caret does on any other selector, so a
+   badge keeps the same place whatever the selection says. */
+.loris-select-indicators {
+    margin-left: auto;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--loris-space-md);
+}
+
+.loris-select-trigger:disabled {
+    cursor: not-allowed;
+}
+
+.loris-select-value {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--loris-space-sm);
+    overflow: hidden;
+}
+
+/* Names are plain text. Only the tags display draws tags, so a selection is
+   never shown as tags and commas at the same time. */
+.loris-select-names {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.loris-select-placeholder {
+    color: var(--loris-text-muted);
+}
+
+/* Rows must not take the text selection highlight while a run is dragged. */
+.loris-select-list {
+    user-select: none;
+}
+
+.loris-select-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--loris-space-xs);
+    overflow: hidden;
+}
+
+/* A tag is a readout of something already chosen. Nothing is happening to it,
+   so it is drawn in the colour a settled choice is drawn in. */
+.loris-select-tag {
+    background: var(--loris-state-selected);
+    border: 1px solid var(--loris-color-accent-border);
+    color: var(--loris-color-accent-strong);
+    border-radius: var(--loris-radius-sm);
+    padding: 1px var(--loris-space-sm);
+    white-space: nowrap;
+}
+
+.loris-select-panel {
+    position: absolute;
+    z-index: 1000;
+    top: 100%;
+    left: 0;
+    margin-top: var(--loris-space-xs);
+    min-width: 100%;
+    width: var(--loris-select-panel-width, 320px);
+    max-width: 90vw;
+    background: var(--loris-surface);
+    border: 1px solid var(--loris-border);
+    border-radius: var(--loris-radius);
+    box-shadow: var(--loris-shadow-overlay);
+    padding: var(--loris-space-md);
+}
+
+.loris-select-controls {
+    display: flex;
+    gap: var(--loris-space-sm);
+    margin-bottom: var(--loris-space-sm);
+    align-items: center;
+}
+
+.loris-select-search {
+    flex: 1 1 0;
+    min-width: 0;
+    height: var(--loris-control-height-sm);
+    padding: var(--loris-space-xs) var(--loris-space-lg);
+    font-family: var(--loris-font-family);
+    font-size: var(--loris-font-size);
+    color: var(--loris-text);
+    background: var(--loris-field-bg);
+    border: 1px solid var(--loris-field-border);
+    border-radius: var(--loris-radius);
+}
+
+/* The outline draws the field whenever there is a label, so the trigger gives
+   up its own border and shadow. The inset shadow in particular has to go: the
+   legend's notch cuts the border, but nothing cuts a shadow, so it would draw
+   a hairline straight across the label and split it in two. */
+.loris-select:has(.loris-select-outline) .loris-select-trigger,
+.loris-select:has(.loris-select-outline) .loris-select-trigger:focus-visible {
+    border-color: transparent;
+    box-shadow: none;
+}
+
+.loris-select-trigger:focus-visible,
+.loris-select-search:focus {
+    outline: 0;
+    border-color: var(--loris-field-border-focus);
+    box-shadow: var(--loris-field-shadow-focus);
+}
+
+/* Focus on a labelled field is the border and the label turning, with no glow.
+   The glow spreads out from the border it follows, and the label sits on that
+   border, so a glow would be read through the label's own letters.
+
+   Matched from the wrapper because the outline is drawn before the trigger, so
+   there is no sibling combinator that reaches it. */
+.loris-select:has(.loris-select-trigger:focus-visible) .loris-select-outline,
+.loris-select.open .loris-select-outline {
+    border-color: var(--loris-field-border-focus);
+}
+
+.loris-select:has(.loris-select-trigger:focus-visible) .loris-select-label.raised,
+.loris-select.open .loris-select-label.raised {
+    color: var(--loris-color-accent);
+}
+
+.loris-select-list {
+    max-height: 220px;
+    overflow-y: auto;
+    border: 1px solid var(--loris-border-subtle);
+    border-radius: var(--loris-radius);
+}
+
+.loris-select-group {
+    position: sticky;
+    top: 0;
+    background: var(--loris-surface-sunken);
+    border-top: 1px solid var(--loris-border-subtle);
+    padding: 7px var(--loris-space-lg) 3px;
+    font-size: var(--loris-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--loris-text-faint);
+}
+
+.loris-select-option {
+    display: flex;
+    align-items: center;
+    gap: var(--loris-space-md);
+    padding: var(--loris-space-xs) var(--loris-space-lg);
+    margin: 0;
+    font-weight: normal;
+    cursor: pointer;
+}
+
+.loris-select-option:hover {
+    background: var(--loris-state-hover);
+}
+
+/* bootstrap gives radios and checkboxes a 4px top margin, at the same
+   specificity as a class rule, so this is qualified by type to outrank it and
+   keep the control centred against its label. */
+.loris-select-option input[type="checkbox"] {
+    margin: 0;
+}
+
+/* Holding one value needs no control of its own. The row is either the chosen
+   one or it is not, so it is marked rather than given a radio to read past. */
+.loris-select-option input[type="radio"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+}
+
+/* Holding one value, the chosen row is marked the way a select has always
+   marked it: by being highlighted, not by carrying a control of its own. It is
+   a settled choice, so it is the selected colour, one step up from the row the
+   pointer merely happens to be over. */
+.loris-select-option.chosen {
+    background: var(--loris-state-selected);
+    box-shadow: inset 2px 0 0 var(--loris-state-selected-solid);
+    color: var(--loris-color-accent-strong);
+    font-weight: 600;
+}
+
+.loris-select-option.disabled {
+    cursor: not-allowed;
+    opacity: .6;
+}
+
+.loris-select-option.disabled:hover {
+    background: none;
+}
+
+.loris-select-empty {
+    padding: var(--loris-space-md) var(--loris-space-lg);
+    color: var(--loris-text-muted);
+}
+
+.loris-select-counts {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--loris-space-md);
+    padding: var(--loris-space-sm) 2px 0;
+    font-size: var(--loris-font-size-sm);
+    color: var(--loris-text-muted);
+}
+
+/* Anything a caller adds sits on its own ground, running the full width of the
+   panel, so it reads as a footer rather than as more of the list. */
+.loris-select-footer {
+    margin: var(--loris-space-md) calc(-1 * var(--loris-space-md))
+            calc(-1 * var(--loris-space-md));
+    padding: var(--loris-space-md);
+    border-top: 1px solid var(--loris-border-divider);
+    background: var(--loris-surface-sunken);
+    border-radius: 0 0 var(--loris-radius) var(--loris-radius);
+}
+
+/* The run a drag is sweeping over, and the only thing in this control drawn in
+   the secondary. The rows are not chosen yet, they are what is about to change
+   when the pointer comes up, so the stroke shows its consequence while it is
+   still being made. */
+.loris-select-option.marked {
+    background: var(--loris-state-active);
+    box-shadow: inset 2px 0 0 var(--loris-state-active-solid);
+}
+
+.loris-select-tag.muted {
+    background: var(--loris-surface-sunken);
+    border-color: var(--loris-border-subtle);
+    color: var(--loris-text-muted);
+}
+
+/* The switch sets a rule going forward and the button acts once on what is
+   already chosen. They are two halves of one decision, so they stay on one
+   line, and the switch's description wraps rather than pushing the button
+   under it. */
+.visit-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--loris-space-lg);
+    flex-wrap: nowrap;
+}
+
+.visit-controls .loris-toggle {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.visit-controls .loris-button {
+    flex: none;
+}
+
+.visit-inherit-badge {
+    color: var(--loris-color-accent-strong);
+}
+
+/* The badge keeps its place whether or not the rule is on, so it reads as a
+   state rather than as something that comes and goes. On, it says a rule is
+   standing, which is what the information colour is for. */
+.visit-inherit-badge {
+    color: var(--loris-text-disabled);
+}
+
+.visit-inherit-badge.on {
+    color: var(--loris-color-info);
+}
+
+/* Names the control without costing a row of its own. While nothing is held it
+   sits where the value would be, reading as a placeholder; once something is
+   held it rises onto the top edge, so the control still says what it is. */
+.loris-select-label {
+    position: absolute;
+    left: var(--loris-space-lg);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--loris-text-muted);
+    pointer-events: none;
+    transition: top .12s ease, font-size .12s ease, color .12s ease;
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+    .loris-select-label {
+        transition: none;
+    }
+}
+
+/* Raised, it sits in the gap the outline's legend leaves in the border, so it
+   needs no backdrop and works on any colour behind the control. Set like the
+   group headings in the list, but in the muted grey rather than the faint one:
+   at this size, on a sunken ground, the faint grey is not readable. */
+.loris-select-label.raised {
+    top: 0;
+    font-size: var(--loris-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--loris-text-muted);
+    background: none;
+    padding: 0 var(--loris-space-xs);
+    left: var(--loris-space-sm);
+    z-index: 1;
+}
+
+/* The border is drawn by a fieldset behind the control rather than on the
+   control itself. Its legend reserves exactly the width of the label, which
+   leaves a real gap in the border, so the label needs no backdrop of its own
+   and works on any colour behind it. */
+.loris-select-outline {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    padding: 0 var(--loris-space-sm);
+    border: 1px solid var(--loris-field-border);
+    border-radius: var(--loris-radius);
+    pointer-events: none;
+    min-width: 0;
+}
+
+.loris-select-outline legend {
+    width: auto;
+    max-width: 100%;
+    padding: 0;
+    border: 0;
+
+    /* The cut has to straddle the border, not sit under it. A legend's box
+       starts inside the fieldset, so without this the top sliver of the border
+       survives and shows as a hairline through the label. */
+    height: 4px;
+    margin: -2px 0 0;
+    visibility: hidden;
+    font-size: var(--loris-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    white-space: nowrap;
+}
+
+/* Nothing is raised, so the border closes up. */
+.loris-select-outline legend.closed {
+    max-width: 0;
+}
+
+.loris-select-outline legend span {
+    display: inline-block;
+    padding: 0 var(--loris-space-xs);
+}
+
+/* Where the options are identifiers rather than prose, the values are set in
+   the monospace so the characters a proportional face lets collide stay apart.
+   A count such as "All (354)" is not one of the values, so it is not. */
+.loris-select.mono .loris-select-option,
+.loris-select.mono .loris-select-names,
+.loris-select.mono .loris-select-tag {
+    font-family: var(--loris-font-family-mono);
+    font-size: var(--loris-font-size-sm);
+}
+
+.loris-select.mono .loris-select-count {
+    font-family: var(--loris-font-family);
+    font-size: var(--loris-font-size);
+}

--- a/jsx/Select.tsx
+++ b/jsx/Select.tsx
@@ -1,0 +1,580 @@
+import React, {useState, useRef, useEffect} from 'react';
+import './Select.css';
+
+type OptionGroup = {
+    label: string,
+    options: string[],
+};
+
+/**
+ * A multiple selection rendered as a dropdown holding a searchable list of
+ * checkboxes, with buttons to select or clear the list.
+ *
+ * The trigger names the first few selected values and counts the rest, so a
+ * large set of options stays readable when most of it is selected. The panel
+ * is absolutely positioned and does not displace the content below it.
+ *
+ * Rows can be marked by clicking one and shift clicking another, which marks
+ * the run between them without changing what is selected. While a run is
+ * marked the buttons act on it rather than on the whole list.
+ *
+ * This is the unwrapped control, with no label or form row around it, so it
+ * can be placed anywhere. SelectElement renders it inside the usual form
+ * layout when its multiple prop is set.
+ *
+ * Options may be split into groups to bring the most relevant values to the
+ * top. Grouping changes the order they are shown in, never which ones are
+ * available or selected.
+ *
+ * @param {object} props - React props
+ * @param {object} props.options - Selectable values, keyed by value
+ * @param {string[]} props.value - The currently selected values
+ * @param {function} props.onChange - Callback given the new list of values
+ * @param {OptionGroup[]|undefined} props.groups - Optional ordered groups. Any
+ *                                                 option not named by a group
+ *                                                 is listed after them.
+ * @param {string[]|undefined} props.disabledOptions - Values that cannot be changed
+ * @param {string|undefined} props.label - Names the control. It sits where the
+ *                                          value would be while nothing is
+ *                                          selected, and rises onto the top
+ *                                          edge once something is, so the
+ *                                          control still says what it is once
+ *                                          it holds a value.
+ * @param {string|undefined} props.placeholder - Shown when nothing is selected.
+ *                                                Empty by default, matching an
+ *                                                unset selector elsewhere.
+ * @param {string|undefined} props.display - How the selection is shown on the
+ *                                           trigger. "names" (the default)
+ *                                           lists them as text, "tags" gives
+ *                                           each one its own tag, and "count"
+ *                                           only ever says how many.
+ * @param {number|undefined} props.maxVisible - How many selected values to name
+ *                                              before counting the rest.
+ *                                              Defaults to 5.
+ * @param {React.ReactNode|undefined} props.badge - Rendered in a fixed place at
+ *                                                  the right of the trigger, for
+ *                                                  state that stays relevant
+ *                                                  while the panel is closed
+ * @param {React.ReactNode|undefined} props.footer - Rendered at the foot of the
+ *                                                   open panel, for controls
+ *                                                   belonging with the selection
+ * @param {string|undefined} props.searchPlaceholder - Placeholder for the search box
+ * @param {string|undefined} props.selectLabel - Label for the select button
+ * @param {string|undefined} props.deselectLabel - Label for the deselect button
+ * @param {string|undefined} props.emptyMessage - Shown when the search matches nothing
+ * @param {boolean|undefined} props.disabled - Disables the trigger
+ * @param {boolean|undefined} props.multiple - Whether more than one option can
+ *                                              be held at once. Defaults to
+ *                                              true. A single selection uses
+ *                                              radios and closes on choosing.
+ * @param {boolean|undefined} props.mono - Set when the options are identifiers
+ *                                          rather than prose, so they are set
+ *                                          in the monospace and their
+ *                                          characters stay apart.
+ * @param {string|undefined} props.name - Name given to the checkbox inputs
+ * @returns {React.ReactElement} - The dropdown
+ */
+function Select(props: {
+    options: {[value: string]: string},
+    value: string[],
+    onChange: (values: string[]) => void,
+    groups?: OptionGroup[],
+    disabledOptions?: string[],
+    label?: string,
+    placeholder?: string,
+    display?: 'names' | 'tags' | 'count',
+    maxVisible?: number,
+    badge?: React.ReactNode,
+    footer?: React.ReactNode,
+    searchPlaceholder?: string,
+    selectLabel?: string,
+    deselectLabel?: string,
+    emptyMessage?: string,
+    disabled?: boolean,
+    multiple?: boolean,
+    mono?: boolean,
+    name?: string,
+}): React.ReactElement {
+  const [open, setOpen] = useState<boolean>(false);
+  const [filter, setFilter] = useState<string>('');
+  const [marked, setMarked] = useState<string[]>([]);
+  const anchor = useRef<string|null>(null);
+  const dragging = useRef<boolean>(false);
+  const dragged = useRef<boolean>(false);
+  const list = useRef<HTMLDivElement>(null);
+  const pointerY = useRef<number>(0);
+  const autoScroll = useRef<number|null>(null);
+  const wrapper = useRef<HTMLDivElement>(null);
+  const search = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    /**
+     * Close the panel when a click lands outside of it
+     *
+     * @param {MouseEvent} e - The click
+     * @returns {void}
+     */
+    const onDocumentClick = (e: MouseEvent) => {
+      if (wrapper.current && !wrapper.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    /**
+     * Close the panel on escape
+     *
+     * @param {KeyboardEvent} e - The keypress
+     * @returns {void}
+     */
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    /**
+     * Stop marking when the pointer is released
+     *
+     * @returns {void}
+     */
+    const onMouseUp = () => {
+      dragging.current = false;
+      if (autoScroll.current !== null) {
+        cancelAnimationFrame(autoScroll.current);
+        autoScroll.current = null;
+      }
+    };
+    /**
+     * Remember where the pointer is so the list can scroll towards it
+     *
+     * @param {MouseEvent} e - The movement
+     * @returns {void}
+     */
+    const onMouseMove = (e: MouseEvent) => {
+      pointerY.current = e.clientY;
+    };
+    document.addEventListener('mousedown', onDocumentClick);
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('mousemove', onMouseMove);
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick);
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.removeEventListener('mousemove', onMouseMove);
+      if (autoScroll.current !== null) {
+        cancelAnimationFrame(autoScroll.current);
+        autoScroll.current = null;
+      }
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open && search.current) {
+      search.current.focus();
+    }
+    if (!open) {
+      setFilter('');
+      setMarked([]);
+      anchor.current = null;
+    }
+  }, [open]);
+
+  const all = Object.keys(props.options);
+  const selected = new Set(props.value);
+  const locked = new Set(props.disabledOptions || []);
+  const maxVisible = props.maxVisible === undefined ? 5 : props.maxVisible;
+  const multiple = props.multiple !== false;
+
+  /**
+   * Apply a new selection, leaving disabled values as they were
+   *
+   * @param {Set<string>} next - The values that should now be selected
+   * @returns {void}
+   */
+  const commit = (next: Set<string>) => {
+    all.forEach((option) => {
+      if (!locked.has(option)) {
+        return;
+      }
+      if (selected.has(option)) {
+        next.add(option);
+      } else {
+        next.delete(option);
+      }
+    });
+    props.onChange(all.filter((option) => next.has(option)));
+  };
+
+  /**
+   * Test an option against the search box
+   *
+   * @param {string} option - The option to test
+   * @returns {boolean} - true if it should be listed
+   */
+  const matches = (option: string) => {
+    const needle = filter.toLowerCase();
+    return (props.options[option] || option).toLowerCase().includes(needle)
+        || option.toLowerCase().includes(needle);
+  };
+
+  const grouped: OptionGroup[] = [];
+  if (props.groups) {
+    const claimed = new Set<string>();
+    props.groups.forEach((group) => {
+      group.options.forEach((el) => claimed.add(el));
+      const options = group.options.filter(matches);
+      if (options.length > 0) {
+        grouped.push({label: group.label, options: options});
+      }
+    });
+    const rest = all.filter((el) => !claimed.has(el) && matches(el));
+    if (rest.length > 0) {
+      grouped.push({label: '', options: rest});
+    }
+  } else {
+    const shown = all.filter(matches);
+    if (shown.length > 0) {
+      grouped.push({label: '', options: shown});
+    }
+  }
+
+  // The options in the order they appear on screen, so a marked run follows
+  // what the user sees rather than the order the options were given in.
+  const listed: string[] = [];
+  grouped.forEach((group) => listed.push(...group.options));
+
+  /**
+   * Mark every row between the anchor and the given one
+   *
+   * @param {string} option - The row the run ends on
+   * @returns {void}
+   */
+  const markRunTo = (option: string) => {
+    if (anchor.current === null) {
+      return;
+    }
+    const from = listed.indexOf(anchor.current);
+    const to = listed.indexOf(option);
+    if (from === -1 || to === -1) {
+      return;
+    }
+    const run = listed.slice(Math.min(from, to), Math.max(from, to) + 1);
+    setMarked(run.filter((el) => !locked.has(el)));
+  };
+
+  /**
+   * Handle a click on a row. Shift marks a run and ctrl or command marks the
+   * single row, both without changing what is selected, so a run can be set up
+   * before deciding what to do with it. A plain click toggles as usual.
+   *
+   * @param {string} option - The row that was clicked
+   * @param {React.MouseEvent} e - The click
+   * @returns {void}
+   */
+  const onRowClick = (option: string, e: React.MouseEvent) => {
+    if (locked.has(option) || !multiple) {
+      return;
+    }
+    if (dragged.current) {
+      // The click that ends a drag should not also toggle the last row.
+      e.preventDefault();
+      dragged.current = false;
+      return;
+    }
+    if (e.shiftKey && anchor.current !== null) {
+      e.preventDefault();
+      markRunTo(option);
+      return;
+    }
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      anchor.current = option;
+      setMarked((prev) => prev.includes(option) ?
+        prev.filter((el) => el !== option) :
+        [...prev, option]);
+      return;
+    }
+    anchor.current = option;
+    if (marked.length > 0) {
+      setMarked([]);
+    }
+  };
+
+  /**
+   * Scroll the list while a drag is held near its top or bottom edge, so a run
+   * can continue past what is currently visible.
+   *
+   * @returns {void}
+   */
+  const scrollTowardsPointer = () => {
+    if (!dragging.current || list.current === null) {
+      autoScroll.current = null;
+      return;
+    }
+    const box = list.current.getBoundingClientRect();
+    const zone = 24;
+    const speed = 12;
+    if (pointerY.current > box.bottom - zone) {
+      list.current.scrollTop += speed;
+    } else if (pointerY.current < box.top + zone) {
+      list.current.scrollTop -= speed;
+    }
+    autoScroll.current = requestAnimationFrame(scrollTowardsPointer);
+  };
+
+  /**
+   * Begin marking a run by dragging down the list
+   *
+   * @param {string} option - The row the drag started on
+   * @param {React.MouseEvent} e - The mousedown
+   * @returns {void}
+   */
+  const onRowMouseDown = (option: string, e: React.MouseEvent) => {
+    if (locked.has(option) || !multiple
+        || e.shiftKey || e.ctrlKey || e.metaKey
+    ) {
+      return;
+    }
+    dragging.current = true;
+    dragged.current = false;
+    anchor.current = option;
+    pointerY.current = e.clientY;
+    if (autoScroll.current === null) {
+      autoScroll.current = requestAnimationFrame(scrollTowardsPointer);
+    }
+  };
+
+  /**
+   * Extend the run while the pointer is held down
+   *
+   * @param {string} option - The row the pointer moved onto
+   * @returns {void}
+   */
+  const onRowMouseEnter = (option: string) => {
+    if (!dragging.current || locked.has(option)) {
+      return;
+    }
+    if (option !== anchor.current) {
+      dragged.current = true;
+    }
+    markRunTo(option);
+  };
+
+  /**
+   * Add or remove a single value from the selection
+   *
+   * @param {string} option - The value that was clicked
+   * @returns {void}
+   */
+  const toggle = (option: string) => {
+    if (!multiple) {
+      props.onChange([option]);
+      setOpen(false);
+      return;
+    }
+    const next = new Set(selected);
+    if (next.has(option)) {
+      next.delete(option);
+    } else {
+      next.add(option);
+    }
+    commit(next);
+  };
+
+  /**
+   * Select the marked run, or everything when nothing is marked
+   *
+   * @returns {void}
+   */
+  const selectTarget = () => {
+    const next = new Set(selected);
+    (marked.length > 0 ? marked : all).forEach((el) => next.add(el));
+    commit(next);
+    setMarked([]);
+  };
+
+  /**
+   * Deselect the marked run, or everything when nothing is marked
+   *
+   * @returns {void}
+   */
+  const deselectTarget = () => {
+    const next = new Set(selected);
+    (marked.length > 0 ? marked : all).forEach((el) => next.delete(el));
+    commit(next);
+    setMarked([]);
+  };
+
+  /**
+   * Render what the trigger shows for the current selection
+   *
+   * @returns {React.ReactElement} - The trigger contents
+   */
+  const renderSelection = () => {
+    if (selected.size === 0) {
+      return <span className="loris-select-placeholder">
+        {props.label ? '' : (props.placeholder || '')}
+      </span>;
+    }
+    if (multiple && selected.size === all.length) {
+      return <span className="loris-select-count">
+        {'All (' + all.length + ')'}
+      </span>;
+    }
+    if (props.display === 'count') {
+      return <span className="loris-select-count">
+        {selected.size + ' of ' + all.length}
+      </span>;
+    }
+    const shown = props.value.slice(0, maxVisible);
+    const hidden = selected.size - shown.length;
+    const names = shown.map((option) => props.options[option] || option);
+    if (props.display === 'tags') {
+      return <span className="loris-select-tags">
+        {shown.map((option, i) => (
+          <span key={option} className="loris-select-tag">{names[i]}</span>
+        ))}
+        {hidden > 0 ?
+          <span className="loris-select-tag muted">
+            {'+' + hidden + ' more'}
+          </span> : null}
+      </span>;
+    }
+    return <span className="loris-select-names">
+      {names.join(', ')}
+      {hidden > 0 ?
+        <span className="loris-select-count">{' +' + hidden + ' more'}</span> :
+        null}
+    </span>;
+  };
+
+  /**
+   * Render a single checkbox row
+   *
+   * @param {string} option - The option to render
+   * @returns {React.ReactElement} - The row
+   */
+  const optionRow = (option: string) => {
+    let className = 'loris-select-option';
+    if (locked.has(option)) {
+      className += ' disabled';
+    }
+    if (marked.includes(option)) {
+      className += ' marked';
+    }
+    if (!multiple && selected.has(option)) {
+      className += ' chosen';
+    }
+    return (
+      <label key={option}
+        className={className}
+        onMouseDown={(e) => onRowMouseDown(option, e)}
+        onMouseEnter={() => onRowMouseEnter(option)}
+        onClick={(e) => onRowClick(option, e)}>
+        <input type={multiple ? 'checkbox' : 'radio'}
+          name={props.name}
+          value={option}
+          disabled={locked.has(option)}
+          checked={selected.has(option)}
+          onChange={() => toggle(option)} />
+        {props.options[option]}
+      </label>
+    );
+  };
+
+  // While a run is marked these two buttons are the only things on screen that
+  // will consume it, so they take the run's own colour and read as part of it
+  // rather than as controls that happen to sit above it.
+  const aimed = marked.length > 0 ? ' targeted' : '';
+  const selectText = marked.length > 0 ?
+    'Select ' + marked.length :
+    (props.selectLabel || 'Select all');
+  const deselectText = marked.length > 0 ?
+    'Deselect ' + marked.length :
+    (props.deselectLabel || 'Deselect all');
+
+  let panel = null;
+  if (open) {
+    panel = <div className="loris-select-panel">
+      <div className="loris-select-controls">
+        <input ref={search}
+          className="loris-select-search"
+          type="text"
+          placeholder={props.searchPlaceholder || 'Search'}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)} />
+        {multiple ? <>
+          <button type="button"
+            className={'loris-button secondary' + aimed}
+            onClick={selectTarget}>
+            {selectText}
+          </button>
+          <button type="button"
+            className={'loris-button secondary' + aimed}
+            onClick={deselectTarget}>
+            {deselectText}
+          </button>
+        </> : null}
+      </div>
+      <div className="loris-select-list" ref={list}>
+        {grouped.length === 0 ?
+          <div className="loris-select-empty">
+            {props.emptyMessage || 'No options'}
+          </div> :
+          grouped.map((group) => (
+            <div key={group.label}>
+              {group.label === '' ? null :
+                <div className="loris-select-group">{group.label}</div>}
+              {group.options.map(optionRow)}
+            </div>
+          ))}
+      </div>
+      {multiple ? <div className="loris-select-counts">
+        <span>{selected.size} selected</span>
+        <span>{all.length} available</span>
+      </div> : null}
+      {props.footer ?
+        <div className="loris-select-footer">{props.footer}</div> : null}
+    </div>;
+  }
+
+  return (
+    <div ref={wrapper}
+      className={'loris-select'
+        + (props.mono ? ' mono' : '')
+        + (open ? ' open' : '')}>
+      {props.label ?
+        <fieldset className="loris-select-outline" aria-hidden="true">
+          <legend className={selected.size > 0 || open ? '' : 'closed'}>
+            <span>{props.label}</span>
+          </legend>
+        </fieldset> :
+        null}
+      <button type="button"
+        className="loris-select-trigger"
+        disabled={props.disabled}
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={() => setOpen(!open)}>
+        {props.label ?
+          <span className={'loris-select-label'
+            + (selected.size > 0 || open ? ' raised' : '')}>
+            {props.label}
+          </span> :
+          null}
+        <span className="loris-select-value">
+          {renderSelection()}
+        </span>
+        <span className="loris-select-indicators">
+          {props.badge}
+          <span className="caret" />
+        </span>
+      </button>
+      {panel}
+    </div>
+  );
+}
+
+export default Select;

--- a/jsx/Textbox.css
+++ b/jsx/Textbox.css
@@ -1,0 +1,175 @@
+/**
+ * Styles for the Textbox component. Values come from the tokens in
+ * htdocs/css/tokens.css.
+ */
+
+.loris-textbox {
+    position: relative;
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+/* The input draws its own field rather than borrowing .form-control. */
+.loris-textbox-input {
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
+    height: var(--loris-control-height);
+    padding: var(--loris-field-padding);
+    font-family: var(--loris-font-family);
+    font-size: var(--loris-font-size);
+    line-height: var(--loris-line-height);
+    color: var(--loris-text);
+    background: var(--loris-field-bg);
+    border: 1px solid var(--loris-field-border);
+    border-radius: var(--loris-radius);
+    box-shadow: var(--loris-field-shadow);
+}
+
+/* The outline draws the field whenever there is a label, so the input gives up
+   its own border and shadow. The inset shadow in particular has to go: the
+   legend's notch cuts the border, but nothing cuts a shadow, so it would draw
+   a hairline straight across the label and split it in two. */
+.loris-textbox:has(.loris-textbox-outline) .loris-textbox-input,
+.loris-textbox:has(.loris-textbox-outline) .loris-textbox-input:focus {
+    border-color: transparent;
+    box-shadow: none;
+}
+
+.loris-textbox-input:focus {
+    outline: 0;
+    border-color: var(--loris-field-border-focus);
+    box-shadow: var(--loris-field-shadow-focus);
+}
+
+/* Focus on a labelled field is the border and the label turning, with no glow.
+   The glow spreads out from the border it follows, and the label sits on that
+   border, so a glow would be read through the label's own letters.
+
+   Matched from the wrapper because the outline is drawn before the input, so
+   there is no sibling combinator that reaches it. */
+.loris-textbox:has(.loris-textbox-input:focus) .loris-textbox-outline {
+    border-color: var(--loris-field-border-focus);
+}
+
+.loris-textbox:has(.loris-textbox-input:focus) .loris-textbox-label.raised {
+    color: var(--loris-color-accent);
+}
+
+.loris-textbox-input:disabled {
+    background: var(--loris-surface-sunken);
+    cursor: not-allowed;
+}
+
+/* Room for whichever affordance sits inside the field. */
+.loris-textbox.searchable .loris-textbox-input {
+    padding-right: calc(var(--loris-control-height) - var(--loris-space-xs));
+}
+
+.loris-textbox-icon,
+.loris-textbox-clear {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: var(--loris-control-height);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--loris-text-faint);
+}
+
+.loris-textbox-icon {
+    pointer-events: none;
+}
+
+.loris-textbox-clear {
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+}
+
+.loris-textbox-clear:hover,
+.loris-textbox-clear:focus-visible {
+    color: var(--loris-color-accent-strong);
+}
+
+/* Matches the select's label, so the two read as one control set in a toolbar. */
+.loris-textbox-label {
+    position: absolute;
+    left: var(--loris-space-lg);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--loris-text-muted);
+    pointer-events: none;
+    transition: top .12s ease, font-size .12s ease;
+    z-index: 1;
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+    .loris-textbox-label {
+        transition: none;
+    }
+}
+
+/* Raised, it sits in the gap the outline's legend leaves in the border, so it
+   needs no backdrop and works on any colour behind the control. Matches the
+   select's label, in the muted grey rather than the faint one: at this size,
+   on a sunken ground, the faint grey is not readable. */
+.loris-textbox-label.raised {
+    top: 0;
+    font-size: var(--loris-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--loris-text-muted);
+    background: none;
+    padding: 0 var(--loris-space-xs);
+    left: var(--loris-space-sm);
+    z-index: 1;
+}
+
+/* The border is drawn by a fieldset behind the control rather than on the
+   control itself. Its legend reserves exactly the width of the label, which
+   leaves a real gap in the border, so the label needs no backdrop of its own
+   and works on any colour behind it. */
+.loris-textbox-outline {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    padding: 0 var(--loris-space-sm);
+    border: 1px solid var(--loris-field-border);
+    border-radius: var(--loris-radius);
+    pointer-events: none;
+    min-width: 0;
+}
+
+.loris-textbox-outline legend {
+    width: auto;
+    max-width: 100%;
+    padding: 0;
+    border: 0;
+
+    /* The cut has to straddle the border, not sit under it. A legend's box
+       starts inside the fieldset, so without this the top sliver of the border
+       survives and shows as a hairline through the label. */
+    height: 4px;
+    margin: -2px 0 0;
+    visibility: hidden;
+    font-size: var(--loris-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    white-space: nowrap;
+}
+
+/* Nothing is raised, so the border closes up. */
+.loris-textbox-outline legend.closed {
+    max-width: 0;
+}
+
+.loris-textbox-outline legend span {
+    display: inline-block;
+    padding: 0 var(--loris-space-xs);
+}

--- a/jsx/Textbox.tsx
+++ b/jsx/Textbox.tsx
@@ -1,0 +1,101 @@
+import React, {useState} from 'react';
+import './Textbox.css';
+
+/**
+ * A single line text input.
+ *
+ * With search set it gains the affordances a search deserves: a magnifier
+ * while it is empty, and a control to clear it once it is not. That is the
+ * only difference, so a box that narrows a list down is this component rather
+ * than one of its own.
+ *
+ * It is the unwrapped control, with no form row or label around it, so it can
+ * be placed anywhere. TextboxElement renders it inside the usual form layout.
+ *
+ * @param {object} props - React props
+ * @param {string} props.value - The current text
+ * @param {function} props.onChange - Callback given the new text
+ * @param {string|undefined} props.label - Names the control. It sits where the
+ *                                          text would be while the box is
+ *                                          empty and unfocused, and rises onto
+ *                                          the top edge otherwise, so the
+ *                                          control still says what it is once
+ *                                          it holds text.
+ * @param {boolean|undefined} props.search - Show the search affordances
+ * @param {string|undefined} props.placeholder - Placeholder for the input
+ * @param {string|undefined} props.clearLabel - Accessible name for the clear control
+ * @param {boolean|undefined} props.disabled - Disables the input
+ * @param {boolean|undefined} props.required - Marks the input as required
+ * @param {string|undefined} props.name - Name given to the input
+ * @param {string|undefined} props.id - Id given to the input
+ * @param {function|undefined} props.onBlur - Callback when the input loses focus
+ * @param {string|undefined} props.autoComplete - Autocomplete hint for the input
+ * @returns {React.ReactElement} - The input
+ */
+function Textbox(props: {
+    value: string,
+    onChange: (value: string) => void,
+    label?: string,
+    search?: boolean,
+    placeholder?: string,
+    clearLabel?: string,
+    disabled?: boolean,
+    required?: boolean,
+    name?: string,
+    id?: string,
+    onBlur?: () => void,
+    autoComplete?: string,
+}): React.ReactElement {
+  const [focused, setFocused] = useState<boolean>(false);
+  const raised = props.value !== '' || focused;
+  let affordance = null;
+  if (props.search) {
+    affordance = props.value === '' ?
+      <span className="loris-textbox-icon" aria-hidden="true">
+        <span className="glyphicon glyphicon-search" />
+      </span> :
+      <button type="button"
+        className="loris-textbox-clear"
+        disabled={props.disabled}
+        aria-label={props.clearLabel || 'Clear'}
+        onClick={() => props.onChange('')}>
+        <span className="glyphicon glyphicon-remove" aria-hidden="true" />
+      </button>;
+  }
+  return (
+    <div className={'loris-textbox' + (props.search ? ' searchable' : '')}>
+      {props.label ?
+        <fieldset className="loris-textbox-outline" aria-hidden="true">
+          <legend className={raised ? '' : 'closed'}>
+            <span>{props.label}</span>
+          </legend>
+        </fieldset> :
+        null}
+      {props.label ?
+        <span className={'loris-textbox-label' + (raised ? ' raised' : '')}>
+          {props.label}
+        </span> :
+        null}
+      <input type="text"
+        className="loris-textbox-input"
+        name={props.name}
+        id={props.id}
+        value={props.value}
+        required={props.required}
+        disabled={props.disabled}
+        placeholder={props.label && !raised ? '' : props.placeholder}
+        autoComplete={props.autoComplete}
+        onFocus={() => setFocused(true)}
+        onBlur={() => {
+          setFocused(false);
+          if (props.onBlur) {
+            props.onBlur();
+          }
+        }}
+        onChange={(e) => props.onChange(e.target.value)} />
+      {affordance}
+    </div>
+  );
+}
+
+export default Textbox;

--- a/jsx/Toggle.css
+++ b/jsx/Toggle.css
@@ -1,0 +1,92 @@
+/**
+ * Styles for the Toggle component, in both of its presentations. Every value
+ * comes from a token in htdocs/css/tokens.css.
+ */
+
+.loris-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--loris-space-md);
+    margin: 0;
+    font-weight: normal;
+    cursor: pointer;
+}
+
+.loris-toggle.disabled {
+    cursor: not-allowed;
+    opacity: .6;
+}
+
+/* As a switch, the real control stays in the accessibility tree and takes
+   focus, but the track and thumb are what is seen. As a checkbox it is drawn
+   by the browser as usual. */
+.loris-toggle.as-switch input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+}
+
+.loris-toggle-track {
+    position: relative;
+    flex: none;
+    width: 34px;
+    height: 18px;
+    border-radius: 9px;
+    background: var(--loris-control-off);
+
+    /* The track is a light shape on a light page, so its own fill cannot be
+       what defines it. The inset ring gives the control an edge that clears
+       3:1 against the page in both states, drawn inside so switching it does
+       not move anything. */
+    box-shadow: inset 0 0 0 1px var(--loris-control-off-edge);
+    transition: background .15s ease, box-shadow .15s ease;
+}
+
+.loris-toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--loris-surface);
+    box-shadow: var(--loris-shadow-raised);
+    transition: transform .15s ease;
+}
+
+/* A switch that is on is a rule now standing, which is information rather than
+   something in flight, so it is the sky and not the secondary. The off track is
+   a darker grey than a border would be, because the sky and a light grey have
+   almost the same luminance and the control would then be saying nothing to a
+   reader who cannot separate the two hues. */
+.loris-toggle.as-switch input:checked + .loris-toggle-track {
+    background: var(--loris-color-info);
+    box-shadow: inset 0 0 0 1px var(--loris-color-info-edge);
+}
+
+.loris-toggle.as-switch input:checked + .loris-toggle-track .loris-toggle-thumb {
+    transform: translateX(16px);
+}
+
+.loris-toggle.as-switch input:focus-visible + .loris-toggle-track {
+    outline: 2px solid var(--loris-color-accent-strong);
+    outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .loris-toggle-track,
+    .loris-toggle-thumb {
+        transition: none;
+    }
+}
+
+/* Same bootstrap margin as in Select.css; qualified by type to outrank it. */
+.loris-toggle.as-checkbox input[type="checkbox"] {
+    margin: 0;
+}

--- a/jsx/Toggle.tsx
+++ b/jsx/Toggle.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import './Toggle.css';
+
+/**
+ * A boolean, drawn either as a switch or as a checkbox.
+ *
+ * Both are the same control over the same input, and differ only in how they
+ * are drawn and in what they say to a screen reader. Choose between them by
+ * what the boolean does:
+ *
+ *   switch    the setting takes effect the moment it changes. Announced as a
+ *             switch, which tells a screen reader user the same thing.
+ *   checkbox  the value is one of several being chosen, and takes effect when
+ *             something else is submitted.
+ *
+ * It is the unwrapped control, with no form row or offset around it, so it can
+ * be placed anywhere.
+ *
+ * @param {object} props - React props
+ * @param {string} props.name - Name given to the underlying input
+ * @param {boolean} props.checked - Whether the boolean is on
+ * @param {function} props.onChange - Callback given the new state
+ * @param {string|undefined} props.display - "switch" (the default) or "checkbox"
+ * @param {string|undefined} props.label - Text shown beside the control
+ * @param {string|undefined} props.value - Value submitted when checked
+ * @param {boolean|undefined} props.disabled - Disables the control
+ * @returns {React.ReactElement} - The control
+ */
+function Toggle(props: {
+    name: string,
+    checked: boolean,
+    onChange: (checked: boolean) => void,
+    display?: 'switch' | 'checkbox',
+    label?: string,
+    value?: string,
+    disabled?: boolean,
+}): React.ReactElement {
+  const asSwitch = props.display !== 'checkbox';
+  return (
+    <label className={'loris-toggle'
+      + (asSwitch ? ' as-switch' : ' as-checkbox')
+      + (props.disabled ? ' disabled' : '')}>
+      <input type="checkbox"
+        role={asSwitch ? 'switch' : undefined}
+        name={props.name}
+        value={props.value}
+        checked={props.checked}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.checked)} />
+      {asSwitch ?
+        <span className="loris-toggle-track" aria-hidden="true">
+          <span className="loris-toggle-thumb" />
+        </span> :
+        null}
+      {props.label ? <span>{props.label}</span> : null}
+    </label>
+  );
+}
+
+export default Toggle;

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -4,6 +4,7 @@
     <head>
         <link rel="stylesheet" href="{$baseurl}/{$css}" type="text/css" />
         <link rel="stylesheet" href="{$baseurl}/fontawesome/css/all.css" type="text/css" />
+        <link rel="stylesheet" href="{$baseurl}/css/tokens.css" type="text/css" />
         <link rel="stylesheet" href="{$baseurl}/css/tooltip.css" type="text/css" />
         <link type="image/x-icon" rel="icon" href="/images/favicon.ico">
 

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -9,6 +9,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{$study_title}</title>
+  <link rel="stylesheet" href="{$baseurl}/css/tokens.css" type="text/css" />
   <link rel="stylesheet" href="{$baseurl}/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="{$baseurl}/css/public_layout.css">
   <link type="image/x-icon" rel="icon" href="{$baseurl}/images/favicon.ico">


### PR DESCRIPTION
> Stacked on #11193. Until that merges the diff here shows the design tokens as well.

## Description

The form elements in `jsx/Form.js` come wrapped in their own label, form row and column offset. A screen that wants one of those controls outside a form has to hand roll its own, which is how the tree ended up with more than one implementation of a multiple select.

This adds four controls in `jsx/` that take no label, row or offset, so they can be placed anywhere, and has `Form.js` render them.

- `Select` is a selection shown as a dropdown over a searchable list. It holds many values, or one with `multiple={false}`. Options can be grouped so the relevant ones sort first, and a run can be marked by dragging or shift clicking, which the select and deselect buttons then act on.
- `Textbox` is a single line input. With `search` it gains a magnifier and a control to clear it.
- `Toggle` is a boolean, drawn as a switch or as a checkbox.
- `Button` performs an action in one of four displays.

`SelectElement` renders `Select` when it holds more than one value, and `TextboxElement` renders `Textbox`. 50 files use `SelectElement` and 42 use `TextboxElement`, and they pick the new controls up without changing.

The controls draw themselves from the tokens rather than from bootstrap classes, so there is nothing of bootstrap's to outrank. `.form-control` sets `display: block` and `.input-group` sets `display: table`, both of which beat an equally specific rule of your own on source order.

## Changes

- Added `Select`, `Textbox`, `Toggle` and `Button` to `jsx/`, each with its own stylesheet.
- `SelectElement` renders `Select` for a multiple selection, and `TextboxElement` renders `Textbox`.

## Testing Instructions

1. Open Candidate List and use the Visit Label filter. It should be a dropdown with a search box, and selecting several visits should filter the table.
2. Open a form with a single value select and confirm it still renders and submits.
3. Tab to a select and press Enter. It should open, and Escape should close it.
4. In a multiple select, click one option and shift click a lower one. The run between them should be marked, and the buttons should act on that run.
