### PR TITLE
[dataquery] Paginate stored query runs

### DIFF
--- a/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
+++ b/modules/dataquery/php/endpoints/queries/query/run/run.class.inc
@@ -114,8 +114,12 @@ class Run extends \LORIS\Http\Endpoint
      */
     private function _jsondecoded(iterable $results, array $CandIDs)
     {
+        $accessible = [];
+        foreach ($CandIDs as $candID) {
+            $accessible[strval($candID)] = true;
+        }
         foreach ($results as $row ) {
-            if (in_array(new CandID(strval($row['CandID'])), $CandIDs)) {
+            if (isset($accessible[strval($row['CandID'])])) {
                 yield json_decode($row['RowData']);
             }
         }


### PR DESCRIPTION
> Stacked on #11191, which rewrites the same method.

## Description

`GET /dataquery/queries/{queryID}/run/{runID}` returns every row of a stored run in one response. This adds optional `count` and `offset` query parameters so a client can page through the rows cached in `dataquery_run_results` for that run.

The rows the user can't access are removed before the page is cut, so every page but the last is full and the offsets line up. The `X-Total-Count` header carries the number of accessible rows. Without either parameter the endpoint returns every row, in CandID order.

On a large run a page comes back faster than the full response and at a small fraction of its size, so a client can show the first rows without waiting for the whole run. Paging through every page returns exactly the same rows as the unpaged request, including for a user who can only access part of the run.

## Changes

- `handle` reads the optional `count` and `offset` query parameters and returns a 400 when either isn't a valid integer.
- `queryResults` orders the run's CandIDs, removes the ones the user can't access, and fetches `RowData` only for the CandID range of the requested page.
- The response carries an `X-Total-Count` header.

## Testing Instructions

1. Run a query that returns a few thousand rows and note its query ID and run ID.
2. Request `GET /dataquery/queries/{queryID}/run/{runID}` with no parameters. It should return every row, with the total in `X-Total-Count`.
3. Request it with `count=100` and increasing `offset` values. Every page but the last should hold 100 rows, and the pages together should match the response from step 2.
4. Repeat step 3 as a user limited to some sites or projects. `X-Total-Count` should drop to the rows they can access, and the pages should still be full.
5. Request it with `count=0` or `offset=-1`. It should return a 400.

## Related Issues

Resolves #11199.
