### PR TITLE
[libraries] Refactor identifier configuration to use template strings

### DIFF
--- a/modules/api/php/views/projects.class.inc
+++ b/modules/api/php/views/projects.class.inc
@@ -49,7 +49,7 @@ class Projects
         $useEDC = $config->getSetting("useEDC");
         $PSCID  = $config->getSetting("PSCID");
 
-        $PSCIDFormat = \Candidate::structureToPCRE($PSCID['structure'], "SITE");
+        $PSCIDFormat = \Candidate::templateToPCRE($PSCID['structure'], "SITE");
 
         $type = in_array($PSCID['generation'], ['sequential', 'random'], true)
             ? 'auto'

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -1181,96 +1181,6 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
     }
 
     /**
-     * Transforms a config structure (such as in PSCID) into a
-     * Perl-compatible regex expression for validation
-     *
-     * @param array       $structure     the structure root
-     * @param string|null $siteAbbrev    the site abbreviation, sometimes used as
-     *                                   part of the PSCID
-     * @param string|null $projectAbbrev the project abbreviation
-     *
-     * @return string the regex pattern
-     *
-     * @note    This should probably be moved to the Candidate class, since it's
-     *       only used there to validate the PSCID
-     * @cleanup
-     */
-    static function structureToPCRE(
-        array $structure,
-        ?string $siteAbbrev = null,
-        ?string $projectAbbrev = null
-    ): string {
-        $seqs = $structure['seq'];
-        // handle the situation where there exists only one seq
-        if (isset($seqs['#'])) {
-            $seqs = [$seqs];
-        }
-        $regex = "";
-        foreach ($seqs AS $seq) {
-            $unit = "";
-
-            switch ($seq['@']['type']) {
-            case 'alpha':
-                $unit .= '[a-z]';
-                break;
-
-            case 'alphanumeric':
-                $unit .= '[0-9a-z]';
-                break;
-
-            case 'numeric':
-                $unit .= '[0-9]';
-                break;
-
-            case 'static':
-                $unit .= '('.$seq['#'].')';
-                break;
-
-            case 'set':
-                if (strpos($seq['#'], '|') !== false) {
-                    $unit .= '('.$seq['#'].')';
-                } else {
-                    $unit .= '['.$seq['#'].']';
-                }
-                break;
-
-            case 'siteAbbrev':
-                $unit .= $siteAbbrev;
-                break;
-            case 'projectAbbrev':
-                $unit .= $projectAbbrev;
-                break;
-            } // end switch
-
-            $length = "";
-            if (isset($seq['@']['length'])) {
-                $length .= $seq['@']['length'];
-            } elseif (isset($seq['@']['minLength'])) {
-                $length .= $seq['@']['minLength'];
-            } else {
-                $length .= '1';
-            }
-
-            $length .= ',';
-
-            if (isset($seq['@']['length'])) {
-                $length .= $seq['@']['length'];
-            } elseif (isset($seq['@']['maxLength'])) {
-                $length .= $seq['@']['maxLength'];
-            } elseif (!isset($seq['@']['length'])
-                && !isset($seq['@']['minLength'])
-            ) {
-                $length .= '1';
-            }
-
-            $regex .= $unit.'{'.$length.'}';
-
-        } // end foreach seq
-
-        return '/^'.$regex.'$/i';
-    }
-
-    /**
      * Transforms an identifier template (such as PSCID) into a
      * Perl-compatible regex expression for validation.
      *
@@ -1309,18 +1219,18 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $characters = '[0-9]';
 
                 if (preg_match(
-                    "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
+                    "/FORMAT{$escaped}:(numeric|alphanumeric|alpha)/i",
                     $matches[2],
                     $type
                 )
                 ) {
                     switch (strtolower($type[1])) {
-                    case 'alpha':
-                        $characters = '[A-Z]';
-                        break;
-
                     case 'alphanumeric':
                         $characters = '[0-9A-Z]';
+                        break;
+
+                    case 'alpha':
+                        $characters = '[A-Z]';
                         break;
                     }
                 }
@@ -1336,18 +1246,18 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                 $characters = '[0-9]';
 
                 if (preg_match(
-                    "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
+                    "/FORMAT{$escaped}:(numeric|alphanumeric|alpha)/i",
                     $matches[2],
                     $type
                 )
                 ) {
                     switch (strtolower($type[1])) {
-                    case 'alpha':
-                        $characters = '[A-Z]';
-                        break;
-
                     case 'alphanumeric':
                         $characters = '[0-9A-Z]';
+                        break;
+
+                    case 'alpha':
+                        $characters = '[A-Z]';
                         break;
                     }
                 }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -995,7 +995,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         $config  = $factory->config();
 
         $PSCIDSettings = $config->getSetting('PSCID');
-        $regex         = self::structureToPCRE(
+        $regex         = self::templateToPCRE(
             $PSCIDSettings['structure'],
             $siteAbbrev,
             $projectAbbrev
@@ -1268,6 +1268,94 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
         } // end foreach seq
 
         return '/^'.$regex.'$/i';
+    }
+
+    /**
+     * Transforms an identifier template (such as PSCID) into a
+     * Perl-compatible regex expression for validation.
+     *
+     * @param string      $template      The identifier template
+     * @param string|null $siteAbbrev    The site abbreviation, sometimes used as
+     *                                   part of the identifier
+     * @param string|null $projectAbbrev The project abbreviation, sometimes used
+     *                                   as part of the identifier
+     *
+     * @return string The regex pattern
+     */
+    static function templateToPCRE(
+        string $template,
+        ?string $siteAbbrev = null,
+        ?string $projectAbbrev = null
+    ): string {
+        $regex = preg_quote($template, '/');
+
+        $regex = str_replace(
+            preg_quote('{SITE:ALIAS}', '/'),
+            preg_quote($siteAbbrev ?? '', '/'),
+            $regex
+        );
+
+        $regex = str_replace(
+            preg_quote('{PROJECT:ALIAS}', '/'),
+            preg_quote($projectAbbrev ?? '', '/'),
+            $regex
+        );
+
+        $escaped = '\\\\';
+
+        $regex = preg_replace_callback(
+            "/{$escaped}\{SEQUENCE{$escaped}:(\d+)([^}]*){$escaped}\}/i",
+            function ($matches) use ($escaped) {
+                $characters = '[0-9]';
+
+                if (preg_match(
+                    "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
+                    $matches[2],
+                    $type
+                )) {
+                    switch (strtolower($type[1])) {
+                        case 'alpha':
+                            $characters = '[A-Z]';
+                            break;
+
+                        case 'alphanumeric':
+                            $characters = '[0-9A-Z]';
+                            break;
+                    }
+                }
+
+                return $characters . '{' . $matches[1] . '}';
+            },
+            $regex
+        );
+
+        $regex = preg_replace_callback(
+            "/{$escaped}\{RANDOM{$escaped}:(\d+)([^}]*){$escaped}\}/i",
+            function ($matches) use ($escaped) {
+                $characters = '[0-9]';
+
+                if (preg_match(
+                    "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
+                    $matches[2],
+                    $type
+                )) {
+                    switch (strtolower($type[1])) {
+                        case 'alpha':
+                            $characters = '[A-Z]';
+                            break;
+
+                        case 'alphanumeric':
+                            $characters = '[0-9A-Z]';
+                            break;
+                    }
+                }
+
+                return $characters . '{' . $matches[1] . '}';
+            },
+            $regex
+        );
+
+        return '/^' . $regex . '$/i';
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -1267,7 +1267,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             $regex
         );
 
-        return '/^' . $regex . '$/i';
+        return '/^'.$regex.'$/i';
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -1312,15 +1312,16 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                     "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
                     $matches[2],
                     $type
-                )) {
+                )
+                ) {
                     switch (strtolower($type[1])) {
-                        case 'alpha':
-                            $characters = '[A-Z]';
-                            break;
+                    case 'alpha':
+                        $characters = '[A-Z]';
+                        break;
 
-                        case 'alphanumeric':
-                            $characters = '[0-9A-Z]';
-                            break;
+                    case 'alphanumeric':
+                        $characters = '[0-9A-Z]';
+                        break;
                     }
                 }
 
@@ -1338,15 +1339,16 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
                     "/FORMAT{$escaped}:(numeric|alpha|alphanumeric)/i",
                     $matches[2],
                     $type
-                )) {
+                )
+                ) {
                     switch (strtolower($type[1])) {
-                        case 'alpha':
-                            $characters = '[A-Z]';
-                            break;
+                    case 'alpha':
+                        $characters = '[A-Z]';
+                        break;
 
-                        case 'alphanumeric':
-                            $characters = '[0-9A-Z]';
-                            break;
+                    case 'alphanumeric':
+                        $characters = '[0-9A-Z]';
+                        break;
                     }
                 }
 

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -72,6 +72,13 @@ abstract class IdentifierGenerator
      */
     protected $prefix;
     /**
+     * The character used to pad the suffix portion of the ID to the
+     * configured length.
+     *
+     * @var string
+     */
+    protected $padding;
+    /**
      * A short name for a Site.
      *
      * @var string
@@ -140,7 +147,7 @@ abstract class IdentifierGenerator
             return str_pad(
                 strval($this->minValue),
                 $this->length,
-                "0",
+                $this->padding,
                 STR_PAD_LEFT
             );
         }
@@ -219,7 +226,7 @@ abstract class IdentifierGenerator
         return str_pad(
             $id,
             $this->length,
-            strval($this->alphabet[0]),
+            $this->padding,
             STR_PAD_LEFT
         );
     }

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -53,6 +53,7 @@ class SiteIDGenerator extends IdentifierGenerator
         $this->generationMethod = $this->_getGeneration();
         $this->length           = $this->_getLength();
         $this->alphabet         = $this->_getAlphabet();
+        $this->padding          = $this->_getPadding();
         $this->minValue         = $this->_getMinValue();
         $this->maxValue         = $this->_getMaxValue();
 
@@ -149,7 +150,7 @@ class SiteIDGenerator extends IdentifierGenerator
      * settings relating to the PSCID structure.
      *
      * @param string $setting One of: 'generation', 'length', 'alphabet',
-     *                        'min', 'max'.
+     *                        'prefix', 'min', 'max', 'padding'.
      *
      * @return array<int,int|string>|string|null
      */
@@ -161,72 +162,102 @@ class SiteIDGenerator extends IdentifierGenerator
 
         if (!is_array($kind)) {
             throw new \LorisException("Invalid config for $this->kind");
-        };
-        // The generation setting can be easily extracted and returned.
-        if ($setting == 'generation') {
+        }
+
+        if (
+            preg_match(
+                '/\{(SEQUENCE|RANDOM):(\d+)([^}]*)\}/i',
+                $kind['structure'],
+                $generation
+            ) !== 1
+        ) {
+            throw new \ConfigurationException(
+                "Invalid generation template for {$this->kind}."
+            );
+        }
+
+        // Intermediate state where generation information is redundant
+        // until the full identifier rework.
+        $expected = $kind['generation'] === 'sequential' ? 'SEQUENCE' : 'RANDOM';
+
+        if (
+            $kind['generation'] !== 'user'
+            && strtoupper($generation[1]) !== $expected
+        ) {
+            throw new \ConfigurationException("Generation methods do not match.");
+        }
+
+        if ($setting === 'generation') {
             return $kind['generation'];
         }
 
-        // Values other than 'generation' are found within 'seq' elements and
-        // require more complex processing.
-        $idStructure = $kind['structure']['seq'];
-
-        if (!$idStructure[0]) {
-            // There's only one seq tag so the param format
-            // needs to be fixed
-            $temp        = [];
-            $temp[]      = $idStructure;
-            $idStructure = $temp;
+        if ($setting === 'length') {
+            return $generation[2];
         }
 
-        try {
-            $seqValue = self::getSeqAttribute($idStructure, $setting);
-        } catch (\ConfigurationException $e) {
-            /* Throw a new exception so that we can inform developers whether
-             * the ConfigurationException arose due to ExternalID or PSCID
-             * settings.
-             */
-            throw new \LorisException(
-                "Cannot create new candidate because of a configuration " .
-                "error in settings for {$this->kind} structure. Details: "
-                . $e->getMessage()
-            );
-        }
         if ($setting === 'alphabet') {
-            switch ($seqValue) {
-            case 'alpha':
-                return range('A', 'Z');
-            case 'numeric':
-                return range('0', '9');
-            case 'alphanumeric':
-                return array_merge(range('0', '9'), range('A', 'Z'));
+            if (preg_match(
+                '/(?:^|,)FORMAT:(alpha|numeric|alphanumeric)(?:,|$)/i',
+                $generation[3],
+                $match
+            )) {
+                switch (strtolower($match[1])) {
+                    case 'alpha':
+                        return range('A', 'Z');
+
+                    case 'alphanumeric':
+                        return array_merge(
+                            range('0', '9'),
+                            range('A', 'Z')
+                        );
+                }
             }
+
+            return range('0', '9');
         }
 
         if ($setting === 'prefix') {
-            if ($seqValue === 'static') {
-                // The 'static' seq attribute must also include a value which
-                // will be a fixed string prefix to be prepended to IDs in
-                // LORIS. This must be extracted manually.
-                foreach ($idStructure as $seq) {
-                    if ($seq['@']['type'] === 'static') {
-                        // This index stores the prefix.
-                        return $seq['#'];
-                    }
-                }
-            } elseif ($seqValue === 'siteAbbrev') {
-                return $this->siteAlias;
-            } elseif ($seqValue === 'projectAbbrev') {
-                return $this->projectAlias;
-            } else {
-                throw new ConfigurationException(
-                    "Incorrect option $seqValue selected for PSCID generation."
-                );
-            }
+            $prefix = substr(
+                $kind['structure'],
+                0,
+                strpos($kind['structure'], $generation[0])
+            );
+
+            $prefix = str_replace(
+                ['{SITE:ALIAS}', '{PROJECT:ALIAS}'],
+                [$this->siteAlias, $this->projectAlias],
+                $prefix
+            );
+
+            return $prefix;
         }
-        // The remaining values - min, max, and length - should be returned as
-        // null if they are not set.
-        return is_null($seqValue) ? $seqValue: $seqValue;
+
+        if ($setting === 'min') {
+            if (preg_match('/(?:^|,)MIN:([^,]+)/i', $generation[3], $match)) {
+                return $match[1];
+            }
+            return null;
+        }
+
+        if ($setting === 'max') {
+            if (preg_match('/(?:^|,)MAX:([^,]+)/i', $generation[3], $match)) {
+                return $match[1];
+            }
+            return null;
+        }
+
+        if ($setting === 'padding') {
+            if (preg_match(
+                '/(?:^|,)PADDING:([^,]+)/i',
+                $generation[3],
+                $match
+            )) {
+                return $match[1];
+            }
+            return null;
+        }
+
+        return null;
     }
 
     /**
@@ -424,5 +455,24 @@ class SiteIDGenerator extends IdentifierGenerator
                 intval($this->length)
             )
         );
+    }
+
+    /**
+     * Returns the padding character for the identifier.
+     *
+     * @return string
+     */
+    private function _getPadding(): string
+    {
+        $padding = $this->_getIDSetting('padding')
+            ?? strval($this->alphabet[0]);
+
+        if (!in_array($padding, $this->alphabet, true)) {
+            throw new \ConfigurationException(
+                "Padding character must be part of the configured alphabet."
+            );
+        }
+
+        return $padding;
     }
 }

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -216,10 +216,21 @@ class SiteIDGenerator extends IdentifierGenerator
         }
 
         if ($setting === 'prefix') {
+            $position = strpos(
+                $kind['structure'],
+                $generation[0],
+            );
+
+            if ($position === false) {
+                throw new \ConfigurationException(
+                    "Invalid generation template for {$this->kind}."
+                );
+            }
+
             $prefix = substr(
                 $kind['structure'],
                 0,
-                strpos($kind['structure'], $generation[0])
+                $position
             );
 
             $prefix = str_replace(

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -164,12 +164,11 @@ class SiteIDGenerator extends IdentifierGenerator
             throw new \LorisException("Invalid config for $this->kind");
         }
 
-        if (
-            preg_match(
-                '/\{(SEQUENCE|RANDOM):(\d+)([^}]*)\}/i',
-                $kind['structure'],
-                $generation
-            ) !== 1
+        if (preg_match(
+            '/\{(SEQUENCE|RANDOM):(\d+)([^}]*)\}/i',
+            $kind['structure'],
+            $generation
+        ) !== 1
         ) {
             throw new \ConfigurationException(
                 "Invalid generation template for {$this->kind}."
@@ -180,8 +179,7 @@ class SiteIDGenerator extends IdentifierGenerator
         // until the full identifier rework.
         $expected = $kind['generation'] === 'sequential' ? 'SEQUENCE' : 'RANDOM';
 
-        if (
-            $kind['generation'] !== 'user'
+        if ($kind['generation'] !== 'user'
             && strtoupper($generation[1]) !== $expected
         ) {
             throw new \ConfigurationException("Generation methods do not match.");
@@ -200,16 +198,17 @@ class SiteIDGenerator extends IdentifierGenerator
                 '/(?:^|,)FORMAT:(alpha|numeric|alphanumeric)(?:,|$)/i',
                 $generation[3],
                 $match
-            )) {
+            )
+            ) {
                 switch (strtolower($match[1])) {
-                    case 'alpha':
-                        return range('A', 'Z');
+                case 'alpha':
+                    return range('A', 'Z');
 
-                    case 'alphanumeric':
-                        return array_merge(
-                            range('0', '9'),
-                            range('A', 'Z')
-                        );
+                case 'alphanumeric':
+                    return array_merge(
+                        range('0', '9'),
+                        range('A', 'Z')
+                    );
                 }
             }
 
@@ -251,7 +250,8 @@ class SiteIDGenerator extends IdentifierGenerator
                 '/(?:^|,)PADDING:([^,]+)/i',
                 $generation[3],
                 $match
-            )) {
+            )
+            ) {
                 return $match[1];
             }
             return null;

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -195,20 +195,20 @@ class SiteIDGenerator extends IdentifierGenerator
 
         if ($setting === 'alphabet') {
             if (preg_match(
-                '/(?:^|,)FORMAT:(alpha|numeric|alphanumeric)(?:,|$)/i',
+                '/(?:^|,)FORMAT:(numeric|alphanumeric|alpha)(?:,|$)/i',
                 $generation[3],
                 $match
             )
             ) {
                 switch (strtolower($match[1])) {
-                case 'alpha':
-                    return range('A', 'Z');
-
                 case 'alphanumeric':
                     return array_merge(
                         range('0', '9'),
                         range('A', 'Z')
                     );
+
+                case 'alpha':
+                    return range('A', 'Z');
                 }
             }
 

--- a/test/config.xml
+++ b/test/config.xml
@@ -34,10 +34,7 @@
         <PSCID>
             <!-- PSCID (Study Center ID) generation method possible options: sequential/random/user -->
             <generation>sequential</generation>
-            <structure>
-                <seq type="siteAbbrev"/>
-                <seq type="alphanumeric" length="4"/> <!-- Ex: AAA0001-->
-            </structure>
+            <structure>{SITE:ALIAS}{SEQUENCE:4,FORMAT:alphanumeric}</structure>
         </PSCID>
 
         <ExternalID>

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -855,7 +855,8 @@ class CandidateTest extends TestCase
             ['PSCID', [
                 'generation' => 'sequential',
                 'structure'  => '{PROJECT:ALIAS}{SEQUENCE:4,FORMAT:numeric}',
-            ]],
+            ]
+            ],
         ];
 
         $this->_configMock->method('getSetting')

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -851,27 +851,11 @@ class CandidateTest extends TestCase
      */
     public function testValidateProjectPSCID()
     {
-        $seq = [
-            'seq' => [
-                0 => [
-                    '#' => '',
-                    '@' => ['type' => 'projectAbbrev'],
-                ],
-                1 => [
-                    '#' => '',
-                    '@' => [
-                        'type'   => 'numeric',
-                        'length' => '4',
-                    ],
-                ],
-            ],
-        ];
         $this->_configMap = [
             ['PSCID', [
                 'generation' => 'sequential',
-                'structure'  => $seq,
-            ]
-            ],
+                'structure'  => '{PROJECT:ALIAS}{SEQUENCE:4,FORMAT:numeric}',
+            ]],
         ];
 
         $this->_configMock->method('getSetting')

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -1096,67 +1096,87 @@ class CandidateTest extends TestCase
     }
 
     /**
-     * Test that structureToPCRE returns the regex form of the given structure.
-     * This test covers the different cases of the function.
+     * Test that templateToPCRE returns the regex form of the given template.
+     * This test covers the different supported generation formats.
      *
-     * @covers Candidate::structureToPCRE
+     * @covers Candidate::templateToPCRE
      * @return void
      */
-    public function testStructureToPCRE()
+    public function testTemplateToPCRE()
     {
-        $structure = [
-            'seq' => [
-                0 => ['@' => ['type' => 'alpha',
-                    'minLength' => '1',
-                    'maxLength' => '5'
-                ]
-                ],
-                1 => ['@' => ['type' => 'alphanumeric',
-                    'length' => '2'
-                ]
-                ],
-                2 => ['@' => ['type' => 'static'],
-                    '#' => '1-3'
-                ],
-                3 => ['@' => ['type' => 'set'],
-                    '#' => '1||3'
-                ],
-                4 => ['@' => ['type' => 'set'],
-                    '#' => '1-3'
-                ],
-            ]
-        ];
         $this->assertEquals(
-            '/^[a-z]{1,5}[0-9a-z]{2,2}(1-3){1,1}(1||3){1,1}[1-3]{1,1}$/i',
-            Candidate::structureToPCRE($structure)
+            '/^TEST\-[0-9]{4}$/i',
+            Candidate::templateToPCRE(
+                'TEST-{SEQUENCE:4}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^NUM\-[0-9]{4}$/i',
+            Candidate::templateToPCRE(
+                'NUM-{SEQUENCE:4,FORMAT:numeric}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^ALPHA\-[A-Z]{4}$/i',
+            Candidate::templateToPCRE(
+                'ALPHA-{SEQUENCE:4,FORMAT:alpha}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^ALPHANUM\-[0-9A-Z]{4}$/i',
+            Candidate::templateToPCRE(
+                'ALPHANUM-{SEQUENCE:4,FORMAT:alphanumeric}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^RAND\-[0-9]{4}$/i',
+            Candidate::templateToPCRE(
+                'RAND-{RANDOM:4,FORMAT:numeric}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^RANDALPHA\-[A-Z]{4}$/i',
+            Candidate::templateToPCRE(
+                'RANDALPHA-{RANDOM:4,FORMAT:alpha}'
+            )
+        );
+
+        $this->assertEquals(
+            '/^RANDALPHANUM\-[0-9A-Z]{4}$/i',
+            Candidate::templateToPCRE(
+                'RANDALPHANUM-{RANDOM:4,FORMAT:alphanumeric}'
+            )
         );
     }
 
     /**
-     * Test structureToPCRE with the site and project abbreviations set
+     * Test templateToPCRE with the site and project abbreviations set
      *
-     * @covers Candidate::structureToPCRE
+     * @covers Candidate::templateToPCRE
      * @return void
      */
-    public function testStructureToPCREWithAbbreviations()
+    public function testTemplateToPCREWithAbbreviations()
     {
-        $structure = [
-            'seq' => [
-                0 => ['@' => ['type' => 'siteAbbrev',
-                    'minLength' => '1',
-                    'maxLength' => '5'
-                ]
-                ],
-                1 => ['@' => ['type' => 'projectAbbrev',
-                    'minLength' => '1',
-                    'maxLength' => '5'
-                ]
-                ]
-            ]
-        ];
         $this->assertEquals(
-            '/^MTL{1,5}P1{1,5}$/i',
-            Candidate::structureToPCRE($structure, "MTL", "P1")
+            '/^MTL[0-9]{4}$/i',
+            Candidate::templateToPCRE(
+                '{SITE:ALIAS}{SEQUENCE:4}',
+                'MTL'
+            )
+        );
+
+        $this->assertEquals(
+            '/^P1[0-9]{4}$/i',
+            Candidate::templateToPCRE(
+                '{PROJECT:ALIAS}{SEQUENCE:4}',
+                null,
+                'P1'
+            )
         );
     }
 


### PR DESCRIPTION
## Brief summary of changes

This PR starts implementing the identifier template strings proposed in the following GitHub Discussion https://github.com/aces/Loris/discussions/9036.

It updates the existing identifier structure configuration to support template strings while keeping the current identifier generation behaviour unchanged.

The existing Candidate tests were updated to work with the new structure, and a new test suite was added for SiteIDGenerator to cover the different template options and generation cases.

#### Testing instructions (if applicable)

```xml
<!-- Sequential numeric (default format) -->
<PSCID>
    <generation>sequential</generation>
    <structure>TEST-{SEQUENCE:4}</structure>
</PSCID>

Expected : TEST-0000

<!-- Sequential numeric boundary -->
<PSCID>
    <generation>sequential</generation>
    <structure>TEST-{SEQUENCE:4}</structure>
</PSCID>

Existing PSCID : TEST-0099
Expected : TEST-0100

<!-- Sequential alpha (default minimum) -->
<PSCID>
    <generation>sequential</generation>
    <structure>ALPHA-{SEQUENCE:4,FORMAT:alpha}</structure>
</PSCID>

Expected : ALPHA-AAAA

<!-- Sequential alpha boundary -->
<PSCID>
    <generation>sequential</generation>
    <structure>ALPHA-{SEQUENCE:4,FORMAT:alpha}</structure>
</PSCID>

Existing PSCID : ALPHA-AAAZ
Expected : ALPHA-AABA

<!-- Sequential alpha near default maximum -->
<PSCID>
    <generation>sequential</generation>
    <structure>ALPHA-{SEQUENCE:4,FORMAT:alpha}</structure>
</PSCID>

Existing PSCID : ALPHA-ZZZX
Expected : ALPHA-ZZZY

<!-- Sequential alpha default maximum exceeded -->
<PSCID>
    <generation>sequential</generation>
    <structure>ALPHA-{SEQUENCE:4,FORMAT:alpha}</structure>
</PSCID>

Existing PSCID : ALPHA-ZZZY
Expected : Error!
Cannot create new identifier because all valid identifiers are in use!

<!-- Random numeric -->
<PSCID>
    <generation>random</generation>
    <structure>RAND-{RANDOM:4,FORMAT:numeric}</structure>
</PSCID>

Expected : RAND-#### where # is a random digit from 0 to 9.
e.g. : RAND-3966, RAND-2971, RAND-0427

<!-- Random alpha -->
<PSCID>
    <generation>random</generation>
    <structure>RANDALPHA-{RANDOM:4,FORMAT:alpha}</structure>
</PSCID>

Expected : RANDALPHA-XXXX where X is a random letter from A-Z.
e.g. : RANDALPHA-JRMK, RANDALPHA-ZJZP, RANDALPHA-IZCH

<!-- Random alphanumeric -->
<PSCID>
    <generation>random</generation>
    <structure>RANDALPHANUM-{RANDOM:4,FORMAT:alphanumeric}</structure>
</PSCID>

Expected : RANDALPHANUM-XXXX where X is a random character from 0-9 or A-Z.
e.g. : RANDALPHANUM-KZLK, RANDALPHANUM-0U0W, RANDALPHANUM-1234

<!-- Numeric padding -->
<PSCID>
    <generation>sequential</generation>
    <structure>PAD-{SEQUENCE:4,FORMAT:numeric,PADDING:2,MIN:1}</structure>
</PSCID>

Expected : PAD-2221

<!-- Invalid numeric padding -->
<PSCID>
    <generation>sequential</generation>
    <structure>PAD-{SEQUENCE:4,FORMAT:numeric,PADDING:X,MIN:1}</structure>
</PSCID>

Expected : Error!
Padding character must be part of the configured alphabet.

<!-- Alpha padding -->
<PSCID>
    <generation>sequential</generation>
    <structure>PADALPHA-{SEQUENCE:4,FORMAT:alpha,PADDING:X,MIN:A}</structure>
</PSCID>

Expected : PADALPHA-XXXA

<!-- MIN/MAX -->
<PSCID>
    <generation>sequential</generation>
    <structure>MAXTEST-{SEQUENCE:4,FORMAT:numeric,MIN:1,MAX:3}</structure>
</PSCID>

Existing PSCIDs : MAXTEST-0001, MAXTEST-0002
Expected : Error!
Cannot create new identifier because all valid identifiers are in use!

<!-- Site alias -->
<PSCID>
    <generation>sequential</generation>
    <structure>{SITE:ALIAS}{SEQUENCE:4,FORMAT:numeric}</structure>
</PSCID>

Expected (Site: Data Coordinating Center): DCC0703 -> DCC0704 
(Site: Montreal): MTL0166

<!-- Project alias -->
<PSCID>
    <generation>sequential</generation>
    <structure>{PROJECT:ALIAS}{SEQUENCE:4,FORMAT:numeric}</structure>
</PSCID>

Expected (Project: Pumpernickel): PUMP0000 -> PUMP0001
(Project: DCP): DCP0000

<!-- Generation mismatch: sequential with RANDOM template -->
<PSCID>
    <generation>sequential</generation>
    <structure>MISMATCH-{RANDOM:4,FORMAT:numeric}</structure>
</PSCID>

Expected : Error!
Generation methods do not match.

<!-- Generation mismatch: random with SEQUENCE template -->
<PSCID>
    <generation>random</generation>
    <structure>MISMATCH-{SEQUENCE:4,FORMAT:numeric}</structure>
</PSCID>

Expected : Error!
Generation methods do not match.
```